### PR TITLE
feat(aztec.js): delay first receipt poll after sending a tx

### DIFF
--- a/yarn-project/aztec.js/src/contract/wait_opts.ts
+++ b/yarn-project/aztec.js/src/contract/wait_opts.ts
@@ -4,7 +4,7 @@ import type { TxStatus } from '@aztec/stdlib/tx';
 export type WaitOpts = {
   /** The amount of time to ignore TxStatus.DROPPED receipts (in seconds) due to the presumption that it is being propagated by the p2p network. Defaults to 5. */
   ignoreDroppedReceiptsFor?: number;
-  /** The maximum time (in seconds) to wait for the transaction to be mined. Defaults to 60. */
+  /** The maximum time (in seconds) to wait for the transaction to be mined. Defaults to 300 (5 min). */
   timeout?: number;
   /** The time interval (in seconds) between retries to fetch the transaction receipt. Defaults to 1. */
   interval?: number;
@@ -12,6 +12,11 @@ export type WaitOpts = {
   dontThrowOnRevert?: boolean;
   /** The minimum inclusion status to wait for. If set, waits until the receipt reaches this status or higher. Defaults to CHECKPOINTED. */
   waitForStatus?: TxStatus;
+  /**
+   * The time (in seconds) to wait before the first receipt poll. Defaults to 0. Used to avoid checking for a receipt
+   * right after sending a tx, when we know it cannot have been mined yet. Counts against `timeout`.
+   */
+  initialDelay?: number;
 };
 
 export const DefaultWaitOpts: WaitOpts = {

--- a/yarn-project/aztec.js/src/utils/node.test.ts
+++ b/yarn-project/aztec.js/src/utils/node.test.ts
@@ -78,6 +78,45 @@ describe('waitForTx', () => {
     });
   });
 
+  describe('initialDelay option', () => {
+    it('delays the first receipt poll', async () => {
+      const start = Date.now();
+      let firstPollAt: number | undefined;
+      node.getTxReceipt.mockImplementation(() => {
+        firstPollAt ??= Date.now();
+        return Promise.resolve(minedReceipt(TxStatus.CHECKPOINTED));
+      });
+
+      const receipt = await waitForTx(node, txHash, { timeout: 1, interval: 0.05, initialDelay: 0.2 });
+
+      expect(receipt.status).toBe(TxStatus.CHECKPOINTED);
+      expect(node.getTxReceipt).toHaveBeenCalledTimes(1);
+      expect(firstPollAt! - start).toBeGreaterThanOrEqual(150);
+    });
+
+    it('does not consume the dropped-receipt grace period', async () => {
+      node.getTxReceipt.mockResolvedValue(new DroppedTxReceipt(txHash, 'Tx dropped'));
+      const start = Date.now();
+
+      await expect(
+        waitForTx(node, txHash, { timeout: 2, interval: 0.05, initialDelay: 0.3, ignoreDroppedReceiptsFor: 0.2 }),
+      ).rejects.toThrow(/dropped/);
+
+      expect(Date.now() - start).toBeGreaterThanOrEqual(450);
+    });
+
+    it('counts against the timeout', async () => {
+      node.getTxReceipt.mockResolvedValue(new PendingTxReceipt(txHash, undefined));
+      const start = Date.now();
+
+      await expect(waitForTx(node, txHash, { timeout: 0.3, interval: 0.05, initialDelay: 1 })).rejects.toThrow(
+        /Timeout/,
+      );
+
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+  });
+
   describe('waitForStatus option', () => {
     it('returns immediately when receipt status matches requested status', async () => {
       node.getTxReceipt.mockResolvedValue(minedReceipt(TxStatus.CHECKPOINTED));

--- a/yarn-project/aztec.js/src/utils/node.ts
+++ b/yarn-project/aztec.js/src/utils/node.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { TxHash, TxReceipt } from '@aztec/stdlib/tx';
 import { SortedTxStatuses, TxStatus } from '@aztec/stdlib/tx';
@@ -47,9 +48,20 @@ function hasReachedStatus(receipt: TxReceipt, desiredStatus: TxStatus): boolean 
  * @throws If the transaction fails and dontThrowOnRevert is not set
  */
 export async function waitForTx(node: AztecNode, txHash: TxHash, opts?: WaitOpts): Promise<TxReceipt> {
-  const startTime = Date.now();
   const ignoreDroppedReceiptsFor = opts?.ignoreDroppedReceiptsFor ?? DefaultWaitOpts.ignoreDroppedReceiptsFor;
   const waitForStatus = opts?.waitForStatus ?? TxStatus.CHECKPOINTED;
+  const timeout = opts?.timeout ?? DefaultWaitOpts.timeout;
+  // The initial delay counts against the timeout: the deadline is fixed before sleeping, and the sleep never
+  // exceeds it.
+  const deadline = timeout ? { deadline: new Date(Date.now() + timeout * 1000) } : undefined;
+
+  if (opts?.initialDelay) {
+    const delay = Math.min(opts.initialDelay, timeout ?? Infinity);
+    await sleep(delay * 1000);
+  }
+
+  // The grace period for DROPPED receipts starts at the first poll, so the initial delay does not consume it.
+  const startTime = Date.now();
 
   const receipt = await retryUntil(
     async () => {
@@ -75,7 +87,7 @@ export async function waitForTx(node: AztecNode, txHash: TxHash, opts?: WaitOpts
       return txReceipt;
     },
     'isMined',
-    opts?.timeout ?? DefaultWaitOpts.timeout,
+    deadline,
     opts?.interval ?? DefaultWaitOpts.interval,
   );
 

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -333,6 +333,7 @@ export const WaitOptsSchema = z.object({
   timeout: optional(z.number()),
   interval: optional(z.number()),
   dontThrowOnRevert: optional(z.boolean()),
+  initialDelay: optional(z.number()),
 });
 
 const FromSchema = z.union([schemas.AztecAddress, z.literal(NO_FROM)]);

--- a/yarn-project/end-to-end/src/automine/double_spend.test.ts
+++ b/yarn-project/end-to-end/src/automine/double_spend.test.ts
@@ -1,6 +1,7 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
+import type { AztecNode } from '@aztec/aztec.js/node';
 import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -11,6 +12,7 @@ import { AutomineTestContext } from './automine_test_context.js';
 // Uses setup(1, AUTOMINE_E2E_OPTS) with one node, automine sequencer, one funded account.
 describe('automine/double_spend', () => {
   let wallet: Wallet;
+  let aztecNode: AztecNode;
   let defaultAccountAddress: AztecAddress;
 
   let logger: Logger;
@@ -20,12 +22,14 @@ describe('automine/double_spend', () => {
 
   beforeAll(async () => {
     // Setup environment
+    const ctx = await AutomineTestContext.setup({ numberOfAccounts: 1 });
     ({
       teardown,
       wallet,
       accounts: [defaultAccountAddress],
       logger,
-    } = (await AutomineTestContext.setup({ numberOfAccounts: 1 })).context);
+    } = ctx.context);
+    aztecNode = ctx.aztecNode;
 
     ({ contract } = await TestContract.deploy(wallet).send({ from: defaultAccountAddress }));
 
@@ -52,6 +56,17 @@ describe('automine/double_spend', () => {
       await expect(
         contract.methods.emit_nullifier_public(nullifier).send({ from: defaultAccountAddress }),
       ).rejects.toThrow(TxExecutionResult.REVERTED);
+    });
+
+    it('rejects re-sending a tx that was already mined', async () => {
+      const { receipt } = await contract.methods.emit_nullifier_public(new Fr(2)).send({
+        from: defaultAccountAddress,
+      });
+
+      const minedTx = await aztecNode.getTxByHash(receipt.txHash, { includeProof: true });
+      expect(minedTx).toBeDefined();
+
+      await expect(aztecNode.sendTx(minedTx!)).rejects.toThrow(/Existing nullifier/);
     });
   });
 });

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
@@ -18,7 +18,6 @@ import {
   NestedProcessReturnValues,
   OFFCHAIN_MESSAGE_IDENTIFIER,
   type OffchainEffect,
-  PendingTxReceipt,
   PrivateExecutionResult,
   Tx,
   TxEffect,
@@ -399,7 +398,6 @@ describe('BaseWallet', () => {
     pxe.getSyncedBlockHeader.mockResolvedValue(BlockHeader.empty());
     wallet.mockAccount.createTxExecutionRequest.mockResolvedValue(mock());
     pxe.proveTx.mockResolvedValue(provenTx);
-    node.getTxReceipt.mockResolvedValue(new PendingTxReceipt(TxHash.random(), undefined));
     node.sendTx.mockResolvedValue();
 
     const payload = new ExecutionPayload([await makeFunctionCall(FunctionType.PRIVATE, false, 'transfer')], [], []);

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -2,9 +2,11 @@ import type { Account, NoFrom } from '@aztec/aztec.js/account';
 import { NO_FROM } from '@aztec/aztec.js/account';
 import type { CallIntent, IntentInnerHash } from '@aztec/aztec.js/authorization';
 import {
+  DefaultWaitOpts,
   type InteractionWaitOptions,
   NO_WAIT,
   type SendReturn,
+  type WaitOpts,
   extractOffchainOutput,
 } from '@aztec/aztec.js/contracts';
 import type { FeePaymentMethod } from '@aztec/aztec.js/fee';
@@ -531,9 +533,6 @@ export abstract class BaseWallet implements Wallet {
     );
     const tx = await provenTx.toTx();
     const txHash = tx.getTxHash();
-    if ((await this.aztecNode.getTxReceipt(txHash)).isMined()) {
-      throw new Error(`A settled tx with equal hash ${txHash.toString()} exists.`);
-    }
     this.log.debug(`Sending transaction ${txHash}`);
     await this.aztecNode.sendTx(tx).catch(err => {
       throw this.contextualizeError(err, inspect(tx));
@@ -547,11 +546,13 @@ export abstract class BaseWallet implements Wallet {
 
     // Otherwise, wait for the full receipt (default behavior on wait: undefined)
     const callerWaitOpts = typeof opts.wait === 'object' ? opts.wait : undefined;
-    const waitOpts =
+    const waitOpts: WaitOpts | undefined =
       this.defaultWaitInterval !== undefined && callerWaitOpts?.interval === undefined
         ? { ...callerWaitOpts, interval: this.defaultWaitInterval }
         : callerWaitOpts;
-    const receipt = await waitForTx(this.aztecNode, txHash, waitOpts);
+    // The tx was just sent, so an immediate first poll cannot find it mined; skip one poll interval up front.
+    const initialDelay = waitOpts?.initialDelay ?? waitOpts?.interval ?? DefaultWaitOpts.interval;
+    const receipt = await waitForTx(this.aztecNode, txHash, { ...waitOpts, initialDelay });
 
     // Display debug logs from public execution if present (served in test mode only)
     if (receipt.isMined() && receipt.debugLogs?.length) {


### PR DESCRIPTION
## Motivation

Follow-up to #25074 and #25076 in the effort to reduce PXE↔node RPC traffic. Two calls per sent tx were guaranteed wasted: a pre-send `getTxReceipt` used only to reject settled duplicates, which the node's tx validation already rejects via its double-spend check, and the first receipt poll of `.wait()`, issued immediately after `sendTx` when the tx cannot have been mined yet.

## The change

- `BaseWallet.sendTx` no longer reads the receipt before sending; duplicate submissions are rejected by the node instead.
- `WaitOpts` gains `initialDelay`: seconds to sleep before the first receipt poll. The wallet defaults it to the poll interval, so the first poll now happens where the second poll used to. Environments where receipts are available immediately after sending (e.g. automine) can pass `initialDelay: 0`.
- The delay counts against `timeout` (the deadline is fixed before sleeping) and does not consume the DROPPED-receipt grace period, which starts at the first poll.

Wallet benchmark results:

| | Before → After |
|---|---|
| `getTxReceipt` calls | 40 → 32 (−20.0%) |
| Total node RPC calls | 232 → 224 (−3.4%) |
| Node RPC round trips | 163 → 156 (−4.3%) |