### PR TITLE
chore: add new client

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -84,7 +84,8 @@ locals {
     "mainnet-rpc-consumer-client9",
     "mainnet-rpc-consumer-client10",
     "mainnet-rpc-consumer-client11",
-    "mainnet-rpc-consumer-client12"
+    "mainnet-rpc-consumer-client12",
+    "mainnet-rpc-consumer-client13"
   ]
 
   consumers = {


### PR DESCRIPTION
Adds `client13` to the mainnet RPC consumers.

Secret created in Secret Manager and `terraform apply`-ed; plan was the expected 2 resources (KongConsumer + ExternalSecret), 0 to change, 0 to destroy. Rate limit 0 = unlimited, matching the other entries in `consumer_secret_names`.

Verified live: KongConsumer `PROGRAMMED=True`, ExternalSecret `SecretSynced`, and an authenticated `node_getNodeInfo` against `canonical.mainnet.rpc.aztec-labs.com` returns a result (keyless still 401s).