### PR TITLE
chore: compose labs cache hashes from component bootstraps

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -18,14 +18,16 @@ function download_solc {
   echo_stderr "Downloading solc $solc_version via svm..."
   # svm-rs always uses ~/.svm if it exists. Make sure it does for a consistent path across OS/architecture.
   mkdir -p "$HOME/.svm"
-  # We build a minimal file to trigger svm download of solc. svm fetches the
+  # We build a minimal file to trigger svm download of solc. It must be a committed
+  # file, not a generated one: this target has no build prerequisites, so generated
+  # sources (e.g. ConstantsGen.sol) may not exist yet when it runs. svm fetches the
   # binary from binaries.soliditylang.org, which intermittently fails to resolve
   # under heavy parallel CI load; retry every 10s for ~5 min to ride out transient
   # DNS drops, but only on connection/DNS failures so a genuine build error fails
   # fast. (The merge queue disables the cache above, so this download path runs
   # every time. stderr is kept so retry can see the DNS error and match on it.)
   RETRY_ATTEMPTS=30 RETRY_SLEEP=10 retry -p 'dns error|Temporary failure in name resolution|error sending request|failed to lookup address|Connection refused|connection reset' \
-    "forge build --use \"$solc_version\" src/core/libraries/ConstantsGen.sol"
+    "forge build --use \"$solc_version\" src/core/interfaces/IVerifier.sol"
 
   # Copy from svm cache to local path
   local svm_path="$HOME/.svm/$solc_version/solc-$solc_version"

--- a/noir-projects/fnd/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/fnd/noir-protocol-circuits/bootstrap.sh
@@ -161,6 +161,7 @@ function generate_vk {
   # Remove temporary json file
   rm $key_path
 }
+
 function check_pinned_vk {
   set -euo pipefail
   local name=$1
@@ -335,6 +336,14 @@ case "$cmd" in
   "clean-keys")
     rm -rf $key_dir
     ;;
+  "hash")
+    # While $circuits_hash is meant for tests, this extended hash
+    # more accuratelly captures the identity of the protocol circuits.
+    hash_str $circuits_hash $(cache_content_hash \
+      "^noir-projects/fnd/noir-protocol-circuits/" \
+      "^noir-projects/fnd/chonk_circuits.json" \
+      "^noir-projects/fnd/rollup_honk_circuits.json")
+  ;;
   "")
     build
     ;;

--- a/noir-projects/labs/contract-snapshots/bootstrap.sh
+++ b/noir-projects/labs/contract-snapshots/bootstrap.sh
@@ -43,12 +43,12 @@ function test_cmds {
       hash=disabled-cache
     else
       hash=$(hash_str \
-        $(../../../noir/bootstrap.sh hash) \
+        $($root/labs-aztec-toolchain/bootstrap.sh hash) \
+        $($root/noir-projects/labs/aztec-nr/bootstrap.sh hash) \
         $(cache_content_hash \
             ^noir-projects/labs/contract-snapshots \
             ^noir-projects/labs/noir-contracts/contracts/app \
-            ^noir-projects/labs/noir-contracts/contracts/test \
-            ^noir-projects/labs/aztec-nr))
+            ^noir-projects/labs/noir-contracts/contracts/test))
     fi
     echo "$hash ./noir-projects/labs/contract-snapshots/bootstrap.sh test"
 }

--- a/noir-projects/labs/noir-contracts/bootstrap.sh
+++ b/noir-projects/labs/noir-contracts/bootstrap.sh
@@ -32,6 +32,8 @@ export BB=${BB:-"$ROOT/labs-aztec-toolchain/bin/bb"}
 export NARGO=${NARGO:-"$ROOT/labs-aztec-toolchain/bin/nargo"}
 AZTEC_TOOLCHAIN_HASH=${AZTEC_TOOLCHAIN_HASH:-$($ROOT/labs-aztec-toolchain/bootstrap.sh hash)}
 export AZTEC_TOOLCHAIN_HASH
+AZTEC_NR_HASH=${AZTEC_NR_HASH:-$($ROOT/noir-projects/labs/aztec-nr/bootstrap.sh hash)}
+export AZTEC_NR_HASH
 # Below the Linux ephemeral range (32768-60999) to reduce accidental port conflicts.
 DEFAULT_TXE_PORT=14730
 
@@ -43,22 +45,22 @@ export PARALLEL_FLAGS="-j${PARALLELISM:-16} --halt now,fail=1 --memsuspend $(mem
 function get_contract_hash {
   local contract_path=$(get_contract_path "$1" "$2")
 
+  # aztec-nr's hash will include the Nargo.toml and therefore the pinned noir-protocol-circuit
+  # in the "aztec" subdirectory (as long as it's pinned to a version and not a path).
   if [ "$2" = "examples" ]; then
     # Called from docs
     hash_str \
       $AZTEC_TOOLCHAIN_HASH \
+      $AZTEC_NR_HASH \
       $(cache_content_hash \
-        ../barretenberg/ts/.rebuild_patterns \
-        "^docs/examples/$contract_path/" \
-        "^noir-projects/labs/aztec-nr/")
+        "^docs/examples/$contract_path/")
   else
     # Called from noir-contracts
     hash_str \
       $AZTEC_TOOLCHAIN_HASH \
+      $AZTEC_NR_HASH \
       $(cache_content_hash \
-        ../../../barretenberg/ts/.rebuild_patterns \
-        "^noir-projects/labs/noir-contracts/contracts/$contract_path/" \
-        "^noir-projects/labs/aztec-nr/")
+        "^noir-projects/labs/noir-contracts/contracts/$contract_path/")
   fi
 }
 export -f get_contract_hash
@@ -190,6 +192,13 @@ function test_cmds {
     folder_name="contracts"
   fi
 
+  # Tests depend on the TXE so we have to inject this dependency.
+  local yarn_project_hash
+  yarn_project_hash=$($ROOT/yarn-project/bootstrap.sh hash)
+  function get_contract_hash_for_testing {
+    hash_str $yarn_project_hash $(get_contract_hash "$1" "$2")
+  }
+
   # Test bb aztec_process command
   echo "$AZTEC_TOOLCHAIN_HASH noir-projects/labs/noir-contracts/scripts/test_aztec_process.sh"
 
@@ -201,7 +210,7 @@ function test_cmds {
   else
     local -A cache
     $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
-      [ -z "${cache[$package]:-}" ] && cache[$package]=$(get_contract_hash $package $folder_name)
+      [ -z "${cache[$package]:-}" ] && cache[$package]=$(get_contract_hash_for_testing $package $folder_name)
       echo "${cache[$package]} noir-projects/labs/scripts/run_test.sh noir-contracts $package $test $txe_port"
     done
   fi
@@ -326,6 +335,9 @@ case "$cmd" in
     ;;
   "pin-standard-build")
     pin-standard-build
+    ;;
+  "hash")
+    hash_str $AZTEC_TOOLCHAIN_HASH $AZTEC_NR_HASH $(cache_content_hash "^noir-projects/labs/noir-contracts/")
     ;;
   *)
     default_cmd_handler "$@"

--- a/yarn-project/.rebuild_patterns
+++ b/yarn-project/.rebuild_patterns
@@ -1,2 +1,1 @@
 ^yarn-project/
-^protocol/constants-codegen/

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -2,11 +2,18 @@
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
 function hash {
+  # Pinned dependencies are hashed via yarn.lock.
+  # NOTE: This does NOT work for portals.
+  # TODO(monorepo-split): Once fnd dependencies are pinned, they should be removed from here. Including l1-contracts!
   hash_str \
-    $(../noir/bootstrap.sh hash) \
     $(../barretenberg/bootstrap.sh hash) \
     $(../ipc-codegen/bootstrap.sh hash) \
-    $(cache_content_hash ../{avm-transpiler,noir-projects,l1-contracts,yarn-project}/.rebuild_patterns)
+    $(../labs-aztec-toolchain/bootstrap.sh hash) \
+    $(../noir-projects/labs/noir-contracts/bootstrap.sh hash) \
+    $(../noir-projects/labs/aztec-nr/bootstrap.sh hash) \
+    $(../noir-projects/fnd/noir-protocol-circuits/bootstrap.sh hash) \
+    $(cache_content_hash "^noir-projects/fnd/mock-protocol-circuits/" "^noir-projects/fnd/noir-contracts/") \
+    $(cache_content_hash ../{l1-contracts,yarn-project}/.rebuild_patterns)
 }
 
 function compile_project {


### PR DESCRIPTION
Reworks the cache/test hashes so each component's key is composed from the bootstraps that own its dependencies, instead of blanket source patterns. This prepares for the labs repo split, where identity comes from the pinned toolchain binaries, `Nargo.toml` git-tag pins, and `yarn.lock` instead of sibling source trees.

Part of https://linear.app/aztec-labs/issue/A-1563/sort-out-how-labs-hashesrebuild-patterns-will-interact-in-the-fnd-repo .
Part of https://linear.app/aztec-labs/issue/A-1547/fix-yarn-project-hash-dependencies .

## Changes

- **`yarn-project`**: the hash is now composed from the toolchain, `labs/noir-contracts`, `labs/aztec-nr`, and `fnd/noir-protocol-circuits` bootstrap hashes, plus patterns for `fnd/mock-protocol-circuits`, `fnd/noir-contracts` (protocol contracts), `l1-contracts` and its own sources. The `noir`/`barretenberg`/`ipc-codegen`/`avm-transpiler` components are dropped: compiler and prover identity reaches the hash through the toolchain's binary content (the transpiler is linked into `bb`), and pinned npm deps are hashed via `yarn.lock`.
- **`labs/noir-contracts`**: `AZTEC_NR_HASH` is computed once and exported alongside `AZTEC_TOOLCHAIN_HASH`. The per-contract hash becomes toolchain + aztec-nr + the contract's own sources — the `barretenberg/ts` and blanket `aztec-nr` patterns go away, and protocol-types identity now flows through aztec-nr's `Nargo.toml` tag pin (#25054). Adds a `hash` subcommand for consumers. TXE test keys additionally mix in `yarn-project`'s hash, so TXE changes re-run contract tests (previously only bb.js changes did, via the removed pattern).
- **`fnd/noir-protocol-circuits`**: exposes `hash` (the existing `circuits_hash`) so consumers can compose it.
- **`labs/contract-snapshots`**: test key uses the toolchain and aztec-nr bootstraps instead of the noir submodule hash — it now tracks the actual `nargo` binary the tests run, which stays correct once the toolchain is downloaded rather than built.
- **`yarn-project/.rebuild_patterns`**: drops `^protocol/constants-codegen/`; the generated constants are committed under `yarn-project/`, so `^yarn-project/` already captures regeneration.

## Follow-ups

- `link:`/`portal:` deps record no checksum in `yarn.lock`, and yarn-project's hash no longer covers `barretenberg/ts`, `wsdb`, or `ipc-runtime` sources — a TS-only change there won't invalidate yarn-project builds/tests until those are consumed as pinned published packages (native `bb` changes still arrive via the toolchain hash). This is the main remaining gap on the monorepo.
- Remove the fnd components and `l1-contracts` from yarn-project's hash once those are consumed as pinned packages (`TODO(monorepo-split)` in the code).
- Same exercise for `boxes`: its hash still carries `barretenberg/*`, `l1-contracts`, and `yarn-project` source patterns because its `resolutions` block links them from source.
- `release-image`'s smoke test is keyed on a hash that omits yarn-project content, so it can cache-skip after a yarn-project change rebuilds the image.
- bb-driven vk changes inside fnd circuit artifacts reach yarn-project's hash only via the toolchain's `bin/bb` content — true on the monorepo where they're the same binary, but worth an explicit comment or mechanism.
- The `protocol_types` tag pin must be kept reasonably fresh; aztec-nr's hash only sees protocol-types changes when the pin moves.

## Also included

- `fix: use committed file to trigger svm solc download` — cherry-pick of #25092 (merge-train/fairies) for this line: `download_solc` forge-built the gitignored `ConstantsGen.sol` to trigger svm's solc fetch, which fails on cache-disabled runs before constants are generated (ci log `7157efbba71d6a7c`). Now triggers on the committed `IVerifier.sol`.
