### PR TITLE
fix(ipc): connect reliability for spawned wsdb/bb-avm-sim services

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm/avm_ipc_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm/avm_ipc_server.cpp
@@ -18,9 +18,49 @@ namespace bb::avm {
 
 int execute_avm_server(const std::string& input_path, const std::string& wsdb_path, const std::string& cdb_path)
 {
-    info("Connecting to aztec-wsdb at ", wsdb_path);
-    constexpr int max_retries = 50;
+    // Create our own IPC server and listen BEFORE connecting to the upstream
+    // wsdb/CDB servers: the owning TS process connects the moment we listen
+    // (its first request waits in the socket buffer until the reactor starts),
+    // so its connect backstop only covers exec + linking + reaching listen(),
+    // never the upstream waits below. It also installs the lifecycle handlers
+    // — including parent-death monitoring — before any potentially long wait.
+    ipc::ServerOptions opts;
+    opts.max_shm_clients = 1;
+    auto server = ipc::make_server(input_path, opts);
+    if (!server) {
+        info("Error: --input path must end with .sock or .shm: ", input_path);
+        return 1;
+    }
+    ipc::install_default_signal_handlers(*server);
+
+    auto cancel_simulation_handler = [](int /*signal*/) {
+        auto* token = g_active_cancellation_token.load(std::memory_order_acquire);
+        if (token) {
+            token->cancel();
+        }
+    };
+    // Installed before listen(): once the socket is up the parent may send
+    // SIGUSR1 (simulation cancellation) at any time, and the default action
+    // for an unhandled SIGUSR1 is process termination.
+    (void)std::signal(SIGUSR1, cancel_simulation_handler);
+
+    if (!server->listen()) {
+        info("Error: Could not start IPC server");
+        return 1;
+    }
+    info("bb-avm-sim listening on ", input_path);
+
+    // Upstream connect retries. The upstream servers also listen before their
+    // heavy initialization, so waiting here normally means draining a
+    // momentarily-full accept backlog, not waiting out init. The budget is a
+    // generous backstop matching the TS client's connect backstop; on failure
+    // we exit and the parent surfaces the exit as the failure cause. If the
+    // parent dies while we wait, parent-death monitoring (installed above)
+    // reaps us.
+    constexpr int max_retries = 600;
     constexpr int retry_delay_ms = 100;
+
+    info("Connecting to aztec-wsdb at ", wsdb_path);
     std::unique_ptr<wsdb::WsdbIpcClient> wsdb_client;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
         try {
@@ -51,30 +91,6 @@ int execute_avm_server(const std::string& input_path, const std::string& wsdb_pa
     }
 
     AvmRequest request{ .cdb_client = *cdb_client, .wsdb_client = *wsdb_client };
-
-    ipc::ServerOptions opts;
-    opts.max_shm_clients = 1;
-    auto server = ipc::make_server(input_path, opts);
-    if (!server) {
-        info("Error: --input path must end with .sock or .shm: ", input_path);
-        return 1;
-    }
-
-    info("bb-avm-sim listening on ", input_path);
-    ipc::install_default_signal_handlers(*server);
-    auto cancel_simulation_handler = [](int /*signal*/) {
-        auto* token = g_active_cancellation_token.load(std::memory_order_acquire);
-        if (token) {
-            token->cancel();
-        }
-    };
-
-    (void)std::signal(SIGUSR1, cancel_simulation_handler);
-
-    if (!server->listen()) {
-        info("Error: Could not start IPC server");
-        return 1;
-    }
 
     info("bb-avm-sim IPC server ready");
 

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
@@ -195,6 +195,38 @@ int execute_wsdb_server(const std::string& input_path,
         }
     }
 
+    // Create the IPC server and listen BEFORE the (potentially slow) WorldState
+    // construction: LMDB open and genesis prefill can take arbitrarily long on
+    // a loaded machine. With the socket already listening, clients connect into
+    // the accept backlog immediately and their first requests wait in the
+    // socket buffer until the reactor starts, so the client-side connect
+    // backstop only has to cover exec + linking + reaching listen() — it never
+    // races database initialization.
+    //
+    // Pick UDS vs MPSC-SHM by path suffix; install the runtime's default
+    // lifecycle signal handlers (SIGTERM/SIGINT → request_shutdown, SIGBUS/SIGSEGV
+    // → close+exit, plus parent-death monitoring via prctl/kqueue).
+    ipc::ServerOptions opts;
+    // TS backend (client 0) + the AVM simulator pool (one connection per
+    // bb-avm-sim process). Sized to cover a default-size pool with headroom so
+    // SHM isn't capped to a single AVM client. (UDS, the default transport, is
+    // unaffected — it admits connections via the listen backlog.)
+    opts.max_shm_clients = 8;
+    opts.shm_request_ring_size = request_ring_size;
+    opts.shm_response_ring_size = response_ring_size;
+    auto server = ipc::make_server(input_path, opts);
+    if (!server) {
+        std::cerr << "Error: --input path must end with .sock or .shm: " << input_path << '\n';
+        return 1;
+    }
+    ipc::install_default_signal_handlers(*server);
+
+    if (!server->listen()) {
+        std::cerr << "Error: Could not start IPC server" << '\n';
+        return 1;
+    }
+    std::cerr << "aztec-wsdb listening on " << input_path << '\n';
+
     // Parse prefilled public data: JSON array of ["slot_hex","value_hex"] pairs
     std::vector<PublicDataLeafValue> prefilled_public_data;
     if (!prefilled_public_data_json.empty()) {
@@ -223,30 +255,6 @@ int execute_wsdb_server(const std::string& input_path,
                                            genesis_timestamp);
 
     WsdbRequest request{ .world_state = *ws };
-
-    // Pick UDS vs MPSC-SHM by path suffix; install the runtime's default
-    // lifecycle signal handlers (SIGTERM/SIGINT → request_shutdown, SIGBUS/SIGSEGV
-    // → close+exit, plus parent-death monitoring via prctl/kqueue).
-    ipc::ServerOptions opts;
-    // TS backend (client 0) + the AVM simulator pool (one connection per
-    // bb-avm-sim process). Sized to cover a default-size pool with headroom so
-    // SHM isn't capped to a single AVM client. (UDS, the default transport, is
-    // unaffected — it admits connections via the listen backlog.)
-    opts.max_shm_clients = 8;
-    opts.shm_request_ring_size = request_ring_size;
-    opts.shm_response_ring_size = response_ring_size;
-    auto server = ipc::make_server(input_path, opts);
-    if (!server) {
-        std::cerr << "Error: --input path must end with .sock or .shm: " << input_path << '\n';
-        return 1;
-    }
-    std::cerr << "aztec-wsdb listening on " << input_path << '\n';
-    ipc::install_default_signal_handlers(*server);
-
-    if (!server->listen()) {
-        std::cerr << "Error: Could not start IPC server" << '\n';
-        return 1;
-    }
 
     std::cerr << "aztec-wsdb IPC server ready" << '\n';
 

--- a/ipc-codegen/echo_example/ts_package/src/reliability_test.ts
+++ b/ipc-codegen/echo_example/ts_package/src/reliability_test.ts
@@ -1,0 +1,244 @@
+/**
+ * Startup/teardown reliability tests for the generated spawn/connect path,
+ * driven through the generated package with real and fake server binaries:
+ *
+ *   1. Server is slow to create its socket — spawn must wait, not fail.
+ *   2. Server dies before listening — spawn must fail promptly with the exit
+ *      code (retry=true), not burn the whole connect backstop.
+ *   3. Server is alive but never listens — spawn must fail once the backstop
+ *      expires AND must kill the wedged process rather than orphan it.
+ *   4. A missing binary fails with retry=false (configuration, not weather).
+ *   5. Without respawn, a killed server fails later calls with retry=true.
+ *   6. With respawn, the next call after a kill gets a fresh process.
+ *
+ * Usage: node dest/reliability_test.js
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EchoService } from "./index.js";
+import { findEchoBinary } from "./platform.js";
+
+const scratch = mkdtempSync(join(tmpdir(), "echo-reliability-"));
+const cleanups: Array<() => void> = [
+  () => rmSync(scratch, { recursive: true, force: true }),
+];
+
+function fakeBinary(name: string, script: string): string {
+  const path = join(scratch, name);
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function assert(cond: boolean, label: string): void {
+  if (!cond) {
+    throw new Error(`assertion failed: ${label}`);
+  }
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForDeath(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processAlive(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !processAlive(pid);
+}
+
+// 1. Slow startup: the server takes several seconds to create its socket
+// (simulating a loaded machine or a server doing init before listen). The
+// connect loop must keep waiting rather than give up early.
+async function testSlowStartup(): Promise<void> {
+  const realBinary = findEchoBinary();
+  assert(realBinary !== null, "echo_server binary present");
+  const slow = fakeBinary(
+    "slow_echo_server",
+    `#!/bin/sh\nsleep 2\nexec "${realBinary}" "$@"\n`,
+  );
+  const service = await EchoService.spawn({
+    binaryPath: slow,
+    transport: "uds",
+  });
+  try {
+    const data = Uint8Array.from([1, 2, 3]);
+    const resp = await service.bytes({ data });
+    assert(resp.data.length === 3, "slow startup echo roundtrip");
+  } finally {
+    await service.destroy();
+  }
+  console.error("reliability: slow startup OK");
+}
+
+// 2. Death before listen: spawn must reject with the real exit code, well
+// before the connect backstop, and must not leave the socket path behind.
+async function testDiesBeforeListen(): Promise<void> {
+  const dying = fakeBinary("dying_echo_server", "#!/bin/sh\nexit 7\n");
+  const started = Date.now();
+  let failure: Error | undefined;
+  try {
+    await EchoService.spawn({ binaryPath: dying, transport: "uds" });
+  } catch (err) {
+    failure = err as Error;
+  }
+  const elapsed = Date.now() - started;
+  assert(failure !== undefined, "spawn rejected for dying server");
+  assert(
+    failure!.message.includes("code=7"),
+    `error carries exit code (got: ${failure!.message})`,
+  );
+  assert(
+    elapsed < 5_000,
+    `failed promptly, not after the backstop (took ${elapsed}ms)`,
+  );
+  console.error("reliability: death before listen OK");
+}
+
+// 3. Wedged server: alive but never listens. With a short backstop, spawn
+// must reject AND the child must be dead afterwards — a failed spawn that
+// orphans the process leaks sockets, memory, and (for wsdb) LMDB locks.
+async function testWedgedServerIsKilled(): Promise<void> {
+  const pidFile = join(scratch, "wedged.pid");
+  const wedged = fakeBinary(
+    "wedged_echo_server",
+    `#!/bin/sh\necho $$ > "${pidFile}"\nexec sleep 600\n`,
+  );
+  let failure: Error | undefined;
+  try {
+    await EchoService.spawn({
+      binaryPath: wedged,
+      transport: "uds",
+      connectTimeoutMs: 1_000,
+    });
+  } catch (err) {
+    failure = err as Error;
+  }
+  assert(failure !== undefined, "spawn rejected for wedged server");
+  const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+  assert(Number.isInteger(pid) && pid > 0, "wedged server wrote its pid");
+  const died = await waitForDeath(pid, 5_000);
+  if (!died) {
+    // Don't leave the orphan behind even when the assertion fails.
+    cleanups.push(() => spawnSync("kill", ["-9", String(pid)]));
+  }
+  assert(died, "wedged server was killed after connect backstop expired");
+  console.error("reliability: wedged server killed OK");
+}
+
+// 4. Missing binary: a configuration error, flagged non-retryable.
+async function testMissingBinaryNotRetryable(): Promise<void> {
+  let failure: (Error & { retry?: boolean }) | undefined;
+  try {
+    await EchoService.spawn({
+      binaryPath: join(scratch, "no_such_binary"),
+      transport: "uds",
+    });
+  } catch (err) {
+    failure = err as Error;
+  }
+  assert(failure !== undefined, "spawn rejected for missing binary");
+  assert(
+    failure!.retry === false,
+    `missing binary carries retry=false (got: ${failure!.retry})`,
+  );
+  console.error("reliability: missing binary not retryable OK");
+}
+
+// 5. Death without respawn: later calls fail with a retryable error — the
+// process is gone, but a caller holding no server-side state may retry
+// against a fresh service.
+async function testDeathWithoutRespawnIsRetryable(): Promise<void> {
+  const realBinary = findEchoBinary()!;
+  const service = await EchoService.spawn({
+    binaryPath: realBinary,
+    transport: "uds",
+  });
+  try {
+    await service.bytes({ data: Uint8Array.from([1]) });
+    service.sendProcessSignal("SIGKILL");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    let failure: (Error & { retry?: boolean }) | undefined;
+    try {
+      await service.bytes({ data: Uint8Array.from([2]) });
+    } catch (err) {
+      failure = err as Error;
+    }
+    assert(failure !== undefined, "call rejected after server death");
+    assert(
+      failure!.retry === true,
+      `death carries retry=true (got: ${failure!.retry})`,
+    );
+  } finally {
+    await service.destroy();
+  }
+  console.error("reliability: death without respawn retryable OK");
+}
+
+// 6. Respawn: the backend transparently recreates the process; the call
+// surface never sees process lifecycle.
+async function testRespawnRecreatesProcess(): Promise<void> {
+  const realBinary = findEchoBinary()!;
+  const service = await EchoService.spawn({
+    binaryPath: realBinary,
+    transport: "uds",
+    respawn: true,
+  });
+  try {
+    const data = Uint8Array.from([1, 2, 3]);
+    const before = await service.bytes({ data });
+    assert(before.data.length === 3, "roundtrip before kill");
+
+    service.sendProcessSignal("SIGKILL");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // The first call after the death may race exit attribution and fail
+    // retryably; the retry must land on a fresh process.
+    let after;
+    try {
+      after = await service.bytes({ data });
+    } catch (err) {
+      assert(
+        (err as { retry?: boolean }).retry === true,
+        "raced failure is retryable",
+      );
+      after = await service.bytes({ data });
+    }
+    assert(after.data.length === 3, "roundtrip after respawn");
+  } finally {
+    await service.destroy();
+  }
+  console.error("reliability: respawn recreates process OK");
+}
+
+try {
+  await testSlowStartup();
+  await testDiesBeforeListen();
+  await testWedgedServerIsKilled();
+  await testMissingBinaryNotRetryable();
+  await testDeathWithoutRespawnIsRetryable();
+  await testRespawnRecreatesProcess();
+  console.error("echo ts package: reliability OK");
+} finally {
+  for (const cleanup of cleanups.reverse()) {
+    cleanup();
+  }
+}

--- a/ipc-codegen/echo_example/ts_package/test.sh
+++ b/ipc-codegen/echo_example/ts_package/test.sh
@@ -5,3 +5,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 transport="${1:-uds}"
 
 (cd "$DIR" && node --no-warnings dest/package_test.js --transport "$transport")
+
+# Startup/teardown failure-mode tests exercise the uds connect path only.
+if [ "$transport" = "uds" ]; then
+  (cd "$DIR" && node --no-warnings dest/reliability_test.js)
+fi

--- a/ipc-codegen/src/typescript_package_codegen.ts
+++ b/ipc-codegen/src/typescript_package_codegen.ts
@@ -286,15 +286,7 @@ process.exit(result.status ?? 1);
       ? "uds"
       : this.opts.transports[0]!;
 
-    return `import { spawn, type ChildProcess } from 'node:child_process';
-import { closeSync, existsSync, openSync, unlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { threadId } from 'node:worker_threads';
-import {
-  ${supportsShm ? "createNapiShmAsyncClient,\n  " : ""}UdsIpcClient,
-  type IpcClientAsync,
-} from '@aztec/ipc-runtime';
+    return `import { IpcSpawnError, SpawnedProcessBackend } from '@aztec/ipc-runtime';
 import { AsyncApi, type IpcErrorFactory } from './generated/async.js';
 import { ${findBinary} } from './platform.js';
 
@@ -312,209 +304,44 @@ export interface ${serviceOptions} {
   env?: NodeJS.ProcessEnv;
   extraArgs?: string[];
   createError?: IpcErrorFactory;
+  /**
+   * Respawn the server on the next call after it dies, instead of failing all
+   * subsequent calls. Only enable for stateless servers: a respawned process
+   * remembers nothing, so any server-side session state held by callers would
+   * silently dangle.
+   */
+  respawn?: boolean;
 ${supportsShm ? "  napiPath?: string;\n  clientId?: number;\n" : ""}}
 
-let instanceCounter = 0;
-const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
-
-class SpawnedBackend implements IpcClientAsync {
-  private destroying = false;
-  private exitError?: Error;
-
-  private constructor(
-    private child: ChildProcess,
-    private client: IpcClientAsync,
-    private ipcPath: string,
-    private transport: ${serviceTransport},
-    private exitPromise: Promise<void>,
-    private logPath: string | undefined,
-  ) {
-${
-  supportsShm
-    ? `    // Detect unexpected server death. Over SHM there is no connection to break,
-    // so without this an in-flight call waits forever for a reply that will
-    // never arrive. Reject in-flight calls and point at the log file.`
-    : `    // Detect unexpected server death and reject in-flight calls with the
-    // child log path included in the error.`
-}
-    this.child.on('exit', (code, signal) => {
-      if (this.destroying) {
-        return;
-      }
-      this.exitError = new Error(
-        '${this.opts.binaryName} exited unexpectedly (code=' + code + ', signal=' + signal + ')' +
-          (this.logPath ? '; see logs: ' + this.logPath : ''),
-      );
-      console.error(this.exitError.message);
-      void this.client.destroy();
-    });
-  }
-
-  static async spawn(options: ${serviceOptions} = {}): Promise<SpawnedBackend> {
-    const binaryPath = ${findBinary}(options.binaryPath);
-    if (!binaryPath) {
-      throw new Error('${this.opts.binaryName} binary not found');
-    }
-
-    const transport = options.transport ?? '${defaultTransport}';
-    const instanceId = '${toSnakeCase(prefix)}-' + process.pid + '-' + threadId + '-' + instanceCounter++;
-    const ipcPath = ${
-      supportsShm
-        ? `transport === 'shm'
-      ? instanceId + '.shm'
-      : join(tmpdir(), instanceId + '.sock')`
-        : `join(tmpdir(), instanceId + '.sock')`
-    };
-
-    if (transport === 'uds' && existsSync(ipcPath)) {
-      unlinkSync(ipcPath);
-    }
-
-    // Without a live logger, capture the child's stdout/stderr to a temp file
-    // (a plain fd, not a pipe — a pipe would keep the libuv loop referenced and
-    // break clean process exit). The path is surfaced if the child dies, so its
-    // errors are recoverable instead of vanishing into an ignored stream.
-    const logPath = options.logger ? undefined : join(tmpdir(), instanceId + '.log');
-    const logFd = logPath !== undefined ? openSync(logPath, 'a') : undefined;
-
-    const ipcPathArgs = ${ipcPathArgs}.map((arg: string) => arg === '{path}' ? ipcPath : arg);
-    const child = spawn(binaryPath, [...ipcPathArgs, ...(options.extraArgs ?? [])], {
-      stdio: [
-        'ignore',
-        options.logger ? 'pipe' : (logFd as number),
-        options.logger ? 'pipe' : (logFd as number),
-      ],
-      env: { ...process.env, ...(options.env ?? {}) },
-    });
-    if (logFd !== undefined) {
-      // The child holds its own dup of the fd; the parent's copy isn't needed.
-      closeSync(logFd);
-    }
-
-    if (options.logger) {
-      child.stdout?.on('data', (data: Buffer) => options.logger?.('[${this.opts.binaryName} stdout] ' + data.toString().trimEnd()));
-      child.stderr?.on('data', (data: Buffer) => options.logger?.('[${this.opts.binaryName} stderr] ' + data.toString().trimEnd()));
-    }
-
-    const exitPromise = new Promise<void>(resolve => {
-      child.on('exit', () => resolve());
-    });
-
-    const childReadyFailure = new Promise<never>((_, reject) => {
-      child.once('error', reject);
-      child.once('exit', (code, signal) => {
-        reject(
-          new Error('${this.opts.binaryName} exited before IPC connection was ready (code=' + code + ', signal=' + signal + ')'),
-        );
-      });
-    });
-
-    const client = await Promise.race([connectClient(child, ipcPath, transport, options), childReadyFailure]);
-    return new SpawnedBackend(child, client, ipcPath, transport, exitPromise, logPath);
-  }
-
-  getIpcPath(): string {
-    return this.ipcPath;
-  }
-
-  call(input: Uint8Array): Promise<Uint8Array> {
-    if (this.exitError) {
-      return Promise.reject(this.exitError);
-    }
-    return this.client.call(input);
-  }
-
-  sendProcessSignal(signal: NodeJS.Signals): void {
-    if (this.child.exitCode === null) {
-      this.child.kill(signal);
-    }
-  }
-
-  async destroy(): Promise<void> {
-    // Mark intentional teardown so the exit handler doesn't report it as an
-    // unexpected death.
-    this.destroying = true;
-    await this.client.destroy();
-    if (this.child.exitCode === null) {
-      this.child.kill('SIGTERM');
-    }
-    await this.exitPromise;
-    this.child.stdout?.destroy();
-    this.child.stderr?.destroy();
-    this.child.removeAllListeners();
-    cleanupIpcPath(this.ipcPath, this.transport);
-  }
-}
-
-async function connectClient(
-  child: ChildProcess,
-  ipcPath: string,
-  transport: ${serviceTransport},
-  options: ${serviceOptions},
-): Promise<IpcClientAsync> {
-  const timeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-
-  while (Date.now() <= deadline) {
-    if (child.exitCode !== null) {
-      throw new Error('${this.opts.binaryName} exited before IPC connection was ready');
-    }
-    try {
-      if (transport === 'uds') {
-        return await UdsIpcClient.connect(ipcPath, { connectTimeoutMs: Math.max(1, deadline - Date.now()) });
-      }
-${
-  supportsShm
-    ? `      if (transport === 'shm') {
-        return createNapiShmAsyncClient(ipcPath.replace(/\\.shm$/, ''), {
-          // Pass clientId through as-is: when unset, the client self-allocates a
-          // free producer slot (don't default to 0, which aliases every client).
-          clientId: options.clientId,
-          customAddonPath: options.napiPath,
-        });
-      }
-`
-    : ""
-}      throw new Error('Unsupported transport: ' + transport);
-    } catch (err) {
-      lastError = err;
-      await new Promise(resolve => setTimeout(resolve, 50));
-    }
-  }
-
-  throw new Error('Timed out connecting to ${this.opts.binaryName}: ' + (lastError instanceof Error ? lastError.message : String(lastError)));
-}
-
-function cleanupIpcPath(ipcPath: string, transport: ${serviceTransport}) {
-  try {
-    if (transport === 'uds' && existsSync(ipcPath)) {
-      unlinkSync(ipcPath);
-    }
-${
-  supportsShm
-    ? `    if (transport === 'shm') {
-      const shmName = ipcPath.replace(/\\.shm$/, '');
-      for (const suffix of ['_request', '_response']) {
-        const shmPath = '/dev/shm/' + shmName + suffix;
-        if (existsSync(shmPath)) {
-          unlinkSync(shmPath);
-        }
-      }
-    }
-`
-    : ""
-}
-  } catch {}
-}
-
+/**
+ * Spawns and talks to a '${this.opts.binaryName}' server process. Process
+ * lifecycle — connectivity, death detection, optional respawn, teardown — is
+ * owned by the backend (see SpawnedProcessBackend in ipc-runtime); it never
+ * leaks onto this API. Failed calls carry a 'retry' property set to true when
+ * the failure was environmental and the operation may be retried.
+ */
 export class ${serviceClass} extends AsyncApi {
-  private constructor(private spawnedBackend: SpawnedBackend, createError?: IpcErrorFactory) {
+  private constructor(private spawnedBackend: SpawnedProcessBackend, createError?: IpcErrorFactory) {
     super(spawnedBackend, createError);
   }
 
   static async spawn(options: ${serviceOptions} = {}): Promise<${serviceClass}> {
-    const backend = await SpawnedBackend.spawn(options);
+    const binaryPath = ${findBinary}(options.binaryPath);
+    if (!binaryPath) {
+      throw new IpcSpawnError('${this.opts.binaryName} binary not found', /*retry=*/ false);
+    }
+    const backend = await SpawnedProcessBackend.spawn({
+      binaryPath,
+      binaryName: '${this.opts.binaryName}',
+      instancePrefix: '${toSnakeCase(prefix)}',
+      ipcPathArgs: ${ipcPathArgs},
+      transport: options.transport ?? '${defaultTransport}',
+      logger: options.logger,
+      connectTimeoutMs: options.connectTimeoutMs,
+      env: options.env,
+      extraArgs: options.extraArgs,
+      respawn: options.respawn,
+${supportsShm ? "      clientId: options.clientId,\n      napiPath: options.napiPath,\n" : ""}    });
     return new ${serviceClass}(backend, options.createError);
   }
 

--- a/ipc-runtime/ts/package.json
+++ b/ipc-runtime/ts/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dest",
-    "test": "tsc -p tsconfig.json && node --test dest/uds.test.js"
+    "test": "tsc -p tsconfig.json && node --test dest/*.test.js"
   },
   "files": [
     "dest",

--- a/ipc-runtime/ts/src/errors.ts
+++ b/ipc-runtime/ts/src/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * Errors thrown by the ipc-runtime transports and process backends.
+ *
+ * The cross-layer contract is the bare `retry` property, not these classes:
+ * an error with `retry === true` failed for environmental reasons (process
+ * death, machine load, a broken connection) and the operation may be retried;
+ * `retry === false` (or no `retry` property at all) means retrying cannot
+ * help. Consumers should feature-detect the property rather than import
+ * these types, so the convention survives package boundaries.
+ */
+export class IpcError extends Error {
+  constructor(
+    message: string,
+    public readonly retry: boolean,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = new.target.name;
+  }
+}
+
+/** The connection to the server broke while calls were in flight or before they could be sent. */
+export class IpcTransportError extends IpcError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, /*retry=*/ true, options);
+  }
+}
+
+/** The spawned server process exited; carries the exit cause and, when captured, the log path. */
+export class IpcProcessExitedError extends IpcError {
+  constructor(
+    message: string,
+    public readonly code: number | null,
+    public readonly signal: NodeJS.Signals | null,
+    public readonly logPath?: string,
+  ) {
+    super(message, /*retry=*/ true);
+  }
+}
+
+/**
+ * The server process could not be started. Environmental failures (spawn
+ * raced a loaded machine, a wedged process hit the connect backstop) are
+ * retryable; configuration failures (binary not found) are not.
+ */
+export class IpcSpawnError extends IpcError {}

--- a/ipc-runtime/ts/src/index.ts
+++ b/ipc-runtime/ts/src/index.ts
@@ -6,6 +6,17 @@ export {
   SOCKET_BACKLOG,
   DEFAULT_CALL_TIMEOUT_NS,
 } from "./types.js";
+export {
+  IpcError,
+  IpcTransportError,
+  IpcProcessExitedError,
+  IpcSpawnError,
+} from "./errors.js";
+export {
+  SpawnedProcessBackend,
+  type SpawnedProcessBackendOptions,
+  type SpawnedTransport,
+} from "./spawned_backend.js";
 export { UdsIpcClient, type UdsIpcClientConnectOptions } from "./uds_client.js";
 export { UdsIpcServer, type IpcServerHandler } from "./uds_server.js";
 export {

--- a/ipc-runtime/ts/src/spawned_backend.test.ts
+++ b/ipc-runtime/ts/src/spawned_backend.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, test } from "node:test";
+import { IpcProcessExitedError, IpcSpawnError } from "./errors.js";
+import { SpawnedProcessBackend } from "./spawned_backend.js";
+
+const scratch = mkdtempSync(join(tmpdir(), "spawned-backend-test-"));
+after(() => rmSync(scratch, { recursive: true, force: true }));
+
+// A minimal length-prefixed echo server speaking the UdsIpcClient wire format.
+// Replies to each request with its own pid as a decimal string, so tests can
+// tell process incarnations apart.
+const PID_ECHO_SERVER = join(scratch, "pid_echo_server.cjs");
+writeFileSync(
+  PID_ECHO_SERVER,
+  `
+const net = require('node:net');
+const server = net.createServer(conn => {
+  let buf = Buffer.alloc(0);
+  conn.on('data', chunk => {
+    buf = Buffer.concat([buf, chunk]);
+    while (buf.length >= 4) {
+      const len = buf.readUInt32LE(0);
+      if (buf.length < 4 + len) return;
+      buf = buf.subarray(4 + len);
+      const payload = Buffer.from(String(process.pid));
+      const out = Buffer.alloc(4 + payload.length);
+      out.writeUInt32LE(payload.length, 0);
+      payload.copy(out, 4);
+      conn.write(out);
+    }
+  });
+});
+server.listen(process.argv[2]);
+`,
+);
+
+function shellScript(name: string, body: string): string {
+  const path = join(scratch, name);
+  writeFileSync(path, `#!/bin/sh\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function spawnPidEcho(
+  opts: { respawn?: boolean; connectTimeoutMs?: number } = {},
+) {
+  return SpawnedProcessBackend.spawn({
+    binaryPath: process.execPath,
+    binaryName: "pid_echo_server",
+    instancePrefix: "pid-echo-test",
+    ipcPathArgs: [PID_ECHO_SERVER, "{path}"],
+    transport: "uds",
+    ...opts,
+  });
+}
+
+async function callPid(backend: SpawnedProcessBackend): Promise<string> {
+  return Buffer.from(await backend.call(Uint8Array.from([1]))).toString();
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  cond: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return cond();
+}
+
+test("spawns, round-trips calls, and destroys cleanly", async () => {
+  const backend = await spawnPidEcho();
+  const pid = await callPid(backend);
+  assert.match(pid, /^\d+$/);
+  await backend.destroy();
+  assert.equal(processAlive(parseInt(pid, 10)), false);
+});
+
+test("without respawn, death rejects in-flight and later calls with a retryable exit error", async () => {
+  const backend = await spawnPidEcho();
+  const pid = parseInt(await callPid(backend), 10);
+
+  process.kill(pid, "SIGKILL");
+  await waitFor(() => !processAlive(pid), 2_000);
+
+  const err = await callPid(backend).then(
+    () => undefined,
+    (e: Error) => e,
+  );
+  assert.ok(
+    err instanceof IpcProcessExitedError,
+    `expected IpcProcessExitedError, got ${err}`,
+  );
+  assert.equal((err as IpcProcessExitedError).retry, true);
+  assert.equal((err as IpcProcessExitedError).signal, "SIGKILL");
+
+  // Still down: same classified error, no zombie respawn.
+  await assert.rejects(callPid(backend), IpcProcessExitedError);
+  await backend.destroy();
+});
+
+test("with respawn, the next call after a death transparently gets a fresh process", async () => {
+  const backend = await spawnPidEcho({ respawn: true });
+  const firstPid = parseInt(await callPid(backend), 10);
+
+  process.kill(firstPid, "SIGKILL");
+  await waitFor(() => !processAlive(firstPid), 2_000);
+
+  // The first call after the death may race the exit event; it is allowed to
+  // fail (with a retryable error) or succeed against the respawned process.
+  let secondPid: number | undefined;
+  try {
+    secondPid = parseInt(await callPid(backend), 10);
+  } catch (err) {
+    assert.equal((err as { retry?: boolean }).retry, true);
+    secondPid = parseInt(await callPid(backend), 10);
+  }
+  assert.notEqual(secondPid, firstPid);
+  assert.equal(processAlive(secondPid!), true);
+
+  // getIpcPath is stable across incarnations.
+  const path = backend.getIpcPath();
+  await backend.destroy();
+  assert.equal(processAlive(secondPid!), false);
+  assert.equal(backend.getIpcPath(), path);
+});
+
+test("a missing binary fails with retry=false", async () => {
+  const err = await SpawnedProcessBackend.spawn({
+    binaryPath: join(scratch, "does_not_exist"),
+    binaryName: "ghost",
+    instancePrefix: "ghost-test",
+    ipcPathArgs: ["{path}"],
+    transport: "uds",
+  }).then(
+    () => undefined,
+    (e: Error) => e,
+  );
+  assert.ok(err instanceof IpcSpawnError, `expected IpcSpawnError, got ${err}`);
+  assert.equal((err as IpcSpawnError).retry, false);
+});
+
+test("a server dying before listen fails promptly with retry=true and the exit code", async () => {
+  const dying = shellScript("dying_server.sh", "exit 7");
+  const started = Date.now();
+  const err = await SpawnedProcessBackend.spawn({
+    binaryPath: dying,
+    binaryName: "dying_server",
+    instancePrefix: "dying-test",
+    ipcPathArgs: ["{path}"],
+    transport: "uds",
+  }).then(
+    () => undefined,
+    (e: Error) => e,
+  );
+  assert.ok(err instanceof IpcSpawnError, `expected IpcSpawnError, got ${err}`);
+  assert.equal((err as IpcSpawnError).retry, true);
+  assert.match((err as IpcSpawnError).message, /code=7/);
+  assert.ok(Date.now() - started < 5_000, "failed before the connect backstop");
+});
+
+test("a wedged server is killed when the connect backstop fires", async () => {
+  const pidFile = join(scratch, "wedged.pid");
+  const wedged = shellScript(
+    "wedged_server.sh",
+    `echo $$ > "${pidFile}"\nexec sleep 600`,
+  );
+  const err = await SpawnedProcessBackend.spawn({
+    binaryPath: wedged,
+    binaryName: "wedged_server",
+    instancePrefix: "wedged-test",
+    ipcPathArgs: ["{path}"],
+    transport: "uds",
+    connectTimeoutMs: 1_000,
+  }).then(
+    () => undefined,
+    (e: Error) => e,
+  );
+  assert.ok(err instanceof IpcSpawnError, `expected IpcSpawnError, got ${err}`);
+  assert.equal((err as IpcSpawnError).retry, true);
+  const { readFileSync } = await import("node:fs");
+  const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+  assert.equal(
+    await waitFor(() => !processAlive(pid), 5_000),
+    true,
+    "wedged process was reaped",
+  );
+});
+
+test("destroy during a pending respawn does not leak the fresh process", async () => {
+  const backend = await spawnPidEcho({ respawn: true });
+  const firstPid = parseInt(await callPid(backend), 10);
+  process.kill(firstPid, "SIGKILL");
+  await waitFor(() => !processAlive(firstPid), 2_000);
+
+  // Trigger the lazy respawn, then destroy while it may still be in flight.
+  const pending = callPid(backend).catch(() => undefined);
+  await backend.destroy();
+  const result = await pending;
+
+  if (result !== undefined) {
+    // The respawn won the race and served the call; destroy() must still have
+    // reaped the fresh process afterwards.
+    assert.equal(
+      await waitFor(() => !processAlive(parseInt(result, 10)), 2_000),
+      true,
+    );
+  }
+});

--- a/ipc-runtime/ts/src/spawned_backend.ts
+++ b/ipc-runtime/ts/src/spawned_backend.ts
@@ -1,0 +1,460 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { open, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { threadId } from "node:worker_threads";
+import { IpcError, IpcProcessExitedError, IpcSpawnError } from "./errors.js";
+import { createNapiShmAsyncClient } from "./shm_client.js";
+import { IpcClientAsync } from "./types.js";
+import { UdsIpcClient } from "./uds_client.js";
+
+export type SpawnedTransport = "uds" | "shm";
+
+export interface SpawnedProcessBackendOptions {
+  /** Absolute path of the server binary to spawn. Callers resolve it (and fail with retry=false if missing). */
+  binaryPath: string;
+  /** Binary name used in error messages and log labels. */
+  binaryName: string;
+  /** Prefix for the per-instance ipc path (socket / shm name). */
+  instancePrefix: string;
+  /** Argv template; each '{path}' is replaced with the backend's ipc path. */
+  ipcPathArgs: string[];
+  transport: SpawnedTransport;
+  /** Receives the child's stdout/stderr lines. Without it, output is captured to a temp log file. */
+  logger?: (msg: string) => void;
+  connectTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  extraArgs?: string[];
+  /**
+   * Respawn the server on the next call() after it dies, instead of failing all
+   * subsequent calls. Only safe for stateless servers: a respawned process
+   * remembers nothing, so any server-side session state (forks, cursors) held
+   * by callers would silently dangle. In-flight calls at the time of death
+   * still reject (with retry=true); only later calls see the fresh process.
+   */
+  respawn?: boolean;
+  /** SHM only: fixed client slot id. When unset the client self-allocates a free slot. */
+  clientId?: number;
+  /** SHM only: override the native addon path. */
+  napiPath?: string;
+}
+
+// Backstop for a spawned server that is alive but never reaches listen().
+// This is a broken-process detector, not a performance expectation: servers
+// create their socket before any heavy initialization, so the timed window
+// covers only exec + linking + minimal init, and requests issued before the
+// server is fully initialized simply wait in the socket buffer. When the
+// backstop fires, the wedged process is killed rather than orphaned.
+const DEFAULT_CONNECT_TIMEOUT_MS = 60_000;
+// After destroy() sends SIGTERM, how long to wait before escalating to
+// SIGKILL so teardown cannot hang on a server that is stuck before its signal
+// handlers were installed (or is wedged inside them).
+const SIGTERM_GRACE_MS = 5_000;
+// How long a failed call() waits for the child's 'exit' event before deciding
+// the process is still alive. The socket usually breaks before 'exit' lands,
+// so without this grace a death would be misreported as a bare transport error.
+const EXIT_ATTRIBUTION_GRACE_MS = 250;
+
+let instanceCounter = 0;
+
+/** One spawned process together with the connection into it. */
+interface Incarnation {
+  child: ChildProcess;
+  client: IpcClientAsync;
+  exitPromise: Promise<void>;
+  exitInfo?: { code: number | null; signal: NodeJS.Signals | null };
+}
+
+/**
+ * An IpcClientAsync backed by a spawned server process. Owns the process
+ * lifecycle end to end: spawn, connect (raced against child death, with a
+ * kill-on-expiry backstop), death detection, optional lazy respawn, and
+ * teardown with SIGTERM→SIGKILL escalation. Failures surface as IpcError
+ * subclasses whose `retry` property tells callers whether the operation may
+ * be retried; no process or transport state is exposed on the API.
+ */
+export class SpawnedProcessBackend implements IpcClientAsync {
+  private current?: Incarnation;
+  private starting?: Promise<Incarnation>;
+  private destroying = false;
+  /** Set when the process died and respawn is disabled; fails all later calls. */
+  private exitError?: IpcProcessExitedError;
+  private readonly respawn: boolean;
+  private readonly ipcPath: string;
+  private readonly logPath?: string;
+
+  private constructor(private readonly options: SpawnedProcessBackendOptions) {
+    this.respawn = options.respawn ?? false;
+    const instanceId = `${options.instancePrefix}-${process.pid}-${threadId}-${instanceCounter++}`;
+    // The ipc path is per-backend, not per-incarnation, so getIpcPath() stays
+    // stable across respawns for anyone who was handed the path.
+    this.ipcPath =
+      options.transport === "shm"
+        ? `${instanceId}.shm`
+        : join(tmpdir(), `${instanceId}.sock`);
+    // Same for the log file: respawns append, preserving the death's last words.
+    this.logPath = options.logger
+      ? undefined
+      : join(tmpdir(), `${instanceId}.log`);
+  }
+
+  static async spawn(
+    options: SpawnedProcessBackendOptions,
+  ): Promise<SpawnedProcessBackend> {
+    if (options.respawn && options.transport === "shm") {
+      throw new IpcError(
+        `respawn is not supported over the shm transport`,
+        /*retry=*/ false,
+      );
+    }
+    const backend = new SpawnedProcessBackend(options);
+    backend.current = await backend.spawnIncarnation();
+    return backend;
+  }
+
+  getIpcPath(): string {
+    return this.ipcPath;
+  }
+
+  async call(input: Uint8Array): Promise<Uint8Array> {
+    const incarnation = await this.ensureUp();
+    try {
+      return await incarnation.client.call(input);
+    } catch (err) {
+      throw await this.attributeCallError(incarnation, err);
+    }
+  }
+
+  sendProcessSignal(signal: NodeJS.Signals): void {
+    const child = this.current?.child;
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill(signal);
+    }
+  }
+
+  async destroy(): Promise<void> {
+    // Mark intentional teardown so the exit handler doesn't report it as an
+    // unexpected death (or trigger a respawn).
+    this.destroying = true;
+    // A respawn may be mid-flight; let it settle so its child can't leak.
+    await this.starting?.then(
+      (incarnation) => {
+        this.current = incarnation;
+      },
+      () => {},
+    );
+    const incarnation = this.current;
+    this.current = undefined;
+    if (!incarnation) {
+      return;
+    }
+    await incarnation.client.destroy();
+    const { child } = incarnation;
+    let killTimer: NodeJS.Timeout | undefined;
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+      }, SIGTERM_GRACE_MS);
+    }
+    await incarnation.exitPromise;
+    if (killTimer !== undefined) {
+      clearTimeout(killTimer);
+    }
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    child.removeAllListeners();
+    await this.cleanupIpcPath();
+  }
+
+  /** Return the live incarnation, lazily respawning one when allowed. */
+  private async ensureUp(): Promise<Incarnation> {
+    if (this.destroying) {
+      throw new IpcError(
+        `${this.options.binaryName} backend destroyed`,
+        /*retry=*/ false,
+      );
+    }
+    if (this.current) {
+      return this.current;
+    }
+    if (this.exitError) {
+      throw this.exitError;
+    }
+    // Lazy, shared respawn: the first caller after a death starts it, everyone
+    // else awaits the same attempt. Lazy (rather than eager-on-exit) so a
+    // crashing binary cannot respawn-loop with no one asking for it.
+    this.starting ??= this.spawnIncarnation()
+      .then((incarnation) => {
+        if (this.destroying) {
+          // destroy() raced us and already awaited this promise; it owns teardown.
+          return incarnation;
+        }
+        this.current = incarnation;
+        return incarnation;
+      })
+      .finally(() => {
+        this.starting = undefined;
+      });
+    return await this.starting;
+  }
+
+  /**
+   * Convert a failed call into the death of the process when that is what
+   * actually happened: the socket breaks before the child's 'exit' event
+   * lands, so wait a short grace for exit attribution before giving up and
+   * rethrowing the transport error as-is.
+   */
+  private async attributeCallError(
+    incarnation: Incarnation,
+    err: unknown,
+  ): Promise<unknown> {
+    if (!incarnation.exitInfo && !this.destroying) {
+      await Promise.race([
+        incarnation.exitPromise,
+        new Promise((resolve) =>
+          setTimeout(resolve, EXIT_ATTRIBUTION_GRACE_MS),
+        ),
+      ]);
+    }
+    if (incarnation.exitInfo && !this.destroying) {
+      const { code, signal } = incarnation.exitInfo;
+      return new IpcProcessExitedError(
+        `${this.options.binaryName} exited unexpectedly (code=${code}, signal=${signal})` +
+          (this.logPath !== undefined ? `; see logs: ${this.logPath}` : ""),
+        code,
+        signal,
+        this.logPath,
+      );
+    }
+    return err;
+  }
+
+  /** Spawn the server process and connect to it; kills the child on any failure. */
+  private async spawnIncarnation(): Promise<Incarnation> {
+    const { options } = this;
+    if (options.transport === "uds") {
+      await rm(this.ipcPath, { force: true });
+    }
+
+    // Without a live logger, capture the child's stdout/stderr to the backend's
+    // log file (a plain fd, not a pipe — a pipe would keep the libuv loop
+    // referenced and break clean process exit). The path is surfaced on
+    // failures so the child's errors are recoverable instead of vanishing.
+    // Async fs throughout: this runs on respawn under exactly the machine
+    // conditions where a sync open against a struggling disk could stall the
+    // whole event loop.
+    const logFile =
+      this.logPath !== undefined ? await open(this.logPath, "a") : undefined;
+    const child = spawn(
+      options.binaryPath,
+      [
+        ...options.ipcPathArgs.map((arg) =>
+          arg === "{path}" ? this.ipcPath : arg,
+        ),
+        ...(options.extraArgs ?? []),
+      ],
+      {
+        stdio: [
+          "ignore",
+          options.logger ? "pipe" : logFile!.fd,
+          options.logger ? "pipe" : logFile!.fd,
+        ],
+        env: { ...process.env, ...(options.env ?? {}) },
+      },
+    );
+    if (options.logger) {
+      child.stdout?.on("data", (data: Buffer) =>
+        options.logger?.(
+          `[${options.binaryName} stdout] ${data.toString().trimEnd()}`,
+        ),
+      );
+      child.stderr?.on("data", (data: Buffer) =>
+        options.logger?.(
+          `[${options.binaryName} stderr] ${data.toString().trimEnd()}`,
+        ),
+      );
+    }
+
+    const incarnation: Partial<Incarnation> & { child: ChildProcess } = {
+      child,
+    };
+    const exitPromise = new Promise<void>((resolve) => {
+      child.on("exit", (code, signal) => {
+        incarnation.exitInfo = { code, signal };
+        this.onIncarnationExit(incarnation as Incarnation, code, signal);
+        resolve();
+      });
+    });
+    incarnation.exitPromise = exitPromise;
+
+    const childReadyFailure = new Promise<never>((_, reject) => {
+      // Spawn syscall failures are the one place errno distinguishes a
+      // configuration error (missing/non-executable binary → retrying cannot
+      // help) from an environmental one.
+      child.once("error", (err) => {
+        const code = (err as NodeJS.ErrnoException).code;
+        const retry = code !== "ENOENT" && code !== "EACCES";
+        reject(
+          new IpcSpawnError(
+            `Failed to spawn ${options.binaryName}: ${err.message}`,
+            retry,
+            { cause: err },
+          ),
+        );
+      });
+      child.once("exit", (code, signal) => {
+        reject(
+          new IpcSpawnError(
+            `${options.binaryName} exited before IPC connection was ready (code=${code}, signal=${signal})`,
+            /*retry=*/ true,
+          ),
+        );
+      });
+    });
+
+    // Observe immediately: childReadyFailure can reject during the awaits
+    // below (spawn failures land on nextTick), before Promise.race attaches
+    // its handler — without this it would count as an unhandled rejection.
+    childReadyFailure.catch(() => {});
+
+    if (logFile !== undefined) {
+      // spawn() dups the fd synchronously; the parent's handle isn't needed.
+      // Closed only now, after the 'error'/'exit' listeners are attached: spawn
+      // failures are emitted on nextTick, so an await between spawn() and the
+      // listeners would let them fire unhandled.
+      await logFile.close();
+    }
+
+    // Liveness-based startup: wait on the connect for as long as the process
+    // is alive (the connect path retries socket-not-ready errors internally),
+    // and fail immediately with the real cause if the process dies first. On
+    // any failure, reap the child and its ipc path so a failed spawn cannot
+    // leak an orphan process still holding sockets or database locks.
+    try {
+      incarnation.client = await Promise.race([
+        this.connectClient(),
+        childReadyFailure,
+      ]);
+    } catch (err) {
+      if (child.pid !== undefined) {
+        // SIGKILL, not SIGTERM: the process never became ready, so it has no
+        // state to flush, and a wedged process may not honour SIGTERM.
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+        await exitPromise;
+      }
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.removeAllListeners();
+      await this.cleanupIpcPath();
+      throw this.asSpawnError(err);
+    }
+    return incarnation as Incarnation;
+  }
+
+  /** Handles an incarnation's death: reject/replace state so later calls behave per the respawn policy. */
+  private onIncarnationExit(
+    incarnation: Incarnation,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    // Break the connection so in-flight calls reject rather than wait forever
+    // (matters over SHM, where there is no socket to break).
+    void incarnation.client?.destroy();
+    if (this.destroying || this.current !== incarnation) {
+      return;
+    }
+    this.current = undefined;
+    if (!this.respawn) {
+      this.exitError = new IpcProcessExitedError(
+        `${this.options.binaryName} exited unexpectedly (code=${code}, signal=${signal})` +
+          (this.logPath !== undefined ? `; see logs: ${this.logPath}` : ""),
+        code,
+        signal,
+        this.logPath,
+      );
+      console.error(this.exitError.message);
+    } else {
+      console.error(
+        `${this.options.binaryName} exited unexpectedly (code=${code}, signal=${signal}); will respawn on next call`,
+      );
+    }
+  }
+
+  private async connectClient(): Promise<IpcClientAsync> {
+    const { options } = this;
+    const timeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    if (options.transport === "uds") {
+      // UdsIpcClient.connect retries socket-not-ready errors (path not yet
+      // created, server not yet accepting, backlog momentarily full) until the
+      // budget expires, and fails immediately on hard errors. Process death is
+      // raced against this by the caller, so a dead server short-circuits the
+      // wait with its real exit cause.
+      return await UdsIpcClient.connect(this.ipcPath, {
+        connectTimeoutMs: timeoutMs,
+      });
+    }
+    // The SHM client attaches to server-created rings, so creation can race
+    // server startup; retry until the backstop expires.
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() <= deadline) {
+      try {
+        return createNapiShmAsyncClient(this.ipcPath.replace(/\.shm$/, ""), {
+          clientId: options.clientId,
+          customAddonPath: options.napiPath,
+        });
+      } catch (err) {
+        lastError = err;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new IpcSpawnError(
+      `Timed out connecting to ${this.options.binaryName}: ${message}`,
+      /*retry=*/ true,
+      { cause: lastError },
+    );
+  }
+
+  /** Wrap a spawn/connect failure as IpcSpawnError and point at the captured log. */
+  private asSpawnError(err: unknown): IpcSpawnError {
+    const logHint =
+      this.logPath !== undefined ? `; see logs: ${this.logPath}` : "";
+    if (err instanceof IpcSpawnError) {
+      // Already classified at its source (child spawn 'error', exit-before-ready).
+      return new IpcSpawnError(err.message + logHint, err.retry, {
+        cause: err.cause ?? err,
+      });
+    }
+    // Everything else reaching here (connect backstop expiry, transient
+    // transport errors) is environmental.
+    const message = err instanceof Error ? err.message : String(err);
+    return new IpcSpawnError(
+      `Failed to start ${this.options.binaryName}: ${message}${logHint}`,
+      /*retry=*/ true,
+      { cause: err },
+    );
+  }
+
+  private async cleanupIpcPath(): Promise<void> {
+    try {
+      if (this.options.transport === "uds") {
+        await rm(this.ipcPath, { force: true });
+      }
+      if (this.options.transport === "shm") {
+        const shmName = this.ipcPath.replace(/\.shm$/, "");
+        for (const suffix of ["_request", "_response"]) {
+          await rm(`/dev/shm/${shmName}${suffix}`, { force: true });
+        }
+      }
+    } catch {
+      // Cleanup is best-effort; the paths live under tmpdir.
+    }
+  }
+}

--- a/ipc-runtime/ts/src/uds_client.ts
+++ b/ipc-runtime/ts/src/uds_client.ts
@@ -1,4 +1,5 @@
 import * as net from "node:net";
+import { IpcTransportError } from "./errors.js";
 import {
   IpcClientAsync,
   CONNECT_RETRY_BUDGET_MS,
@@ -39,8 +40,16 @@ export class UdsIpcClient implements IpcClientAsync {
 
   private constructor(private conn: net.Socket) {
     conn.on("data", (chunk) => this.onData(chunk));
-    conn.on("error", (err) => this.failAll(err));
-    conn.on("close", () => this.failAll(new Error("socket closed")));
+    conn.on("error", (err) =>
+      this.failAll(
+        new IpcTransportError(`UdsIpcClient: socket error: ${err.message}`, {
+          cause: err,
+        }),
+      ),
+    );
+    conn.on("close", () =>
+      this.failAll(new IpcTransportError("socket closed")),
+    );
   }
 
   static async connect(
@@ -68,10 +77,12 @@ export class UdsIpcClient implements IpcClientAsync {
 
   async call(input: Uint8Array): Promise<Uint8Array> {
     if (this.destroyed) {
-      throw new Error("UdsIpcClient: call() after destroy()");
+      throw new IpcTransportError("UdsIpcClient: call() after destroy()");
     }
     if (this.closed) {
-      throw new Error("UdsIpcClient: call() on a closed/errored socket");
+      throw new IpcTransportError(
+        "UdsIpcClient: call() on a closed/errored socket",
+      );
     }
     return new Promise<Uint8Array>((resolve, reject) => {
       this.pending.push({ resolve, reject });
@@ -86,7 +97,7 @@ export class UdsIpcClient implements IpcClientAsync {
     this.destroyed = true;
     this.conn.removeAllListeners();
     this.conn.destroy();
-    this.failAll(new Error("UdsIpcClient destroyed"));
+    this.failAll(new IpcTransportError("UdsIpcClient destroyed"));
   }
 
   private onData(chunk: Buffer): void {
@@ -101,7 +112,7 @@ export class UdsIpcClient implements IpcClientAsync {
         // claimed size.
         this.conn.destroy();
         this.failAll(
-          new Error(
+          new IpcTransportError(
             `UdsIpcClient: oversized frame (${len} bytes exceeds MAX_FRAME_SIZE)`,
           ),
         );
@@ -131,11 +142,13 @@ export class UdsIpcClient implements IpcClientAsync {
 }
 
 /**
- * Connect to `socketPath`, retrying on ECONNREFUSED until `timeoutMs`
- * elapses. ECONNREFUSED happens in the narrow window between the server's
- * bind() and listen(); other errors fail immediately. Each attempt is also
- * capped at the remaining budget, so a bound-but-never-accepting server
- * cannot hang the connect past the deadline.
+ * Connect to `socketPath`, retrying "server not ready" errors until
+ * `timeoutMs` elapses: ENOENT (socket file not created yet), ECONNREFUSED
+ * (the window between the server's bind() and listen()), and EAGAIN (Linux
+ * reports this for a UDS connect when the accept backlog is momentarily
+ * full). Other errors fail immediately. Each attempt is also capped at the
+ * remaining budget, so a bound-but-never-accepting server cannot hang the
+ * connect past the deadline.
  */
 async function connectWithRetry(
   socketPath: string,
@@ -154,12 +167,19 @@ async function connectWithRetry(
       if (
         code !== "ECONNREFUSED" &&
         code !== "ENOENT" &&
-        code !== "ETIMEDOUT"
+        code !== "ETIMEDOUT" &&
+        code !== "EAGAIN"
       ) {
-        throw new Error(`UdsIpcClient: connect failed: ${lastErr.message}`);
+        throw new IpcTransportError(
+          `UdsIpcClient: connect failed: ${lastErr.message}`,
+          { cause: lastErr },
+        );
       }
       if (Date.now() >= deadline) {
-        throw new Error(`UdsIpcClient: connect timed out: ${lastErr.message}`);
+        throw new IpcTransportError(
+          `UdsIpcClient: connect timed out: ${lastErr.message}`,
+          { cause: lastErr },
+        );
       }
       const delay = Math.min(50, 5 * 2 ** attempt++);
       await new Promise((resolve) => setTimeout(resolve, delay));

--- a/yarn-project/simulator/src/public/avm_simulator_pool.test.ts
+++ b/yarn-project/simulator/src/public/avm_simulator_pool.test.ts
@@ -1,0 +1,180 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+
+import { mock } from 'jest-mock-extended';
+
+import type { AvmContractsDBContext } from './avm_simulator.js';
+import { type AvmProcessHandle, AvmSimulatorPool, type AvmSimulatorPoolOptions } from './avm_simulator_pool.js';
+import type { PublicContractsDB } from './public_db_sources.js';
+
+const RESULT = Uint8Array.from([42]);
+const INPUT = Uint8Array.from([1, 2, 3]);
+
+// Process-death failures are flagged retry: true by the generated service; the pool interprets the
+// flag and nothing above it ever sees it.
+const processDeathError = (message: string) => Object.assign(new Error(message), { retry: true });
+
+class FakeAvmService implements AvmProcessHandle {
+  public destroyed = false;
+
+  constructor(private onSimulate: (service: FakeAvmService) => Promise<Uint8Array> = () => Promise.resolve(RESULT)) {}
+
+  simulate(): Promise<Uint8Array> {
+    return this.onSimulate(this);
+  }
+
+  simulateWithHints(): Promise<Uint8Array> {
+    return this.onSimulate(this);
+  }
+
+  destroy(): Promise<void> {
+    this.destroyed = true;
+    return Promise.resolve();
+  }
+}
+
+describe('AvmSimulatorPool', () => {
+  const context: AvmContractsDBContext = { contractsDB: mock<PublicContractsDB>(), forkId: 1, timestamp: 0n };
+  const pools: AvmSimulatorPool[] = [];
+
+  const makePool = (
+    spawnProcess: () => Promise<AvmProcessHandle>,
+    options: Partial<AvmSimulatorPoolOptions> = {},
+  ): AvmSimulatorPool => {
+    const pool = new AvmSimulatorPool({
+      wsdbIpcPath: '/tmp/unused-wsdb.sock',
+      maxSize: 2,
+      spawnRetryIntervalMs: 1,
+      spawnProcess,
+      ...options,
+    });
+    pools.push(pool);
+    return pool;
+  };
+
+  afterEach(async () => {
+    await Promise.all(pools.splice(0).map(pool => pool.destroy().catch(() => {})));
+  });
+
+  it('simulates on a pooled service', async () => {
+    const pool = makePool(() => Promise.resolve(new FakeAvmService()));
+    await expect(pool.simulate(INPUT, context)).resolves.toEqual(RESULT);
+  });
+
+  it('keeps retrying environmental spawn failures until one succeeds', async () => {
+    let attempts = 0;
+    const pool = makePool(() => {
+      attempts++;
+      return attempts < 8 ? Promise.reject(processDeathError('spawn failed')) : Promise.resolve(new FakeAvmService());
+    });
+    await expect(pool.simulate(INPUT, context)).resolves.toEqual(RESULT);
+    expect(attempts).toBe(8);
+  });
+
+  it('stops the spawn retry loop when the caller aborts', async () => {
+    let attempts = 0;
+    const pool = makePool(() => {
+      attempts++;
+      return Promise.reject(processDeathError('spawn failed'));
+    });
+    const controller = new AbortController();
+    const simulation = pool.simulate(INPUT, context, controller.signal);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    controller.abort();
+    await expect(simulation).rejects.toThrow(/aborted/);
+    const attemptsAtAbort = attempts;
+    await new Promise(resolve => setTimeout(resolve, 30));
+    expect(attempts).toBe(attemptsAtAbort);
+  });
+
+  it('propagates configuration spawn errors immediately instead of retrying', async () => {
+    let attempts = 0;
+    const pool = makePool(() => {
+      attempts++;
+      return Promise.reject(new Error('bb-avm-sim binary not found'));
+    });
+    await expect(pool.simulate(INPUT, context)).rejects.toThrow(/binary not found/);
+    expect(attempts).toBe(1);
+  });
+
+  it('re-issues a simulation once when its process dies', async () => {
+    // The service respawns its process under the hood, so the retry lands on the same handle.
+    let calls = 0;
+    const pool = makePool(() =>
+      Promise.resolve(
+        new FakeAvmService(() => {
+          calls++;
+          return calls === 1 ? Promise.reject(processDeathError('process died mid-call')) : Promise.resolve(RESULT);
+        }),
+      ),
+    );
+    await expect(pool.simulate(INPUT, context)).resolves.toEqual(RESULT);
+    expect(calls).toBe(2);
+  });
+
+  it('attributes a second process death to the input', async () => {
+    let calls = 0;
+    const pool = makePool(() =>
+      Promise.resolve(
+        new FakeAvmService(() => {
+          calls++;
+          return Promise.reject(processDeathError('process died mid-call'));
+        }),
+      ),
+    );
+    const err = await pool.simulate(INPUT, context).then(
+      () => undefined,
+      (e: Error) => e,
+    );
+    expect(err?.message).toMatch(/died twice.*attributing the failure to the input/);
+    // The verdict is the tx's, not an environmental flag anything upstream should interpret.
+    expect((err as Error & { retry?: unknown }).retry).toBeUndefined();
+    expect(calls).toBe(2);
+  });
+
+  it('does not re-issue simulations that fail on their own merits', async () => {
+    let calls = 0;
+    const pool = makePool(() =>
+      Promise.resolve(
+        new FakeAvmService(() => {
+          calls++;
+          return Promise.reject(new Error('simulation rejected the input'));
+        }),
+      ),
+    );
+    await expect(pool.simulate(INPUT, context)).rejects.toThrow(/rejected the input/);
+    expect(calls).toBe(1);
+  });
+
+  it('rejects a checkout waiting on a full pool when the caller aborts', async () => {
+    const blockedSim = promiseWithResolvers<Uint8Array>();
+    const pool = makePool(() => Promise.resolve(new FakeAvmService(() => blockedSim.promise)), { maxSize: 1 });
+
+    const sim1 = pool.simulate(INPUT, context);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const controller = new AbortController();
+    const sim2 = pool.simulate(INPUT, context, controller.signal);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    controller.abort();
+    await expect(sim2).rejects.toThrow(/aborted/);
+
+    blockedSim.resolve(RESULT);
+    await expect(sim1).resolves.toEqual(RESULT);
+  });
+
+  it('rejects queued checkouts when the pool is destroyed', async () => {
+    const blockedSim = promiseWithResolvers<Uint8Array>();
+    const pool = makePool(() => Promise.resolve(new FakeAvmService(() => blockedSim.promise)), { maxSize: 1 });
+
+    const sim1 = pool.simulate(INPUT, context);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const sim2 = pool.simulate(INPUT, context);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const destroyPromise = pool.destroy();
+    await expect(sim2).rejects.toThrow(/destroyed/);
+    blockedSim.resolve(RESULT);
+    await expect(sim1).resolves.toEqual(RESULT);
+    await destroyPromise;
+  });
+});

--- a/yarn-project/simulator/src/public/avm_simulator_pool.ts
+++ b/yarn-project/simulator/src/public/avm_simulator_pool.ts
@@ -1,5 +1,7 @@
 import { AvmService } from '@aztec/bb-avm-sim';
+import { AbortError } from '@aztec/foundation/error';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 
 import type { AvmContractsDBContext, AvmSimulator } from './avm_simulator.js';
 import { CdbIpcServer } from './cdb_ipc_server.js';
@@ -13,44 +15,106 @@ export interface AvmSimulatorPoolOptions {
   wsdbIpcPath: string;
   /** Optional logger function for AVM process output. */
   logger?: (msg: string) => void;
+  /**
+   * Flat delay between environmental spawn failures (default 1s). No backoff: sequencers live on
+   * ~6s slots, so sleeping longer than this after a failure costs whole blocks while the machine may
+   * have recovered — and a spawn attempt is cheap. Spawning never gives up on its own; the caller's
+   * deadline (abort signal) is the bound.
+   */
+  spawnRetryIntervalMs?: number;
+  /** Process spawner override. Test hook; defaults to spawning a real bb-avm-sim via the generated AvmService. */
+  spawnProcess?: (options: AvmProcessSpawnOptions) => Promise<AvmProcessHandle>;
+}
+
+/** Options handed to the process spawner for each new pool slot. */
+export interface AvmProcessSpawnOptions {
+  binaryPath?: string;
+  wsdbIpcPath: string;
+  cdbIpcPath: string;
+  logger?: (msg: string) => void;
 }
 
 /**
- * A raw handle to a single bb-avm-sim process: it runs a serialized simulation and connects back to the
+ * A handle to a single bb-avm-sim service: it runs serialized simulations and connects back to the
  * shared CDB/WSDB servers for state, but is unaware of which fork's contract data it is reading — that is
- * routed by the fork id baked into the input buffer.
+ * routed by the fork id baked into the input buffer. The underlying service owns its process lifecycle
+ * (including respawn-on-death), so a handle stays usable for the life of the pool.
  */
-interface AvmProcessHandle {
+export interface AvmProcessHandle {
   simulate(inputBuffer: Uint8Array, signal?: AbortSignal): Promise<Uint8Array>;
   simulateWithHints(inputBuffer: Uint8Array): Promise<Uint8Array>;
   destroy(): Promise<void>;
 }
 
 /**
- * The public-execution AVM backend: a lazily-grown pool of bb-avm-sim processes plus the CDB server that
+ * The generated service flags errors caused by the death of the underlying process (rather than by the
+ * request itself) with `retry: true`. That distinction is interpreted here and goes no further: process
+ * lifecycle is invisible to the pool's callers.
+ */
+function isProcessFailure(err: unknown): boolean {
+  return err instanceof Error && (err as Error & { retry?: unknown }).retry === true;
+}
+
+/** Sleep that wakes early (without throwing) when the signal aborts; callers re-check the signal. */
+async function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return sleep(ms);
+  }
+  let onAbort: () => void;
+  const aborted = new Promise<void>(resolve => {
+    onAbort = resolve;
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    await Promise.race([sleep(ms), aborted]);
+  } finally {
+    signal.removeEventListener('abort', onAbort!);
+  }
+}
+
+// After a cancellation is requested, how long the C++ process gets to cancel cooperatively (SIGUSR1
+// checkpoint) before it is SIGKILLed. Killing is safe: the service respawns its process lazily, so the
+// pool slot recovers instead of being leaked to a wedged simulation.
+const CANCEL_KILL_GRACE_MS = 5_000;
+
+/**
+ * The public-execution AVM backend: a lazily-grown pool of bb-avm-sim services plus the CDB server that
  * answers those processes' contract-data callbacks. Callers hold this as an {@link AvmSimulator}; the pool,
  * the CDB server, its IPC path, and fork-id routing are all hidden behind that interface. Each `simulate`
  * registers the call's contracts DB on the CDB server for the duration of the simulation (keyed by fork id
  * so concurrent simulations on different forks don't collide) and unregisters it once the call returns.
+ *
+ * Process lifecycle is invisible to callers, exactly as when the simulator ran in-process: a simulation
+ * either produces a result, fails on its own merits, or runs until the caller's deadline aborts it.
+ * Environmental trouble is absorbed here — spawn failures retry indefinitely on a backoff ladder (bounded
+ * only by the caller's abort signal), and a simulation whose process dies is re-issued on the respawned
+ * process. The one deliberate exception: an input that kills the process twice is treated as a failing
+ * transaction, so a simulator-crashing tx gets evicted instead of burning a process per block forever.
  */
 export class AvmSimulatorPool implements AvmSimulator {
-  private slots: Array<AvmProcessHandle | null> = [];
+  private slots: AvmProcessHandle[] = [];
   private available: number[] = [];
   private waiters: Array<{ resolve: (simulator: AvmProcessHandle) => void; reject: (error: Error) => void }> = [];
   private createdCount = 0;
+  private destroyed = false;
   private log: Logger;
   private maxSize: number;
   private cdbServer: CdbIpcServer;
+  private readonly spawnRetryIntervalMs: number;
+  private readonly spawnProcess: (options: AvmProcessSpawnOptions) => Promise<AvmProcessHandle>;
 
   constructor(private options: AvmSimulatorPoolOptions) {
     this.log = createLogger('simulator:avm-pool');
     this.maxSize = options.maxSize ?? parseInt(process.env.AVM_MAX_CONCURRENT_SIMULATIONS ?? '4', 10);
     this.cdbServer = new CdbIpcServer();
+    this.spawnRetryIntervalMs = options.spawnRetryIntervalMs ?? 1_000;
+    this.spawnProcess = options.spawnProcess ?? (spawnOptions => AvmSimulatorProcess.spawn(spawnOptions));
   }
 
   static async spawn(options: AvmSimulatorPoolOptions): Promise<AvmSimulatorPool> {
     const pool = new AvmSimulatorPool(options);
     // Always start one process up front so the first simulate() doesn't pay process spawn/connect cost.
+    // This is also where configuration errors (missing binary) surface, fast and fatally.
     await pool.prewarm();
     return pool;
   }
@@ -64,12 +128,7 @@ export class AvmSimulatorPool implements AvmSimulator {
     // and unregister once the simulation returns — registration is only needed while the call is running.
     this.cdbServer.registerFork(context.forkId, context.contractsDB, context.timestamp);
     try {
-      const simulator = await this.checkout();
-      try {
-        return await simulator.simulate(inputBuffer, signal);
-      } finally {
-        this.return(simulator);
-      }
+      return await this.runOnPool(simulator => simulator.simulate(inputBuffer, signal), signal);
     } finally {
       this.cdbServer.unregisterFork(context.forkId);
     }
@@ -77,28 +136,17 @@ export class AvmSimulatorPool implements AvmSimulator {
 
   async simulateWithHints(inputBuffer: Uint8Array): Promise<Uint8Array> {
     // The hinted path makes no contract-data callbacks, so no CDB registration is needed.
-    const simulator = await this.checkout();
-    try {
-      return await simulator.simulateWithHints(inputBuffer);
-    } finally {
-      this.return(simulator);
-    }
+    return await this.runOnPool(simulator => simulator.simulateWithHints(inputBuffer));
   }
 
-  /** Destroy all AVM processes in the pool and close the CDB server. */
+  /** Destroy all AVM services in the pool and close the CDB server. */
   async destroy(): Promise<void> {
-    for (const waiter of this.waiters) {
+    this.destroyed = true;
+    for (const waiter of this.waiters.splice(0)) {
       waiter.reject(new Error('AVM simulator pool destroyed'));
     }
-    this.waiters = [];
 
-    const destroyPromises: Promise<void>[] = [];
-    for (const slot of this.slots) {
-      if (slot) {
-        destroyPromises.push(slot.destroy());
-      }
-    }
-    await Promise.all(destroyPromises);
+    await Promise.all(this.slots.map(slot => slot.destroy()));
 
     this.slots = [];
     this.available = [];
@@ -115,31 +163,82 @@ export class AvmSimulatorPool implements AvmSimulator {
     const target = Math.min(count, this.maxSize);
     const created: AvmProcessHandle[] = [];
     while (this.createdCount < target) {
-      created.push(await this.createSlot());
+      created.push(await this.checkout());
     }
-    // Hand the freshly-spawned processes back to the pool so checkout() reuses them.
+    // Hand the checked-out processes back to the pool so checkout() reuses them.
     for (const simulator of created) {
       this.return(simulator);
     }
   }
 
-  /** Check out an AVM process from the pool, blocking until one is free. Caller must return() it when done. */
-  private async checkout(): Promise<AvmProcessHandle> {
+  /**
+   * Run a call on a pooled service. A call that fails because its process died is re-issued on the
+   * respawned process; a second death for the same input is attributed to the input and surfaces as an
+   * ordinary error (the pre-IPC equivalent — a native crash — took down the whole node, so a failed tx
+   * is strictly gentler). Non-process failures surface as-is: they are the simulation's own verdict.
+   */
+  private async runOnPool<T>(fn: (simulator: AvmProcessHandle) => Promise<T>, signal?: AbortSignal): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      const simulator = await this.checkout(signal);
+      try {
+        return await fn(simulator);
+      } catch (err) {
+        if (!isProcessFailure(err) || signal?.aborted) {
+          throw err;
+        }
+        if (attempt > 0) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            `AVM simulator process died twice running this simulation; attributing the failure to the input: ${message}`,
+            { cause: err },
+          );
+        }
+        this.log.warn(`AVM process died during simulation; re-issuing once on the respawned process`, { err });
+      } finally {
+        this.return(simulator);
+      }
+    }
+  }
+
+  /** Check out an AVM service from the pool, blocking until one is free. Caller must return() it when done. */
+  private async checkout(signal?: AbortSignal): Promise<AvmProcessHandle> {
+    if (this.destroyed) {
+      throw new Error('AVM simulator pool destroyed');
+    }
     const idx = this.available.pop();
-    if (idx !== undefined && this.slots[idx]) {
-      return this.slots[idx]!;
+    if (idx !== undefined) {
+      return this.slots[idx];
     }
 
-    if (this.createdCount < this.maxSize || (idx !== undefined && !this.slots[idx])) {
-      return await this.createSlot(idx);
+    if (this.createdCount < this.maxSize) {
+      return await this.createSlot(signal);
     }
 
     return new Promise<AvmProcessHandle>((resolve, reject) => {
-      this.waiters.push({ resolve, reject });
+      const waiter = { resolve, reject };
+      if (signal) {
+        const onAbort = () => {
+          const at = this.waiters.indexOf(waiter);
+          if (at >= 0) {
+            this.waiters.splice(at, 1);
+            reject(new AbortError('AVM checkout aborted'));
+          }
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+        waiter.resolve = simulator => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(simulator);
+        };
+        waiter.reject = err => {
+          signal.removeEventListener('abort', onAbort);
+          reject(err);
+        };
+      }
+      this.waiters.push(waiter);
     });
   }
 
-  /** Return an AVM process to the pool after use. */
+  /** Return an AVM service to the pool after use. */
   private return(simulator: AvmProcessHandle): void {
     const waiter = this.waiters.shift();
     if (waiter) {
@@ -152,59 +251,85 @@ export class AvmSimulatorPool implements AvmSimulator {
     }
   }
 
-  private async createSlot(reuseIdx?: number): Promise<AvmProcessHandle> {
-    const reuse = reuseIdx !== undefined && reuseIdx < this.slots.length;
+  private async createSlot(signal?: AbortSignal): Promise<AvmProcessHandle> {
     // Reserve the slot count synchronously, before the async spawn, so concurrent checkouts can't all
     // observe `createdCount < maxSize` and overshoot the pool (the count is only bumped once control has
-    // yielded on the await). Roll back the reservation if the spawn itself fails.
-    if (!reuse) {
-      this.createdCount++;
-    }
-    let simulator: AvmProcessHandle;
+    // yielded on the await). Roll back the reservation if the spawn is abandoned.
+    this.createdCount++;
     try {
-      simulator = await AvmSimulatorProcess.spawn({
-        binaryPath: this.options.avmBinaryPath,
-        wsdbIpcPath: this.options.wsdbIpcPath,
-        cdbIpcPath: this.cdbServer.ipcPath,
-        logger: this.options.logger,
-      });
+      const simulator = await this.spawnUntilUp(signal);
+      this.slots.push(simulator);
+      this.log.debug(`Created AVM pool slot (${this.createdCount}/${this.maxSize})`);
+      return simulator;
     } catch (err) {
-      if (!reuse) {
-        this.createdCount--;
-      }
+      this.createdCount--;
       throw err;
     }
-    if (reuse) {
-      this.slots[reuseIdx!] = simulator;
-    } else {
-      this.slots.push(simulator);
+  }
+
+  /**
+   * Spawn a service, retrying environmental failures on a flat cadence indefinitely — the bound is
+   * the caller's own deadline (abort signal), matching the pre-IPC contract where a simulation either
+   * completed or was deadlined out. The cadence is deliberately fast and constant: an attempt is cheap,
+   * a slow one self-paces inside the backend's connect backstop, and backing off would cost a
+   * ~6s-slot sequencer whole blocks after the machine has already recovered. Configuration errors
+   * (missing binary, flagged non-retryable by the generated service) throw immediately; the boot-time
+   * prewarm is where those are meant to surface.
+   */
+  private async spawnUntilUp(signal?: AbortSignal): Promise<AvmProcessHandle> {
+    for (let failures = 0; ; failures++) {
+      if (this.destroyed) {
+        throw new Error('AVM simulator pool destroyed');
+      }
+      if (signal?.aborted) {
+        throw new AbortError('AVM process spawn aborted');
+      }
+      try {
+        return await this.spawnProcess({
+          binaryPath: this.options.avmBinaryPath,
+          wsdbIpcPath: this.options.wsdbIpcPath,
+          cdbIpcPath: this.cdbServer.ipcPath,
+          logger: this.options.logger,
+        });
+      } catch (err) {
+        if (!isProcessFailure(err)) {
+          throw err;
+        }
+        this.log.warn(
+          `Failed to spawn AVM process (attempt ${failures + 1}); retrying in ${this.spawnRetryIntervalMs}ms`,
+          { err },
+        );
+        await abortableSleep(this.spawnRetryIntervalMs, signal);
+      }
     }
-    this.log.debug(`Created AVM pool slot (${this.createdCount}/${this.maxSize})`);
-    return simulator;
   }
 }
 
 class AvmSimulatorProcess implements AvmProcessHandle {
   private constructor(private service: AvmService) {}
 
-  static async spawn(options: {
-    binaryPath?: string;
-    wsdbIpcPath: string;
-    cdbIpcPath: string;
-    logger?: (msg: string) => void;
-  }): Promise<AvmSimulatorProcess> {
+  static async spawn(options: AvmProcessSpawnOptions): Promise<AvmSimulatorProcess> {
     const service = await AvmService.spawn({
       binaryPath: options.binaryPath,
       transport: 'uds',
       logger: options.logger,
       extraArgs: ['--wsdb', options.wsdbIpcPath, '--cdb', options.cdbIpcPath],
+      // Each simulation is self-contained (state comes from the WSDB/CDB servers, routed by fork id),
+      // so a fresh process can safely serve the next call after a death.
+      respawn: true,
     });
     return new AvmSimulatorProcess(service);
   }
 
   public async simulate(inputBuffer: Uint8Array, signal?: AbortSignal): Promise<Uint8Array> {
-    // Signal the C++ process to stop at its next cancellation checkpoint when the caller aborts.
-    const onAbort = () => this.service.sendProcessSignal('SIGUSR1');
+    let killTimer: NodeJS.Timeout | undefined;
+    // Cooperative cancellation first: SIGUSR1 makes the C++ process stop at its next cancellation
+    // checkpoint. If it doesn't respond within the grace (wedged in a slow op), SIGKILL it — the
+    // service respawns lazily, so this reclaims the pool slot rather than leaking it.
+    const onAbort = () => {
+      this.service.sendProcessSignal('SIGUSR1');
+      killTimer = setTimeout(() => this.service.sendProcessSignal('SIGKILL'), CANCEL_KILL_GRACE_MS);
+    };
     if (signal?.aborted) {
       onAbort();
     }
@@ -213,6 +338,9 @@ class AvmSimulatorProcess implements AvmProcessHandle {
       return (await this.service.simulate({ inputs: inputBuffer })).result;
     } finally {
       signal?.removeEventListener('abort', onAbort);
+      if (killTimer !== undefined) {
+        clearTimeout(killTimer);
+      }
     }
   }
 

--- a/yarn-project/world-state/src/native/ipc_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/ipc_world_state_instance.ts
@@ -370,7 +370,9 @@ export class IpcWorldState implements NativeWorldStateInstance {
 
   /**
    * Spawn an `aztec-wsdb` subprocess and return an IPC-backed world state wrapping it.
-   * Encapsulates wsdb binary discovery, service construction, and readiness wait.
+   * Encapsulates wsdb binary discovery, service construction, and connection. wsdb listens before it
+   * initializes its database, so spawn resolves as soon as the socket is up and the first calls block
+   * until initialization completes.
    */
   static async spawn(
     dataDir: string,


### PR DESCRIPTION
Hardens the spawn-and-connect path used by the generated IPC packages (`@aztec/wsdb`, `@aztec/bb-avm-sim`), and makes bb-avm-sim failures non-fatal to the prover. Reviewing this stack against the bb socket incident fixed in #24802 showed the specific shared-budget bug from that incident does not reproduce here, but the same failure *family* was present — in the connect path, and in how environmental failures were classified downstream.

## Commit 1 — connect reliability

**Servers listen before heavy init.** `aztec-wsdb` previously constructed its entire `WorldState` (LMDB open, genesis prefill) *before* `listen()`, and `bb-avm-sim` connected to its upstream wsdb/CDB servers before creating its own socket — so the client-side connect timeout was a bet on how fast a loaded machine can do real, unbounded work. Both servers now listen first: clients connect straight into the kernel accept backlog and first requests wait in the socket buffer until the reactor starts, so the connect backstop only ever covers exec + linking + reaching `listen()`. A server that dies during init surfaces its real exit cause instead of a spurious connect timeout. `bb-avm-sim` also installs its SIGUSR1 cancellation handler before the socket is reachable (the default disposition is process termination) and its lifecycle handlers — including parent-death monitoring — before the potentially-long upstream waits, whose budget goes from a hard-coded 5s to a 60s backstop.

**Client-side liveness-based connect.** The connect wait is raced against child death (a dead server fails immediately with its exit code/signal); the backstop (60s) is purely a broken-process detector and now **kills** the wedged child instead of orphaning it (an orphaned wsdb holds LMDB locks on its data dir, poisoning any respawn). Every spawn-failure path reaps the child, unlinks the ipc path, and points at the child's captured log. Hard connect errors (EACCES etc.) fail immediately instead of being retried until the deadline; `EAGAIN` (momentarily full accept backlog under simultaneous pool spawns) is retryable. `destroy()` escalates SIGTERM → SIGKILL after 5s.

One behavioural consequence: spawn resolving no longer implies the server finished initializing. All consumers issue their first call immediately after spawn and simply block until init completes; an init failure surfaces on that first call with the child's exit code and log path.

## Commits 2+3 — the backend owns process lifecycle; callers keep pre-IPC semantics

Previously a bb-avm-sim spawn failure or crash was fatal to the prover: the error was rewrapped into `SimulationError`, the tx reported failed, the checkpoint prover failed, and the session manager blocks that epoch until a prune replaces the failed prover — i.e. forever (`hasFailedProver`). The pool also never evicted dead processes, so one crash permanently poisoned a slot; and the sequencer drops failed txs from P2P, so environmental failures evicted innocent txs.

The design principle: **process lifecycle belongs to the layer that owns the process, and never appears above it.** Pre-IPC (in-process NAPI), callers could assume every failure was an actual tx failure, with the processor's deadline as the only environmental bound; that contract is preserved exactly.

- **ipc-runtime** gains `SpawnedProcessBackend`, extracted from the codegen template (which embedded ~200 lines of process machinery per generated package, untestable except through them). It owns spawn, connect, death detection, teardown — and opt-in **lazy respawn**: the next `call()` after a death transparently gets a fresh process (one shared respawn attempt, stable ipc path, lazy-only so a crashing binary can't respawn-loop unprompted). Errors are typed — `IpcTransportError`, `IpcProcessExitedError`, `IpcSpawnError` — and carry a `retry` flag distinguishing process death from configuration errors. Call failures that race the child's `exit` event (the socket breaks first) are attributed to the death after a short grace, so deaths are never misreported as bare transport errors.
- **Generated packages** shrink to binary resolution + backend config, plus a `respawn?: boolean` spawn option. The call surface gains nothing.
- **The AVM pool** spawns its services with `respawn: true` (each simulation is self-contained; state is routed via WSDB/CDB by fork id) and is the *only* interpreter of the backend's error flags. It absorbs environmental trouble outright: spawn failures retry indefinitely on a flat 1s cadence — no backoff: sequencers live on ~6s slots, so sleeping longer after a failure costs whole blocks while the machine may have recovered, and slow attempts self-pace inside the backend connect backstop, bounded by the **caller's own deadline** — the abort signal threads through checkout, the spawn-retry loop, and full-pool waits, all of which stop promptly on abort. For the sequencer that bound is the slot deadline (`execWithSignal`); for the prover, the epoch deadline — meaning a checkpoint prover riding out a load spike just waits (loudly logged) and the epoch fails only at its true deadline, rather than being permanently poisoned after a fixed budget. Configuration errors (missing binary) still fail fast, at the boot-time prewarm.
- **Poison-tx bound**: a simulation whose process dies is re-issued once on the respawned process; a second death for the same input is attributed to the input and surfaces as an ordinary failed tx — so a simulator-crashing tx is evicted from the mempool instead of burning a process per slot forever. (Pre-IPC, the same event killed the whole node.)
- **Guaranteed cancellation cleanup**: on deadline abort, SIGUSR1 asks the C++ process to cancel at its next checkpoint; if it doesn't respond within 5s, it is SIGKILLed. Killing is safe because the service respawns lazily — a wedged simulation can no longer leak a pool slot.
- **Upstream layers are untouched relative to pre-IPC**: no retry classification in the public tx simulator, public processor, or foundation. A simulation produces a result, fails on its own merits, or runs until deadlined out.

**wsdb deliberately keeps fail-fast semantics**: a respawned wsdb loses all forks, checkpoints, and uncommitted state, so clients holding forkIds would silently read wrong state; its death remains a node-level event, surfaced with typed cause and log path.

Deliberately out of scope: SHM readiness/call timeouts (shm has no readiness handshake; nothing deploys shm-wsdb today — it's exercised only by a parameterized world-state test).

## Tests

- `ipc-runtime`: unit tests for `SpawnedProcessBackend` against script-based fake servers — death → typed exit error, lazy respawn gets a fresh pid, missing binary flagged as configuration, dies-before-listen fails promptly with the exit code, wedged process killed at the backstop, destroy during a pending respawn leaks nothing.
- Echo `ts_package` reliability tests (run in ipc-codegen CI, uds + shm): slow-to-listen, dies-before-listen, wedged-then-killed (fails on the pre-#25073 code by construction), missing-binary classification, death-without-respawn, respawn-recreates-process.
- Simulator: 9 pool tests — indefinite flat-cadence spawn retry, abort stops the retry loop and full-pool waits, config errors propagate immediately, re-issue-once on process death, second death attributed to the input (no environmental flag escapes), destroy semantics. Public processor suite unchanged from pre-IPC semantics; full `public_tx_simulator` suite green.
- Verified end-to-end locally: `aztec-wsdb`/`bb-avm-sim` compile, a manual wsdb run shows `listening on` before `Creating WorldState` with a clean socket unlink on failed init, both generated packages rebuilt, full yarn-project TS build passes.

