### PR TITLE
feat: make docs recursive_verification example consume released bb/noir packages

### DIFF
--- a/docs/.yarnrc.yml
+++ b/docs/.yarnrc.yml
@@ -2,4 +2,11 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 7d
 
-npmPreapprovedPackages: []
+# The recursive_verification example installs first-party packages (and their dependencies) exact-pinned to the
+# toolchain's BB_VERSION (see labs-aztec-toolchain/bootstrap.sh), a nightly that is always younger than the age gate.
+npmPreapprovedPackages:
+  - "@aztec/bb.js"
+  - "@aztec/noir-noir_js"
+  - "@aztec/noir-types"
+  - "@aztec/noir-acvm_js"
+  - "@aztec/noir-noirc_abi"

--- a/docs/examples/contracts/recursive_verification_contract/Nargo.toml
+++ b/docs/examples/contracts/recursive_verification_contract/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.25.0"
 
 [dependencies]
 aztec = { path = "../../../../noir-projects/labs/aztec-nr/aztec" }
-bb_proof_verification = { path = "../../../../barretenberg/noir/bb_proof_verification" }
+bb_proof_verification = { git = "https://github.com/AztecProtocol/aztec-packages", tag = "v6.0.0-nightly.20260729", directory = "barretenberg/noir/bb_proof_verification" }

--- a/docs/examples/ts/recursive_verification/config.yaml
+++ b/docs/examples/ts/recursive_verification/config.yaml
@@ -10,7 +10,6 @@ contracts:
 
 # Dependencies:
 #   - @aztec/* packages are auto-linked from yarn-project/
-#   - Use link:path for packages outside yarn-project/
 #   - Use npm:package-name or npm:package-name@range for external npm packages
 dependencies:
   - "@aztec/aztec.js"
@@ -19,20 +18,7 @@ dependencies:
   - "@aztec/kv-store"
   - "@aztec/pxe"
   - "@aztec/noir-contracts.js"
-  # Packages outside yarn-project/ - use explicit link paths
-  - "link:@aztec/bb.js:barretenberg/ts/bb.js"
-  - "link:@aztec/noir-noir_js:noir/packages/noir_js"
-  # Transitive dependencies of @aztec/noir-noir_js
-  - "link:@aztec/noir-acvm_js:noir/packages/acvm_js"
-  - "link:@aztec/noir-noirc_abi:noir/packages/noirc_abi"
-  - "link:@aztec/noir-types:noir/packages/types"
-  # Runtime deps of @aztec/bb.js (linked, so its own deps are not auto-installed).
-  # Version ranges must mirror bb.js's package.json: these are bare `yarn add`s, so leaving them
-  # unversioned installs the latest major and breaks when a dep ships a breaking release (e.g. pako 3.0.0
-  # dropped the ESM default export that bb.js's `import pako from 'pako'` relies on).
-  - "npm:pako@^2.1.0"
-  - "npm:msgpackr@^1.11.2"
-  - "npm:comlink@^4.4.1"
-  - "npm:idb-keyval@^6.2.1"
-  - "npm:commander@^12.1.0"
-  - "npm:tslib@^2.4.0"
+  # Published packages pinned to the toolchain's BB_VERSION (enforced by
+  # labs-aztec-toolchain/bootstrap.sh).
+  - "npm:@aztec/bb.js@6.0.0-nightly.20260729"
+  - "npm:@aztec/noir-noir_js@6.0.0-nightly.20260729"

--- a/docs/scripts/netlify-preview-build.sh
+++ b/docs/scripts/netlify-preview-build.sh
@@ -9,23 +9,15 @@ DOCS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "=== Installing noirup and nargo ==="
 export PATH="$HOME/.nargo/bin:$PATH"
 
-# Ensure noir submodule is available for version detection
+# Install the noir release the labs toolchain pins (the single source of truth for
+# the nargo version this repo builds against). The toolchain binaries themselves are
+# not provisioned on Netlify, so the pin is read from the file rather than the record
+# a toolchain build would produce.
 REPO_ROOT="$DOCS_ROOT/.."
-if [ ! -f "$REPO_ROOT/noir/noir-repo/.git" ] && [ ! -d "$REPO_ROOT/noir/noir-repo/.git" ]; then
-    git -C "$REPO_ROOT" submodule update --init --depth 1 noir/noir-repo
-fi
-
-# Fetch tags so git describe can identify the exact noir version pinned by the submodule.
-# The shallow clone (--depth 1) does not fetch tags, causing describe to fail and the
-# build to fall back to "nightly", which may pull a newer nargo with breaking stdlib changes.
-git -C "$REPO_ROOT/noir/noir-repo" fetch --tags --depth 1 2>/dev/null || true
-
-# Use the pinned noir version from the submodule
-NOIR_TAG=$(git -C "$REPO_ROOT/noir/noir-repo" describe --tags --exact-match 2>/dev/null || echo "")
+NOIR_TAG=$(sed -n 's/^NOIR_VERSION=//p' "$REPO_ROOT/labs-aztec-toolchain/bootstrap.sh")
 if [ -z "$NOIR_TAG" ]; then
-    echo "WARNING: Could not determine noir version from submodule tags. Falling back to 'nightly'."
-    echo "This may install a newer nargo with breaking stdlib changes."
-    NOIR_TAG="nightly"
+    echo "ERROR: Could not read NOIR_VERSION from labs-aztec-toolchain/bootstrap.sh"
+    exit 1
 fi
 echo "Using noir version: $NOIR_TAG"
 

--- a/labs-aztec-toolchain/bootstrap.sh
+++ b/labs-aztec-toolchain/bootstrap.sh
@@ -12,11 +12,14 @@ NOIR_PROFILER_BINARY=noir-profiler
 # nargo only reports its base cargo version, never the nightly/release tag.
 PIN_FILE=$TARGET_DIR/.pin
 
-# Pinned versions installed in the labs repo (see build_labs).
+# Pinned versions installed in the labs repo (see build_labs). These versions are also
+# hardcoded in other files throughout the monorepo, so a change here requires also updating
+# those. check_pin_drift detects any drift between this and those declarations.
 # The monorepo links the locally built binaries instead.
 # Note that BB is downloaded from the AztecProtocol/barretenberg mirror first (via bbup).
 BB_VERSION=6.0.0-nightly.20260729
 NOIR_VERSION=1.0.0-beta.25
+
 # The installers and sources are fetched at build time; overridable for testing/mirroring.
 BBUP_URL=${BBUP_URL:-https://raw.githubusercontent.com/AztecProtocol/aztec-packages/86f69c8751f63ca604a1dab5967f208b211a1611/barretenberg/bbup/bbup}
 NOIRUP_URL=${NOIRUP_URL:-https://raw.githubusercontent.com/noir-lang/noirup/324a51fca2c410d2477400316efc5ce0d743a5b3/noirup}
@@ -322,7 +325,40 @@ function clean {
   rm -rf $TARGET_DIR
 }
 
+# The pinned versions above are also written out in files that consume the release
+# directly and cannot read them from here. This asserts they all match BB_VERSION
+# so a pin bump cannot leave one behind.
+function check_pin_drift {
+  local repo_root=$(git rev-parse --show-toplevel)
+  local failed=false
+
+  local hit tag
+  while IFS= read -r hit; do
+    tag=$(sed -n 's/.*tag *= *"\([^"]*\)".*/\1/p' <<< "${hit#*:*:}")
+    if [ "$tag" != "v$BB_VERSION" ]; then
+      echo_stderr "${hit%%:*}:$(cut -d: -f2 <<< "$hit"): aztec-packages git dep pins tag \"$tag\", expected \"v$BB_VERSION\" (BB_VERSION in labs-aztec-toolchain/bootstrap.sh)."
+      failed=true
+    fi
+  done < <(git -C "$repo_root" grep -n 'github.com/AztecProtocol/aztec-packages' -- '*Nargo.toml' || true)
+
+  local config=$repo_root/docs/examples/ts/recursive_verification/config.yaml
+  local pin version
+  while IFS= read -r pin; do
+    version=${pin##*@}
+    if [ "$version" != "$BB_VERSION" ]; then
+      echo_stderr "$config: \"$pin\" pins version \"$version\", expected \"$BB_VERSION\" (BB_VERSION in labs-aztec-toolchain/bootstrap.sh)."
+      failed=true
+    fi
+  done < <(grep -o 'npm:@aztec/[^"]*' "$config" 2>/dev/null || true)
+
+  if $failed; then
+    echo_stderr "Pinned release versions drifted - align them with BB_VERSION."
+    exit 1
+  fi
+}
+
 function build {
+  check_pin_drift
   build_labs
 }
 

--- a/labs-aztec-toolchain/bootstrap.sh
+++ b/labs-aztec-toolchain/bootstrap.sh
@@ -18,6 +18,11 @@ PIN_FILE=$TARGET_DIR/.pin
 # The monorepo links the locally built binaries instead.
 # Note that BB is downloaded from the AztecProtocol/barretenberg mirror first (via bbup).
 BB_VERSION=6.0.0-nightly.20260729
+# NOIR_VERSION must be the noir release the $BB_VERSION aztec-packages release was built
+# against (its noir submodule): the pinned nargo's output is consumed by tools from that
+# release (bb, and the @aztec/noir-* js packages, which are that submodule republished).
+# Skew is not detected by check_pin_drift, it surfaces in other places (e.g. the docs
+# examples' runtime tests).
 NOIR_VERSION=1.0.0-beta.25
 
 # The installers and sources are fetched at build time; overridable for testing/mirroring.
@@ -349,7 +354,9 @@ function check_pin_drift {
       echo_stderr "$config: \"$pin\" pins version \"$version\", expected \"$BB_VERSION\" (BB_VERSION in labs-aztec-toolchain/bootstrap.sh)."
       failed=true
     fi
-  done < <(grep -o 'npm:@aztec/[^"]*' "$config" 2>/dev/null || true)
+  # Only bb.js and the noir packages track BB_VERSION: other @aztec-scoped pins
+  # (e.g. the viem fork) version independently and must not be checked.
+  done < <(grep -oE 'npm:@aztec/(bb\.js|noir-[^@"]*)@[^"]*' "$config" 2>/dev/null || true)
 
   if $failed; then
     echo_stderr "Pinned release versions drifted - align them with BB_VERSION."


### PR DESCRIPTION
This example was importing a noir lib in bb from source, I changed that to be a published one. But since the version *must* match that of the binary we're using, I also added a small fn in the bootstrap script to check that all such references to the bb version match, avoiding drift between files. It means that bumping the version requires touching all these files.