### PR TITLE
chore(yarn-project): drop build-time oracle version sync checks

### DIFF
--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -1,11 +1,8 @@
 import { keccak256String } from '@aztec/foundation/crypto/keccak';
 
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-
 import { ORACLE_REGISTRY } from '../contract_function_simulator/index.js';
-import { ORACLE_INTERFACE_HASH, ORACLE_VERSION_MAJOR } from '../oracle_version.js';
-import { getOracleRegistrySignature, readNumericGlobal } from './oracle_version_helpers.js';
+import { ORACLE_INTERFACE_HASH } from '../oracle_version.js';
+import { getOracleRegistrySignature } from './oracle_version_helpers.js';
 
 /**
  * Verifies that the Oracle interface matches the expected interface hash.
@@ -28,45 +25,4 @@ function assertOracleInterfaceMatches(): void {
   }
 }
 
-/**
- * Verifies that `ORACLE_VERSION_MAJOR` is identical across all of its hand-maintained copies.
- *
- * The major version is duplicated across the PXE TypeScript constant and two Noir constants (Aztec.nr and the protocol
- * contracts' `aztec_sublib`) because those layers can't import each other. This static check fails fast at build time,
- * naming each file and its value.
- *
- * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract
- * minor" tolerance, so asserting minor equality would false-positive.
- */
-function assertContractOracleVersionMajorInSync(): void {
-  const currentDir = dirname(fileURLToPath(import.meta.url));
-  // Go up from dest/bin/ or src/bin/ to the package root (pxe/), then up two more to the git root.
-  const packageRoot = dirname(dirname(currentDir));
-  const gitRoot = join(packageRoot, '..', '..');
-
-  const copies = [
-    { label: 'pxe/src/oracle_version.ts', value: ORACLE_VERSION_MAJOR },
-    {
-      label: 'aztec-nr/aztec/src/oracle/version.nr',
-      value: readNumericGlobal(
-        join(gitRoot, 'noir-projects/labs/aztec-nr/aztec/src/oracle/version.nr'),
-        'ORACLE_VERSION_MAJOR',
-      ),
-    },
-    {
-      label: 'aztec_sublib/src/oracle/version.nr',
-      value: readNumericGlobal(
-        join(gitRoot, 'noir-projects/fnd/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr'),
-        'ORACLE_VERSION_MAJOR',
-      ),
-    },
-  ];
-
-  if (new Set(copies.map(copy => copy.value)).size > 1) {
-    const details = copies.map(copy => `${copy.label}=${copy.value}`).join(', ');
-    throw new Error(`ORACLE_VERSION_MAJOR is out of sync: ${details}. Bump all copies together.`);
-  }
-}
-
 assertOracleInterfaceMatches();
-assertContractOracleVersionMajorInSync();

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,1 +1,1 @@
-export { getOracleRegistrySignature, readNumericGlobal } from './oracle_version_helpers.js';
+export { getOracleRegistrySignature } from './oracle_version_helpers.js';

--- a/yarn-project/pxe/src/bin/oracle_version_helpers.test.ts
+++ b/yarn-project/pxe/src/bin/oracle_version_helpers.test.ts
@@ -1,57 +1,7 @@
 /* eslint-disable camelcase */
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
 import { ARRAY, AZTEC_ADDRESS, BOOL, FIELD, OPTION, U32, makeEntry } from '../contract_function_simulator/index.js';
 import { TX_HASH } from '../contract_function_simulator/oracle/oracle_type_mappings.js';
-import { getOracleRegistrySignature, readNumericGlobal } from './oracle_version_helpers.js';
-
-describe('readNumericGlobal', () => {
-  let dir: string;
-
-  beforeAll(() => {
-    dir = mkdtempSync(join(tmpdir(), 'oracle-version-'));
-  });
-
-  afterAll(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it('extracts the value from a Noir global declaration', () => {
-    const path = writeFixture(
-      dir,
-      'version.nr',
-      `pub global ORACLE_VERSION_MAJOR: Field = 28;\npub global ORACLE_VERSION_MINOR: Field = 3;\n`,
-    );
-    expect(readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toBe(28);
-    expect(readNumericGlobal(path, 'ORACLE_VERSION_MINOR')).toBe(3);
-  });
-
-  it('extracts the value from a TypeScript const declaration', () => {
-    const path = writeFixture(dir, 'oracle_version.ts', `export const ORACLE_VERSION_MAJOR = 28;\n`);
-    expect(readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toBe(28);
-  });
-
-  it('reads the declaration and ignores later usages of the constant', () => {
-    const path = writeFixture(
-      dir,
-      'usage.nr',
-      `pub global TXE_ORACLE_VERSION_MAJOR: Field = 5;\nfoo(TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR);\n`,
-    );
-    expect(readNumericGlobal(path, 'TXE_ORACLE_VERSION_MAJOR')).toBe(5);
-  });
-
-  it('does not match a constant whose name extends the requested name', () => {
-    const path = writeFixture(dir, 'prefixed.nr', `pub global SOME_ORACLE_VERSION_MAJOR: Field = 9;\n`);
-    expect(() => readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toThrow(/Could not find numeric global/);
-  });
-
-  it('throws when the global is absent', () => {
-    const path = writeFixture(dir, 'empty.nr', `pub global SOMETHING_ELSE: Field = 1;\n`);
-    expect(() => readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toThrow(/Could not find numeric global/);
-  });
-});
+import { getOracleRegistrySignature } from './oracle_version_helpers.js';
 
 describe('getOracleRegistrySignature', () => {
   const SAMPLE_REGISTRY = {
@@ -103,9 +53,3 @@ describe('getOracleRegistrySignature', () => {
     expect(getOracleRegistrySignature(registry)).toBe('aztec_utl_foo(a: option(array(field))): aztec-address');
   });
 });
-
-const writeFixture = (dir: string, name: string, contents: string): string => {
-  const path = join(dir, name);
-  writeFileSync(path, contents);
-  return path;
-};

--- a/yarn-project/pxe/src/bin/oracle_version_helpers.ts
+++ b/yarn-project/pxe/src/bin/oracle_version_helpers.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'fs';
-
 import type { OracleRegistryEntry } from '../contract_function_simulator/index.js';
 
 /**
@@ -29,26 +27,4 @@ export function getOracleRegistrySignature(registry: Record<string, OracleRegist
   oracleSignatures.sort();
 
   return oracleSignatures.join('\n');
-}
-
-/**
- * Reads an integer-valued global constant from a Noir or TypeScript source file.
- *
- * Matches both the Noir form (`pub global NAME: Field = N;`) and the TypeScript form (`export const NAME = N;`). This
- * lets us compare a version constant that is hand-duplicated across the TS and Noir layers (which can't import each
- * other) without depending on either compiler. Only the assignment form `NAME = N` matches, so later usages of the
- * constant are ignored regardless of their order in the file.
- *
- * @param sourcePath - Absolute path to the source file to read.
- * @param name - Name of the global constant whose integer value should be extracted.
- * @returns The integer value assigned to the constant.
- * @throws If the constant's declaration is not found in the file.
- */
-export function readNumericGlobal(sourcePath: string, name: string): number {
-  const sourceCode = readFileSync(sourcePath, 'utf-8');
-  const match = sourceCode.match(new RegExp(`\\b${name}\\s*(?::\\s*\\w+\\s*)?=\\s*(\\d+)`));
-  if (!match) {
-    throw new Error(`Could not find numeric global '${name}' in ${sourcePath}.`);
-  }
-  return Number(match[1]);
 }

--- a/yarn-project/txe/src/bin/check_txe_oracle_version.ts
+++ b/yarn-project/txe/src/bin/check_txe_oracle_version.ts
@@ -1,12 +1,9 @@
 import { keccak256String } from '@aztec/foundation/crypto/keccak';
-import { getOracleRegistrySignature, readNumericGlobal } from '@aztec/pxe/bin';
+import { getOracleRegistrySignature } from '@aztec/pxe/bin';
 import { ORACLE_REGISTRY, type OracleRegistryEntry } from '@aztec/pxe/simulator';
 
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-
 import { TXE_ORACLE_REGISTRY } from '../oracle/txe_oracle_registry.js';
-import { TXE_ORACLE_INTERFACE_HASH, TXE_ORACLE_VERSION_MAJOR } from '../oracle/txe_oracle_version.js';
+import { TXE_ORACLE_INTERFACE_HASH } from '../oracle/txe_oracle_version.js';
 
 /**
  * Verifies that the TXE oracle interfaces match the expected interface hash.
@@ -31,37 +28,4 @@ function assertTxeOracleInterfaceMatches(): void {
   }
 }
 
-/**
- * Verifies that `TXE_ORACLE_VERSION_MAJOR` is identical across its two hand-maintained copies: the TXE TypeScript
- * constant and the Aztec.nr Noir test helper constant. These layers can't import each other, so the major version is
- * duplicated by hand and a mismatch otherwise only surfaces at runtime. This is the TXE counterpart of the contract
- * oracle version check in `pxe/src/bin/check_oracle_version.ts`; the two version families are tracked separately.
- *
- * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract
- * minor" tolerance, so asserting minor equality would false-positive.
- */
-function assertTxeOracleVersionMajorInSync(): void {
-  const currentDir = dirname(fileURLToPath(import.meta.url));
-  // Go up from dest/bin/ or src/bin/ to the package root (txe/), then up two more to the git root.
-  const packageRoot = dirname(dirname(currentDir));
-  const gitRoot = join(packageRoot, '..', '..');
-
-  const copies = [
-    { label: 'txe/src/txe_oracle_version.ts', value: TXE_ORACLE_VERSION_MAJOR },
-    {
-      label: 'aztec-nr/aztec/src/test/helpers/txe_oracles.nr',
-      value: readNumericGlobal(
-        join(gitRoot, 'noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr'),
-        'TXE_ORACLE_VERSION_MAJOR',
-      ),
-    },
-  ];
-
-  if (new Set(copies.map(copy => copy.value)).size > 1) {
-    const details = copies.map(copy => `${copy.label}=${copy.value}`).join(', ');
-    throw new Error(`TXE_ORACLE_VERSION_MAJOR is out of sync: ${details}. Bump all copies together.`);
-  }
-}
-
 assertTxeOracleInterfaceMatches();
-assertTxeOracleVersionMajorInSync();


### PR DESCRIPTION
## Summary

- Removes `assertContractOracleVersionMajorInSync` and `assertTxeOracleVersionMajorInSync`, which regex-read `ORACLE_VERSION_MAJOR` out of Noir source files to compare it against the TypeScript constant. The runtime `aztec_misc_assertCompatibleOracleVersion` and `aztec_txe_assertCompatibleOracleVersion` oracles already enforce the same invariant against the value actually compiled into the bytecode, which is the authoritative one.
- Drops the `readNumericGlobal` helper along with them; `getOracleRegistrySignature` and both `ORACLE_INTERFACE_HASH` checks are unaffected.

The static checks were a strictly weaker duplicate of the runtime guard. They compared hand-maintained constants rather than what shipped, parsed Noir with a regex whose first match wins regardless of comments, and reached the Noir tree by climbing two directories up from `dest/bin/` to the git root — a working-tree coupling that stops holding as packages move apart.

Verified both runtime guards fire, by bumping each constant in aztec-nr and running a TXE test:

- `ORACLE_VERSION_MAJOR` 30 → 31: `Incompatible aztec cli version: ... (expected oracle major version 30, got 31)`
- `TXE_ORACLE_VERSION_MAJOR` 4 → 5: `Incompatible test environment version: ... (expected test oracle major version 4, got 5)`

Both fire in `TestEnvironment::new_opts`, so they are the first thing any test hits.

The trade-off is error quality, not coverage: a mismatch now fails every TXE test with the same message instead of failing the build once with both file paths named.