### PR TITLE
feat(slasher): warn on own-validator slash votes using VoteCast vote index

### DIFF
--- a/l1-contracts/src/core/slashing/SlashingProposer.sol
+++ b/l1-contracts/src/core/slashing/SlashingProposer.sol
@@ -257,9 +257,12 @@ contract SlashingProposer is EIP712 {
   /**
    * @notice Emitted when a proposer casts a vote in a slashing round
    * @param round The round number in which the vote was cast
+   * @param slot The slot in which the vote was cast
    * @param proposer The address of the proposer who cast the vote
+   * @param voteIndex The position of the vote within the round, from 0 to the round's vote count (exclusive), as
+   * accepted by getVotes
    */
-  event VoteCast(SlashRound indexed round, Slot indexed slot, address indexed proposer);
+  event VoteCast(SlashRound indexed round, Slot indexed slot, address indexed proposer, uint256 voteIndex);
 
   /**
    * @notice Emitted when a slashing round is executed and validators are slashed
@@ -375,7 +378,7 @@ contract SlashingProposer is EIP712 {
    *             Signature covers the vote data and current slot number.
    *
    * Emits:
-   * - VoteCast: When the vote is successfully recorded
+   * - VoteCast: When the vote is successfully recorded, carrying the vote's index within the round
    *
    * Reverts with:
    * - SlashingProposer__VotingNotOpen: If current round is less than SLASH_OFFSET_IN_ROUNDS
@@ -415,7 +418,7 @@ contract SlashingProposer is EIP712 {
     // Increment the vote count for this round (all other fields remain unchanged)
     _setRoundData(round, slot, voteCount + 1, roundData.executed);
 
-    emit VoteCast(round, slot, proposer);
+    emit VoteCast(round, slot, proposer, voteCount);
   }
 
   /**

--- a/l1-contracts/test/slashing/SlashingProposer.t.sol
+++ b/l1-contracts/test/slashing/SlashingProposer.t.sol
@@ -52,7 +52,7 @@ contract SlashingProposerTest is TestBase {
   uint256[] internal validatorKeys;
   address[] internal validators;
 
-  event VoteCast(SlashRound indexed round, address indexed proposer);
+  event VoteCast(SlashRound indexed round, Slot indexed slot, address indexed proposer, uint256 voteIndex);
   event SlashRoundExecuted(SlashRound indexed round, uint256 slashCount);
 
   function setUp() public {
@@ -291,6 +291,25 @@ contract SlashingProposerTest is TestBase {
 
     // Second vote in same slot should fail
     _castVote(Errors.SlashingProposer__VoteAlreadyCastInCurrentSlot.selector);
+  }
+
+  function test_voteEmitsVoteIndex() public {
+    _jumpToSlashRound(FIRST_SLASH_ROUND);
+
+    for (uint256 expectedVoteIndex = 0; expectedVoteIndex < 2; expectedVoteIndex++) {
+      Slot slot = rollup.getCurrentSlot();
+      address proposer = rollup.getCurrentProposer();
+      bytes memory voteData = _createVoteData(new uint8[](COMMITTEE_SIZE * ROUND_SIZE_IN_EPOCHS));
+      Signature memory sig = _createSignature(_getProposerKey(), slot, voteData);
+
+      vm.expectEmit(true, true, true, true, address(slashingProposer));
+      emit VoteCast(SlashRound.wrap(FIRST_SLASH_ROUND), slot, proposer, expectedVoteIndex);
+
+      vm.prank(proposer);
+      slashingProposer.vote(voteData, sig);
+
+      timeCheater.cheat__progressSlot();
+    }
   }
 
   function test_voteAccumulatesAcrossSlots() public {

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
@@ -1,6 +1,7 @@
 import { EthCheatCodes, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -288,6 +289,41 @@ describe('SlashingProposer', () => {
       const votes = decodeSlashConsensusVotes(buffer);
 
       expect(votes).toEqual([0, 0, 1, 2, 3, 2, 1, 0]);
+    });
+  });
+
+  describe('getVoteAt', () => {
+    it('decodes the slash targets of a vote read by its index in the round', async () => {
+      // Slash targets are the committees of a round some rounds back, so vote from a round late enough that those
+      // committees have already been formed
+      await rollupCheatCodes.advanceToEpoch(EpochNumber(18));
+      const round = await slashingProposer.getCurrentRound();
+      const { voteCount } = await slashingProposer.getRound(round);
+
+      // Every byte of the vote holds four validators, so a byte of 0x01 votes one small slash unit against the
+      // first validator of a committee and nothing against the other three
+      const votes = bufferToHex(Buffer.alloc(testConfig.slashingRoundSizeInEpochs, 1));
+      const slot = await rollup.getSlotNumber();
+      const proposer = await rollup.getCurrentProposer();
+      const proposerKey = validatorsPrivateKeys[validatorsAddresses.findIndex(addr => addr.equals(proposer))];
+      const request = await slashingProposer.buildVoteRequestFromSigner(votes, slot, typedData =>
+        proposerKey.signTypedData(typedData),
+      );
+      const hash = await writeClient.sendTransaction(request);
+      await writeClient.waitForTransactionReceipt({ hash });
+
+      const committeeSize = testConfig.aztecTargetCommitteeSize;
+      const validators = await slashingProposer.getSlashTargetValidators(round);
+      expect(validators).toHaveLength(committeeSize * testConfig.slashingRoundSizeInEpochs);
+
+      // Validators voted for zero units are left out, so only the first validator of each committee is returned
+      expect(await slashingProposer.getVoteAt(round, voteCount)).toEqual(
+        times(testConfig.slashingRoundSizeInEpochs, epochIndex => ({
+          validator: validators[epochIndex * committeeSize],
+          slashAmount: testConfig.slashAmountSmall,
+          position: epochIndex * committeeSize,
+        })),
+      );
     });
   });
 });

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
@@ -10,6 +10,7 @@ import { bufferToHex } from '@aztec/foundation/string';
 import { DateProvider } from '@aztec/foundation/timer';
 import { SlashingProposerAbi } from '@aztec/l1-artifacts/SlashingProposerAbi';
 
+import { jest } from '@jest/globals';
 import { type Hex, type TypedDataDefinition, encodeFunctionData, hashTypedData } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -332,6 +333,45 @@ describe('SlashingProposer', () => {
           position: epochIndex * committeeSize,
         })),
       );
+    });
+  });
+
+  describe('getSlashTargetValidators', () => {
+    it('reads the committees of a round from L1 only once', async () => {
+      await rollupCheatCodes.advanceToEpoch(EpochNumber(24));
+      const round = await slashingProposer.getCurrentRound();
+      const simulate = jest.spyOn(writeClient, 'simulateContract');
+
+      try {
+        const [first, second] = await Promise.all([
+          slashingProposer.getSlashTargetValidators(round),
+          slashingProposer.getSlashTargetValidators(round),
+        ]);
+
+        expect(first).not.toHaveLength(0);
+        expect(second).toEqual(first);
+        expect(await slashingProposer.getSlashTargetValidators(round)).toEqual(first);
+        // A round's targets cannot change while it is live, so every vote of the round decodes off a single read
+        expect(simulate).toHaveBeenCalledTimes(1);
+
+        await slashingProposer.getSlashTargetValidators(round - 1n);
+        expect(simulate).toHaveBeenCalledTimes(2);
+      } finally {
+        simulate.mockRestore();
+      }
+    });
+
+    it('retries after a failed read instead of caching the failure', async () => {
+      // Voting only opens once SLASH_OFFSET_IN_ROUNDS rounds have passed, so round 0 has no targets to look up
+      const simulate = jest.spyOn(writeClient, 'simulateContract');
+
+      try {
+        await expect(slashingProposer.getSlashTargetValidators(0n)).rejects.toThrow();
+        await expect(slashingProposer.getSlashTargetValidators(0n)).rejects.toThrow();
+        expect(simulate).toHaveBeenCalledTimes(2);
+      } finally {
+        simulate.mockRestore();
+      }
     });
   });
 });

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.test.ts
@@ -310,7 +310,15 @@ describe('SlashingProposer', () => {
         proposerKey.signTypedData(typedData),
       );
       const hash = await writeClient.sendTransaction(request);
-      await writeClient.waitForTransactionReceipt({ hash });
+      const receipt = await writeClient.waitForTransactionReceipt({ hash });
+
+      // The event identifies the vote it recorded, so consumers can read it back without deriving its index
+      expect(slashingProposer.tryExtractVoteCastEvent(receipt.logs)?.args).toEqual({
+        round,
+        slot: BigInt(slot),
+        proposer: proposer.toChecksumString(),
+        voteIndex: voteCount,
+      });
 
       const committeeSize = testConfig.aztecTargetCommitteeSize;
       const validators = await slashingProposer.getSlashTargetValidators(round);

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -3,6 +3,7 @@ import type { ViemClient } from '@aztec/ethereum/types';
 import { mergeAbis, tryExtractEvent } from '@aztec/ethereum/utils';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
+import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { hexToBuffer } from '@aztec/foundation/string';
@@ -64,6 +65,8 @@ export class SlashingProposerContract {
     return this.contract.read.EXECUTION_DELAY_IN_ROUNDS();
   }
 
+  /** Returns the slash amounts for the three slash unit levels. Immutable on the contract, so memoized. */
+  @memoize
   public getSlashingAmounts(): Promise<[bigint, bigint, bigint]> {
     return Promise.all([
       this.contract.read.SLASH_AMOUNT_SMALL(),
@@ -234,19 +237,29 @@ export class SlashingProposerContract {
     };
   }
 
+  /** Returns the validators eligible to be voted against in a round, in the order votes encode them */
+  public async getSlashTargetValidators(round: bigint): Promise<EthAddress[]> {
+    const { result } = await this.contract.simulate.getSlashTargetCommittees([round]);
+    return result.flat().map(validator => EthAddress.fromString(validator));
+  }
+
+  /**
+   * Returns the slash amount voted for each target validator by a single vote of a round.
+   * @param index - Position of the vote within the round, from 0 (inclusive) to the round's vote count (exclusive)
+   */
+  public async getVoteAt(round: bigint, index: bigint): Promise<SlashVoteTarget[]> {
+    const [validators, vote, slashAmounts] = await Promise.all([
+      this.getSlashTargetValidators(round),
+      this.contract.read.getVotes([round, index]),
+      this.getSlashingAmounts(),
+    ]);
+    return decodeVote(vote, validators, slashAmounts);
+  }
+
   /** Returns the last vote emitted for a given round  */
   public async getLastVote(round: bigint) {
     const { voteCount } = await this.getRound(round);
-    const validators = (await this.contract.simulate.getSlashTargetCommittees([round])).result.flat();
-    const vote = await this.contract.read.getVotes([round, voteCount - 1n]);
-    const decoded = decodeSlashConsensusVotes(hexToBuffer(vote));
-    const slashAmounts = await this.getSlashingAmounts();
-    return decoded
-      .map((units, i) => ({
-        validator: EthAddress.fromString(validators[i]),
-        slashAmount: slashAmounts[units - 1] ?? 0n,
-      }))
-      .filter(v => v.slashAmount > 0n);
+    return await this.getVoteAt(round, voteCount - 1n);
   }
 
   /**
@@ -292,6 +305,23 @@ export class SlashingProposerContract {
       },
     );
   }
+}
+
+/**
+ * A validator targeted by a slashing vote, with the amount voted. The position is the validator's index in the
+ * round's flattened slash target committees — the unit the contract tallies quorum by. A validator sitting in
+ * several of the round's committees holds several positions, each with its own tally.
+ */
+export type SlashVoteTarget = { validator: EthAddress; slashAmount: bigint; position: number };
+
+function decodeVote(vote: Hex, validators: EthAddress[], slashAmounts: [bigint, bigint, bigint]): SlashVoteTarget[] {
+  return decodeSlashConsensusVotes(hexToBuffer(vote))
+    .map((units, position) => ({
+      validator: validators[position],
+      slashAmount: slashAmounts[units - 1] ?? 0n,
+      position,
+    }))
+    .filter(v => v.slashAmount > 0n);
 }
 
 /**

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -26,6 +26,14 @@ import {
 export class SlashingProposerContract {
   private readonly contract: GetContractReturnType<typeof SlashingProposerAbi, ViemClient>;
 
+  /**
+   * Slash target validators of the last round asked for. Safe to cache because a round's targets are the committees
+   * of epochs that had already ended when the round opened (see SLASH_OFFSET_IN_ROUNDS), and those committees are
+   * sampled from validator set and randao snapshots taken before the epoch started, so they cannot change while the
+   * round is live. The promise is cached rather than the result, so concurrent callers share one in-flight read.
+   */
+  private slashTargetValidators: { round: bigint; validators: Promise<EthAddress[]> } | undefined;
+
   constructor(
     public readonly client: ViemClient,
     address: Hex | EthAddress,
@@ -237,8 +245,30 @@ export class SlashingProposerContract {
     };
   }
 
-  /** Returns the validators eligible to be voted against in a round, in the order votes encode them */
-  public async getSlashTargetValidators(round: bigint): Promise<EthAddress[]> {
+  /**
+   * Returns the validators eligible to be voted against in a round, in the order votes encode them. Cached for the
+   * last round asked for: reading them runs a committee sampling simulation on L1, and every vote of a round decodes
+   * against the same list, so a caller walking a round's votes would otherwise repeat that call per vote. Only the
+   * last round is kept since callers move forward round by round.
+   */
+  public getSlashTargetValidators(round: bigint): Promise<EthAddress[]> {
+    const cached = this.slashTargetValidators;
+    if (cached?.round === round) {
+      return cached.validators;
+    }
+
+    const entry = { round, validators: this.fetchSlashTargetValidators(round) };
+    this.slashTargetValidators = entry;
+    // A failed read must not stay cached, or every later vote of the round would replay the same rejection
+    entry.validators.catch(() => {
+      if (this.slashTargetValidators === entry) {
+        this.slashTargetValidators = undefined;
+      }
+    });
+    return entry.validators;
+  }
+
+  private async fetchSlashTargetValidators(round: bigint): Promise<EthAddress[]> {
     const { result } = await this.contract.simulate.getSlashTargetCommittees([round]);
     return result.flat().map(validator => EthAddress.fromString(validator));
   }

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -264,18 +264,21 @@ export class SlashingProposerContract {
 
   /**
    * Listen for VoteCast events
-   * @param callback - Callback function to handle vote cast events
+   * @param callback - Callback receiving the round, the vote's index within the round as accepted by `getVoteAt`,
+   * and the proposer that cast it
    * @returns Unwatch function
    */
-  public listenToVoteCast(callback: (args: { round: bigint; proposer: string }) => void): () => void {
+  public listenToVoteCast(
+    callback: (args: { round: bigint; voteIndex: bigint; proposer: string }) => void,
+  ): () => void {
     return this.contract.watchEvent.VoteCast(
       {},
       {
         onLogs: logs => {
           for (const log of logs) {
-            const { round, proposer } = log.args;
-            if (round !== undefined && proposer) {
-              callback({ round, proposer });
+            const { round, voteIndex, proposer } = log.args;
+            if (round !== undefined && voteIndex !== undefined && proposer) {
+              callback({ round, voteIndex, proposer });
             }
           }
         },

--- a/yarn-project/slasher/src/factory/create_facade.ts
+++ b/yarn-project/slasher/src/factory/create_facade.ts
@@ -25,7 +25,10 @@ export async function createSlasherFacade(
   watchers: Watcher[],
   dateProvider: DateProvider,
   epochCache: EpochCache,
-  /** List of own validator addresses to add to the slashValidatorNever list unless slashSelfAllowed is true */
+  /**
+   * List of own validator addresses. Added to the slashValidatorNever list unless slashSelfAllowed is true, and used
+   * (independently of slashSelfAllowed) to warn and record metrics when they are targeted by onchain slashing.
+   */
   validatorAddresses: EthAddress[] = [],
   logger = createLogger('slasher'),
 ): Promise<SlasherClientInterface> {
@@ -76,6 +79,7 @@ export async function createSlasherFacade(
     dateProvider,
     kvStore,
     rollupRegisteredAtL2Slot,
+    validatorAddresses,
     logger,
   );
 }

--- a/yarn-project/slasher/src/factory/create_implementation.ts
+++ b/yarn-project/slasher/src/factory/create_implementation.ts
@@ -2,6 +2,7 @@ import { EpochCache } from '@aztec/epoch-cache';
 import { RollupContract, SlashingProposerContract } from '@aztec/ethereum/contracts';
 import type { ViemClient } from '@aztec/ethereum/types';
 import type { SlotNumber } from '@aztec/foundation/branded-types';
+import type { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { AztecLMDBStoreV2 } from '@aztec/kv-store/lmdb-v2';
@@ -24,6 +25,7 @@ export async function createSlasherImplementation(
   dateProvider: DateProvider,
   kvStore: AztecLMDBStoreV2,
   rollupRegisteredAtL2Slot: SlotNumber,
+  ownValidators: EthAddress[] = [],
   logger = createLogger('slasher'),
 ) {
   const proposer = await rollup.getSlashingProposer();
@@ -39,6 +41,7 @@ export async function createSlasherImplementation(
       epochCache,
       kvStore,
       rollupRegisteredAtL2Slot,
+      ownValidators,
       logger,
     );
   }
@@ -53,6 +56,7 @@ async function createSlasher(
   epochCache: EpochCache,
   kvStore: AztecLMDBStoreV2,
   rollupRegisteredAtL2Slot: SlotNumber,
+  ownValidators: EthAddress[] = [],
   logger = createLogger('slasher'),
 ): Promise<SlasherClient> {
   const settings = { ...(await getSlasherSettings(rollup, slashingProposer)), rollupRegisteredAtL2Slot };
@@ -73,6 +77,7 @@ async function createSlasher(
     epochCache,
     dateProvider,
     offensesStore,
+    ownValidators,
     logger,
   );
 }

--- a/yarn-project/slasher/src/metrics.ts
+++ b/yarn-project/slasher/src/metrics.ts
@@ -1,19 +1,59 @@
 import {
+  type Gauge,
   Metrics,
   type TelemetryClient,
   type UpDownCounter,
   createUpDownCounterWithDefault,
 } from '@aztec/telemetry-client';
 
+import { formatEther } from 'viem/utils';
+
 export class SlasherMetrics {
   private readonly roundExecuted: UpDownCounter;
+  private readonly ownValidatorTargeted: UpDownCounter;
+  private readonly ownValidatorSlashedCount: UpDownCounter;
+  private readonly ownValidatorSlashedAmount: UpDownCounter;
+  private readonly ownValidatorCurrentRoundVotesMax: Gauge;
+  private readonly quorumSize: Gauge;
 
   constructor(client: TelemetryClient, name = 'Slasher') {
     const meter = client.getMeter(name);
     this.roundExecuted = createUpDownCounterWithDefault(meter, Metrics.SLASHER_ROUND_EXECUTED_COUNT);
+    this.ownValidatorTargeted = createUpDownCounterWithDefault(meter, Metrics.SLASHER_OWN_VALIDATOR_TARGETED_COUNT);
+    this.ownValidatorSlashedCount = createUpDownCounterWithDefault(meter, Metrics.SLASHER_OWN_VALIDATOR_SLASHED_COUNT);
+    this.ownValidatorSlashedAmount = createUpDownCounterWithDefault(
+      meter,
+      Metrics.SLASHER_OWN_VALIDATOR_SLASHED_AMOUNT,
+    );
+    this.ownValidatorCurrentRoundVotesMax = meter.createGauge(Metrics.SLASHER_OWN_VALIDATOR_CURRENT_ROUND_VOTES_MAX);
+    this.quorumSize = meter.createGauge(Metrics.SLASHER_QUORUM_SIZE);
   }
 
   public recordRoundExecuted(): void {
     this.roundExecuted.add(1);
+  }
+
+  /** Records the quorum a validator must reach in a round to be slashed, so dashboards can plot the threshold. */
+  public recordQuorumSize(quorum: number): void {
+    this.quorumSize.record(quorum);
+  }
+
+  /** Records that an onchain slashing vote named one of the node's own validators as a target. */
+  public recordOwnValidatorTargeted(): void {
+    this.ownValidatorTargeted.add(1);
+  }
+
+  /**
+   * Records how close the most-voted committee position held by the node's own validators is to quorum this round.
+   * Recorded as an absolute value rather than a delta so a vote seen across a round rollover cannot make it drift.
+   */
+  public recordCurrentRoundVotesMax(votes: number): void {
+    this.ownValidatorCurrentRoundVotesMax.record(votes);
+  }
+
+  /** Records an executed slash against one of the node's own validators. */
+  public recordOwnValidatorSlashed(amount: bigint): void {
+    this.ownValidatorSlashedCount.add(1);
+    this.ownValidatorSlashedAmount.add(parseFloat(formatEther(amount)));
   }
 }

--- a/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
@@ -60,8 +60,6 @@ describe('OwnValidatorSlashMonitor', () => {
     position: opts.position ?? committee.findIndex(member => member.equals(validator)),
   });
 
-  const roundWithVotes = (voteCount: bigint) => ({ isExecuted: false, voteCount });
-
   beforeEach(() => {
     logger = createLogger('test');
     warnSpy = jest.spyOn(logger, 'warn');
@@ -73,10 +71,9 @@ describe('OwnValidatorSlashMonitor', () => {
 
   describe('vote tallying', () => {
     it('warns and increments the targeted metric when a vote names an own validator', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator), voteAgainst(committee[1])]);
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
@@ -88,11 +85,10 @@ describe('OwnValidatorSlashMonitor', () => {
     });
 
     it('warns on every vote against a validator, not just the first of a round', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
+      await monitor.handleVoteCast(round, 1n);
 
       expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(warnSpy).toHaveBeenLastCalledWith(
@@ -107,13 +103,12 @@ describe('OwnValidatorSlashMonitor', () => {
     it('tallies per committee position when a validator sits in several of the round committees', async () => {
       // A single vote names the validator once per position it holds, but each position races quorum separately,
       // so this is one vote of quorum rather than two
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([
         voteAgainst(ownValidator, { position: 7 }),
         voteAgainst(ownValidator, { position: 7 + committeeSize }),
       ]);
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
@@ -126,14 +121,13 @@ describe('OwnValidatorSlashMonitor', () => {
 
     it('warns for each own validator named in a vote', async () => {
       createMonitor([committee[6], committee[7]]);
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([
         voteAgainst(committee[6]),
         voteAgainst(committee[7], { slashAmount: slashingUnit * 2n }),
         voteAgainst(committee[1]),
       ]);
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(getTargeted()).toEqual([0, 1, 1]);
@@ -141,22 +135,20 @@ describe('OwnValidatorSlashMonitor', () => {
 
     it('reports how close the most targeted validator is when several are named', async () => {
       createMonitor([committee[6], committee[7]]);
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
       slashingProposer.getVoteAt
         .mockResolvedValueOnce([voteAgainst(committee[6]), voteAgainst(committee[7])])
         .mockResolvedValueOnce([voteAgainst(committee[7])]);
 
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
+      await monitor.handleVoteCast(round, 1n);
 
       expect(getVotesMax().at(-1)).toEqual(2);
     });
 
     it('does not warn when votes only name other validators', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(committee[1])]);
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect(getTargeted()).toEqual([0]);
@@ -166,10 +158,9 @@ describe('OwnValidatorSlashMonitor', () => {
 
   describe('rounds', () => {
     it('resets the tally and zeroes the gauge when the clock announces a new round', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
       monitor.handleNewRound(round + 1n);
 
       expect(getVotesMax()).toEqual([0, 1, 0]);
@@ -181,22 +172,20 @@ describe('OwnValidatorSlashMonitor', () => {
     });
 
     it('keeps the tally when the clock announces the round a vote already rolled to', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round + 1n);
+      await monitor.handleVoteCast(round + 1n, 0n);
       monitor.handleNewRound(round + 1n);
-      await monitor.handleVoteCast(round + 1n);
+      await monitor.handleVoteCast(round + 1n, 1n);
 
       expect(getVotesMax().at(-1)).toEqual(2);
     });
 
     it('rolls the tally and reads from the first vote when an event beats the clock to a new round', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(2n)).mockResolvedValueOnce(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round + 1n);
+      await monitor.handleVoteCast(round, 1n);
+      await monitor.handleVoteCast(round + 1n, 0n);
 
       expect(slashingProposer.getVoteAt.mock.calls).toEqual([
         [round, 0n],
@@ -207,23 +196,20 @@ describe('OwnValidatorSlashMonitor', () => {
     });
 
     it('ignores votes cast for a round that has already closed', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round + 1n);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round + 1n, 0n);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(slashingProposer.getRound).toHaveBeenCalledTimes(1);
-      expect(slashingProposer.getRound).toHaveBeenCalledWith(round + 1n);
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([[round + 1n, 0n]]);
     });
 
     it('drops a vote whose round closes while it is being read', async () => {
       const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockReturnValue(pendingVote.promise);
 
-      const drain = monitor.handleVoteCast(round);
+      const drain = monitor.handleVoteCast(round, 0n);
       await sleep(1);
       monitor.handleNewRound(round + 1n);
       pendingVote.resolve([voteAgainst(ownValidator)]);
@@ -236,22 +222,20 @@ describe('OwnValidatorSlashMonitor', () => {
 
   describe('vote index cursor', () => {
     it('reads each vote of a round exactly once across duplicate events', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(slashingProposer.getVoteAt).toHaveBeenCalledTimes(1);
     });
 
     it('catches up on votes whose events never arrived', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(3n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
+      await monitor.handleVoteCast(round, 2n);
 
       expect(slashingProposer.getVoteAt.mock.calls).toEqual([
         [round, 0n],
@@ -265,41 +249,55 @@ describe('OwnValidatorSlashMonitor', () => {
       ]);
     });
 
+    it('ignores an event for a vote the cursor already passed', async () => {
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round, 1n);
+      await monitor.handleVoteCast(round, 0n);
+
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
+        [round, 0n],
+        [round, 1n],
+      ]);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
     it('retries a vote whose read failed on the next event', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockRejectedValueOnce(new Error('L1 unavailable'));
 
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
 
       expect(warnSpy).not.toHaveBeenCalled();
 
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 1n);
 
-      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(slashingProposer.getVoteAt.mock.calls).toEqual([
         [round, 0n],
         [round, 0n],
+        [round, 1n],
       ]);
     });
 
     it('processes one drain at a time, in the order the events arrived', async () => {
-      const pendingRound = promiseWithResolvers<{ isExecuted: boolean; voteCount: bigint }>();
-      slashingProposer.getRound.mockReturnValueOnce(pendingRound.promise).mockResolvedValue(roundWithVotes(2n));
-      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+      const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
+      slashingProposer.getVoteAt
+        .mockReturnValueOnce(pendingVote.promise)
+        .mockResolvedValue([voteAgainst(ownValidator)]);
 
-      const first = monitor.handleVoteCast(round);
-      const second = monitor.handleVoteCast(round);
+      const first = monitor.handleVoteCast(round, 0n);
+      const second = monitor.handleVoteCast(round, 1n);
       await sleep(1);
 
-      // The second drain cannot even read the round while the first one is still in flight
-      expect(slashingProposer.getRound).toHaveBeenCalledTimes(1);
+      // The second drain cannot read its vote while the first one is still in flight
+      expect(slashingProposer.getVoteAt).toHaveBeenCalledTimes(1);
 
-      pendingRound.resolve(roundWithVotes(1n));
+      pendingVote.resolve([voteAgainst(ownValidator)]);
       await first;
       await second;
 
-      expect(slashingProposer.getRound).toHaveBeenCalledTimes(2);
+      expect(slashingProposer.getVoteAt).toHaveBeenCalledTimes(2);
       expect(warnSpy.mock.calls.map(([message]) => message)).toEqual([
         expect.stringContaining('(1 of 10 votes needed to slash)'),
         expect.stringContaining('(2 of 10 votes needed to slash)'),
@@ -308,54 +306,32 @@ describe('OwnValidatorSlashMonitor', () => {
   });
 
   describe('start', () => {
-    it('records the quorum size so the round tally can be read against it', async () => {
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(0n));
-
-      await monitor.start(round);
-      await monitor.handleVoteCast(round);
+    it('records the quorum size without reading from L1', () => {
+      monitor.start(round);
 
       expect(getValues(Metrics.SLASHER_QUORUM_SIZE.name)).toEqual([settings.slashingQuorumSize]);
+      expect(getVotesMax()).toEqual([0]);
+      expect(slashingProposer.getVoteAt).not.toHaveBeenCalled();
     });
 
     it('skips the votes already cast when starting mid-round', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(3n)).mockResolvedValueOnce(roundWithVotes(4n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
-      await monitor.start(round);
-      await monitor.handleVoteCast(round);
+      monitor.start(round);
+      await monitor.handleVoteCast(round, 4n);
 
-      expect(slashingProposer.getVoteAt.mock.calls).toEqual([[round, 3n]]);
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([[round, 4n]]);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(getVotesMax()).toEqual([0, 1]);
-    });
-
-    it('falls back to the latest vote only when the baseline read fails', async () => {
-      slashingProposer.getRound
-        .mockRejectedValueOnce(new Error('L1 unavailable'))
-        .mockResolvedValueOnce(roundWithVotes(5n))
-        .mockResolvedValueOnce(roundWithVotes(6n));
-      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
-
-      await monitor.start(round);
-      await monitor.handleVoteCast(round);
-      await monitor.handleVoteCast(round);
-
-      // The cursor recovers from the fallback index, so the next event does not re-read what it processed
-      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
-        [round, 4n],
-        [round, 5n],
-      ]);
-      expect(getVotesMax()).toEqual([0, 1, 2]);
     });
   });
 
   describe('stop', () => {
     it('waits for the drain in flight and drops its vote', async () => {
       const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
-      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockReturnValue(pendingVote.promise);
 
-      const drain = monitor.handleVoteCast(round);
+      const drain = monitor.handleVoteCast(round, 0n);
       await sleep(1);
       const stopped = monitor.stop();
       pendingVote.resolve([voteAgainst(ownValidator)]);
@@ -367,17 +343,16 @@ describe('OwnValidatorSlashMonitor', () => {
     });
 
     it('ignores events and executed slashes after stop and tracks fresh state after a restart', async () => {
-      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(0n)).mockResolvedValueOnce(roundWithVotes(1n));
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 
       await monitor.stop();
-      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round, 0n);
       monitor.handleSlashes(round, [{ attester: ownValidator, amount: slashingUnit }], '0x1');
-      expect(slashingProposer.getRound).not.toHaveBeenCalled();
+      expect(slashingProposer.getVoteAt).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
 
-      await monitor.start(round);
-      await monitor.handleVoteCast(round);
+      monitor.start(round);
+      await monitor.handleVoteCast(round, 0n);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(getVotesMax().at(-1)).toEqual(1);
     });
@@ -413,12 +388,11 @@ describe('OwnValidatorSlashMonitor', () => {
     });
 
     it('never reads from L1, warns, or records gauges', async () => {
-      await monitor.start(round);
+      monitor.start(round);
       monitor.handleNewRound(round + 1n);
-      await monitor.handleVoteCast(round + 1n);
+      await monitor.handleVoteCast(round + 1n, 0n);
       monitor.handleSlashes(round + 1n, [{ attester: ownValidator, amount: slashingUnit }], '0x1');
 
-      expect(slashingProposer.getRound).not.toHaveBeenCalled();
       expect(slashingProposer.getVoteAt).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
       expect(getVotesMax()).toEqual([]);

--- a/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
@@ -1,0 +1,431 @@
+import type { SlashVoteTarget, SlashingProposerContract } from '@aztec/ethereum/contracts';
+import { times } from '@aztec/foundation/collection';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
+import { Metrics } from '@aztec/telemetry-client';
+import { BenchmarkTelemetryClient } from '@aztec/telemetry-client/bench';
+
+import { jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { SlasherMetrics } from './metrics.js';
+import { OwnValidatorSlashMonitor } from './own_validator_slash_monitor.js';
+
+describe('OwnValidatorSlashMonitor', () => {
+  let slashingProposer: MockProxy<SlashingProposerContract>;
+  let telemetryClient: BenchmarkTelemetryClient;
+  let logger: Logger;
+  let warnSpy: jest.SpiedFunction<Logger['warn']>;
+  let monitor: OwnValidatorSlashMonitor;
+
+  let committee: EthAddress[];
+  let ownValidator: EthAddress;
+
+  const round = 5n;
+  const committeeSize = 8;
+  const settings = { slashingQuorumSize: 10 };
+  const slashingUnit = 1000000000000000000n; // 1 ETH in wei
+
+  const createMonitor = (ownValidators: EthAddress[]) => {
+    telemetryClient = new BenchmarkTelemetryClient();
+    monitor = new OwnValidatorSlashMonitor(
+      slashingProposer,
+      settings,
+      ownValidators,
+      new SlasherMetrics(telemetryClient),
+      logger,
+    );
+    return monitor;
+  };
+
+  const getPoints = (name: string) =>
+    telemetryClient
+      .getMeters()
+      .flatMap(meter => meter.metrics)
+      .find(metric => metric.name === name)?.points ?? [];
+
+  const getValues = (name: string) => getPoints(name).map(point => point.value);
+  const getVotesMax = () => getValues(Metrics.SLASHER_OWN_VALIDATOR_CURRENT_ROUND_VOTES_MAX.name);
+  const getTargeted = () => getValues(Metrics.SLASHER_OWN_VALIDATOR_TARGETED_COUNT.name);
+
+  /** A vote entry naming a validator, defaulting its committee index as the flattened committee position */
+  const voteAgainst = (
+    validator: EthAddress,
+    opts: { position?: number; slashAmount?: bigint } = {},
+  ): SlashVoteTarget => ({
+    validator,
+    slashAmount: opts.slashAmount ?? slashingUnit,
+    position: opts.position ?? committee.findIndex(member => member.equals(validator)),
+  });
+
+  const roundWithVotes = (voteCount: bigint) => ({ isExecuted: false, voteCount });
+
+  beforeEach(() => {
+    logger = createLogger('test');
+    warnSpy = jest.spyOn(logger, 'warn');
+    slashingProposer = mock<SlashingProposerContract>();
+    committee = times(committeeSize, i => EthAddress.fromNumber(i + 1));
+    ownValidator = committee[7];
+    createMonitor([ownValidator]);
+  });
+
+  describe('vote tallying', () => {
+    it('warns and increments the targeted metric when a vote names an own validator', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator), voteAgainst(committee[1])]);
+
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Own validator ${ownValidator} targeted by slashing vote (1 of ${settings.slashingQuorumSize} votes needed to slash)`,
+        { round, validator: ownValidator.toString(), votes: 1, quorum: settings.slashingQuorumSize },
+      );
+      expect(getTargeted()).toEqual([0, 1]);
+      expect(getVotesMax()).toEqual([0, 1]);
+    });
+
+    it('warns on every vote against a validator, not just the first of a round', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        expect.stringContaining(`(2 of ${settings.slashingQuorumSize} votes needed to slash)`),
+        expect.objectContaining({ votes: 2 }),
+      );
+      // The round tally climbs towards the quorum, unlike the cumulative counter
+      expect(getTargeted()).toEqual([0, 1, 1]);
+      expect(getVotesMax()).toEqual([0, 1, 2]);
+    });
+
+    it('tallies per committee position when a validator sits in several of the round committees', async () => {
+      // A single vote names the validator once per position it holds, but each position races quorum separately,
+      // so this is one vote of quorum rather than two
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([
+        voteAgainst(ownValidator, { position: 7 }),
+        voteAgainst(ownValidator, { position: 7 + committeeSize }),
+      ]);
+
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`(1 of ${settings.slashingQuorumSize} votes needed to slash)`),
+        expect.objectContaining({ votes: 1 }),
+      );
+      expect(getTargeted()).toEqual([0, 1]);
+      expect(getVotesMax()).toEqual([0, 1]);
+    });
+
+    it('warns for each own validator named in a vote', async () => {
+      createMonitor([committee[6], committee[7]]);
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([
+        voteAgainst(committee[6]),
+        voteAgainst(committee[7], { slashAmount: slashingUnit * 2n }),
+        voteAgainst(committee[1]),
+      ]);
+
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(getTargeted()).toEqual([0, 1, 1]);
+    });
+
+    it('reports how close the most targeted validator is when several are named', async () => {
+      createMonitor([committee[6], committee[7]]);
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
+      slashingProposer.getVoteAt
+        .mockResolvedValueOnce([voteAgainst(committee[6]), voteAgainst(committee[7])])
+        .mockResolvedValueOnce([voteAgainst(committee[7])]);
+
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round);
+
+      expect(getVotesMax().at(-1)).toEqual(2);
+    });
+
+    it('does not warn when votes only name other validators', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(committee[1])]);
+
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getTargeted()).toEqual([0]);
+      expect(getVotesMax()).toEqual([0, 0]);
+    });
+  });
+
+  describe('rounds', () => {
+    it('resets the tally and zeroes the gauge when the clock announces a new round', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round);
+      monitor.handleNewRound(round + 1n);
+
+      expect(getVotesMax()).toEqual([0, 1, 0]);
+      // The quorum gauge is re-recorded on every rollover so it does not go stale between export cycles
+      expect(getValues(Metrics.SLASHER_QUORUM_SIZE.name)).toEqual([
+        settings.slashingQuorumSize,
+        settings.slashingQuorumSize,
+      ]);
+    });
+
+    it('keeps the tally when the clock announces the round a vote already rolled to', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(2n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round + 1n);
+      monitor.handleNewRound(round + 1n);
+      await monitor.handleVoteCast(round + 1n);
+
+      expect(getVotesMax().at(-1)).toEqual(2);
+    });
+
+    it('rolls the tally and reads from the first vote when an event beats the clock to a new round', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(2n)).mockResolvedValueOnce(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round + 1n);
+
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
+        [round, 0n],
+        [round, 1n],
+        [round + 1n, 0n],
+      ]);
+      expect(getVotesMax().at(-1)).toEqual(1);
+    });
+
+    it('ignores votes cast for a round that has already closed', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round + 1n);
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(slashingProposer.getRound).toHaveBeenCalledTimes(1);
+      expect(slashingProposer.getRound).toHaveBeenCalledWith(round + 1n);
+    });
+
+    it('drops a vote whose round closes while it is being read', async () => {
+      const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockReturnValue(pendingVote.promise);
+
+      const drain = monitor.handleVoteCast(round);
+      await sleep(1);
+      monitor.handleNewRound(round + 1n);
+      pendingVote.resolve([voteAgainst(ownValidator)]);
+      await drain;
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getVotesMax()).toEqual([0, 0]);
+    });
+  });
+
+  describe('vote index cursor', () => {
+    it('reads each vote of a round exactly once across duplicate events', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(slashingProposer.getVoteAt).toHaveBeenCalledTimes(1);
+    });
+
+    it('catches up on votes whose events never arrived', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(1n)).mockResolvedValueOnce(roundWithVotes(3n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round);
+
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
+        [round, 0n],
+        [round, 1n],
+        [round, 2n],
+      ]);
+      expect(warnSpy.mock.calls.map(([message]) => message)).toEqual([
+        expect.stringContaining('(1 of 10 votes needed to slash)'),
+        expect.stringContaining('(2 of 10 votes needed to slash)'),
+        expect.stringContaining('(3 of 10 votes needed to slash)'),
+      ]);
+    });
+
+    it('retries a vote whose read failed on the next event', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockRejectedValueOnce(new Error('L1 unavailable'));
+
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+      await monitor.handleVoteCast(round);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
+        [round, 0n],
+        [round, 0n],
+      ]);
+    });
+
+    it('processes one drain at a time, in the order the events arrived', async () => {
+      const pendingRound = promiseWithResolvers<{ isExecuted: boolean; voteCount: bigint }>();
+      slashingProposer.getRound.mockReturnValueOnce(pendingRound.promise).mockResolvedValue(roundWithVotes(2n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      const first = monitor.handleVoteCast(round);
+      const second = monitor.handleVoteCast(round);
+      await sleep(1);
+
+      // The second drain cannot even read the round while the first one is still in flight
+      expect(slashingProposer.getRound).toHaveBeenCalledTimes(1);
+
+      pendingRound.resolve(roundWithVotes(1n));
+      await first;
+      await second;
+
+      expect(slashingProposer.getRound).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls.map(([message]) => message)).toEqual([
+        expect.stringContaining('(1 of 10 votes needed to slash)'),
+        expect.stringContaining('(2 of 10 votes needed to slash)'),
+      ]);
+    });
+  });
+
+  describe('start', () => {
+    it('records the quorum size so the round tally can be read against it', async () => {
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(0n));
+
+      await monitor.start(round);
+      await monitor.handleVoteCast(round);
+
+      expect(getValues(Metrics.SLASHER_QUORUM_SIZE.name)).toEqual([settings.slashingQuorumSize]);
+    });
+
+    it('skips the votes already cast when starting mid-round', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(3n)).mockResolvedValueOnce(roundWithVotes(4n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.start(round);
+      await monitor.handleVoteCast(round);
+
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([[round, 3n]]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(getVotesMax()).toEqual([0, 1]);
+    });
+
+    it('falls back to the latest vote only when the baseline read fails', async () => {
+      slashingProposer.getRound
+        .mockRejectedValueOnce(new Error('L1 unavailable'))
+        .mockResolvedValueOnce(roundWithVotes(5n))
+        .mockResolvedValueOnce(roundWithVotes(6n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.start(round);
+      await monitor.handleVoteCast(round);
+      await monitor.handleVoteCast(round);
+
+      // The cursor recovers from the fallback index, so the next event does not re-read what it processed
+      expect(slashingProposer.getVoteAt.mock.calls).toEqual([
+        [round, 4n],
+        [round, 5n],
+      ]);
+      expect(getVotesMax()).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe('stop', () => {
+    it('waits for the drain in flight and drops its vote', async () => {
+      const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
+      slashingProposer.getRound.mockResolvedValue(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockReturnValue(pendingVote.promise);
+
+      const drain = monitor.handleVoteCast(round);
+      await sleep(1);
+      const stopped = monitor.stop();
+      pendingVote.resolve([voteAgainst(ownValidator)]);
+      await stopped;
+      await drain;
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getVotesMax()).toEqual([0]);
+    });
+
+    it('ignores events and executed slashes after stop and tracks fresh state after a restart', async () => {
+      slashingProposer.getRound.mockResolvedValueOnce(roundWithVotes(0n)).mockResolvedValueOnce(roundWithVotes(1n));
+      slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
+
+      await monitor.stop();
+      await monitor.handleVoteCast(round);
+      monitor.handleSlashes(round, [{ attester: ownValidator, amount: slashingUnit }], '0x1');
+      expect(slashingProposer.getRound).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      await monitor.start(round);
+      await monitor.handleVoteCast(round);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(getVotesMax().at(-1)).toEqual(1);
+    });
+  });
+
+  describe('handleSlashes', () => {
+    it('warns and records metrics for own validators only', () => {
+      monitor.handleSlashes(
+        round,
+        [
+          { attester: ownValidator, amount: slashingUnit * 2n },
+          { attester: committee[1], amount: slashingUnit },
+        ],
+        '0x1',
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(`Own validator ${ownValidator} was slashed for ${slashingUnit * 2n}`, {
+        round,
+        validator: ownValidator.toString(),
+        amount: slashingUnit * 2n,
+        l1BlockHash: '0x1',
+      });
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_SLASHED_COUNT.name)).toEqual([0, 1]);
+      // The 2e18 base-unit slash is recorded as 2 whole staking-asset tokens
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_SLASHED_AMOUNT.name)).toEqual([0, 2]);
+    });
+  });
+
+  describe('without own validators', () => {
+    beforeEach(() => {
+      createMonitor([]);
+    });
+
+    it('never reads from L1, warns, or records gauges', async () => {
+      await monitor.start(round);
+      monitor.handleNewRound(round + 1n);
+      await monitor.handleVoteCast(round + 1n);
+      monitor.handleSlashes(round + 1n, [{ attester: ownValidator, amount: slashingUnit }], '0x1');
+
+      expect(slashingProposer.getRound).not.toHaveBeenCalled();
+      expect(slashingProposer.getVoteAt).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getVotesMax()).toEqual([]);
+      expect(getValues(Metrics.SLASHER_QUORUM_SIZE.name)).toEqual([]);
+      // The counters are zero-seeded on construction, so only the seeds are expected
+      expect(getTargeted()).toEqual([0]);
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_SLASHED_COUNT.name)).toEqual([0]);
+    });
+  });
+});

--- a/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.test.ts
@@ -342,6 +342,27 @@ describe('OwnValidatorSlashMonitor', () => {
       expect(getVotesMax()).toEqual([0]);
     });
 
+    it('settles the events queued behind the drain in flight without reading their votes', async () => {
+      const pendingVote = promiseWithResolvers<SlashVoteTarget[]>();
+      slashingProposer.getVoteAt
+        .mockReturnValueOnce(pendingVote.promise)
+        .mockResolvedValue([voteAgainst(ownValidator)]);
+
+      const inFlight = monitor.handleVoteCast(round, 0n);
+      const queued = monitor.handleVoteCast(round, 1n);
+      await sleep(1);
+      const stopped = monitor.stop();
+      pendingVote.resolve([voteAgainst(ownValidator)]);
+      await stopped;
+      // Both callers' promises resolve: the queued drain is run rather than discarded, and returns doing nothing
+      await inFlight;
+      await queued;
+
+      expect(slashingProposer.getVoteAt).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getVotesMax()).toEqual([0]);
+    });
+
     it('ignores events and executed slashes after stop and tracks fresh state after a restart', async () => {
       slashingProposer.getVoteAt.mockResolvedValue([voteAgainst(ownValidator)]);
 

--- a/yarn-project/slasher/src/own_validator_slash_monitor.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.ts
@@ -1,0 +1,187 @@
+import type { SlashVoteTarget, SlashingProposerContract } from '@aztec/ethereum/contracts';
+import { maxBigint } from '@aztec/foundation/bigint';
+import { uniqueBy } from '@aztec/foundation/collection';
+import type { EthAddress } from '@aztec/foundation/eth-address';
+import { createLogger } from '@aztec/foundation/log';
+
+import type { Hex } from 'viem';
+
+import type { SlasherMetrics } from './metrics.js';
+
+/**
+ * Watches slashing activity that targets the node's own validators: warns and counts on every vote naming one of
+ * them, tracks how close the current round's tally is to quorum, and reports executed slashes. Does nothing when
+ * the node runs no validators. Lifecycle calls must be sequential: start() awaited before events are wired, and
+ * stop() awaited before any restart.
+ */
+export class OwnValidatorSlashMonitor {
+  /**
+   * Tally for the single round being tracked (votes are only ever cast for the current round). `nextVoteIndex` is
+   * the cursor: the index of the first vote in the round not yet processed. It is undefined until the startup
+   * baseline read completes; if that read fails, the first event falls back to counting from the latest vote only,
+   * so votes cast before the node subscribed are never replayed into the cumulative metrics.
+   * The tally is per flattened committee position because that is the unit the contract tallies quorum by.
+   */
+  private state: { round: bigint; nextVoteIndex: bigint | undefined; countByPosition: Map<number, number> } = {
+    round: -1n,
+    nextVoteIndex: undefined,
+    countByPosition: new Map(),
+  };
+
+  /**
+   * All vote processing (including the startup baseline) runs through this queue, one job at a time in arrival
+   * order. Serialization is what makes the cursor sound: without it, concurrent event handlers could process the
+   * same index twice or emit warnings with out-of-order running tallies.
+   */
+  private queue: Promise<void> = Promise.resolve();
+
+  private stopped = false;
+
+  constructor(
+    private readonly slashingProposer: SlashingProposerContract,
+    private readonly settings: { slashingQuorumSize: number },
+    private readonly ownValidators: EthAddress[],
+    private readonly metrics: SlasherMetrics,
+    private readonly log = createLogger('slasher:own-validators'),
+  ) {}
+
+  private get enabled(): boolean {
+    return this.ownValidators.length > 0;
+  }
+
+  /**
+   * Starts tracking at the given round. Reads a baseline of the round's current vote count so votes cast before
+   * startup are skipped: replaying them would warn about votes the operator can no longer react to sooner, and
+   * would double-count cumulative counters across restarts. Await the returned promise before subscribing to vote
+   * events, so a vote cast after the baseline read always sits at an index past the cursor and is caught up by a
+   * later drain instead of being skipped as pre-startup. A failed baseline read resolves rather than rejects, and
+   * the first drain falls back to processing the latest vote only.
+   */
+  public start(currentRound: bigint): Promise<void> {
+    if (!this.enabled) {
+      return Promise.resolve();
+    }
+    this.stopped = false;
+    this.state = { round: currentRound, nextVoteIndex: undefined, countByPosition: new Map() };
+    this.metrics.recordQuorumSize(this.settings.slashingQuorumSize);
+    this.metrics.recordCurrentRoundVotesMax(0);
+    return this.enqueue(async () => {
+      const { voteCount } = await this.slashingProposer.getRound(currentRound);
+      // The round may have rolled while awaiting, in which case the cursor is already 0 for the new round
+      if (!this.stopped && this.state.round === currentRound && this.state.nextVoteIndex === undefined) {
+        this.state.nextVoteIndex = voteCount;
+      }
+    });
+  }
+
+  /** Stops processing and waits for any in-flight drain, so no warning or metric is emitted after shutdown. */
+  public async stop(): Promise<void> {
+    this.stopped = true;
+    await this.queue;
+  }
+
+  /**
+   * Called by the round monitor clock. Strictly greater so the clock catching up to a round an event already rolled
+   * to keeps the tally.
+   */
+  public handleNewRound(round: bigint): void {
+    if (this.enabled && round > this.state.round) {
+      this.rollTo(round);
+    }
+  }
+
+  /** Called on each VoteCast event. The event is only a trigger: the drain reads all not-yet-seen votes from L1. */
+  public handleVoteCast(round: bigint): Promise<void> {
+    if (!this.enabled || this.stopped) {
+      return Promise.resolve();
+    }
+    return this.enqueue(() => this.drainVotes(round));
+  }
+
+  /** Reports executed slashes against own validators. Called with the Slashed events already fetched by the client. */
+  public handleSlashes(round: bigint, slashes: { attester: EthAddress; amount: bigint }[], l1BlockHash: Hex): void {
+    if (!this.enabled || this.stopped) {
+      return;
+    }
+    for (const { attester, amount } of slashes.filter(slash => this.isOwnValidator(slash.attester))) {
+      this.log.warn(`Own validator ${attester} was slashed for ${amount}`, {
+        round,
+        validator: attester.toString(),
+        amount,
+        l1BlockHash,
+      });
+      this.metrics.recordOwnValidatorSlashed(amount);
+    }
+  }
+
+  /** Serializes a job behind all previously enqueued ones. Errors are logged and never break the chain. */
+  private enqueue(job: () => Promise<void>): Promise<void> {
+    this.queue = this.queue.then(job).catch(err => this.log.error('Error processing slashing votes', err));
+    return this.queue;
+  }
+
+  /** Processes votes [cursor, voteCount) of a round, in order, advancing the cursor after each success. */
+  private async drainVotes(round: bigint): Promise<void> {
+    if (this.stopped) {
+      return; // enqueued before stop() but not yet started: emit nothing and read nothing after shutdown
+    }
+    if (round < this.state.round) {
+      return; // a vote for a round that already closed can no longer reach quorum
+    }
+    if (round > this.state.round) {
+      this.rollTo(round); // the event beat the round-monitor clock to the boundary
+    }
+
+    const { voteCount } = await this.slashingProposer.getRound(round);
+    if (this.stopped || round !== this.state.round) {
+      return; // stopped, or rolled to a newer round while awaiting
+    }
+
+    // If the startup baseline failed, start from the latest vote only: earlier votes predate the subscription
+    const from = this.state.nextVoteIndex ?? maxBigint(voteCount - 1n, 0n);
+    for (let index = from; index < voteCount; index++) {
+      const vote = await this.slashingProposer.getVoteAt(round, index);
+      if (this.stopped || round !== this.state.round) {
+        return; // stopped, or rolled mid-drain: either way this vote must no longer be counted
+      }
+      this.processVote(round, vote);
+      // Advanced only after successful processing, so a failed read is retried on the next event
+      this.state.nextVoteIndex = index + 1n;
+    }
+  }
+
+  private processVote(round: bigint, vote: SlashVoteTarget[]): void {
+    const own = vote.filter(target => this.isOwnValidator(target.validator));
+    for (const { position } of own) {
+      this.state.countByPosition.set(position, (this.state.countByPosition.get(position) ?? 0) + 1);
+    }
+
+    // Warn once per (vote, validator) at the validator's highest position tally: the operator cares about the
+    // validator, not which of its committee seats is being voted on. No slash amount (the amount voted is not
+    // necessarily the amount slashed) and no proposer (a catch-up drain cannot attribute votes to proposers).
+    const quorum = this.settings.slashingQuorumSize;
+    for (const { validator } of uniqueBy(own, target => target.validator.toString())) {
+      const votes = Math.max(
+        ...own.filter(t => t.validator.equals(validator)).map(t => this.state.countByPosition.get(t.position)!),
+      );
+      this.metrics.recordOwnValidatorTargeted();
+      this.log.warn(
+        `Own validator ${validator} targeted by slashing vote (${votes} of ${quorum} votes needed to slash)`,
+        { round, validator: validator.toString(), votes, quorum },
+      );
+    }
+
+    this.metrics.recordCurrentRoundVotesMax(Math.max(0, ...this.state.countByPosition.values()));
+  }
+
+  /** Starts a fresh tally, zeroing the gauge so a quiet round does not keep the previous round's value. */
+  private rollTo(round: bigint): void {
+    this.state = { round, nextVoteIndex: 0n, countByPosition: new Map() };
+    this.metrics.recordCurrentRoundVotesMax(0);
+    this.metrics.recordQuorumSize(this.settings.slashingQuorumSize); // keeps the gauge fresh across export cycles
+  }
+
+  private isOwnValidator(address: EthAddress): boolean {
+    return this.ownValidators.some(validator => validator.equals(address));
+  }
+}

--- a/yarn-project/slasher/src/own_validator_slash_monitor.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.ts
@@ -1,5 +1,4 @@
 import type { SlashVoteTarget, SlashingProposerContract } from '@aztec/ethereum/contracts';
-import { maxBigint } from '@aztec/foundation/bigint';
 import { uniqueBy } from '@aztec/foundation/collection';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
@@ -11,15 +10,15 @@ import type { SlasherMetrics } from './metrics.js';
 /**
  * Watches slashing activity that targets the node's own validators: warns and counts on every vote naming one of
  * them, tracks how close the current round's tally is to quorum, and reports executed slashes. Does nothing when
- * the node runs no validators. Lifecycle calls must be sequential: start() awaited before events are wired, and
- * stop() awaited before any restart.
+ * the node runs no validators. Lifecycle calls must be sequential: start() before events are wired, and stop()
+ * awaited before any restart.
  */
 export class OwnValidatorSlashMonitor {
   /**
    * Tally for the single round being tracked (votes are only ever cast for the current round). `nextVoteIndex` is
-   * the cursor: the index of the first vote in the round not yet processed. It is undefined until the startup
-   * baseline read completes; if that read fails, the first event falls back to counting from the latest vote only,
-   * so votes cast before the node subscribed are never replayed into the cumulative metrics.
+   * the cursor: the index of the first vote in the round not yet processed, advanced from the indices the VoteCast
+   * events carry. It is undefined until the first event of a round that started mid-round, whose own vote is then
+   * the first one counted, so votes cast before the node subscribed are never replayed into the cumulative metrics.
    * The tally is per flattened committee position because that is the unit the contract tallies quorum by.
    */
   private state: { round: bigint; nextVoteIndex: bigint | undefined; countByPosition: Map<number, number> } = {
@@ -29,9 +28,9 @@ export class OwnValidatorSlashMonitor {
   };
 
   /**
-   * All vote processing (including the startup baseline) runs through this queue, one job at a time in arrival
-   * order. Serialization is what makes the cursor sound: without it, concurrent event handlers could process the
-   * same index twice or emit warnings with out-of-order running tallies.
+   * All vote processing runs through this queue, one job at a time in arrival order. Serialization is what makes
+   * the cursor sound: without it, concurrent event handlers could process the same index twice or emit warnings
+   * with out-of-order running tallies.
    */
   private queue: Promise<void> = Promise.resolve();
 
@@ -50,28 +49,18 @@ export class OwnValidatorSlashMonitor {
   }
 
   /**
-   * Starts tracking at the given round. Reads a baseline of the round's current vote count so votes cast before
-   * startup are skipped: replaying them would warn about votes the operator can no longer react to sooner, and
-   * would double-count cumulative counters across restarts. Await the returned promise before subscribing to vote
-   * events, so a vote cast after the baseline read always sits at an index past the cursor and is caught up by a
-   * later drain instead of being skipped as pre-startup. A failed baseline read resolves rather than rejects, and
-   * the first drain falls back to processing the latest vote only.
+   * Starts tracking at the given round, leaving the cursor unset so the round's votes already cast are skipped:
+   * replaying them would warn about votes the operator can no longer react to sooner, and would double-count
+   * cumulative counters across restarts.
    */
-  public start(currentRound: bigint): Promise<void> {
+  public start(currentRound: bigint): void {
     if (!this.enabled) {
-      return Promise.resolve();
+      return;
     }
     this.stopped = false;
     this.state = { round: currentRound, nextVoteIndex: undefined, countByPosition: new Map() };
     this.metrics.recordQuorumSize(this.settings.slashingQuorumSize);
     this.metrics.recordCurrentRoundVotesMax(0);
-    return this.enqueue(async () => {
-      const { voteCount } = await this.slashingProposer.getRound(currentRound);
-      // The round may have rolled while awaiting, in which case the cursor is already 0 for the new round
-      if (!this.stopped && this.state.round === currentRound && this.state.nextVoteIndex === undefined) {
-        this.state.nextVoteIndex = voteCount;
-      }
-    });
   }
 
   /** Stops processing and waits for any in-flight drain, so no warning or metric is emitted after shutdown. */
@@ -90,12 +79,15 @@ export class OwnValidatorSlashMonitor {
     }
   }
 
-  /** Called on each VoteCast event. The event is only a trigger: the drain reads all not-yet-seen votes from L1. */
-  public handleVoteCast(round: bigint): Promise<void> {
+  /**
+   * Called on each VoteCast event with the index the event carries. Reads every vote from the cursor up to that
+   * index, so an event delivery that never arrived is healed by the next one.
+   */
+  public handleVoteCast(round: bigint, voteIndex: bigint): Promise<void> {
     if (!this.enabled || this.stopped) {
       return Promise.resolve();
     }
-    return this.enqueue(() => this.drainVotes(round));
+    return this.enqueue(() => this.drainVotesTo(round, voteIndex));
   }
 
   /** Reports executed slashes against own validators. Called with the Slashed events already fetched by the client. */
@@ -120,8 +112,8 @@ export class OwnValidatorSlashMonitor {
     return this.queue;
   }
 
-  /** Processes votes [cursor, voteCount) of a round, in order, advancing the cursor after each success. */
-  private async drainVotes(round: bigint): Promise<void> {
+  /** Processes votes [cursor, voteIndex] of a round, in order, advancing the cursor after each success. */
+  private async drainVotesTo(round: bigint, voteIndex: bigint): Promise<void> {
     if (this.stopped) {
       return; // enqueued before stop() but not yet started: emit nothing and read nothing after shutdown
     }
@@ -132,14 +124,13 @@ export class OwnValidatorSlashMonitor {
       this.rollTo(round); // the event beat the round-monitor clock to the boundary
     }
 
-    const { voteCount } = await this.slashingProposer.getRound(round);
-    if (this.stopped || round !== this.state.round) {
-      return; // stopped, or rolled to a newer round while awaiting
+    // The first event of a round tracked from mid-round counts its own vote only: earlier ones predate the subscription
+    const from = this.state.nextVoteIndex ?? voteIndex;
+    if (voteIndex < from) {
+      return; // a duplicate or out-of-order delivery of a vote already processed
     }
 
-    // If the startup baseline failed, start from the latest vote only: earlier votes predate the subscription
-    const from = this.state.nextVoteIndex ?? maxBigint(voteCount - 1n, 0n);
-    for (let index = from; index < voteCount; index++) {
+    for (let index = from; index <= voteIndex; index++) {
       const vote = await this.slashingProposer.getVoteAt(round, index);
       if (this.stopped || round !== this.state.round) {
         return; // stopped, or rolled mid-drain: either way this vote must no longer be counted

--- a/yarn-project/slasher/src/own_validator_slash_monitor.ts
+++ b/yarn-project/slasher/src/own_validator_slash_monitor.ts
@@ -2,6 +2,7 @@ import type { SlashVoteTarget, SlashingProposerContract } from '@aztec/ethereum/
 import { uniqueBy } from '@aztec/foundation/collection';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import { SerialQueue } from '@aztec/foundation/queue';
 
 import type { Hex } from 'viem';
 
@@ -30,9 +31,10 @@ export class OwnValidatorSlashMonitor {
   /**
    * All vote processing runs through this queue, one job at a time in arrival order. Serialization is what makes
    * the cursor sound: without it, concurrent event handlers could process the same index twice or emit warnings
-   * with out-of-order running tallies.
+   * with out-of-order running tallies. Replaced on every start(), since a queue that has been ended cannot run
+   * jobs again.
    */
-  private queue: Promise<void> = Promise.resolve();
+  private queue = new SerialQueue();
 
   private stopped = false;
 
@@ -42,7 +44,9 @@ export class OwnValidatorSlashMonitor {
     private readonly ownValidators: EthAddress[],
     private readonly metrics: SlasherMetrics,
     private readonly log = createLogger('slasher:own-validators'),
-  ) {}
+  ) {
+    this.queue.start();
+  }
 
   private get enabled(): boolean {
     return this.ownValidators.length > 0;
@@ -58,6 +62,8 @@ export class OwnValidatorSlashMonitor {
       return;
     }
     this.stopped = false;
+    this.queue = new SerialQueue();
+    this.queue.start();
     this.state = { round: currentRound, nextVoteIndex: undefined, countByPosition: new Map() };
     this.metrics.recordQuorumSize(this.settings.slashingQuorumSize);
     this.metrics.recordCurrentRoundVotesMax(0);
@@ -66,7 +72,9 @@ export class OwnValidatorSlashMonitor {
   /** Stops processing and waits for any in-flight drain, so no warning or metric is emitted after shutdown. */
   public async stop(): Promise<void> {
     this.stopped = true;
-    await this.queue;
+    // Jobs already queued are no-ops now that the flag is set, so end() runs through them at no cost while still
+    // settling the promises their callers hold, where cancel() would discard them and leave those promises pending.
+    await this.queue.end();
   }
 
   /**
@@ -87,7 +95,11 @@ export class OwnValidatorSlashMonitor {
     if (!this.enabled || this.stopped) {
       return Promise.resolve();
     }
-    return this.enqueue(() => this.drainVotesTo(round, voteIndex));
+    // Errors are logged rather than propagated: callers fire and forget, and a failed read is retried by the drain
+    // the next event triggers.
+    return this.queue
+      .put(() => this.drainVotesTo(round, voteIndex))
+      .catch(err => this.log.error('Error processing slashing votes', err));
   }
 
   /** Reports executed slashes against own validators. Called with the Slashed events already fetched by the client. */
@@ -104,12 +116,6 @@ export class OwnValidatorSlashMonitor {
       });
       this.metrics.recordOwnValidatorSlashed(amount);
     }
-  }
-
-  /** Serializes a job behind all previously enqueued ones. Errors are logged and never break the chain. */
-  private enqueue(job: () => Promise<void>): Promise<void> {
-    this.queue = this.queue.then(job).catch(err => this.log.error('Error processing slashing votes', err));
-    return this.queue;
   }
 
   /** Processes votes [cursor, voteIndex] of a round, in order, advancing the cursor after each success. */

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -1117,7 +1117,7 @@ describe('SlasherClient', () => {
 
   describe('own validator slash monitor wiring', () => {
     let ownValidator: EthAddress;
-    let voteCastCallback: (args: { round: bigint; proposer: string }) => void;
+    let voteCastCallback: (args: { round: bigint; voteIndex: bigint; proposer: string }) => void;
 
     // Recreates the telemetry client along with the slasher client so metric assertions only see this client's data
     const setupClient = (ownValidators: EthAddress[]) => {
@@ -1160,7 +1160,11 @@ describe('SlasherClient', () => {
 
       await slasherClient.start();
       // A round ahead of the one the monitor started tracking, so its vote is read regardless of the startup baseline
-      voteCastCallback({ round: slasherClient.getCurrentRound() + 1n, proposer: EthAddress.random().toString() });
+      voteCastCallback({
+        round: slasherClient.getCurrentRound() + 1n,
+        voteIndex: 0n,
+        proposer: EthAddress.random().toString(),
+      });
 
       await retryFastUntil(
         () => getValues(Metrics.SLASHER_OWN_VALIDATOR_TARGETED_COUNT.name).length > 1 || undefined,

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -1156,12 +1156,10 @@ describe('SlasherClient', () => {
       slashingProposer.getVoteAt.mockResolvedValue([
         { validator: ownValidator, slashAmount: slashingUnit, position: 7 },
       ]);
-      slashingProposer.getRound.mockResolvedValue({ isExecuted: false, voteCount: 1n });
 
       await slasherClient.start();
-      // A round ahead of the one the monitor started tracking, so its vote is read regardless of the startup baseline
       voteCastCallback({
-        round: slasherClient.getCurrentRound() + 1n,
+        round: slasherClient.getCurrentRound(),
         voteIndex: 0n,
         proposer: EthAddress.random().toString(),
       });

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -174,7 +174,11 @@ describe('SlasherClient', () => {
     slashingProposer.listenToRoundExecuted.mockReturnValue(() => {});
 
     // Create consensus slasher client with proper constructor parameters
-    slasherClient = new TestSlasherClient(
+    slasherClient = createClient();
+  });
+
+  const createClient = (ownValidators: EthAddress[] = []) =>
+    new TestSlasherClient(
       config,
       settings,
       slashingProposer,
@@ -184,10 +188,10 @@ describe('SlasherClient', () => {
       mockEpochCache,
       dateProvider,
       offensesStore,
+      ownValidators,
       logger,
       new SlasherMetrics(telemetryClient),
     );
-  });
 
   afterEach(async () => {
     await slasherClient.stop();
@@ -1110,6 +1114,78 @@ describe('SlasherClient', () => {
       });
     });
   });
+
+  describe('own validator slash monitor wiring', () => {
+    let ownValidator: EthAddress;
+    let voteCastCallback: (args: { round: bigint; proposer: string }) => void;
+
+    // Recreates the telemetry client along with the slasher client so metric assertions only see this client's data
+    const setupClient = (ownValidators: EthAddress[]) => {
+      telemetryClient = new BenchmarkTelemetryClient();
+      slasherClient = createClient(ownValidators);
+    };
+
+    const getValues = (name: string) =>
+      telemetryClient
+        .getMeters()
+        .flatMap(meter => meter.metrics)
+        .find(metric => metric.name === name)
+        ?.points.map(point => point.value) ?? [];
+
+    beforeEach(() => {
+      ownValidator = committee[7];
+      setupClient([ownValidator]);
+      slashingProposer.listenToVoteCast.mockImplementation(callback => {
+        voteCastCallback = callback;
+        return () => {};
+      });
+    });
+
+    it('subscribes to vote cast events only when running own validators', async () => {
+      setupClient([]);
+      await slasherClient.start();
+      expect(slashingProposer.listenToVoteCast).not.toHaveBeenCalled();
+      await slasherClient.stop();
+
+      setupClient([ownValidator]);
+      await slasherClient.start();
+      expect(slashingProposer.listenToVoteCast).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a vote cast event that names an own validator', async () => {
+      slashingProposer.getVoteAt.mockResolvedValue([
+        { validator: ownValidator, slashAmount: slashingUnit, position: 7 },
+      ]);
+      slashingProposer.getRound.mockResolvedValue({ isExecuted: false, voteCount: 1n });
+
+      await slasherClient.start();
+      // A round ahead of the one the monitor started tracking, so its vote is read regardless of the startup baseline
+      voteCastCallback({ round: slasherClient.getCurrentRound() + 1n, proposer: EthAddress.random().toString() });
+
+      await retryFastUntil(
+        () => getValues(Metrics.SLASHER_OWN_VALIDATOR_TARGETED_COUNT.name).length > 1 || undefined,
+        'own validator to be reported as targeted',
+        5,
+        0.05,
+      );
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_TARGETED_COUNT.name)).toEqual([0, 1]);
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_CURRENT_ROUND_VOTES_MAX.name).at(-1)).toEqual(1);
+    });
+
+    it('reports an own validator slashed at round execution', async () => {
+      rollup.getSlashEvents.mockResolvedValue([
+        { attester: ownValidator, amount: slashingUnit * 2n },
+        { attester: committee[1], amount: slashingUnit },
+      ]);
+
+      await slasherClient.handleRoundExecuted(7n, 2n, '0x1');
+
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_SLASHED_COUNT.name)).toEqual([0, 1]);
+      // The 2e18 base-unit slash is recorded as 2 whole staking-asset tokens
+      expect(getValues(Metrics.SLASHER_OWN_VALIDATOR_SLASHED_AMOUNT.name)).toEqual([0, 2]);
+      expect(getValues(Metrics.SLASHER_ROUND_EXECUTED_COUNT.name)).toEqual([0, 1]);
+    });
+  });
 });
 
 // Test helper class that exposes protected methods for testing
@@ -1120,6 +1196,10 @@ class TestSlasherClient extends SlasherClient {
 
   public override handleNewRound(round: bigint): Promise<void> {
     return super.handleNewRound(round);
+  }
+
+  public getCurrentRound(): bigint {
+    return this.roundMonitor.getCurrentRound().round;
   }
 
   public override getExecuteSlashAction(slotNumber: SlotNumber): Promise<ProposerSlashAction | undefined> {

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -22,6 +22,7 @@ import { getTelemetryClient } from '@aztec/telemetry-client';
 import type { Hex } from 'viem';
 
 import { SlasherMetrics } from './metrics.js';
+import { OwnValidatorSlashMonitor } from './own_validator_slash_monitor.js';
 import {
   SlashOffensesCollector,
   type SlashOffensesCollectorConfig,
@@ -91,6 +92,7 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
   protected unwatchCallbacks: (() => void)[] = [];
   protected roundMonitor: SlashRoundMonitor;
   protected offensesCollector: SlashOffensesCollector;
+  protected readonly ownValidatorMonitor: OwnValidatorSlashMonitor;
 
   constructor(
     private config: SlasherClientConfig,
@@ -102,11 +104,13 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
     private epochCache: EpochCache,
     private dateProvider: DateProvider,
     private offensesStore: SlasherOffensesStore,
+    private readonly ownValidators: EthAddress[] = [],
     private log = createLogger('slasher:consensus'),
     private readonly metrics = new SlasherMetrics(getTelemetryClient()),
   ) {
     this.roundMonitor = new SlashRoundMonitor(settings, dateProvider);
     this.offensesCollector = new SlashOffensesCollector(config, settings, watchers, offensesStore);
+    this.ownValidatorMonitor = new OwnValidatorSlashMonitor(slashingProposer, settings, ownValidators, this.metrics);
   }
 
   public async start() {
@@ -128,6 +132,16 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
     // Check for round changes
     this.unwatchCallbacks.push(this.roundMonitor.listenToNewRound(round => this.handleNewRound(round)));
 
+    // Warn early when a slashing vote names one of our own validators. Skipped entirely when running none, so
+    // those nodes pay no extra L1 subscription. Subscribed only after the monitor's baseline read completes, so a
+    // vote cast in between is caught up by a later drain instead of being mistaken for a pre-startup vote.
+    if (this.ownValidators.length > 0) {
+      await this.ownValidatorMonitor.start(this.roundMonitor.getCurrentRound().round);
+      this.unwatchCallbacks.push(
+        this.slashingProposer.listenToVoteCast(({ round }) => void this.ownValidatorMonitor.handleVoteCast(round)),
+      );
+    }
+
     this.log.info(`Started slasher client`);
     return Promise.resolve();
   }
@@ -141,6 +155,7 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
     }
 
     this.roundMonitor.stop();
+    await this.ownValidatorMonitor.stop();
     await this.offensesCollector.stop();
 
     this.log.info('Slasher client stopped');
@@ -159,14 +174,16 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
   /** Triggered on a time basis when we enter a new slashing round. Clears expired offenses. */
   protected async handleNewRound(round: bigint) {
     this.log.info(`Starting new slashing round ${round}`);
+    this.ownValidatorMonitor.handleNewRound(round);
     await this.offensesCollector.handleNewRound(round);
   }
 
-  /** Called when we see a RoundExecuted event on the SlashingProposer (just for logging). */
+  /** Called when we see a RoundExecuted event on the SlashingProposer (just for logging and metrics). */
   protected async handleRoundExecuted(round: bigint, slashCount: bigint, l1BlockHash: Hex) {
     this.metrics.recordRoundExecuted();
     const slashes = await this.rollup.getSlashEvents(l1BlockHash);
     this.log.info(`Slashing round ${round} has been executed with ${slashCount} slashes`, { slashes });
+    this.ownValidatorMonitor.handleSlashes(round, slashes, l1BlockHash);
   }
 
   /**

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -133,12 +133,13 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
     this.unwatchCallbacks.push(this.roundMonitor.listenToNewRound(round => this.handleNewRound(round)));
 
     // Warn early when a slashing vote names one of our own validators. Skipped entirely when running none, so
-    // those nodes pay no extra L1 subscription. Subscribed only after the monitor's baseline read completes, so a
-    // vote cast in between is caught up by a later drain instead of being mistaken for a pre-startup vote.
+    // those nodes pay no extra L1 subscription.
     if (this.ownValidators.length > 0) {
-      await this.ownValidatorMonitor.start(this.roundMonitor.getCurrentRound().round);
+      this.ownValidatorMonitor.start(this.roundMonitor.getCurrentRound().round);
       this.unwatchCallbacks.push(
-        this.slashingProposer.listenToVoteCast(({ round }) => void this.ownValidatorMonitor.handleVoteCast(round)),
+        this.slashingProposer.listenToVoteCast(
+          ({ round, voteIndex }) => void this.ownValidatorMonitor.handleVoteCast(round, voteIndex),
+        ),
       );
     }
 

--- a/yarn-project/slasher/src/slasher_client_facade.ts
+++ b/yarn-project/slasher/src/slasher_client_facade.ts
@@ -2,6 +2,7 @@ import { EpochCache } from '@aztec/epoch-cache';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemClient } from '@aztec/ethereum/types';
 import type { SlotNumber } from '@aztec/foundation/branded-types';
+import type { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { AztecLMDBStoreV2 } from '@aztec/kv-store/lmdb-v2';
@@ -31,6 +32,7 @@ export class SlasherClientFacade implements SlasherClientInterface {
     private dateProvider: DateProvider,
     private kvStore: AztecLMDBStoreV2,
     private rollupRegisteredAtL2Slot: SlotNumber,
+    private ownValidators: EthAddress[] = [],
     private logger = createLogger('slasher'),
   ) {}
 
@@ -83,6 +85,7 @@ export class SlasherClientFacade implements SlasherClientInterface {
       this.dateProvider,
       this.kvStore,
       this.rollupRegisteredAtL2Slot,
+      this.ownValidators,
       this.logger,
     );
   }

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -548,6 +548,41 @@ export const SLASHER_ROUND_EXECUTED_COUNT: MetricDefinition = {
   description: 'The number of slashing rounds executed',
   valueType: ValueType.INT,
 };
+export const SLASHER_OWN_VALIDATOR_TARGETED_COUNT: MetricDefinition = {
+  name: 'aztec.slasher.own_validator.targeted_count',
+  description:
+    "The number of times one of the node's own validators was named as a slash target by an onchain vote, counted " +
+    'once per vote per validator. Votes cast while the node is offline or starting up are not counted, and L1 ' +
+    'reorgs can cause small drift within a round.',
+  valueType: ValueType.INT,
+};
+export const SLASHER_OWN_VALIDATOR_CURRENT_ROUND_VOTES_MAX: MetricDefinition = {
+  name: 'aztec.slasher.own_validator.current_round_votes_max',
+  description:
+    "Highest number of votes cast against any committee position held by the node's own validators in the current " +
+    'slashing round, to compare against aztec.slasher.quorum_size (the contract tallies quorum per position). ' +
+    'Resets to zero when a new round starts. Votes cast while the node is offline or starting up are not counted, ' +
+    'and L1 reorgs can cause small drift within a round.',
+  valueType: ValueType.INT,
+};
+export const SLASHER_QUORUM_SIZE: MetricDefinition = {
+  name: 'aztec.slasher.quorum_size',
+  description: 'The number of votes a validator must receive in a round to be slashed',
+  valueType: ValueType.INT,
+};
+export const SLASHER_OWN_VALIDATOR_SLASHED_COUNT: MetricDefinition = {
+  name: 'aztec.slasher.own_validator.slashed_count',
+  description: "The number of times one of the node's own validators was slashed, from executed Slashed events",
+  valueType: ValueType.INT,
+};
+export const SLASHER_OWN_VALIDATOR_SLASHED_AMOUNT: MetricDefinition = {
+  name: 'aztec.slasher.own_validator.slashed_amount',
+  description:
+    "Cumulative amount slashed from the node's own validators in whole staking-asset tokens, from executed " +
+    'Slashed events',
+  unit: 'tokens',
+  valueType: ValueType.DOUBLE,
+};
 export const SEQUENCER_CHECKPOINT_SUCCESS_COUNT: MetricDefinition = {
   name: 'aztec.sequencer.checkpoint.success_count',
   description: 'The number of times checkpoint publishing succeeded',


### PR DESCRIPTION
Next-line counterpart of #25058 (itself a rework of #24923), which targets the v5 line. Closes A-1443 alongside it.

Three commits, kept separate (`ci-no-squash`).

### `feat(slasher): warn and expose metrics when own validators are slash targets`

- Warns when an onchain slashing vote names one of the node's own validators, and when an executed round slashes one of them.
- Adds five node-level metrics: `own_validator.targeted_count`, `own_validator.current_round_votes_max`, `own_validator.slashed_count`, `own_validator.slashed_amount`, and `quorum_size`.
- Tallies per flattened committee position, which is the unit the contract tallies quorum by: a validator sitting in several of a round's committees holds several positions, each racing quorum independently. Warnings report the validator's highest position tally.
- The whole feature is skipped when the node runs no validators, so those nodes pay no extra L1 subscription.

### `feat(l1): emit vote index in SlashingProposer VoteCast event`

- `VoteCast` gains a non-indexed `uint256 voteIndex` carrying the index of the vote it recorded within the round (the value `getVotes(round, index)` accepts).
- The event becomes self-identifying: a listener can read the vote back without re-deriving the index from the round's vote count, which needed an extra L1 read per event and could only ever approximate which vote the event referred to.
- This changes the event signature and therefore its topic0. External indexers filtering on `VoteCast` need to update their ABI. The unrelated `VoteCast` on `Governance` is untouched.
- TS ripple: `SlashingProposerContract.listenToVoteCast` now hands `{ round, voteIndex, proposer }` to its callback.

### `refactor(slasher): drive own-validator vote tracking from the VoteCast vote index`

- The monitor's cursor is now fed purely by event indices: no `getRound` read per event, and no startup baseline read (`start()` is synchronous, and the client no longer has to await it before subscribing).
- A missed event delivery is healed by gap-filling from the cursor up to the latest event's index; a duplicate or out-of-order delivery is a no-op. A failed vote read leaves the cursor put, so the next event retries it.
- Starting mid-round still counts only votes cast from the first event onwards, so cumulative counters are not double-counted across restarts.
- Vote processing stays serialized through the existing queue, which is what keeps the cursor sound and the warning tallies monotonic.

### Tests

- `l1-contracts`: 34 tests under `test/slashing/` pass, including a new `test_voteEmitsVoteIndex` asserting the index the event carries across two votes in a round.
- `@aztec/ethereum`: 22 tests in `slashing_proposer.test.ts` pass; the anvil-backed vote test now also asserts the emitted event's `voteIndex`.
- `@aztec/slasher`: 22 tests in `own_validator_slash_monitor.test.ts` (duplicate delivery, gap-fill, stale index, mid-round start, failed-read retry, drain serialization, rollover mid-drain, stop/restart) and 44 in `slasher_client.test.ts` pass.
