### PR TITLE
docs: remove nr protocol include_codes

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
@@ -48,11 +48,7 @@ The context inputs includes all of the information that is passed from the kerne
 
 As shown in the snippet, the application context is made up of 3 main structures. The call context, the block header, and the private global variables.
 
-First of all, the call context.
-
-#include_code call-context /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/call_context.nr rust
-
-The call context contains information about the current call being made:
+First of all, the [`CallContext`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/call_context/struct.CallContext.html), which contains information about the current call being made:
 
 1. Msg Sender
    - The message sender is the account (Aztec Contract) that sent the message to the current context. In the first call of the kernel circuit (often the account contract call), this value will be empty. For all subsequent calls the value will be the previous call.
@@ -71,15 +67,11 @@ The call context contains information about the current call being made:
 
 ### Block Header
 
-Another structure that is contained within the context is the `BlockHeader` object, which is the header of the block used to generate proofs against.
-
-#include_code block-header /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/block_header.nr rust
+Another structure that is contained within the context is the [`BlockHeader`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/block_header/struct.BlockHeader.html) object, which is the header of the block used to generate proofs against.
 
 ### Transaction Context
 
-The private context provides access to the transaction context as well, which are user-defined values for the transaction in general that stay constant throughout its execution.
-
-#include_code tx-context /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/transaction/tx_context.nr rust
+The private context provides access to the [`TxContext`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/transaction/tx_context/struct.TxContext.html) as well, which holds user-defined values for the transaction in general that stay constant throughout its execution.
 
 ### Args Hash
 
@@ -138,6 +130,4 @@ The Public Context includes all of the information passed from the `Public VM` i
 
 ### Public Global Variables
 
-The public global variables are provided by the rollup sequencer and consequently contain some more values than the private global variables.
-
-#include_code global-variables /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/global_variables.nr rust
+The public global variables ([`GlobalVariables`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/global_variables/struct.GlobalVariables.html)) are provided by the rollup sequencer and consequently contain some more values than the private global variables.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
@@ -13,11 +13,7 @@ Aztec has two execution environments—Private and Public—each with different 
 
 ## Private Global Variables
 
-Private functions access transaction context via `TxContext`:
-
-#include_code tx-context /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/transaction/tx_context.nr rust
-
-The following fields are accessible via `context` methods:
+Private functions access transaction context via [`TxContext`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/transaction/tx_context/struct.TxContext.html). The following fields are accessible via `context` methods:
 
 ### Chain Id
 
@@ -45,9 +41,7 @@ self.context.gas_settings();
 
 ## Public Global Variables
 
-Public functions access block-level context via `GlobalVariables`:
-
-#include_code global-variables /noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/global_variables.nr rust
+Public functions access block-level context via [`GlobalVariables`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/abis/global_variables/struct.GlobalVariables.html).
 
 :::note
 Not all fields in `GlobalVariables` are exposed via context methods. The `coinbase`, `fee_recipient`, and `slot_number` fields are used internally by the protocol.

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -112,9 +112,27 @@ Due to the rigidity of zk-SNARK circuits, there are upper bounds on the amount o
 
 > Blockchain developers are no stranger to restrictive computational environments. Ethereum has gas limits, local variable stack limits, call stack limits, contract deployment size limits, log size limits, etc.
 
-Here are the current constants:
+Here are the current limits:
 
-#include_code constants /noir-projects/fnd/noir-protocol-circuits/crates/types/src/constants.nr rust
+| Limit | Per call | Per transaction |
+| --- | --- | --- |
+| Note hashes | `MAX_NOTE_HASHES_PER_CALL` = 16 | `MAX_NOTE_HASHES_PER_TX` = 64 |
+| Nullifiers | `MAX_NULLIFIERS_PER_CALL` = 16 | `MAX_NULLIFIERS_PER_TX` = 64 |
+| Private function calls | `MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL` = 8 | `MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX` = 16 |
+| Enqueued public calls | `MAX_ENQUEUED_CALLS_PER_CALL` = 32 | `MAX_ENQUEUED_CALLS_PER_TX` = 32 |
+| L2 to L1 messages | `MAX_L2_TO_L1_MSGS_PER_CALL` = 8 | `MAX_L2_TO_L1_MSGS_PER_TX` = 8 |
+| Private logs | `MAX_PRIVATE_LOGS_PER_CALL` = 16 | `MAX_PRIVATE_LOGS_PER_TX` = 64 |
+| Contract class logs | `MAX_CONTRACT_CLASS_LOGS_PER_CALL` = 1 | `MAX_CONTRACT_CLASS_LOGS_PER_TX` = 1 |
+| Note hash read requests | `MAX_NOTE_HASH_READ_REQUESTS_PER_CALL` = 16 | `MAX_NOTE_HASH_READ_REQUESTS_PER_TX` = 64 |
+| Nullifier read requests | `MAX_NULLIFIER_READ_REQUESTS_PER_CALL` = 16 | `MAX_NULLIFIER_READ_REQUESTS_PER_TX` = 64 |
+| Key validation requests | `MAX_KEY_VALIDATION_REQUESTS_PER_CALL` = 16 | `MAX_KEY_VALIDATION_REQUESTS_PER_TX` = 64 |
+| Public data writes | n/a | `MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX` = 63 |
+| Public data reads | n/a | `MAX_PUBLIC_DATA_READS_PER_TX` = 64 |
+
+:::note
+Public data writes have no per-call limit, and one of the 64 write slots per transaction is reserved by the protocol for the fee payer's fee juice balance update.
+The full list of protocol constants, including tree heights and other protocol parameters, is available in the [API reference](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/constants/index.html).
+:::
 
 #### What are the consequences?
 


### PR DESCRIPTION
I replaced these with either apilinks to structs, or raw content + link to github for constants.