### PR TITLE
refactor(pxe): serve note and event validation from cached tx data

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -26,6 +26,7 @@ import {
   type ContractInstanceWithAddress,
   computeContractAddressFromInstance,
 } from '@aztec/stdlib/contract';
+import { computeUniqueNoteHash, siloNoteHash } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
@@ -67,6 +68,8 @@ import { EphemeralArrayService } from '../ephemeral_array_service.js';
 import { BoundedVec } from '../noir-structs/bounded_vec.js';
 import type { EmbeddedCurvePoint } from '../noir-structs/embedded_curve_point.js';
 import { EphemeralArray } from '../noir-structs/ephemeral_array.js';
+import type { EventValidationRequest } from '../noir-structs/event_validation_request.js';
+import { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
 import { Option } from '../noir-structs/option.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
 import { TransientArrayService } from '../transient_array_service.js';
@@ -803,6 +806,106 @@ describe('Utility Execution test suite', () => {
         await secondOracle.getTxEffects(EphemeralArray.fromValues(service, [txHash]));
         expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
       });
+    });
+
+    describe('validateAndStoreEnqueuedNotesAndEvents', () => {
+      const service = new EphemeralArrayService();
+
+      it('validates notes of a tx seen by log retrieval without reading its receipt', async () => {
+        const oracle = makeOracle({ contractAddress, scopes: [owner] });
+        const txHash = TxHash.random();
+        const { request, uniqueNoteHash } = await makeNoteRequest(txHash);
+
+        const secret = Fr.random();
+        const mode = AppTaggingSecretKind.CONSTRAINED;
+        const tag = await SiloedTag.compute({
+          extendedSecret: new AppTaggingSecret(secret, contractAddress, mode),
+          index: 0,
+        });
+        const log = {
+          logData: [tag.value, Fr.random()],
+          blockNumber: anchorBlockHeader.globalVariables.blockNumber,
+          blockHash: await anchorBlockHeader.hash(),
+          blockTimestamp: anchorBlockHeader.globalVariables.timestamp,
+          txHash,
+          txIndexWithinBlock: 3,
+          logIndexWithinTx: 0,
+          noteHashes: [uniqueNoteHash],
+          nullifiers: [Fr.random()],
+        };
+        aztecNode.getPrivateLogsByTags.mockImplementation(query =>
+          Promise.resolve(query.tags.map(entry => (('tag' in entry ? entry.tag : entry).equals(tag) ? [log] : []))),
+        );
+
+        await oracle.getPendingTaggedLogsV2(
+          owner,
+          EphemeralArray.fromValues<ProvidedSecret>(service, [{ secret, mode }]),
+        );
+        await oracle.validateAndStoreEnqueuedNotesAndEvents(
+          EphemeralArray.fromValues(service, [request]),
+          EphemeralArray.fromValues<EventValidationRequest>(service, []),
+          owner,
+        );
+
+        expect(aztecNode.getTxReceipt).not.toHaveBeenCalled();
+        const [storedNotes] = noteStore.addNotes.mock.calls[0];
+        expect(storedNotes.map(note => [note.noteHash, note.l2BlockNumber, note.txIndexInBlock])).toEqual([
+          [request.noteHash, log.blockNumber, log.txIndexWithinBlock],
+        ]);
+      });
+
+      it('reads the receipt once for a tx that log retrieval never returned', async () => {
+        const oracle = makeOracle({ contractAddress, scopes: [owner] });
+        const txHash = TxHash.random();
+        const first = await makeNoteRequest(txHash);
+        const second = await makeNoteRequest(txHash);
+        aztecNode.getTxReceipt.mockResolvedValue(
+          makeMinedReceiptWithNoteHashes(txHash, [first.uniqueNoteHash, second.uniqueNoteHash]),
+        );
+
+        await oracle.validateAndStoreEnqueuedNotesAndEvents(
+          EphemeralArray.fromValues(service, [first.request, second.request]),
+          EphemeralArray.fromValues<EventValidationRequest>(service, []),
+          owner,
+        );
+
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+        const [storedNotes] = noteStore.addNotes.mock.calls[0];
+        expect(storedNotes.map(note => note.noteHash)).toEqual([first.request.noteHash, second.request.noteHash]);
+      });
+
+      async function makeNoteRequest(txHash: TxHash) {
+        const noteNonce = Fr.random();
+        const noteHash = Fr.random();
+        const request = new NoteValidationRequest(
+          contractAddress,
+          owner,
+          Fr.random(),
+          Fr.random(),
+          noteNonce,
+          [Fr.random()],
+          noteHash,
+          Fr.random(),
+          txHash,
+        );
+        const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
+        return { request, uniqueNoteHash };
+      }
+
+      function makeMinedReceiptWithNoteHashes(txHash: TxHash, noteHashes: Fr[]) {
+        return new MinedTxReceipt(
+          txHash,
+          TxStatus.FINALIZED,
+          TxExecutionResult.SUCCESS,
+          0n,
+          BlockHash.random(),
+          BlockNumber(syncedBlockNumber),
+          SlotNumber(1),
+          0,
+          EpochNumber(1),
+          TxEffect.from({ ...TxEffect.empty(), txHash, noteHashes }),
+        );
+      }
     });
 
     describe('fact store', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -1,4 +1,4 @@
-import { ARCHIVE_HEIGHT, type NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
+import { ARCHIVE_HEIGHT, type NOTE_HASH_TREE_HEIGHT, PRIVATE_LOG_CIPHERTEXT_LEN } from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { uniqueBy } from '@aztec/foundation/collection';
 import { Aes128 } from '@aztec/foundation/crypto/aes128';
@@ -33,7 +33,6 @@ import {
   type BlockHeader,
   CallContext,
   type Capsule,
-  type IndexedTxEffect,
   type OffchainEffect,
   type TxEffect,
   type TxHash,
@@ -42,12 +41,12 @@ import {
 
 import type { ContractSyncService } from '../../contract/contract_sync_service.js';
 import { createContractLogger, logContractMessage, stripAztecnrLogPrefix } from '../../contract_logging.js';
-import { EventService } from '../../events/event_service.js';
+import { EventService, type EventValidationTxData } from '../../events/event_service.js';
 import type { UtilityCallAuthorizationRequest } from '../../hooks/authorize_utility_call.js';
 import type { ExecutionHooks } from '../../hooks/index.js';
-import { LogService } from '../../logs/log_service.js';
-import { TxResolverService } from '../../messages/tx_resolver_service.js';
-import { NoteService } from '../../notes/note_service.js';
+import { LogService, type RetrievedTaggedLog } from '../../logs/log_service.js';
+import { type TxOnchainContext, TxResolverService } from '../../messages/tx_resolver_service.js';
+import { NoteService, type NoteValidationTxData } from '../../notes/note_service.js';
 import { ORACLE_VERSION_MAJOR } from '../../oracle_version.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import { assertAllowedScope } from '../../storage/allowed_scopes.js';
@@ -122,7 +121,13 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   private offchainEffects: OffchainEffect[] = [];
   private readonly ephemeralArrayService = new EphemeralArrayService();
   protected readonly transientArrayService: TransientArrayService;
-  readonly #txReceipts = new Map<string, Promise<TxReceipt<{ includeTxEffect: true }>>>();
+  /** Keyed by tx hash string. */
+  private readonly txReceiptsCache = new Map<string, Promise<TxReceipt<{ includeTxEffect: true }>>>();
+  /**
+   * Keyed by tx hash string. Holds every tx surfaced by this execution's tagged-log queries, which is where validation
+   * requests overwhelmingly point; only txs reached through other paths (e.g. offchain inbox messages) need a receipt.
+   */
+  private readonly validationTxDataCache = new Map<string, ValidationTxData>();
 
   // We store oracle version to be able to show a nice error message when an oracle handler is missing.
   private contractOracleVersion: { major: number; minor: number } | undefined;
@@ -600,8 +605,10 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       .map(ps => new AppTaggingSecret(ps.secret, this.contractAddress, ps.mode));
 
     const logService = this.#createLogService();
-    const logs = await logService.fetchTaggedLogs(this.contractAddress, scope, secrets);
-    return EphemeralArray.fromValues(this.ephemeralArrayService, logs);
+    const retrievedLogs = await logService.fetchTaggedLogs(this.contractAddress, scope, secrets);
+    // Cache each tx's onchain context so later validation requests for it cost no node reads.
+    retrievedLogs.forEach(log => this.validationTxDataCache.set(log.txHash.toString(), toValidationTxData(log)));
+    return EphemeralArray.fromValues(this.ephemeralArrayService, retrievedLogs.map(toPendingTaggedLog));
   }
 
   #createLogService(): LogService {
@@ -636,7 +643,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     eventValidationRequests: EventValidationRequest[],
     scope: AztecAddress,
   ) {
-    const txEffects = await this.#fetchTxEffects([
+    const validationTxData = await this.#getValidationTxData([
       ...noteValidationRequests.map(r => r.txHash),
       ...eventValidationRequests.map(r => r.txHash),
     ]);
@@ -645,8 +652,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const eventService = new EventService(this.anchorBlockHeader, this.aztecNode, this.privateEventStore, this.jobId);
 
     await Promise.all([
-      noteService.validateAndStoreNotes(noteValidationRequests, scope, txEffects),
-      eventService.validateAndStoreEvents(eventValidationRequests, scope, txEffects),
+      noteService.validateAndStoreNotes(noteValidationRequests, scope, validationTxData),
+      eventService.validateAndStoreEvents(eventValidationRequests, scope, validationTxData),
     ]);
   }
 
@@ -656,11 +663,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const logRetrievalRequests = requests.readAll(this.ephemeralArrayService);
     const logService = this.#createLogService();
 
-    const logRetrievalResponses = await logService.fetchLogsByTag(this.contractAddress, logRetrievalRequests);
+    const retrievedLogsPerRequest = await logService.fetchLogsByTag(this.contractAddress, logRetrievalRequests);
+    // Cache each tx's onchain context so later validation requests for it cost no node reads.
+    retrievedLogsPerRequest
+      .flat()
+      .forEach(log => this.validationTxDataCache.set(log.txHash.toString(), toValidationTxData(log)));
 
     // Create an inner ephemeral array for each request's matching logs, then wrap all slots in an outer array.
-    const innerArrays = logRetrievalResponses.map(responses =>
-      EphemeralArray.fromValues(this.ephemeralArrayService, responses),
+    const innerArrays = retrievedLogsPerRequest.map(retrievedLogs =>
+      EphemeralArray.fromValues(this.ephemeralArrayService, retrievedLogs.map(toLogRetrievalResponse)),
     );
 
     return EphemeralArray.fromValues(this.ephemeralArrayService, innerArrays);
@@ -671,8 +682,12 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const txHashes = requests.readAll(this.ephemeralArrayService);
 
     const resolved = await this.txResolver.resolveTxs(txHashes, this.anchorBlockHeader.getBlockNumber());
+    // Cache each tx's onchain context so later validation requests for it cost no node reads.
+    resolved
+      .filter(tx => tx !== null)
+      .forEach(tx => this.validationTxDataCache.set(tx.txHash.toString(), toValidationTxData(tx)));
 
-    const options = resolved.map(r => (r ? Option.some(r) : Option.none<ResolvedTx>()));
+    const options = resolved.map(tx => (tx ? Option.some(toResolvedTx(tx)) : Option.none<ResolvedTx>()));
     return EphemeralArray.fromValues(this.ephemeralArrayService, options);
   }
 
@@ -1107,15 +1122,28 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   /**
-   * Fetches tx effects for the given hashes in parallel. Returns a map keyed by `TxHash.toString()`; hashes for which
-   * the node has no tx effect are omitted.
+   * Returns the {@link ValidationTxData} for the given hashes, keyed by `TxHash.toString()`. Txs this execution has
+   * already seen are served from {@link validationTxDataCache}; the rest go through
+   * {@link #getTxReceiptWithEffect}, in parallel. Hashes with no tx effect are omitted.
    */
-  async #fetchTxEffects(txHashes: TxHash[]): Promise<Map<string, IndexedTxEffect>> {
-    const uniqueTxHashes = uniqueBy(txHashes, h => h.toString());
-    const fetched = await Promise.all(uniqueTxHashes.map(h => this.#getTxReceiptWithEffect(h)));
-    return new Map(
-      uniqueTxHashes
-        .map((h, i): [string, IndexedTxEffect | undefined] => {
+  async #getValidationTxData(txHashes: TxHash[]): Promise<Map<string, ValidationTxData>> {
+    const known: [string, ValidationTxData][] = [];
+    const misses: TxHash[] = [];
+    for (const txHash of uniqueBy(txHashes, h => h.toString())) {
+      const key = txHash.toString();
+      const cached = this.validationTxDataCache.get(key);
+      if (cached) {
+        known.push([key, cached]);
+      } else {
+        misses.push(txHash);
+      }
+    }
+
+    const fetched = await Promise.all(misses.map(h => this.#getTxReceiptWithEffect(h)));
+    return new Map([
+      ...known,
+      ...misses
+        .map((h, i): [string, ValidationTxData | undefined] => {
           const receipt = fetched[i];
           if (!receipt.isMined() || !receipt.txEffect) {
             return [h.toString(), undefined];
@@ -1123,16 +1151,16 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
           return [
             h.toString(),
             {
-              data: receipt.txEffect,
+              noteHashes: receipt.txEffect.noteHashes,
+              nullifiers: receipt.txEffect.nullifiers,
               l2BlockNumber: receipt.blockNumber,
               l2BlockHash: receipt.blockHash,
               txIndexInBlock: receipt.txIndexInBlock,
-              slotNumber: receipt.slotNumber,
             },
           ];
         })
-        .filter((entry): entry is [string, IndexedTxEffect] => entry[1] !== undefined),
-    );
+        .filter((entry): entry is [string, ValidationTxData] => entry[1] !== undefined),
+    ]);
   }
 
   /**
@@ -1145,13 +1173,13 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    */
   #getTxReceiptWithEffect(txHash: TxHash) {
     const key = txHash.toString();
-    let receipt = this.#txReceipts.get(key);
+    let receipt = this.txReceiptsCache.get(key);
     if (!receipt) {
       receipt = this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true }).catch(err => {
-        this.#txReceipts.delete(key);
+        this.txReceiptsCache.delete(key);
         throw err;
       });
-      this.#txReceipts.set(key, receipt);
+      this.txReceiptsCache.set(key, receipt);
     }
     return receipt;
   }
@@ -1249,3 +1277,41 @@ async function isStandardHandshakeRegistryUtilityRead(
   );
   return matches.some(Boolean);
 }
+
+function toPendingTaggedLog(retrievedLog: RetrievedTaggedLog): PendingTaggedLog {
+  return { log: retrievedLog.logData, context: toResolvedTx(retrievedLog) };
+}
+
+function toResolvedTx(tx: TxOnchainContext): ResolvedTx {
+  const { txHash, blockNumber, blockHash, noteHashes, nullifiers } = tx;
+  return {
+    txHash,
+    uniqueNoteHashesInTx: noteHashes,
+    firstNullifierInTx: nullifiers[0],
+    blockNumber,
+    blockHash: blockHash.toFr(),
+  };
+}
+
+function toLogRetrievalResponse(retrievedLog: RetrievedTaggedLog): LogRetrievalResponse {
+  const { logData, txHash, blockNumber, blockHash, blockTimestamp, noteHashes, nullifiers } = retrievedLog;
+  return {
+    // Skip the tag, and clip to the wire cap: public logs can exceed PRIVATE_LOG_CIPHERTEXT_LEN, which is the fixed
+    // size of the oracle's BoundedVec slot. A no-op for private logs, which are already within the cap.
+    logPayload: logData.slice(1, 1 + PRIVATE_LOG_CIPHERTEXT_LEN),
+    txHash,
+    uniqueNoteHashesInTx: noteHashes,
+    firstNullifierInTx: nullifiers[0],
+    blockNumber,
+    blockTimestamp,
+    blockHash,
+  };
+}
+
+function toValidationTxData(tx: TxOnchainContext): ValidationTxData {
+  const { blockNumber, blockHash, txIndexInBlock, noteHashes, nullifiers } = tx;
+  return { noteHashes, nullifiers, l2BlockNumber: blockNumber, l2BlockHash: blockHash, txIndexInBlock };
+}
+
+/** The onchain context of a tx served to note and event validation: the union of what the two services read. */
+type ValidationTxData = NoteValidationTxData & EventValidationTxData;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -124,8 +124,10 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   /** Keyed by tx hash string. */
   private readonly txReceiptsCache = new Map<string, Promise<TxReceipt<{ includeTxEffect: true }>>>();
   /**
-   * Keyed by tx hash string. Holds every tx surfaced by this execution's tagged-log queries, which is where validation
-   * requests overwhelmingly point; only txs reached through other paths (e.g. offchain inbox messages) need a receipt.
+   * Information that can be used to validate the existence of a note or an event, keyed by tx hash string. It is
+   * populated by the node queries that precede validation (tagged log retrieval, tx resolution), which already return
+   * everything validation needs, so validating a note or event created in one of those txs costs no node roundtrip.
+   * Notes and events reached through other paths (e.g. offchain inbox messages) still need a receipt.
    */
   private readonly validationTxDataCache = new Map<string, ValidationTxData>();
 
@@ -606,8 +608,9 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
     const logService = this.#createLogService();
     const retrievedLogs = await logService.fetchTaggedLogs(this.contractAddress, scope, secrets);
-    // Cache each tx's onchain context so later validation requests for it cost no node reads.
-    retrievedLogs.forEach(log => this.validationTxDataCache.set(log.txHash.toString(), toValidationTxData(log)));
+
+    this.#cacheValidationTxData(retrievedLogs);
+
     return EphemeralArray.fromValues(this.ephemeralArrayService, retrievedLogs.map(toPendingTaggedLog));
   }
 
@@ -664,10 +667,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const logService = this.#createLogService();
 
     const retrievedLogsPerRequest = await logService.fetchLogsByTag(this.contractAddress, logRetrievalRequests);
-    // Cache each tx's onchain context so later validation requests for it cost no node reads.
-    retrievedLogsPerRequest
-      .flat()
-      .forEach(log => this.validationTxDataCache.set(log.txHash.toString(), toValidationTxData(log)));
+
+    this.#cacheValidationTxData(retrievedLogsPerRequest.flat());
 
     // Create an inner ephemeral array for each request's matching logs, then wrap all slots in an outer array.
     const innerArrays = retrievedLogsPerRequest.map(retrievedLogs =>
@@ -682,10 +683,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const txHashes = requests.readAll(this.ephemeralArrayService);
 
     const resolved = await this.txResolver.resolveTxs(txHashes, this.anchorBlockHeader.getBlockNumber());
-    // Cache each tx's onchain context so later validation requests for it cost no node reads.
-    resolved
-      .filter(tx => tx !== null)
-      .forEach(tx => this.validationTxDataCache.set(tx.txHash.toString(), toValidationTxData(tx)));
+
+    this.#cacheValidationTxData(resolved.filter(tx => tx !== null));
 
     const options = resolved.map(tx => (tx ? Option.some(toResolvedTx(tx)) : Option.none<ResolvedTx>()));
     return EphemeralArray.fromValues(this.ephemeralArrayService, options);
@@ -1121,10 +1120,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return this.offchainEffects;
   }
 
+  /** Stores the onchain context of the given txs, so that validating the notes and events they created is free. */
+  #cacheValidationTxData(txs: TxOnchainContext[]) {
+    txs.forEach(tx => this.validationTxDataCache.set(tx.txHash.toString(), toValidationTxData(tx)));
+  }
+
   /**
-   * Returns the {@link ValidationTxData} for the given hashes, keyed by `TxHash.toString()`. Txs this execution has
-   * already seen are served from {@link validationTxDataCache}; the rest go through
-   * {@link #getTxReceiptWithEffect}, in parallel. Hashes with no tx effect are omitted.
+   * Returns the information needed to validate the notes and events created in the given txs, keyed by
+   * `TxHash.toString()`. Txs already in {@link validationTxDataCache} cost no node request, and the rest are read from
+   * the node. Txs with no tx effect are absent from the returned map.
    */
   async #getValidationTxData(txHashes: TxHash[]): Promise<Map<string, ValidationTxData>> {
     const known: [string, ValidationTxData][] = [];

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -1,4 +1,4 @@
-import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Logger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -8,13 +8,13 @@ import { BlockHash } from '@aztec/stdlib/block';
 import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { makeBlockHeader } from '@aztec/stdlib/testing';
-import { type IndexedTxEffect, TxEffect } from '@aztec/stdlib/tx';
+import { TxEffect } from '@aztec/stdlib/tx';
 
 import { mock } from 'jest-mock-extended';
 
 import type { EventValidationRequest } from '../contract_function_simulator/noir-structs/event_validation_request.js';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
-import { EventService } from './event_service.js';
+import { EventService, type EventValidationTxData } from './event_service.js';
 
 describe('validateAndStoreEvents', () => {
   let blockNumber: BlockNumber;
@@ -24,7 +24,7 @@ describe('validateAndStoreEvents', () => {
   let eventCommitment: Fr;
   let eventNullifier: Fr;
   let txEffect: TxEffect;
-  let indexedTxEffect: IndexedTxEffect;
+  let validationTxData: EventValidationTxData;
   let contractAddress: AztecAddress;
   let recipient: AztecAddress;
 
@@ -58,12 +58,11 @@ describe('validateAndStoreEvents', () => {
       nullifiers: [eventNullifier],
     });
 
-    indexedTxEffect = {
+    validationTxData = {
       l2BlockNumber: blockNumber,
       l2BlockHash: BlockHash.random(),
-      data: txEffect,
+      nullifiers: txEffect.nullifiers,
       txIndexInBlock: 0,
-      slotNumber: SlotNumber(Number(blockNumber)),
     };
 
     /* Happy path context conditions:
@@ -81,7 +80,7 @@ describe('validateAndStoreEvents', () => {
     overrides: {
       eventContent?: Fr[];
       eventCommitment?: Fr;
-      txEffectsMap?: Map<string, IndexedTxEffect>;
+      validationTxDataMap?: Map<string, EventValidationTxData>;
     } = {},
   ) {
     const request: EventValidationRequest = {
@@ -93,21 +92,21 @@ describe('validateAndStoreEvents', () => {
       txHash: txEffect.txHash,
     };
 
-    const map = overrides.txEffectsMap ?? defaultTxEffectsMap();
+    const map = overrides.validationTxDataMap ?? defaultValidationTxDataMap();
     await eventService.validateAndStoreEvents([request], recipient, map);
 
     await privateEventStore.commit('test');
   }
 
   it('should throw when tx does not exist or has no effects', async () => {
-    const txEffectsMap = new Map();
-    await expect(() => runStoreEvent({ txEffectsMap })).rejects.toThrow(/Could not find tx effect for tx hash/);
+    const validationTxDataMap = new Map();
+    await expect(() => runStoreEvent({ validationTxDataMap })).rejects.toThrow(/Could not find tx effect for tx hash/);
   });
 
   it('should throw when tx block has not yet been synchronized', async () => {
-    const laterIndexedTxEffect = { ...indexedTxEffect, l2BlockNumber: BlockNumber(blockNumber + 1) };
-    const txEffectsMap = new Map([[txEffect.txHash.toString(), laterIndexedTxEffect]]);
-    await expect(() => runStoreEvent({ txEffectsMap })).rejects.toThrow(
+    const laterTxData = { ...validationTxData, l2BlockNumber: BlockNumber(blockNumber + 1) };
+    const validationTxDataMap = new Map([[txEffect.txHash.toString(), laterTxData]]);
+    await expect(() => runStoreEvent({ validationTxDataMap })).rejects.toThrow(
       /Obtained a newer tx effect for .* for an event validation request than the anchor block/,
     );
   });
@@ -160,7 +159,7 @@ describe('validateAndStoreEvents', () => {
     expect(result[0].packedEvent).toEqual(eventContent);
   });
 
-  function defaultTxEffectsMap() {
-    return new Map([[txEffect.txHash.toString(), indexedTxEffect]]);
+  function defaultValidationTxDataMap() {
+    return new Map([[txEffect.txHash.toString(), validationTxData]]);
   }
 });

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -1,8 +1,10 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { InBlock } from '@aztec/stdlib/block';
 import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import type { BlockHeader, IndexedTxEffect } from '@aztec/stdlib/tx';
+import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { EventValidationRequest } from '../contract_function_simulator/noir-structs/event_validation_request.js';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
@@ -17,17 +19,17 @@ export class EventService {
   ) {}
 
   /**
-   * Validates and stores a batch of private events against pre-fetched tx effects.
+   * Validates and stores a batch of private events against the pre-fetched onchain context of their txs.
    *
    * @param requests - The events to validate and store.
    * @param scope - The scope under which the events are being stored.
-   * @param txEffects - Pre-fetched tx effects keyed by `TxHash.toString()`. Must contain entries for every request's
-   *                   txHash; missing entries are treated as a node bug and cause an error.
+   * @param validationTxData - The onchain context of each request's tx, keyed by `TxHash.toString()`. Must contain
+   * entries for every request's txHash; missing entries are treated as a node bug and cause an error.
    */
   public async validateAndStoreEvents(
     requests: EventValidationRequest[],
     scope: AztecAddress,
-    txEffects: Map<string, IndexedTxEffect>,
+    validationTxData: ReadonlyMap<string, EventValidationTxData>,
   ): Promise<void> {
     if (requests.length === 0) {
       return;
@@ -35,13 +37,15 @@ export class EventService {
 
     const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
 
-    await Promise.all(requests.map(req => this.#validateAndStoreEvent(req, scope, txEffects, anchorBlockNumber)));
+    await Promise.all(
+      requests.map(req => this.#validateAndStoreEvent(req, scope, validationTxData, anchorBlockNumber)),
+    );
   }
 
   async #validateAndStoreEvent(
     request: EventValidationRequest,
     scope: AztecAddress,
-    txEffects: Map<string, IndexedTxEffect>,
+    validationTxData: ReadonlyMap<string, EventValidationTxData>,
     anchorBlockNumber: number,
   ): Promise<void> {
     const {
@@ -71,15 +75,15 @@ export class EventService {
     // since `fetchTaggedLogs` only processes logs up to the synced block.
     const siloedEventCommitment = await siloNullifier(contractAddress, eventCommitment);
 
-    const txEffect = txEffects.get(txHash.toString());
-    if (!txEffect) {
+    const txData = validationTxData.get(txHash.toString());
+    if (!txData) {
       // We error out instead of just logging a warning and skipping the event because this would indicate a bug. This
       // is because the node has already served info about this tx either when obtaining the log (LogResult carries
       // the tx info) or when getting metadata for the offchain message (before the message got passed to `process_log`).
       throw new Error(`Could not find tx effect for tx hash ${txHash} when processing an event.`);
     }
 
-    if (txEffect.l2BlockNumber > anchorBlockNumber) {
+    if (txData.l2BlockNumber > anchorBlockNumber) {
       // We should never process a message from a tx past the anchor block. If we got here, a preprocessing step made
       // a mistake.
       throw new Error(
@@ -88,7 +92,7 @@ export class EventService {
     }
 
     // Find the index of the event commitment in the nullifiers array to determine event ordering within the tx
-    const eventIndexInTx = txEffect.data.nullifiers.findIndex(n => n.equals(siloedEventCommitment));
+    const eventIndexInTx = txData.nullifiers.findIndex(n => n.equals(siloedEventCommitment));
     if (eventIndexInTx === -1) {
       // Unlike in NoteService, this might not be a bug since the commitment hasn't been verified yet in the message
       // processing pipeline. A malformed or malicious message could trigger this condition. Because of this we don't
@@ -108,12 +112,18 @@ export class EventService {
         contractAddress,
         scope,
         txHash,
-        l2BlockNumber: txEffect.l2BlockNumber,
-        l2BlockHash: txEffect.l2BlockHash,
-        txIndexInBlock: txEffect.txIndexInBlock,
+        l2BlockNumber: txData.l2BlockNumber,
+        l2BlockHash: txData.l2BlockHash,
+        txIndexInBlock: txData.txIndexInBlock,
         eventIndexInTx,
       },
       this.jobId,
     );
   }
 }
+
+/** The onchain context of the tx an event validation request points at: where it was mined and its nullifiers. */
+export type EventValidationTxData = InBlock & {
+  nullifiers: Fr[];
+  txIndexInBlock: number;
+};

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -352,7 +352,7 @@ describe('LogService', () => {
 
       const logs = await logService.fetchTaggedLogs(contractAddress, recipient, []);
 
-      const txHashes = logs.map(l => l.context.txHash);
+      const txHashes = logs.map(l => l.txHash);
       expect(txHashes).toContainEqual(unconstrainedLog.txHash);
       expect(txHashes).toContainEqual(constrainedLog.txHash);
     });
@@ -374,7 +374,7 @@ describe('LogService', () => {
 
       const logs = await logService.fetchTaggedLogs(contractAddress, recipient, []);
 
-      const txHashes = logs.map(l => l.context.txHash);
+      const txHashes = logs.map(l => l.txHash);
       expect(txHashes).toContainEqual(directionalLog.txHash);
       expect(txHashes).not.toContainEqual(handshakeStreamLog.txHash);
     });
@@ -395,7 +395,7 @@ describe('LogService', () => {
 
       const logs = await logService.fetchTaggedLogs(contractAddress, recipient, []);
 
-      const txHashes = logs.map(l => l.context.txHash);
+      const txHashes = logs.map(l => l.txHash);
       expect(txHashes).toContainEqual(handshakeStreamLog.txHash);
       expect(txHashes).not.toContainEqual(directionalLog.txHash);
     });
@@ -477,7 +477,7 @@ describe('LogService', () => {
       const discovered = await logService.fetchTaggedLogs(contractAddress, recipient, []);
 
       expect(discovered).toHaveLength(1);
-      expect(discovered[0].context.txHash).toEqual(senderLog.txHash);
+      expect(discovered[0].txHash).toEqual(senderLog.txHash);
     });
   });
 });

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -1,5 +1,5 @@
-import { PRIVATE_LOG_CIPHERTEXT_LEN } from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
@@ -15,13 +15,13 @@ import {
   computeSharedTaggingSecret,
 } from '@aztec/stdlib/logs';
 import type { BlockHeader } from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
 
 import {
   type LogRetrievalRequest,
   LogSource,
 } from '../contract_function_simulator/noir-structs/log_retrieval_request.js';
-import type { LogRetrievalResponse } from '../contract_function_simulator/noir-structs/log_retrieval_response.js';
-import type { PendingTaggedLog } from '../contract_function_simulator/noir-structs/pending_tagged_log.js';
+import type { TxOnchainContext } from '../messages/tx_resolver_service.js';
 import { AddressStore } from '../storage/address_store/address_store.js';
 import { assertAllowedScope } from '../storage/allowed_scopes.js';
 import type { RecipientTaggingStore } from '../storage/tagging_store/recipient_tagging_store.js';
@@ -58,7 +58,7 @@ export class LogService {
   public async fetchLogsByTag(
     contractAddress: AztecAddress,
     logRetrievalRequests: LogRetrievalRequest[],
-  ): Promise<LogRetrievalResponse[][]> {
+  ): Promise<RetrievedTaggedLog[][]> {
     for (const request of logRetrievalRequests) {
       if (!contractAddress.equals(request.contractAddress)) {
         throw new Error(`Got a log retrieval request from ${request.contractAddress}, expected ${contractAddress}`);
@@ -77,8 +77,8 @@ export class LogService {
     ]);
 
     return logRetrievalRequests.map((_request, i) => [
-      ...publicLogsPerRequest[i].map(LogService.#toLogRetrievalResponse),
-      ...privateLogsPerRequest[i].map(LogService.#toLogRetrievalResponse),
+      ...publicLogsPerRequest[i].map(LogService.#toRetrievedTaggedLog),
+      ...privateLogsPerRequest[i].map(LogService.#toRetrievedTaggedLog),
     ]);
   }
 
@@ -164,7 +164,7 @@ export class LogService {
     return groups;
   }
 
-  static #toLogRetrievalResponse(log: LogResult): LogRetrievalResponse {
+  static #toRetrievedTaggedLog(log: LogResult): RetrievedTaggedLog {
     // includeEffects: true was used, so noteHashes and nullifiers are populated. Every tx has at least one nullifier
     // (the first nullifier derived from the tx hash); empty here would indicate a buggy node.
     const noteHashes = log.noteHashes!;
@@ -173,23 +173,25 @@ export class LogService {
       throw new Error(`Log for tx ${log.txHash} returned no nullifiers from the node`);
     }
     return {
-      // Skip the tag, and clip to the wire cap: public logs can exceed PRIVATE_LOG_CIPHERTEXT_LEN, which is the fixed
-      // size of the oracle's BoundedVec slot. A no-op for private logs, which are already within the cap.
-      logPayload: log.logData.slice(1, 1 + PRIVATE_LOG_CIPHERTEXT_LEN),
+      logData: log.logData,
       txHash: log.txHash,
-      uniqueNoteHashesInTx: noteHashes,
-      firstNullifierInTx: nullifiers[0],
+      noteHashes,
+      nullifiers,
       blockNumber: log.blockNumber,
       blockTimestamp: log.blockTimestamp,
       blockHash: log.blockHash,
+      // The log index and the tx receipt both count the tx's position in `block.body.txEffects`, so this is the same
+      // index a receipt reports. Note ordering depends on the two staying in agreement.
+      txIndexInBlock: log.txIndexWithinBlock,
     };
   }
 
+  /** Fetches the pending tagged logs for a recipient across all its tagging secrets for the contract. */
   public async fetchTaggedLogs(
     contractAddress: AztecAddress,
     recipient: AztecAddress,
     providedSecrets: AppTaggingSecret[],
-  ): Promise<PendingTaggedLog[]> {
+  ): Promise<RetrievedTaggedLog[]> {
     assertAllowedScope(recipient, this.scopes);
 
     this.log.verbose(
@@ -216,23 +218,7 @@ export class LogService {
       this.jobId,
     );
 
-    return logs.map(log => {
-      const noteHashes = log.noteHashes!;
-      const nullifiers = log.nullifiers!;
-      if (nullifiers.length === 0) {
-        throw new Error(`Log for tx ${log.txHash} returned no nullifiers from the node`);
-      }
-      return {
-        log: log.logData,
-        context: {
-          txHash: log.txHash,
-          uniqueNoteHashesInTx: noteHashes,
-          firstNullifierInTx: nullifiers[0],
-          blockNumber: log.blockNumber,
-          blockHash: log.blockHash.toFr(),
-        },
-      };
-    });
+    return logs.map(log => LogService.#toRetrievedTaggedLog(log));
   }
 
   /**
@@ -298,3 +284,10 @@ export class LogService {
     );
   }
 }
+
+/** A tagged log fetched from the node, together with the onchain context of the tx that emitted it. */
+export type RetrievedTaggedLog = TxOnchainContext & {
+  /** The raw log payload, tag included. */
+  logData: Fr[];
+  blockTimestamp: UInt64;
+};

--- a/yarn-project/pxe/src/messages/tx_resolver_service.test.ts
+++ b/yarn-project/pxe/src/messages/tx_resolver_service.test.ts
@@ -98,10 +98,10 @@ describe('TxResolverService', () => {
     );
   });
 
-  it('resolves a valid tx hash into a ResolvedTx', async () => {
+  it('resolves a valid tx hash into its onchain context', async () => {
     const txHash = TxHash.random();
     const noteHashes = [Fr.random(), Fr.random()];
-    const firstNullifier = Fr.random();
+    const nullifiers = [Fr.random(), Fr.random()];
     const blockHash = BlockHash.random();
     const blockNumber = anchorBlockNumber - 1;
 
@@ -109,23 +109,16 @@ describe('TxResolverService', () => {
       await minedReceipt({
         txHash,
         noteHashes,
-        nullifiers: [firstNullifier, Fr.random()],
+        nullifiers,
         blockNumber,
         blockHash,
+        txIndexInBlock: 3,
       }),
     );
 
     const results = await service.resolveTxs([txHash.hash], anchorBlockNumber);
 
-    expect(results).toEqual([
-      {
-        txHash,
-        uniqueNoteHashesInTx: noteHashes,
-        firstNullifierInTx: firstNullifier,
-        blockNumber,
-        blockHash: blockHash.toFr(),
-      },
-    ]);
+    expect(results).toEqual([{ txHash, noteHashes, nullifiers, blockNumber, blockHash, txIndexInBlock: 3 }]);
   });
 
   it('resolves tx hashes in different situations', async () => {
@@ -164,7 +157,7 @@ describe('TxResolverService', () => {
     const results = await service.resolveTxs(
       [
         Fr.ZERO, // zero → null
-        validTxHash.hash, // valid → ResolvedTx
+        validTxHash.hash, // valid → resolved
         notFoundTxHash.hash, // not found → null
         futureTxHash.hash, // beyond anchor → null
       ],
@@ -175,10 +168,11 @@ describe('TxResolverService', () => {
       null,
       {
         txHash: validTxHash,
-        uniqueNoteHashesInTx: validNoteHashes,
-        firstNullifierInTx: validNullifier,
+        noteHashes: validNoteHashes,
+        nullifiers: [validNullifier],
         blockNumber: anchorBlockNumber,
-        blockHash: validBlockHash.toFr(),
+        blockHash: validBlockHash,
+        txIndexInBlock: 0,
       },
       null,
       null,
@@ -217,10 +211,11 @@ describe('TxResolverService', () => {
 
     const expected = {
       txHash: txEffect.txHash,
-      uniqueNoteHashesInTx: txEffect.noteHashes,
-      firstNullifierInTx: txEffect.nullifiers[0],
+      noteHashes: txEffect.noteHashes,
+      nullifiers: txEffect.nullifiers,
       blockNumber,
-      blockHash: blockHash.toFr(),
+      blockHash,
+      txIndexInBlock: 0,
     };
     expect(results).toEqual([expected, expected, expected]);
     expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);

--- a/yarn-project/pxe/src/messages/tx_resolver_service.ts
+++ b/yarn-project/pxe/src/messages/tx_resolver_service.ts
@@ -1,22 +1,22 @@
+import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { uniqueBy } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type IndexedTxEffect, TxHash } from '@aztec/stdlib/tx';
 
-import type { ResolvedTx } from '../contract_function_simulator/noir-structs/resolved_tx.js';
-
-/** Resolves transaction hashes into their on-chain context (note hashes, first nullifier, and mined block). */
+/** Resolves transaction hashes into their on-chain context (note hashes, nullifiers, and mined position). */
 export class TxResolverService {
   constructor(private readonly aztecNode: AztecNode) {}
 
   /**
    * Resolves a list of tx hashes into their on-chain context.
    *
-   * For each tx hash, looks up the corresponding tx effect and extracts the note hashes, first nullifier, and the
-   * number and hash of the block it was mined in. Returns `null` for tx hashes that are zero, not yet available, or in
-   * blocks beyond the anchor block.
+   * For each tx hash, looks up the corresponding tx effect and extracts its note hashes and nullifiers, and the
+   * position it was mined at. Returns `null` for tx hashes that are zero, not yet available, or in blocks beyond the
+   * anchor block.
    */
-  async resolveTxs(txHashes: Fr[], anchorBlockNumber: number): Promise<(ResolvedTx | null)[]> {
+  async resolveTxs(txHashes: Fr[], anchorBlockNumber: number): Promise<(TxOnchainContext | null)[]> {
     const nonZeroTxHashes = txHashes.filter(h => !h.isZero()).map(h => TxHash.fromField(h));
     const uniqueTxHashes = uniqueBy(nonZeroTxHashes, h => h.toString());
     const fetched = await Promise.all(
@@ -51,7 +51,7 @@ export class TxResolverService {
       }
 
       // Every tx has at least one nullifier (the first nullifier derived from the tx hash). Hitting this condition
-      // would mean a buggy node, but since we need to access data.nullifiers[0], the defensive check does no harm.
+      // would mean a buggy node, but since consumers rely on nullifiers[0], the defensive check does no harm.
       const data = txEffect.data;
       if (data.nullifiers.length === 0) {
         throw new Error(`Tx effect for ${txHash} has no nullifiers`);
@@ -59,11 +59,22 @@ export class TxResolverService {
 
       return {
         txHash: data.txHash,
-        uniqueNoteHashesInTx: data.noteHashes,
-        firstNullifierInTx: data.nullifiers[0],
+        noteHashes: data.noteHashes,
+        nullifiers: data.nullifiers,
         blockNumber: txEffect.l2BlockNumber,
-        blockHash: txEffect.l2BlockHash.toFr(),
+        blockHash: txEffect.l2BlockHash,
+        txIndexInBlock: txEffect.txIndexInBlock,
       };
     });
   }
 }
+
+/** The onchain context of a tx: the position it was mined at, and the effects it produced. */
+export type TxOnchainContext = {
+  txHash: TxHash;
+  noteHashes: Fr[];
+  nullifiers: Fr[];
+  blockNumber: BlockNumber;
+  blockHash: BlockHash;
+  txIndexInBlock: number;
+};

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -1,4 +1,4 @@
-import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -11,14 +11,14 @@ import { deriveKeys } from '@aztec/stdlib/keys';
 import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 import { makeBlockHeader } from '@aztec/stdlib/testing';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
-import { type IndexedTxEffect, TxEffect, TxHash } from '@aztec/stdlib/tx';
+import { TxEffect, TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
 import type { NoteValidationRequest } from '../contract_function_simulator/noir-structs/note_validation_request.js';
 import { NoteStore } from '../storage/note_store/note_store.js';
-import { NoteService } from './note_service.js';
+import { NoteService, type NoteValidationTxData } from './note_service.js';
 
 describe('NoteService', () => {
   let noteStore: NoteStore;
@@ -213,7 +213,7 @@ describe('NoteService', () => {
 
     let txHash: TxHash;
     let txEffect: TxEffect;
-    let indexedTxEffect: IndexedTxEffect;
+    let validationTxData: NoteValidationTxData;
     let blockNumber: BlockNumber;
 
     let buildRequest: (overrides?: Partial<NoteValidationRequest>) => NoteValidationRequest;
@@ -239,12 +239,11 @@ describe('NoteService', () => {
         noteHashes: [uniqueNoteHash],
       });
 
-      indexedTxEffect = {
+      validationTxData = {
         l2BlockNumber: blockNumber,
         l2BlockHash: BlockHash.random(),
-        data: txEffect,
+        noteHashes: txEffect.noteHashes,
         txIndexInBlock: 0,
-        slotNumber: SlotNumber(Number(blockNumber)),
       };
 
       /* Happy path context conditions:
@@ -273,7 +272,7 @@ describe('NoteService', () => {
     });
 
     it('should store note if it exists in a tx effect', async () => {
-      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap());
+      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultValidationTxDataMap());
 
       // Verify note was stored
       const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'test');
@@ -297,7 +296,7 @@ describe('NoteService', () => {
         noteService.validateAndStoreNotes(
           [buildRequest({ txHash: TxHash.random() })],
           recipient.address,
-          defaultTxEffectsMap(),
+          defaultValidationTxDataMap(),
         ),
       ).rejects.toThrow(/Could not find tx effect/);
     });
@@ -307,7 +306,7 @@ describe('NoteService', () => {
         noteService.validateAndStoreNotes(
           [buildRequest({ noteHash: Fr.random() })],
           recipient.address,
-          defaultTxEffectsMap(),
+          defaultValidationTxDataMap(),
         ),
       ).rejects.toThrow(/is not present in tx/);
     });
@@ -316,12 +315,12 @@ describe('NoteService', () => {
       setSyncedBlockNumber(BlockNumber(blockNumber - 1));
 
       await expect(
-        noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap()),
+        noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultValidationTxDataMap()),
       ).rejects.toThrow(/Obtained a newer tx effect for .* for a note validation request than the anchor block/);
     });
 
     it('should batch findLeavesIndexes across notes', async () => {
-      // Two notes from the same tx so we can reuse the indexedTxEffect; each carries its own unique note hash.
+      // Two notes from the same tx so we can reuse the validationTxData; each carries its own unique note hash.
       const otherNoteHash = Fr.random();
       const otherNullifier = Fr.random();
       const otherNoteNonce = Fr.random();
@@ -330,14 +329,11 @@ describe('NoteService', () => {
         await siloNoteHash(contractAddress, otherNoteHash),
       );
 
-      const sharedTxEffect: IndexedTxEffect = {
-        ...indexedTxEffect,
-        data: TxEffect.from({
-          ...indexedTxEffect.data,
-          noteHashes: [uniqueNoteHash, otherUniqueNoteHash],
-        }),
+      const sharedTxData: NoteValidationTxData = {
+        ...validationTxData,
+        noteHashes: [uniqueNoteHash, otherUniqueNoteHash],
       };
-      const map = new Map([[txHash.toString(), sharedTxEffect]]);
+      const map = new Map([[txHash.toString(), sharedTxData]]);
 
       await noteService.validateAndStoreNotes(
         [
@@ -367,7 +363,7 @@ describe('NoteService', () => {
         );
       });
 
-      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap());
+      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultValidationTxDataMap());
 
       const verifyNoteNullifiedInJobContext = async (jobId: string) => {
         // Now we verify that the note is stored as nullified by checking it can be retrieved only with
@@ -400,8 +396,8 @@ describe('NoteService', () => {
       await verifyNoteNullifiedInJobContext('fresh-job');
     });
 
-    function defaultTxEffectsMap() {
-      return new Map([[txHash.toString(), indexedTxEffect]]);
+    function defaultValidationTxDataMap() {
+      return new Map([[txHash.toString(), validationTxData]]);
     }
   });
 });

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,12 +1,12 @@
 import { chunk } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHash, type DataInBlock } from '@aztec/stdlib/block';
+import { BlockHash, type DataInBlock, type InBlock } from '@aztec/stdlib/block';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
 import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
-import type { BlockHeader, IndexedTxEffect } from '@aztec/stdlib/tx';
+import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { NoteValidationRequest } from '../contract_function_simulator/noir-structs/note_validation_request.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
@@ -96,7 +96,7 @@ export class NoteService {
   }
 
   /**
-   * Validates and stores a batch of notes against pre-fetched tx effects.
+   * Validates and stores a batch of notes against the pre-fetched onchain context of their txs.
    *
    * For each request we must verify that:
    *  - the note actually exists in the corresponding tx effect (and thus in the note hash tree), and
@@ -112,13 +112,13 @@ export class NoteService {
    *
    * @param requests - The notes to validate and store.
    * @param scope - The scope under which the notes are being stored.
-   * @param txEffects - Pre-fetched tx effects keyed by `TxHash.toString()`. Must contain entries for every request's
-   *                   txHash; missing entries are treated as a node bug and cause an error.
+   * @param validationTxData - The onchain context of each request's tx, keyed by `TxHash.toString()`. Must contain
+   * entries for every request's txHash; missing entries are treated as a node bug and cause an error.
    */
   public async validateAndStoreNotes(
     requests: NoteValidationRequest[],
     scope: AztecAddress,
-    txEffects: Map<string, IndexedTxEffect>,
+    validationTxData: ReadonlyMap<string, NoteValidationTxData>,
   ): Promise<void> {
     if (requests.length === 0) {
       return;
@@ -159,8 +159,8 @@ export class NoteService {
       const { uniqueNoteHash, siloedNullifier } = computed[i];
       const nullifierIndex = nullifierIndexes[i];
 
-      const txEffect = txEffects.get(txHash.toString());
-      if (!txEffect) {
+      const txData = validationTxData.get(txHash.toString());
+      if (!txData) {
         // We error out instead of just logging a warning and skipping the note because this would indicate a bug. This
         // is because the node has already served info about this tx either when obtaining the log (LogResult carries
         // the tx info) or when getting metadata for the offchain message (before the message got passed to
@@ -168,7 +168,7 @@ export class NoteService {
         throw new Error(`Could not find tx effect for tx hash ${txHash} when processing a note.`);
       }
 
-      if (txEffect.l2BlockNumber > anchorBlockNumber) {
+      if (txData.l2BlockNumber > anchorBlockNumber) {
         // If the message was delivered onchain, this would indicate a bug: log sync should never load logs from blocks
         // newer than the anchor block. If the note came via an offchain message, it would likely also be a bug, since
         // we sync a new anchor block before calling `process_message`. For this not to be a bug, the message would
@@ -181,7 +181,7 @@ export class NoteService {
       }
 
       // Find the index of the note hash in the noteHashes array to determine note ordering within the tx
-      const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
+      const noteIndexInTx = txData.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
       if (noteIndexInTx === -1) {
         // Similar to the comment above - we error out as this would indicate a bug in nonce discovery.
         throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
@@ -198,9 +198,9 @@ export class NoteService {
           noteHash,
           siloedNullifier,
           txHash,
-          txEffect.l2BlockNumber,
-          txEffect.l2BlockHash.toString(),
-          txEffect.txIndexInBlock,
+          txData.l2BlockNumber,
+          txData.l2BlockHash.toString(),
+          txData.txIndexInBlock,
           noteIndexInTx,
         ),
       );
@@ -228,3 +228,9 @@ export class NoteService {
     ).flat();
   }
 }
+
+/** The onchain context of the tx a note validation request points at: where it was mined and its note hashes. */
+export type NoteValidationTxData = InBlock & {
+  noteHashes: Fr[];
+  txIndexInBlock: number;
+};


### PR DESCRIPTION
## Motivation

Follow-up to #24969. Note and event validation needs the onchain context of the tx that produced each note or event: the note hashes and nullifiers it emitted, and where it was mined. PXE was reading that context back from the node with `getTxReceipt`, once per tx per validation batch.

That read is redundant by construction. Every path that reaches validation has already been told the same facts:

- tagged-log responses are fetched with effects, so each log carries its tx's note hashes, nullifiers and mined position;
- offchain messages go through `TxResolverService`, which fetches the receipt itself and then discarded most of what it read.

The receipt is also one of the few reads #24969's cache cannot help with: `withCache` only memoizes reads pinned to a block hash, and a receipt is not one (pending, mined and finalized are all correct answers to the same call over time), so every validation request went to the node.

## The change

- `LogService` returns a `RetrievedTaggedLog` carrying the tx context the node already sent, and `TxResolverService.resolveTxs` returns the full `TxOnchainContext` instead of dropping the fields validation needs.
- The utility execution oracle caches that context per execution as tagged logs and resolved txs come in, and serves validation from it. Only txs no earlier step surfaced fall back to a receipt read.
- Note and event validation now take the context as a parameter, each declaring the slice of it that it reads, instead of fetching it themselves.

## Metrics

Same method as #24969: an identical counting wrapper between the benchmarking wallet and the in-process node, applied to both sides. Round trips count how many times the client blocks waiting on the node, so client-perceived latency scales with them.

### Per RPC

| RPC call | Node calls |
|---|---|
| `getTxReceipt` | 22 → 0 (−100.0%) |
| everything else | 328 → 328 |
| **Total** | **350 → 328 (−6.3%)** |

Every receipt these benchmarks read was a validation re-fetch, so the method goes to zero and nothing else moves.

### Per scenario

| Flow | RPC calls | Round trips |
|---|---|---|
| `ecdsar1+transfer_0_recursions+sponsored_fpc` | 35 → 33 (−5.7%) | 26 → 24 (−7.7%) |
| `ecdsar1+transfer_1_recursions+sponsored_fpc` | 37 → 34 (−8.1%) | 23 → 20 (−13.0%) |
| `ecdsar1+transfer_0_recursions+private_fpc` | 56 → 51 (−8.9%) | 35 → 32 (−8.6%) |
| `ecdsar1+transfer_1_recursions+private_fpc` | 56 → 51 (−8.9%) | 31 → 30 (−3.2%) |
| `ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc` | 63 → 59 (−6.3%) | 37 → 34 (−8.1%) |
| `deploy_ecdsar1+sponsored_fpc` | 21 → 21 | 18 → 18 |
| `deploy_schnorr+sponsored_fpc` | 14 → 14 | 11 → 11 |
| `ecdsar1+deploy_tokenContract_with_registration+sponsored_fpc` | 21 → 20 (−4.8%) | 18 → 17 (−5.6%) |
| `schnorr+deploy_tokenContract_with_registration+sponsored_fpc` | 22 → 21 (−4.5%) | 16 → 15 (−6.2%) |
| `ecdsar1+storage_proof_7_layers+sponsored_fpc` | 25 → 24 (−4.0%) | 19 → 18 (−5.3%) |
| **Total** | **350 → 328 (−6.3%)** | **234 → 219 (−6.4%)** |