### PR TITLE
feat(pxe): cache tag log queries bounded at the anchor block

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -38,7 +38,7 @@ import {
 import { NoteService } from '../../notes/note_service.js';
 import { assertAllowedScope } from '../../storage/allowed_scopes.js';
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
-import { syncSenderTaggingIndexes } from '../../tagging/index.js';
+import { logQueryAnchorOf, syncSenderTaggingIndexes } from '../../tagging/index.js';
 import type { ExecutionNoteCache } from '../execution_note_cache.js';
 import { ExecutionTaggingIndexCache } from '../execution_tagging_index_cache.js';
 import type { HashedValuesCache } from '../hashed_values_cache.js';
@@ -375,16 +375,16 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       // This is a tagging secret we've not yet used in this tx, so first sync our store to make sure its indices
       // are up to date. We do this here because this store is not synced as part of the global sync because
       // that'd be wasteful as most tagging secrets are not used in each tx.
-      const [{ finalized }, anchorBlockHash] = await Promise.all([
+      const [{ finalized }, anchor] = await Promise.all([
         this.l2TipsStore.getL2Tips(),
-        this.anchorBlockHeader.hash(),
+        logQueryAnchorOf(this.anchorBlockHeader),
       ]);
       await syncSenderTaggingIndexes(
         secret,
         this.aztecNode,
         this.senderTaggingStore,
         finalized.block.number,
-        anchorBlockHash,
+        anchor,
         this.jobId,
       );
 

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -482,6 +482,10 @@ describe('LogService', () => {
   });
 });
 
+// Tag queries are bounded at the anchor block, so the anchor has to sit above every `toBlock` these tests pass or
+// their forwarding assertions would see a clamped value.
+const ANCHOR_BLOCK_ABOVE_TEST_RANGES = BlockNumber(1000);
+
 async function createTestLogService(
   l2TipsProvider: MockProxy<L2TipsProvider> = mock<L2TipsProvider>(),
   scopes: AztecAddress[] = [],
@@ -491,9 +495,8 @@ async function createTestLogService(
   const taggingSecretSourcesStore = new TaggingSecretSourcesStore(await openTmpStore('test'));
   const addressStore = new AddressStore(await openTmpStore('test'));
   const aztecNode = mock<AztecNode>();
-  // Anchor block header is required for bulkRetrieveLogs. Queries are bounded at the anchor block, so it sits well
-  // above the block ranges the tests ask for, leaving those ranges to reach the node as written.
-  const anchorBlockHeader = makeBlockHeader(randomInt(1000), { blockNumber: BlockNumber(1000) });
+  // Anchor block header is required for bulkRetrieveLogs.
+  const anchorBlockHeader = makeBlockHeader(randomInt(1000), { blockNumber: ANCHOR_BLOCK_ABOVE_TEST_RANGES });
 
   const logService = new LogService(
     aztecNode,

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -491,8 +491,9 @@ async function createTestLogService(
   const taggingSecretSourcesStore = new TaggingSecretSourcesStore(await openTmpStore('test'));
   const addressStore = new AddressStore(await openTmpStore('test'));
   const aztecNode = mock<AztecNode>();
-  // Anchor block header is required for bulkRetrieveLogs.
-  const anchorBlockHeader = makeBlockHeader(randomInt(1000), { blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
+  // Anchor block header is required for bulkRetrieveLogs. Queries are bounded at the anchor block, so it sits well
+  // above the block ranges the tests ask for, leaving those ranges to reach the node as written.
+  const anchorBlockHeader = makeBlockHeader(randomInt(1000), { blockNumber: BlockNumber(1000) });
 
   const logService = new LogService(
     aztecNode,

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -4,7 +4,7 @@ import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { BlockHash, L2TipsProvider } from '@aztec/stdlib/block';
+import type { L2TipsProvider } from '@aztec/stdlib/block';
 import type { CompleteAddress } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import {
@@ -27,8 +27,10 @@ import { assertAllowedScope } from '../storage/allowed_scopes.js';
 import type { RecipientTaggingStore } from '../storage/tagging_store/recipient_tagging_store.js';
 import type { TaggingSecretSourcesStore } from '../storage/tagging_store/tagging_secret_sources_store.js';
 import {
+  type LogQueryAnchor,
   getAllPrivateLogsByTags,
   getAllPublicLogsByTagsFromContract,
+  logQueryAnchorOf,
   syncTaggedPrivateLogs,
 } from '../tagging/index.js';
 
@@ -69,11 +71,11 @@ export class LogService {
       return [];
     }
 
-    const anchorBlockHash = await this.anchorBlockHeader.hash();
+    const anchor = await logQueryAnchorOf(this.anchorBlockHeader);
 
     const [publicLogsPerRequest, privateLogsPerRequest] = await Promise.all([
-      this.#fetchPublicLogs(contractAddress, logRetrievalRequests, anchorBlockHash),
-      this.#fetchPrivateLogs(logRetrievalRequests, anchorBlockHash),
+      this.#fetchPublicLogs(contractAddress, logRetrievalRequests, anchor),
+      this.#fetchPrivateLogs(logRetrievalRequests, anchor),
     ]);
 
     return logRetrievalRequests.map((_request, i) => [
@@ -85,7 +87,7 @@ export class LogService {
   async #fetchPublicLogs(
     contractAddress: AztecAddress,
     requests: LogRetrievalRequest[],
-    anchorBlockHash: BlockHash,
+    anchor: LogQueryAnchor,
   ): Promise<LogResult[][]> {
     const indices = requests.flatMap((r, i) => (r.source !== LogSource.PRIVATE ? [i] : []));
     if (indices.length === 0) {
@@ -98,13 +100,11 @@ export class LogService {
     await Promise.all(
       Array.from(groups.values()).map(async group => {
         const tags = group.entries.map(e => e.request.tag);
-        const results = await getAllPublicLogsByTagsFromContract(
-          this.aztecNode,
-          contractAddress,
-          tags,
-          anchorBlockHash,
-          { fromBlock: group.fromBlock, toBlock: group.toBlock, includeEffects: true },
-        );
+        const results = await getAllPublicLogsByTagsFromContract(this.aztecNode, contractAddress, tags, anchor, {
+          fromBlock: group.fromBlock,
+          toBlock: group.toBlock,
+          includeEffects: true,
+        });
         group.entries.forEach((entry, i) => {
           resultsPerRequest[entry.index] = results[i];
         });
@@ -114,7 +114,7 @@ export class LogService {
     return resultsPerRequest;
   }
 
-  async #fetchPrivateLogs(requests: LogRetrievalRequest[], anchorBlockHash: BlockHash): Promise<LogResult[][]> {
+  async #fetchPrivateLogs(requests: LogRetrievalRequest[], anchor: LogQueryAnchor): Promise<LogResult[][]> {
     const indices = requests.flatMap((r, i) => (r.source !== LogSource.PUBLIC ? [i] : []));
     if (indices.length === 0) {
       return requests.map(() => []);
@@ -128,7 +128,7 @@ export class LogService {
         const siloedTags = await Promise.all(
           group.entries.map(e => SiloedTag.computeFromTagAndApp(e.request.tag, e.request.contractAddress)),
         );
-        const results = await getAllPrivateLogsByTags(this.aztecNode, siloedTags, anchorBlockHash, {
+        const results = await getAllPrivateLogsByTags(this.aztecNode, siloedTags, anchor, {
           fromBlock: group.fromBlock,
           toBlock: group.toBlock,
           includeEffects: true,

--- a/yarn-project/pxe/src/node/caching_aztec_node.test.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.test.ts
@@ -7,7 +7,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type BlockParameter, randomInBlock } from '@aztec/stdlib/block';
 import type { BlockResponse } from '@aztec/stdlib/interfaces/client';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { SiloedTag } from '@aztec/stdlib/logs';
+import { LogCursor, type PrivateLogsQuery, SiloedTag, Tag, randomLogResult } from '@aztec/stdlib/logs';
 import { AppendOnlyTreeSnapshot, MerkleTreeId, PublicDataWitness } from '@aztec/stdlib/trees';
 import { BlockHeader, type NodeStats } from '@aztec/stdlib/tx';
 
@@ -421,6 +421,100 @@ describe('withCache', () => {
     });
   });
 
+  describe('log queries by tag', () => {
+    it('caches a page per tag and only fetches the tags a later query has not seen', async () => {
+      const anchorHash = BlockHash.random();
+      const [tagA, tagB] = [new SiloedTag(Fr.random()), new SiloedTag(Fr.random())];
+      const logsForB = [randomLogResult()];
+      aztecNode.getPrivateLogsByTags.mockResolvedValueOnce([[]]).mockResolvedValueOnce([logsForB]);
+
+      // An empty page is an answer like any other: no log can appear in a range that is already closed.
+      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA]))).resolves.toEqual([[]]);
+      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
+        [],
+        logsForB,
+      ]);
+
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenLastCalledWith(pinnedLogsQuery(anchorHash, [tagB]));
+    });
+
+    it('keys each page of a paginated tag by its cursor', async () => {
+      const anchorHash = BlockHash.random();
+      const tag = new SiloedTag(Fr.random());
+      const firstPage = pinnedLogsQuery(anchorHash, [tag]);
+      const secondPage = { ...firstPage, tags: [{ tag, afterLog: LogCursor.random() }] };
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[randomLogResult()]]);
+
+      await cachedNode.getPrivateLogsByTags(firstPage);
+      await cachedNode.getPrivateLogsByTags(secondPage);
+      await cachedNode.getPrivateLogsByTags(firstPage);
+      await cachedNode.getPrivateLogsByTags(secondPage);
+
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps queries that ask for different data apart', async () => {
+      const anchorHash = BlockHash.random();
+      const tag = new SiloedTag(Fr.random());
+      const query = pinnedLogsQuery(anchorHash, [tag]);
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[randomLogResult()]]);
+
+      await cachedNode.getPrivateLogsByTags(query);
+      await cachedNode.getPrivateLogsByTags({ ...query, includeEffects: true });
+      await cachedNode.getPrivateLogsByTags({ ...query, fromBlock: BlockNumber(50) });
+
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(3);
+    });
+
+    it('keys public queries by the contract that emitted the logs', async () => {
+      const anchorHash = BlockHash.random();
+      const tag = new Tag(Fr.random());
+      const [contract, otherContract] = await Promise.all([AztecAddress.random(), AztecAddress.random()]);
+      const query = { ...pinnedLogsQuery(anchorHash, []), tags: [tag], contractAddress: contract };
+      aztecNode.getPublicLogsByTags.mockResolvedValue([[]]);
+
+      await cachedNode.getPublicLogsByTags(query);
+      await cachedNode.getPublicLogsByTags({ ...query, contractAddress: otherContract });
+      await cachedNode.getPublicLogsByTags(query);
+
+      expect(aztecNode.getPublicLogsByTags).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes queries that leave the block range open through to the node', async () => {
+      const tags = [new SiloedTag(Fr.random())];
+      const anchorOnly = { tags, referenceBlock: BlockHash.random() };
+      const boundOnly = { tags, toBlock: BlockNumber(101) };
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
+
+      // An anchor names the chain to answer on, and a bound with no anchor cannot detect a reorg. Neither on its own
+      // makes the answer a fact about blocks that can no longer change.
+      await cachedNode.getPrivateLogsByTags(anchorOnly);
+      await cachedNode.getPrivateLogsByTags(anchorOnly);
+      await cachedNode.getPrivateLogsByTags(boundOnly);
+      await cachedNode.getPrivateLogsByTags(boundOnly);
+
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(4);
+    });
+
+    it('rejects and evicts a batch whose response is shorter than the request', async () => {
+      const anchorHash = BlockHash.random();
+      const [tagA, tagB] = [new SiloedTag(Fr.random()), new SiloedTag(Fr.random())];
+      const logs = [randomLogResult()];
+      aztecNode.getPrivateLogsByTags.mockResolvedValueOnce([logs]).mockResolvedValueOnce([logs, []]);
+
+      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).rejects.toThrow(
+        'returned 1 results for 2 requested tags',
+      );
+      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
+        logs,
+        [],
+      ]);
+
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('uncached methods', () => {
     it('passes repeated reads through to the node', async () => {
       aztecNode.getBlockNumber.mockResolvedValue(BlockNumber(42));
@@ -429,16 +523,6 @@ describe('withCache', () => {
       await expect(cachedNode.getBlockNumber()).resolves.toBe(42);
 
       expect(aztecNode.getBlockNumber).toHaveBeenCalledTimes(2);
-    });
-
-    it('passes tag-addressed log queries through to the node', async () => {
-      const query = { tags: [new SiloedTag(Fr.random())] };
-      aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
-
-      await expect(cachedNode.getPrivateLogsByTags(query)).resolves.toEqual([[]]);
-      await expect(cachedNode.getPrivateLogsByTags(query)).resolves.toEqual([[]]);
-
-      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
     });
 
     it('binds passthrough methods to the node', async () => {
@@ -523,6 +607,14 @@ describe('withCache', () => {
     });
   });
 });
+
+/**
+ * A tag query pinned to an immutable block range: `referenceBlock` names the chain to answer on, and `toBlock` closes
+ * the range at the anchor block, so no later block can add to the answer.
+ */
+function pinnedLogsQuery(anchorHash: BlockHash, tags: SiloedTag[]): PrivateLogsQuery {
+  return { tags, referenceBlock: anchorHash, toBlock: BlockNumber(101) };
+}
 
 /** How many reads of each method `stats` saw, dropping the timings. */
 function callCounts(stats: NodeStats) {

--- a/yarn-project/pxe/src/node/caching_aztec_node.test.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.test.ts
@@ -429,20 +429,20 @@ describe('withCache', () => {
       aztecNode.getPrivateLogsByTags.mockResolvedValueOnce([[]]).mockResolvedValueOnce([logsForB]);
 
       // An empty page is an answer like any other: no log can appear in a range that is already closed.
-      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA]))).resolves.toEqual([[]]);
-      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
+      await expect(cachedNode.getPrivateLogsByTags(cacheableLogsQuery(anchorHash, [tagA]))).resolves.toEqual([[]]);
+      await expect(cachedNode.getPrivateLogsByTags(cacheableLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
         [],
         logsForB,
       ]);
 
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
-      expect(aztecNode.getPrivateLogsByTags).toHaveBeenLastCalledWith(pinnedLogsQuery(anchorHash, [tagB]));
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenLastCalledWith(cacheableLogsQuery(anchorHash, [tagB]));
     });
 
     it('keys each page of a paginated tag by its cursor', async () => {
       const anchorHash = BlockHash.random();
       const tag = new SiloedTag(Fr.random());
-      const firstPage = pinnedLogsQuery(anchorHash, [tag]);
+      const firstPage = cacheableLogsQuery(anchorHash, [tag]);
       const secondPage = { ...firstPage, tags: [{ tag, afterLog: LogCursor.random() }] };
       aztecNode.getPrivateLogsByTags.mockResolvedValue([[randomLogResult()]]);
 
@@ -457,7 +457,7 @@ describe('withCache', () => {
     it('keeps queries that ask for different data apart', async () => {
       const anchorHash = BlockHash.random();
       const tag = new SiloedTag(Fr.random());
-      const query = pinnedLogsQuery(anchorHash, [tag]);
+      const query = cacheableLogsQuery(anchorHash, [tag]);
       aztecNode.getPrivateLogsByTags.mockResolvedValue([[randomLogResult()]]);
 
       await cachedNode.getPrivateLogsByTags(query);
@@ -471,7 +471,7 @@ describe('withCache', () => {
       const anchorHash = BlockHash.random();
       const tag = new Tag(Fr.random());
       const [contract, otherContract] = await Promise.all([AztecAddress.random(), AztecAddress.random()]);
-      const query = { ...pinnedLogsQuery(anchorHash, []), tags: [tag], contractAddress: contract };
+      const query = { ...cacheableLogsQuery(anchorHash, []), tags: [tag], contractAddress: contract };
       aztecNode.getPublicLogsByTags.mockResolvedValue([[]]);
 
       await cachedNode.getPublicLogsByTags(query);
@@ -481,13 +481,13 @@ describe('withCache', () => {
       expect(aztecNode.getPublicLogsByTags).toHaveBeenCalledTimes(2);
     });
 
-    it('passes queries that leave the block range open through to the node', async () => {
+    it('passes queries whose answer can still change through to the node', async () => {
       const tags = [new SiloedTag(Fr.random())];
       const anchorOnly = { tags, referenceBlock: BlockHash.random() };
       const boundOnly = { tags, toBlock: BlockNumber(101) };
       aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
 
-      // Neither half of the pin is enough on its own, see `isBlockRangePinned`.
+      // Neither condition is enough on its own, see `hasImmutableAnswer`.
       await cachedNode.getPrivateLogsByTags(anchorOnly);
       await cachedNode.getPrivateLogsByTags(anchorOnly);
       await cachedNode.getPrivateLogsByTags(boundOnly);
@@ -502,11 +502,11 @@ describe('withCache', () => {
       const logs = [randomLogResult()];
       aztecNode.getPrivateLogsByTags.mockResolvedValueOnce([logs]).mockResolvedValueOnce([logs, []]);
 
-      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).rejects.toThrow(
+      await expect(cachedNode.getPrivateLogsByTags(cacheableLogsQuery(anchorHash, [tagA, tagB]))).rejects.toThrow(
         'returned 1 results for 2 requested tags',
       );
       // Nothing from the rejected batch is kept, so the identical query re-fetches and gets the full response.
-      await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
+      await expect(cachedNode.getPrivateLogsByTags(cacheableLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
         logs,
         [],
       ]);
@@ -515,11 +515,11 @@ describe('withCache', () => {
     });
 
     /**
-     * A tag query pinned to an immutable block range: `referenceBlock` names the chain to answer on, and `toBlock`
-     * closes the range at the anchor block, so no later block can add to the answer. The height itself is arbitrary,
-     * only naming one matters.
+     * A tag query whose answer can no longer change: `referenceBlock` names the chain to answer on, and `toBlock`
+     * stops it at the anchor block, so no later block can add to the answer. The height itself is arbitrary, only
+     * naming one matters.
      */
-    function pinnedLogsQuery(anchorHash: BlockHash, tags: SiloedTag[]): PrivateLogsQuery {
+    function cacheableLogsQuery(anchorHash: BlockHash, tags: SiloedTag[]): PrivateLogsQuery {
       return { tags, referenceBlock: anchorHash, toBlock: BlockNumber(101) };
     }
   });

--- a/yarn-project/pxe/src/node/caching_aztec_node.test.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.test.ts
@@ -487,8 +487,7 @@ describe('withCache', () => {
       const boundOnly = { tags, toBlock: BlockNumber(101) };
       aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
 
-      // An anchor names the chain to answer on, and a bound with no anchor cannot detect a reorg. Neither on its own
-      // makes the answer a fact about blocks that can no longer change.
+      // Neither half of the pin is enough on its own, see `isBlockRangePinned`.
       await cachedNode.getPrivateLogsByTags(anchorOnly);
       await cachedNode.getPrivateLogsByTags(anchorOnly);
       await cachedNode.getPrivateLogsByTags(boundOnly);
@@ -506,6 +505,7 @@ describe('withCache', () => {
       await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).rejects.toThrow(
         'returned 1 results for 2 requested tags',
       );
+      // Nothing from the rejected batch is kept, so the identical query re-fetches and gets the full response.
       await expect(cachedNode.getPrivateLogsByTags(pinnedLogsQuery(anchorHash, [tagA, tagB]))).resolves.toEqual([
         logs,
         [],
@@ -513,6 +513,15 @@ describe('withCache', () => {
 
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
     });
+
+    /**
+     * A tag query pinned to an immutable block range: `referenceBlock` names the chain to answer on, and `toBlock`
+     * closes the range at the anchor block, so no later block can add to the answer. The height itself is arbitrary,
+     * only naming one matters.
+     */
+    function pinnedLogsQuery(anchorHash: BlockHash, tags: SiloedTag[]): PrivateLogsQuery {
+      return { tags, referenceBlock: anchorHash, toBlock: BlockNumber(101) };
+    }
   });
 
   describe('uncached methods', () => {
@@ -607,14 +616,6 @@ describe('withCache', () => {
     });
   });
 });
-
-/**
- * A tag query pinned to an immutable block range: `referenceBlock` names the chain to answer on, and `toBlock` closes
- * the range at the anchor block, so no later block can add to the answer.
- */
-function pinnedLogsQuery(anchorHash: BlockHash, tags: SiloedTag[]): PrivateLogsQuery {
-  return { tags, referenceBlock: anchorHash, toBlock: BlockNumber(101) };
-}
 
 /** How many reads of each method `stats` saw, dropping the timings. */
 function callCounts(stats: NodeStats) {

--- a/yarn-project/pxe/src/node/caching_aztec_node.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.ts
@@ -32,8 +32,8 @@ export interface CachingAztecNode extends BenchmarkedAztecNode {
  * differently, and even an `undefined` witness or leaf index is kept as a non-membership fact. That makes the wrapper
  * safe for any consumer, whatever its anchor block. Uncached methods, and reads that name a block any other way (see
  * {@link hashReferenceOf}), pass straight through. A few entries below opt out even when hash-pinned, where the answer
- * can still change, and the tag queries opt in only once the request also closes the block range they cover (see
- * {@link isBlockRangePinned}).
+ * can still change, and the tag queries opt in only once the request also stops short of blocks yet to be produced
+ * (see {@link hasImmutableAnswer}).
  *
  * Wiping (see {@link CachingAztecNode.wipeCache}) bounds memory. Correctness does not depend on it.
  */
@@ -151,7 +151,7 @@ export function withCache(node: AztecNode): CachingAztecNode {
     },
 
     getPrivateLogsByTags: (query: PrivateLogsQuery) => {
-      if (!isBlockRangePinned(query)) {
+      if (!hasImmutableAnswer(query)) {
         return source.getPrivateLogsByTags(query);
       }
       const keyPrefix = `private-logs:${privateLogsQueryKey(query)}`;
@@ -164,7 +164,7 @@ export function withCache(node: AztecNode): CachingAztecNode {
     },
 
     getPublicLogsByTags: (query: PublicLogsQuery) => {
-      if (!isBlockRangePinned(query)) {
+      if (!hasImmutableAnswer(query)) {
         return source.getPublicLogsByTags(query);
       }
       const keyPrefix = `public-logs:${publicLogsQueryKey(query)}`;
@@ -329,15 +329,15 @@ function readBatchedPerKey<T>(
 }
 
 /**
- * Whether a tag query names a block range fixed enough to cache its answer.
+ * Whether a tag query's answer can no longer change, and so can be cached.
  *
- * Both ends have to be pinned. `referenceBlock` names the chain the answer belongs to and fails the call once that
- * block is gone, but it does not tell this wrapper which blocks the answer covers, so it cannot key a response by
- * them. An explicit `toBlock` closes the range in the request itself, making the response a fact about blocks that
- * can no longer change. PXE's tag queries get that bound from `getAllPrivateLogsByTags`, which derives it from the
- * anchor block they are already pinned to.
+ * Two things would let it change, and the query has to rule out both. `referenceBlock` names the chain the answer
+ * belongs to, so the call fails once that block is gone rather than answering from a chain that reorged. `toBlock`
+ * stops the query below the tip, so blocks yet to be produced cannot add logs to the answer. Where the query starts
+ * does not matter: an open lower end reaches only blocks that are already behind it, which no longer move. PXE's tag
+ * queries get both from the `getAll*LogsByTags` helpers, which take them from the anchor block the query is pinned to.
  */
-function isBlockRangePinned(query: LogsQueryBase): boolean {
+function hasImmutableAnswer(query: LogsQueryBase): boolean {
   return query.referenceBlock !== undefined && query.toBlock !== undefined;
 }
 

--- a/yarn-project/pxe/src/node/caching_aztec_node.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.ts
@@ -154,10 +154,10 @@ export function withCache(node: AztecNode): CachingAztecNode {
       if (!isBlockRangePinned(query)) {
         return source.getPrivateLogsByTags(query);
       }
-      const envelope = `private-logs:${logsQueryKey(query)}`;
+      const keyPrefix = `private-logs:${logsQueryKey(query)}`;
       return readBatchedPerKey<LogResult[]>(
         cache,
-        query.tags.map(tag => `${envelope}:${tagQueryKey(tag)}`),
+        query.tags.map(tag => `${keyPrefix}:${tagQueryKey(tag)}`),
         missing => source.getPrivateLogsByTags({ ...query, tags: missing.map(i => query.tags[i]) }),
         { method: 'getPrivateLogsByTags', requested: 'tags' },
       );
@@ -167,10 +167,10 @@ export function withCache(node: AztecNode): CachingAztecNode {
       if (!isBlockRangePinned(query)) {
         return source.getPublicLogsByTags(query);
       }
-      const envelope = `public-logs:${keyPart(query.contractAddress)}:${logsQueryKey(query)}`;
+      const keyPrefix = `public-logs:${keyPart(query.contractAddress)}:${logsQueryKey(query)}`;
       return readBatchedPerKey<LogResult[]>(
         cache,
-        query.tags.map(tag => `${envelope}:${tagQueryKey(tag)}`),
+        query.tags.map(tag => `${keyPrefix}:${tagQueryKey(tag)}`),
         missing => source.getPublicLogsByTags({ ...query, tags: missing.map(i => query.tags[i]) }),
         { method: 'getPublicLogsByTags', requested: 'tags' },
       );
@@ -332,11 +332,10 @@ function readBatchedPerKey<T>(
  * Whether a tag query names a block range fixed enough to cache its answer.
  *
  * Both ends have to be pinned. `referenceBlock` names the chain the answer belongs to and fails the call once that
- * block is gone, but on its own it leaves the top of the range at the chain tip: nothing in the query type promises
- * that an anchor also caps results, so a response kept on that basis would rest on node behavior outside our control.
- * An explicit `toBlock` closes the range in the request itself, making the response a fact about blocks that can no
- * longer change. PXE's tag queries get that bound from `getAllPrivateLogsByTags`, which derives it from the anchor
- * block they are already pinned to.
+ * block is gone, but it does not tell this wrapper which blocks the answer covers, so it cannot key a response by
+ * them. An explicit `toBlock` closes the range in the request itself, making the response a fact about blocks that
+ * can no longer change. PXE's tag queries get that bound from `getAllPrivateLogsByTags`, which derives it from the
+ * anchor block they are already pinned to.
  */
 function isBlockRangePinned(query: LogsQueryBase): boolean {
   return query.referenceBlock !== undefined && query.toBlock !== undefined;
@@ -344,9 +343,17 @@ function isBlockRangePinned(query: LogsQueryBase): boolean {
 
 /** Cache-key segment for the parts of a tag query that every tag in it shares. */
 function logsQueryKey(query: LogsQueryBase): string {
-  return [query.referenceBlock, query.fromBlock, query.toBlock, query.txHash, query.includeEffects, query.limitPerTag]
-    .map(keyPart)
-    .join(':');
+  // Total over the query type, so a field added to `LogsQueryBase` fails to compile here rather than
+  // silently being left out of the key and colliding with a query that differs only in it.
+  const parts: { [K in keyof Required<LogsQueryBase>]: unknown } = {
+    referenceBlock: query.referenceBlock,
+    fromBlock: query.fromBlock,
+    toBlock: query.toBlock,
+    txHash: query.txHash,
+    includeEffects: query.includeEffects,
+    limitPerTag: query.limitPerTag,
+  };
+  return Object.values(parts).map(keyPart).join(':');
 }
 
 /**

--- a/yarn-project/pxe/src/node/caching_aztec_node.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.ts
@@ -154,7 +154,7 @@ export function withCache(node: AztecNode): CachingAztecNode {
       if (!isBlockRangePinned(query)) {
         return source.getPrivateLogsByTags(query);
       }
-      const keyPrefix = `private-logs:${logsQueryKey(query)}`;
+      const keyPrefix = `private-logs:${privateLogsQueryKey(query)}`;
       return readBatchedPerKey<LogResult[]>(
         cache,
         query.tags.map(tag => `${keyPrefix}:${tagQueryKey(tag)}`),
@@ -167,7 +167,7 @@ export function withCache(node: AztecNode): CachingAztecNode {
       if (!isBlockRangePinned(query)) {
         return source.getPublicLogsByTags(query);
       }
-      const keyPrefix = `public-logs:${keyPart(query.contractAddress)}:${logsQueryKey(query)}`;
+      const keyPrefix = `public-logs:${publicLogsQueryKey(query)}`;
       return readBatchedPerKey<LogResult[]>(
         cache,
         query.tags.map(tag => `${keyPrefix}:${tagQueryKey(tag)}`),
@@ -341,11 +341,33 @@ function isBlockRangePinned(query: LogsQueryBase): boolean {
   return query.referenceBlock !== undefined && query.toBlock !== undefined;
 }
 
-/** Cache-key segment for the parts of a tag query that every tag in it shares. */
-function logsQueryKey(query: LogsQueryBase): string {
-  // Total over the query type, so a field added to `LogsQueryBase` fails to compile here rather than
-  // silently being left out of the key and colliding with a query that differs only in it.
-  const parts: { [K in keyof Required<LogsQueryBase>]: unknown } = {
+/** Cache-key segment for the parts of a private tag query that every tag in it shares. */
+function privateLogsQueryKey(query: PrivateLogsQuery): string {
+  const parts: QueryKeyParts<PrivateLogsQuery> = { ...sharedQueryKeyParts(query) };
+  return Object.values(parts).map(keyPart).join(':');
+}
+
+/** Cache-key segment for the parts of a public tag query that every tag in it shares. */
+function publicLogsQueryKey(query: PublicLogsQuery): string {
+  const parts: QueryKeyParts<PublicLogsQuery> = {
+    ...sharedQueryKeyParts(query),
+    contractAddress: query.contractAddress,
+  };
+  return Object.values(parts).map(keyPart).join(':');
+}
+
+/**
+ * The fields of a query that a key has to cover, which is all of them but `tags`: each tag is keyed on its own by
+ * {@link tagQueryKey}.
+ *
+ * The key builders are total over this type, so a field added to a query fails to compile there rather than silently
+ * being left out of the key and colliding with a query that differs only in it.
+ */
+type QueryKeyParts<T extends LogsQueryBase> = { [K in keyof Required<Omit<T, 'tags'>>]: unknown };
+
+/** The key parts {@link PrivateLogsQuery} and {@link PublicLogsQuery} have in common. */
+function sharedQueryKeyParts(query: LogsQueryBase): QueryKeyParts<LogsQueryBase> {
+  return {
     referenceBlock: query.referenceBlock,
     fromBlock: query.fromBlock,
     toBlock: query.toBlock,
@@ -353,7 +375,6 @@ function logsQueryKey(query: LogsQueryBase): string {
     includeEffects: query.includeEffects,
     limitPerTag: query.limitPerTag,
   };
-  return Object.values(parts).map(keyPart).join(':');
 }
 
 /**

--- a/yarn-project/pxe/src/node/caching_aztec_node.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.ts
@@ -3,6 +3,15 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type BlockParameter, type DataInBlock } from '@aztec/stdlib/block';
 import type { BlockIncludeOptions } from '@aztec/stdlib/interfaces/client';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import type {
+  LogResult,
+  LogsQueryBase,
+  PrivateLogsQuery,
+  PublicLogsQuery,
+  SiloedTag,
+  Tag,
+  TagQuery,
+} from '@aztec/stdlib/logs';
 import type { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import { type BenchmarkedAztecNode, withRecording } from './benchmarked_node.js';
@@ -23,7 +32,8 @@ export interface CachingAztecNode extends BenchmarkedAztecNode {
  * differently, and even an `undefined` witness or leaf index is kept as a non-membership fact. That makes the wrapper
  * safe for any consumer, whatever its anchor block. Uncached methods, and reads that name a block any other way (see
  * {@link hashReferenceOf}), pass straight through. A few entries below opt out even when hash-pinned, where the answer
- * can still change.
+ * can still change, and the tag queries opt in only once the request also closes the block range they cover (see
+ * {@link isBlockRangePinned}).
  *
  * Wiping (see {@link CachingAztecNode.wipeCache}) bounds memory. Correctness does not depend on it.
  */
@@ -127,36 +137,43 @@ export function withCache(node: AztecNode): CachingAztecNode {
       if (referenceHash === undefined) {
         return source.findLeavesIndexes(referenceBlock, treeId, leafValues);
       }
-      const keyOf = (leaf: Fr) => `leaf-index:${referenceHash.toString()}:${treeId}:${leaf.toString()}`;
-      const keys = leafValues.map(keyOf);
-      const cached = cache.peekAll<DataInBlock<bigint> | undefined>(keys);
-      // Held by cache key, so a leaf repeated in `leafValues` is asked of the node once and each of its positions
-      // reads the single entry that one request seeds.
-      const missingLeaves = new Map<string, Fr>(
-        leafValues.filter((_leaf, index) => cached[index] === undefined).map(leaf => [keyOf(leaf), leaf]),
+      return readBatchedPerKey<DataInBlock<bigint> | undefined>(
+        cache,
+        leafValues.map(leaf => `leaf-index:${referenceHash.toString()}:${treeId}:${leaf.toString()}`),
+        missing =>
+          source.findLeavesIndexes(
+            referenceBlock,
+            treeId,
+            missing.map(i => leafValues[i]),
+          ),
+        { method: 'findLeavesIndexes', requested: 'leaves' },
       );
-      const fetches = new Map<string, Promise<DataInBlock<bigint> | undefined>>();
-      if (missingLeaves.size > 0) {
-        const batch = source.findLeavesIndexes(referenceBlock, treeId, [...missingLeaves.values()]).then(fetched => {
-          if (fetched.length !== missingLeaves.size) {
-            // Each leaf's cache entry is filled from the batch response by position (fetched[batchIndex]). If the node
-            // returned fewer results than we asked for, the positions past the end would read undefined, and the cache
-            // keeps undefined as a genuine "leaf not in tree" answer, so a truncated response would be cached as fact.
-            // Rejecting the whole batch evicts those entries instead, so a retry re-fetches every leaf.
-            throw new Error(
-              `findLeavesIndexes returned ${fetched.length} results for ${missingLeaves.size} requested leaves`,
-            );
-          }
-          return fetched;
-        });
-        [...missingLeaves.keys()].forEach((key, batchIndex) => {
-          fetches.set(
-            key,
-            cache.fetch(key, () => batch.then(fetched => fetched[batchIndex])),
-          );
-        });
+    },
+
+    getPrivateLogsByTags: (query: PrivateLogsQuery) => {
+      if (!isBlockRangePinned(query)) {
+        return source.getPrivateLogsByTags(query);
       }
-      return Promise.all(keys.map((key, index) => cached[index] ?? fetches.get(key)));
+      const envelope = `private-logs:${logsQueryKey(query)}`;
+      return readBatchedPerKey<LogResult[]>(
+        cache,
+        query.tags.map(tag => `${envelope}:${tagQueryKey(tag)}`),
+        missing => source.getPrivateLogsByTags({ ...query, tags: missing.map(i => query.tags[i]) }),
+        { method: 'getPrivateLogsByTags', requested: 'tags' },
+      );
+    },
+
+    getPublicLogsByTags: (query: PublicLogsQuery) => {
+      if (!isBlockRangePinned(query)) {
+        return source.getPublicLogsByTags(query);
+      }
+      const envelope = `public-logs:${keyPart(query.contractAddress)}:${logsQueryKey(query)}`;
+      return readBatchedPerKey<LogResult[]>(
+        cache,
+        query.tags.map(tag => `${envelope}:${tagQueryKey(tag)}`),
+        missing => source.getPublicLogsByTags({ ...query, tags: missing.map(i => query.tags[i]) }),
+        { method: 'getPublicLogsByTags', requested: 'tags' },
+      );
     },
   };
 
@@ -256,6 +273,88 @@ function hashReferenceOf(block: BlockParameter | undefined): BlockHash | undefin
     return block.hash;
   }
   return undefined;
+}
+
+/**
+ * Answers one result per entry of `keys`, taking whatever the cache already holds and fetching the rest in a single
+ * batched call. Each fetched result is cached under its own key, so a later call that overlaps this one fetches only
+ * the entries it has not seen, and a key repeated within `keys` is asked of the node once.
+ *
+ * `fetchMissing` receives the indexes still missing, in order, and must answer one result per requested index.
+ * `shortResponse` names the method and what it requests, for the error raised when it does not.
+ */
+function readBatchedPerKey<T>(
+  cache: AztecNodeCache,
+  keys: string[],
+  fetchMissing: (missingIndexes: number[]) => Promise<T[]>,
+  shortResponse: { method: string; requested: string },
+): Promise<T[]> {
+  const cached = cache.peekAll<T>(keys);
+
+  // One request per missing key rather than per missing position, so a key repeated in `keys` seeds a single entry
+  // that every position carrying it then reads.
+  const requestIndexByKey = new Map<string, number>();
+  cached.forEach((result, index) => {
+    if (result === undefined && !requestIndexByKey.has(keys[index])) {
+      requestIndexByKey.set(keys[index], index);
+    }
+  });
+
+  const fetchedByKey = new Map<string, Promise<T>>();
+  if (requestIndexByKey.size > 0) {
+    const requestedIndexes = [...requestIndexByKey.values()];
+    const batch = fetchMissing(requestedIndexes).then(fetched => {
+      if (fetched.length !== requestedIndexes.length) {
+        // Each entry is filled from the batch response by position. If the node returned fewer results than we asked
+        // for, the positions past the end would read undefined, which the cache keeps as a genuine answer, so a
+        // truncated response would be cached as fact. Rejecting the whole batch evicts those entries instead, so a
+        // retry re-fetches every one of them.
+        throw new Error(
+          `${shortResponse.method} returned ${fetched.length} results for ${requestedIndexes.length} requested ` +
+            `${shortResponse.requested}`,
+        );
+      }
+      return fetched;
+    });
+    [...requestIndexByKey.keys()].forEach((key, batchIndex) => {
+      fetchedByKey.set(
+        key,
+        cache.fetch(key, () => batch.then(fetched => fetched[batchIndex])),
+      );
+    });
+  }
+
+  // Every position is answered: a cache hit, or the entry its key's request seeded just above.
+  return Promise.all(keys.map((key, index) => cached[index] ?? fetchedByKey.get(key)!));
+}
+
+/**
+ * Whether a tag query names a block range fixed enough to cache its answer.
+ *
+ * Both ends have to be pinned. `referenceBlock` names the chain the answer belongs to and fails the call once that
+ * block is gone, but on its own it leaves the top of the range at the chain tip: nothing in the query type promises
+ * that an anchor also caps results, so a response kept on that basis would rest on node behavior outside our control.
+ * An explicit `toBlock` closes the range in the request itself, making the response a fact about blocks that can no
+ * longer change. PXE's tag queries get that bound from `getAllPrivateLogsByTags`, which derives it from the anchor
+ * block they are already pinned to.
+ */
+function isBlockRangePinned(query: LogsQueryBase): boolean {
+  return query.referenceBlock !== undefined && query.toBlock !== undefined;
+}
+
+/** Cache-key segment for the parts of a tag query that every tag in it shares. */
+function logsQueryKey(query: LogsQueryBase): string {
+  return [query.referenceBlock, query.fromBlock, query.toBlock, query.txHash, query.includeEffects, query.limitPerTag]
+    .map(keyPart)
+    .join(':');
+}
+
+/**
+ * Cache-key segment for one tag entry, covering the pagination cursor as well as the tag: each page of a tag's stream
+ * is a read of its own, and a repeated query asks for the same pages in the same order.
+ */
+function tagQueryKey(entry: TagQuery<Tag | SiloedTag>): string {
+  return 'tag' in entry ? `${keyPart(entry.tag)}@${keyPart(entry.afterLog)}` : keyPart(entry);
 }
 
 /**

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -12,7 +12,7 @@ import { getAllPrivateLogsByTags } from './get_all_logs_by_tags.js';
 // We don't bother testing getAllPublicLogsByTagsFromContract because both of the functions are a simple wrapper around
 // the same per-tag pagination loop, so testing the private logs function is enough.
 
-const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
+const MOCK_ANCHOR = { hash: BlockHash.random(), number: BlockNumber(100) };
 
 /** Builds a log with a stable blockNumber/logIndexWithinTx so we can assert cursor wiring. */
 function makeLog({ blockNumber = 1, logIndexWithinTx = 0 }: { blockNumber?: number; logIndexWithinTx?: number } = {}) {
@@ -42,14 +42,14 @@ describe('getAllPrivateLogsByTags', () => {
   it('returns empty arrays when no logs found', async () => {
     aztecNode.getPrivateLogsByTags.mockResolvedValue(tags.map(() => []));
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR);
 
     expect(result).toEqual([[], [], []]);
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith({
       tags,
-      referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+      referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: undefined,
+      toBlock: BlockNumber(101),
       includeEffects: false,
     } satisfies PrivateLogsQuery);
   });
@@ -58,7 +58,7 @@ describe('getAllPrivateLogsByTags', () => {
     const logsPerTag = tags.map((_tag, i) => Array.from({ length: i + 1 }, () => makeLog()));
     aztecNode.getPrivateLogsByTags.mockResolvedValue(logsPerTag);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR);
 
     expect(result.map(logs => logs.length)).toEqual([1, 2, 3]);
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(1);
@@ -71,7 +71,7 @@ describe('getAllPrivateLogsByTags', () => {
 
     aztecNode.getPrivateLogsByTags.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR);
 
     expect(result.map(logs => logs.length)).toEqual([MAX_LOGS_PER_TAG + 5, 1, 0]);
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
@@ -79,18 +79,18 @@ describe('getAllPrivateLogsByTags', () => {
     // Round 1: all tags queried with bare tags
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(1, {
       tags,
-      referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+      referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: undefined,
+      toBlock: BlockNumber(101),
       includeEffects: false,
     });
 
     // Round 2: only tag[0] re-queried, with an afterLog cursor pointing at the last log of round 1
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, {
       tags: [{ tag: tags[0], afterLog: LogCursor.fromLog(lastLogOfFirstPage) }],
-      referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+      referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: undefined,
+      toBlock: BlockNumber(101),
       includeEffects: false,
     });
   });
@@ -98,7 +98,7 @@ describe('getAllPrivateLogsByTags', () => {
   it('handles empty tags array', async () => {
     aztecNode.getPrivateLogsByTags.mockResolvedValue([]);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, [], MOCK_ANCHOR_BLOCK_HASH);
+    const result = await getAllPrivateLogsByTags(aztecNode, [], MOCK_ANCHOR);
 
     expect(result).toEqual([]);
     expect(aztecNode.getPrivateLogsByTags).not.toHaveBeenCalled();
@@ -107,7 +107,7 @@ describe('getAllPrivateLogsByTags', () => {
   it('forwards options (fromBlock/toBlock/includeEffects/limitPerTag) to the node', async () => {
     aztecNode.getPrivateLogsByTags.mockResolvedValue(tags.map(() => []));
 
-    await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH, {
+    await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR, {
       fromBlock: BlockNumber(5),
       toBlock: BlockNumber(10),
       includeEffects: true,
@@ -116,12 +116,20 @@ describe('getAllPrivateLogsByTags', () => {
 
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith({
       tags,
-      referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+      referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: BlockNumber(5),
       toBlock: BlockNumber(10),
       includeEffects: true,
       limitPerTag: 3,
     });
+  });
+
+  it('narrows a toBlock that reaches past the anchor block', async () => {
+    aztecNode.getPrivateLogsByTags.mockResolvedValue(tags.map(() => []));
+
+    await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR, { toBlock: BlockNumber(500) });
+
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(expect.objectContaining({ toBlock: BlockNumber(101) }));
   });
 
   describe('batching when tags exceed MAX_RPC_LEN', () => {
@@ -139,7 +147,7 @@ describe('getAllPrivateLogsByTags', () => {
         return Promise.resolve(query.tags.map(() => [makeLog()]));
       });
 
-      const result = await getAllPrivateLogsByTags(aztecNode, manyTags, MOCK_ANCHOR_BLOCK_HASH);
+      const result = await getAllPrivateLogsByTags(aztecNode, manyTags, MOCK_ANCHOR);
 
       expect(result).toHaveLength(MAX_RPC_LEN + 50);
       expect(result.every(logs => logs.length === 1)).toBe(true);
@@ -148,16 +156,16 @@ describe('getAllPrivateLogsByTags', () => {
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(1, {
         tags: batch1Tags,
-        referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+        referenceBlock: MOCK_ANCHOR.hash,
         fromBlock: undefined,
-        toBlock: undefined,
+        toBlock: BlockNumber(101),
         includeEffects: false,
       });
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, {
         tags: batch2Tags,
-        referenceBlock: MOCK_ANCHOR_BLOCK_HASH,
+        referenceBlock: MOCK_ANCHOR.hash,
         fromBlock: undefined,
-        toBlock: undefined,
+        toBlock: BlockNumber(101),
         includeEffects: false,
       });
     });
@@ -184,7 +192,7 @@ describe('getAllPrivateLogsByTags', () => {
         return Promise.resolve(query.tags.map(() => [makeLog()]));
       });
 
-      const result = await getAllPrivateLogsByTags(aztecNode, manyTags, MOCK_ANCHOR_BLOCK_HASH);
+      const result = await getAllPrivateLogsByTags(aztecNode, manyTags, MOCK_ANCHOR);
 
       expect(result).toHaveLength(MAX_RPC_LEN + 50);
       // First tag in batch 1 got paginated: MAX_LOGS_PER_TAG + 3

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -14,6 +14,9 @@ import { getAllPrivateLogsByTags } from './get_all_logs_by_tags.js';
 
 const MOCK_ANCHOR = { hash: BlockHash.random(), number: BlockNumber(100) };
 
+/** The exclusive upper bound queries anchored at `MOCK_ANCHOR` are expected to carry: one block past its number. */
+const MOCK_ANCHOR_TO_BLOCK = BlockNumber(MOCK_ANCHOR.number + 1);
+
 /** Builds a log with a stable blockNumber/logIndexWithinTx so we can assert cursor wiring. */
 function makeLog({ blockNumber = 1, logIndexWithinTx = 0 }: { blockNumber?: number; logIndexWithinTx?: number } = {}) {
   return { ...randomLogResult(), blockNumber: BlockNumber(blockNumber), logIndexWithinTx };
@@ -49,7 +52,7 @@ describe('getAllPrivateLogsByTags', () => {
       tags,
       referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: BlockNumber(101),
+      toBlock: MOCK_ANCHOR_TO_BLOCK,
       includeEffects: false,
     } satisfies PrivateLogsQuery);
   });
@@ -81,7 +84,7 @@ describe('getAllPrivateLogsByTags', () => {
       tags,
       referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: BlockNumber(101),
+      toBlock: MOCK_ANCHOR_TO_BLOCK,
       includeEffects: false,
     });
 
@@ -90,7 +93,7 @@ describe('getAllPrivateLogsByTags', () => {
       tags: [{ tag: tags[0], afterLog: LogCursor.fromLog(lastLogOfFirstPage) }],
       referenceBlock: MOCK_ANCHOR.hash,
       fromBlock: undefined,
-      toBlock: BlockNumber(101),
+      toBlock: MOCK_ANCHOR_TO_BLOCK,
       includeEffects: false,
     });
   });
@@ -129,7 +132,9 @@ describe('getAllPrivateLogsByTags', () => {
 
     await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR, { toBlock: BlockNumber(500) });
 
-    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(expect.objectContaining({ toBlock: BlockNumber(101) }));
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(
+      expect.objectContaining({ toBlock: MOCK_ANCHOR_TO_BLOCK }),
+    );
   });
 
   describe('batching when tags exceed MAX_RPC_LEN', () => {
@@ -158,14 +163,14 @@ describe('getAllPrivateLogsByTags', () => {
         tags: batch1Tags,
         referenceBlock: MOCK_ANCHOR.hash,
         fromBlock: undefined,
-        toBlock: BlockNumber(101),
+        toBlock: MOCK_ANCHOR_TO_BLOCK,
         includeEffects: false,
       });
       expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, {
         tags: batch2Tags,
         referenceBlock: MOCK_ANCHOR.hash,
         fromBlock: undefined,
-        toBlock: BlockNumber(101),
+        toBlock: MOCK_ANCHOR_TO_BLOCK,
         includeEffects: false,
       });
     });

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -1,4 +1,4 @@
-import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { BlockHash } from '@aztec/stdlib/block';
 import { MAX_RPC_LEN } from '@aztec/stdlib/interfaces/api-limit';
@@ -11,6 +11,28 @@ import {
   queryAllPrivateLogsByTags,
   queryAllPublicLogsByTags,
 } from '@aztec/stdlib/logs';
+import type { BlockHeader } from '@aztec/stdlib/tx';
+
+/**
+ * The block a tag query is anchored to.
+ *
+ * `hash` names the chain the query must be answered on: the node throws if that block is gone, which is how a reorg
+ * surfaces. `number` is the height of that same block, and bounds the query to blocks at or below it.
+ *
+ * Both fields come from one header (see {@link logQueryAnchorOf}), which is what keeps the bound and the reorg check
+ * talking about the same block.
+ */
+export type LogQueryAnchor = {
+  /** Hash of the anchor block. */
+  hash: BlockHash;
+  /** Height of the anchor block. */
+  number: BlockNumber;
+};
+
+/** Anchors tag queries to `anchorBlockHeader`, hashing it once for all the queries that share the anchor. */
+export async function logQueryAnchorOf(anchorBlockHeader: BlockHeader): Promise<LogQueryAnchor> {
+  return { hash: await anchorBlockHeader.hash(), number: anchorBlockHeader.getBlockNumber() };
+}
 
 /** Optional block-range, effects opt-in, and pagination cap shared by both wrappers. */
 export type GetAllLogsByTagsOptions = {
@@ -57,19 +79,32 @@ async function getAllPagesInBatches<T extends Tag | SiloedTag, Opts extends LogI
 }
 
 /**
+ * Exclusive upper block bound for a query anchored at `anchor`: one past the anchor block, or the caller's own
+ * `toBlock` when that is tighter.
+ *
+ * Anchored queries are bounded here instead of leaving the bound implicit in `referenceBlock`, so that the request
+ * itself names a fixed block range. That is what lets the node read cache keep a response: a range derived from a
+ * block the caller has already synced to cannot widen later, whatever the chain does next.
+ */
+function exclusiveUpperBound(anchor: LogQueryAnchor, toBlock: BlockNumber | undefined): BlockNumber {
+  const anchorBound = BlockNumber(anchor.number + 1);
+  return toBlock === undefined ? anchorBound : BlockNumber(Math.min(toBlock, anchorBound));
+}
+
+/**
  * Fetches all private logs for the given tags, automatically paginating per-tag via `afterLog` cursors.
  *
  * @param aztecNode - The Aztec node to query.
  * @param tags - The siloed tags to search for.
- * @param anchorBlockHash - Reference block for the Aztec node query, throws if block is not found there (typically
- *   because of reorgs).
+ * @param anchor - Block the query is anchored to: results stop there, and the call throws if that block is not found
+ *   (typically because of reorgs).
  * @param options - Optional `fromBlock`/`toBlock` range and `includeEffects` opt-in.
  * @returns An array of log arrays, one per tag, containing all logs across all pages.
  */
 export function getAllPrivateLogsByTags<Opts extends GetAllLogsByTagsOptions = GetAllLogsByTagsOptions>(
   aztecNode: AztecNode,
   tags: SiloedTag[],
-  anchorBlockHash: BlockHash,
+  anchor: LogQueryAnchor,
   options: Opts = {} as Opts,
 ): Promise<LogResult<Opts>[][]> {
   return getAllPagesInBatches<SiloedTag, Opts>(
@@ -77,9 +112,9 @@ export function getAllPrivateLogsByTags<Opts extends GetAllLogsByTagsOptions = G
     batch =>
       queryAllPrivateLogsByTags(aztecNode, {
         tags: batch,
-        referenceBlock: anchorBlockHash,
+        referenceBlock: anchor.hash,
         fromBlock: options.fromBlock,
-        toBlock: options.toBlock,
+        toBlock: exclusiveUpperBound(anchor, options.toBlock),
         includeEffects: options.includeEffects ?? false,
         limitPerTag: options.limitPerTag,
       }) as Promise<LogResult<Opts>[][]>,
@@ -92,8 +127,8 @@ export function getAllPrivateLogsByTags<Opts extends GetAllLogsByTagsOptions = G
  * @param aztecNode - The Aztec node to query.
  * @param contractAddress - The contract address to search logs for.
  * @param tags - The tags to search for.
- * @param anchorBlockHash - Reference block for the Aztec node query, throws if block is not found there (typically
- *   because of reorgs).
+ * @param anchor - Block the query is anchored to: results stop there, and the call throws if that block is not found
+ *   (typically because of reorgs).
  * @param options - Optional `fromBlock`/`toBlock` range and `includeEffects` opt-in.
  * @returns An array of log arrays, one per tag, containing all logs across all pages.
  */
@@ -101,7 +136,7 @@ export function getAllPublicLogsByTagsFromContract<Opts extends GetAllLogsByTags
   aztecNode: AztecNode,
   contractAddress: AztecAddress,
   tags: Tag[],
-  anchorBlockHash: BlockHash,
+  anchor: LogQueryAnchor,
   options: Opts = {} as Opts,
 ): Promise<LogResult<Opts>[][]> {
   return getAllPagesInBatches<Tag, Opts>(
@@ -110,9 +145,9 @@ export function getAllPublicLogsByTagsFromContract<Opts extends GetAllLogsByTags
       queryAllPublicLogsByTags(aztecNode, {
         contractAddress,
         tags: batch,
-        referenceBlock: anchorBlockHash,
+        referenceBlock: anchor.hash,
         fromBlock: options.fromBlock,
-        toBlock: options.toBlock,
+        toBlock: exclusiveUpperBound(anchor, options.toBlock),
         includeEffects: options.includeEffects ?? false,
         limitPerTag: options.limitPerTag,
       }) as Promise<LogResult<Opts>[][]>,

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -16,20 +16,23 @@ import type { BlockHeader } from '@aztec/stdlib/tx';
 /**
  * The block a tag query is anchored to.
  *
- * `hash` names the chain the query must be answered on: the node throws if that block is gone, which is how a reorg
- * surfaces. `number` is the height of that same block, and bounds the query to blocks at or below it.
- *
  * Both fields come from one header (see {@link logQueryAnchorOf}), which is what keeps the bound and the reorg check
  * talking about the same block.
  */
 export type LogQueryAnchor = {
-  /** Hash of the anchor block. */
+  /**
+   * Hash of the anchor block, naming the chain the query must be answered on: the node throws if that block is gone,
+   * which is how a reorg surfaces.
+   */
   hash: BlockHash;
-  /** Height of the anchor block. */
+  /** Height of the anchor block, bounding the query to blocks at or below it. */
   number: BlockNumber;
 };
 
-/** Anchors tag queries to `anchorBlockHeader`, hashing it once for all the queries that share the anchor. */
+/**
+ * The {@link LogQueryAnchor} naming `anchorBlockHeader`: its hash and its height. Callers build it once and reuse
+ * it across every query anchored to that block, so the header is hashed only once.
+ */
 export async function logQueryAnchorOf(anchorBlockHeader: BlockHeader): Promise<LogQueryAnchor> {
   return { hash: await anchorBlockHeader.hash(), number: anchorBlockHeader.getBlockNumber() };
 }
@@ -76,19 +79,6 @@ async function getAllPagesInBatches<T extends Tag | SiloedTag, Opts extends LogI
   }
   const batchResults = await Promise.all(batches.map(fetchAllPagesForBatch));
   return batchResults.flat();
-}
-
-/**
- * Exclusive upper block bound for a query anchored at `anchor`: one past the anchor block, or the caller's own
- * `toBlock` when that is tighter.
- *
- * Anchored queries are bounded here instead of leaving the bound implicit in `referenceBlock`, so that the request
- * itself names a fixed block range. That is what lets the node read cache keep a response: a range derived from a
- * block the caller has already synced to cannot widen later, whatever the chain does next.
- */
-function exclusiveUpperBound(anchor: LogQueryAnchor, toBlock: BlockNumber | undefined): BlockNumber {
-  const anchorBound = BlockNumber(anchor.number + 1);
-  return toBlock === undefined ? anchorBound : BlockNumber(Math.min(toBlock, anchorBound));
 }
 
 /**
@@ -152,4 +142,15 @@ export function getAllPublicLogsByTagsFromContract<Opts extends GetAllLogsByTags
         limitPerTag: options.limitPerTag,
       }) as Promise<LogResult<Opts>[][]>,
   );
+}
+
+/**
+ * Exclusive upper block bound for a query anchored at `anchor`: one past the anchor block, or the caller's own
+ * `toBlock` when that is tighter.
+ *
+ * The bound is spelled out in the request rather than left implicit in `referenceBlock`, so the request itself
+ * names a fixed block range that no later block can widen.
+ */
+function exclusiveUpperBound(anchor: LogQueryAnchor, toBlock: BlockNumber | undefined): BlockNumber {
+  return BlockNumber(Math.min(toBlock ?? Infinity, anchor.number + 1));
 }

--- a/yarn-project/pxe/src/tagging/index.ts
+++ b/yarn-project/pxe/src/tagging/index.ts
@@ -13,7 +13,12 @@ export { syncTaggedPrivateLogs } from './recipient_sync/sync_tagged_private_logs
 export { syncSenderTaggingIndexes } from './sender_sync/sync_sender_tagging_indexes.js';
 export { persistSenderTaggingIndexRangesForTx } from './persist_sender_tagging_index_ranges.js';
 export { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN, INITIAL_CONSTRAINED_PROBE_LEN } from './constants.js';
-export { getAllPrivateLogsByTags, getAllPublicLogsByTagsFromContract } from './get_all_logs_by_tags.js';
+export {
+  type LogQueryAnchor,
+  getAllPrivateLogsByTags,
+  getAllPublicLogsByTagsFromContract,
+  logQueryAnchorOf,
+} from './get_all_logs_by_tags.js';
 
 // Re-export tagging-related types from stdlib
 export { AppTaggingSecret, Tag, SiloedTag } from '@aztec/stdlib/logs';

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
@@ -1,6 +1,5 @@
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { isDefined } from '@aztec/foundation/types';
-import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { AppTaggingSecret, LogResult } from '@aztec/stdlib/logs';
 import { AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
@@ -12,7 +11,7 @@ import {
   UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN,
   unfinalizedTaggingIndexesWindowEnd,
 } from '../constants.js';
-import { getAllPrivateLogsByTags } from '../get_all_logs_by_tags.js';
+import { type LogQueryAnchor, getAllPrivateLogsByTags, logQueryAnchorOf } from '../get_all_logs_by_tags.js';
 import { findHighestIndexes } from './utils/find_highest_indexes.js';
 
 /**
@@ -94,8 +93,7 @@ export async function syncTaggedPrivateLogs(
     return [];
   }
 
-  const anchorBlockNumber = anchorBlockHeader.getBlockNumber();
-  const anchorBlockHash = await anchorBlockHeader.hash();
+  const anchor = await logQueryAnchorOf(anchorBlockHeader);
   const currentTimestamp = anchorBlockHeader.globalVariables.timestamp;
 
   // Read stored indexes from the db and compute the initial [start, end) range for each secret
@@ -104,7 +102,7 @@ export async function syncTaggedPrivateLogs(
 
   while (pending.length > 0) {
     // Compute tags for all pending secrets and fetch logs in batched RPC calls
-    const logsPerSecret = await fetchLogsForSecrets(pending, aztecNode, anchorBlockNumber, anchorBlockHash);
+    const logsPerSecret = await fetchLogsForSecrets(pending, aztecNode, anchor);
 
     const nextRound = await Promise.all(
       pending.map(async (pendingSecret, i) => {
@@ -185,8 +183,7 @@ function getIndexRangesForSecrets(
 async function fetchLogsForSecrets(
   pending: PendingSecret[],
   aztecNode: AztecNode,
-  anchorBlockNumber: BlockNumber,
-  anchorBlockHash: BlockHash,
+  anchor: LogQueryAnchor,
 ): Promise<LogWithIndex[][]> {
   // Determine the index range for each secret
   const indexesPerSecret = pending.map(({ start, end }) => Array.from({ length: end - start }, (_, i) => start + i));
@@ -200,14 +197,10 @@ async function fetchLogsForSecrets(
 
   const allTags = tagsPerSecret.flat();
 
-  // getAllPrivateLogsByTags handles MAX_RPC_LEN chunking internally. Recipient sync builds `PendingTaggedLog` from
-  // each log's note hashes and first nullifier, so we opt into effects. The `toBlock` cap (anchor block + 1,
-  // exclusive) tells the node to skip any logs in blocks past the anchor — the same guard previously enforced
-  // by an in-memory filter on the response.
-  const allResults = await getAllPrivateLogsByTags(aztecNode, allTags, anchorBlockHash, {
-    includeEffects: true,
-    toBlock: BlockNumber(anchorBlockNumber + 1),
-  });
+  // getAllPrivateLogsByTags handles MAX_RPC_LEN chunking internally, and bounds the query at the anchor block so
+  // logs from later blocks are never returned. Recipient sync builds `PendingTaggedLog` from each log's note hashes
+  // and first nullifier, so we opt into effects.
+  const allResults = await getAllPrivateLogsByTags(aztecNode, allTags, anchor, { includeEffects: true });
 
   // Split flat results back per secret using the known lengths
   const logsPerSecret: LogWithIndex[][] = [];

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -16,7 +16,7 @@ import { computeSiloedTagForIndex, extractTags } from '../testing/tag_query_test
 import { syncSenderTaggingIndexes } from './sync_sender_tagging_indexes.js';
 import { minedReceipt } from './utils/test_utils.js';
 
-const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
+const MOCK_ANCHOR = { hash: BlockHash.random(), number: BlockNumber(100) };
 // The finalized tip the tests sync against, and log block numbers on either side of it.
 const MOCK_FINALIZED_BLOCK_NUMBER = BlockNumber(15);
 const FINALIZED_LOG_BLOCK = MOCK_FINALIZED_BLOCK_NUMBER - 1;
@@ -510,6 +510,6 @@ describe('syncSenderTaggingIndexes', () => {
   }
 
   function sync({ finalizedAt = MOCK_FINALIZED_BLOCK_NUMBER }: { finalizedAt?: BlockNumber } = {}) {
-    return syncSenderTaggingIndexes(secret, aztecNode, taggingStore, finalizedAt, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    return syncSenderTaggingIndexes(secret, aztecNode, taggingStore, finalizedAt, MOCK_ANCHOR, 'test');
   }
 });

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
@@ -1,10 +1,10 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
-import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { AppTaggingSecret } from '@aztec/stdlib/logs';
 
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import { unfinalizedTaggingIndexesWindowEnd } from '../constants.js';
+import type { LogQueryAnchor } from '../get_all_logs_by_tags.js';
 import { loadAndStoreNewTaggingIndexes } from './utils/load_and_store_new_tagging_indexes.js';
 import { resolvePendingTxs } from './utils/resolve_pending_txs.js';
 
@@ -25,7 +25,7 @@ export async function syncSenderTaggingIndexes(
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
   finalizedBlockNumber: BlockNumber,
-  anchorBlockHash: BlockHash,
+  anchor: LogQueryAnchor,
   jobId: string,
 ): Promise<void> {
   // # Explanation of how syncing works
@@ -58,15 +58,7 @@ export async function syncSenderTaggingIndexes(
   let newFinalizedIndex = undefined;
 
   while (true) {
-    const txsInLogs = await loadAndStoreNewTaggingIndexes(
-      secret,
-      start,
-      end,
-      aztecNode,
-      taggingStore,
-      anchorBlockHash,
-      jobId,
-    );
+    const txsInLogs = await loadAndStoreNewTaggingIndexes(secret, start, end, aztecNode, taggingStore, anchor, jobId);
 
     // Pending txs for this window: prior syncs, txs this PXE itself sent, and what the logs just stored.
     const pendingTxs = await taggingStore.getPendingTxs(secret, start, end, jobId);

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
@@ -17,7 +18,7 @@ import type { SenderTaggingStore } from '../../../storage/tagging_store/sender_t
 import { computeSiloedTagForIndex, extractTags } from '../../testing/tag_query_test_utils.js';
 import { loadAndStoreNewTaggingIndexes } from './load_and_store_new_tagging_indexes.js';
 
-const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
+const MOCK_ANCHOR = { hash: BlockHash.random(), number: BlockNumber(100) };
 
 describe('loadAndStoreNewTaggingIndexes', () => {
   let secret: AppTaggingSecret;
@@ -43,7 +44,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       return Promise.resolve(tags.map(() => []));
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).not.toHaveBeenCalled();
   });
@@ -58,7 +59,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       return Promise.resolve(tags.map((t: SiloedTag) => (t.equals(tag) ? [makeLog(txHash, tag.value)] : [])));
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(1);
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledWith(
@@ -89,7 +90,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(1);
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledWith(
@@ -121,7 +122,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(2);
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledWith(
@@ -150,7 +151,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(2);
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledWith(
@@ -202,7 +203,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(3);
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledWith(
@@ -246,7 +247,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, start, end, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, start, end, aztecNode, taggingStore, MOCK_ANCHOR, 'test');
 
     // Only the log at start should be stored; end is exclusive
     expect(taggingStore.mergePendingIndexes).toHaveBeenCalledTimes(1);

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -1,11 +1,10 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
-import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type AppTaggingSecret, type LogResult, SiloedTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import type { SenderTaggingStore } from '../../../storage/tagging_store/sender_tagging_store.js';
-import { getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
+import { type LogQueryAnchor, getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
 
 /**
  * Loads tagging indexes from the Aztec node and stores them in the tagging data provider. Returns the txs the
@@ -18,7 +17,7 @@ import { getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
  * @param end - The ending index (exclusive) of the window to process.
  * @param aztecNode - The Aztec node instance to query for logs.
  * @param taggingStore - The data provider to store pending indexes.
- * @param anchorBlockHash - Hash of a block to use as reference block when querying node.
+ * @param anchor - Block the log query is anchored to.
  * @param jobId - Job identifier, used to keep writes in-memory until they can be persisted in a data integrity
  * preserving way.
  */
@@ -28,7 +27,7 @@ export async function loadAndStoreNewTaggingIndexes(
   end: number,
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
-  anchorBlockHash: BlockHash,
+  anchor: LogQueryAnchor,
   jobId: string,
 ): Promise<Map<string, TxInLogs>> {
   // We compute the tags for the current window of indexes
@@ -36,7 +35,7 @@ export async function loadAndStoreNewTaggingIndexes(
     Array.from({ length: end - start }, (_, i) => SiloedTag.compute({ extendedSecret, index: start + i })),
   );
 
-  const allLogs = await getAllPrivateLogsByTags(aztecNode, siloedTagsForWindow, anchorBlockHash);
+  const allLogs = await getAllPrivateLogsByTags(aztecNode, siloedTagsForWindow, anchor);
   if (allLogs.length !== siloedTagsForWindow.length) {
     throw new Error(
       `Number of log arrays does not match number of tags. ${allLogs.length} !== ${siloedTagsForWindow.length}`,

--- a/yarn-project/stdlib/src/logs/logs_query.ts
+++ b/yarn-project/stdlib/src/logs/logs_query.ts
@@ -33,11 +33,8 @@ export type LogsQueryBase = {
    */
   txHash?: TxHash;
   /**
-   * Reorg-safety anchor: the latest block hash the caller has synced to. If set and the block is no
-   * longer present, the call throws. Results are also capped at the anchor block, which `toBlock` can
-   * narrow further but not widen. A caller that depends on that bound is better off stating it as a
-   * `toBlock` of its own, so the range it covers is fixed by the request rather than by the node it
-   * happens to be talking to.
+   * Reorg-safety anchor: the latest block hash the caller has synced to. The call throws if that block is no longer
+   * present. Results are capped at that block, and `toBlock` can only narrow the range further, never past it.
    */
   referenceBlock?: BlockHash;
   /** When set, each log also carries `noteHashes` and all `nullifiers` for note-nonce discovery. */

--- a/yarn-project/stdlib/src/logs/logs_query.ts
+++ b/yarn-project/stdlib/src/logs/logs_query.ts
@@ -34,7 +34,10 @@ export type LogsQueryBase = {
   txHash?: TxHash;
   /**
    * Reorg-safety anchor: the latest block hash the caller has synced to. If set and the block is no
-   * longer present, the call throws. Distinct from `toBlock`, which is a filter, not a safety check.
+   * longer present, the call throws. Results are also capped at the anchor block, which `toBlock` can
+   * narrow further but not widen. A caller that depends on that bound is better off stating it as a
+   * `toBlock` of its own, so the range it covers is fixed by the request rather than by the node it
+   * happens to be talking to.
    */
   referenceBlock?: BlockHash;
   /** When set, each log also carries `noteHashes` and all `nullifiers` for note-nonce discovery. */


### PR DESCRIPTION
## Motivation

Tag log queries are the largest single source of node round trips PXE makes, about a quarter of them in the `key_flows` transfers benchmark, and the one read family the anchor-scoped cache from #24969 had to skip. A tag query pins only the chain it is answered on (`referenceBlock`) and leaves the top of its range at the tip, so two identical-looking calls can correctly return different results.

## The change

The tag query wrappers now take a `LogQueryAnchor` (the anchor block's hash and number) and send an exclusive `toBlock` one past it, so the request names its own fixed range instead of relying on the node to treat the reference block as a cap. With both ends pinned the read cache keeps the answers, keyed per tag and per pagination cursor, so an overlapping query fetches only the tags it has not seen. Reorg behavior is unchanged.

On the transfers benchmark: 1.5% fewer node calls, 2.4% fewer round trips. What dedupes is repeated simulation of the same transaction, not the scans themselves, so the win scales with re-simulation rather than tag volume.
