### PR TITLE
fix: use committed file to trigger svm solc download

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -18,14 +18,16 @@ function download_solc {
   echo_stderr "Downloading solc $solc_version via svm..."
   # svm-rs always uses ~/.svm if it exists. Make sure it does for a consistent path across OS/architecture.
   mkdir -p "$HOME/.svm"
-  # We build a minimal file to trigger svm download of solc. svm fetches the
+  # We build a minimal file to trigger svm download of solc. It must be a committed
+  # file, not a generated one: this target has no build prerequisites, so generated
+  # sources (e.g. ConstantsGen.sol) may not exist yet when it runs. svm fetches the
   # binary from binaries.soliditylang.org, which intermittently fails to resolve
   # under heavy parallel CI load; retry every 10s for ~5 min to ride out transient
   # DNS drops, but only on connection/DNS failures so a genuine build error fails
   # fast. (The merge queue disables the cache above, so this download path runs
   # every time. stderr is kept so retry can see the DNS error and match on it.)
   RETRY_ATTEMPTS=30 RETRY_SLEEP=10 retry -p 'dns error|Temporary failure in name resolution|error sending request|failed to lookup address|Connection refused|connection reset' \
-    "forge build --use \"$solc_version\" src/core/libraries/ConstantsGen.sol"
+    "forge build --use \"$solc_version\" src/core/interfaces/IVerifier.sol"
 
   # Copy from svm cache to local path
   local svm_path="$HOME/.svm/$solc_version/solc-$solc_version"


### PR DESCRIPTION
`download_solc` triggers svm's solc fetch by forge-building a single file. That file was `ConstantsGen.sol`, which is gitignored (generated by constants-codegen since #24730) — but the `l1-contracts-solc` make target deliberately has no prerequisites, so on any run where the solc cache is unavailable (the merge queue disables it) forge ran before the file existed and failed with:

```
Error: No source files found in specified build paths.
```

This surfaced on the monorepo-split/labs line (ci log `7157efbba71d6a7c`) but the code is identical on this line — it's masked here only while the cache artifact is available. Inside `build_src` the old trigger was safe (`remake-constants.sh` runs first); the standalone `l1-contracts-solc` target — the "single owner of the svm download" that other forge projects wait on — was the broken path.

Fix: trigger on `src/core/interfaces/IVerifier.sol` (committed, 7 lines, no imports), and document that the trigger must be a committed file.

Verified red/green locally: with `ConstantsGen.sol` absent the old command reproduces the CI error; the new one builds fine, and `./bootstrap.sh download_solc` runs clean.

The same fix is applied to the labs line via #25083.
