### PR TITLE
fix: TxEffect deserializability

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/main.nr
@@ -1,11 +1,14 @@
+mod test;
+
 use aztec::macros::aztec;
 
-/// A contract used to exercise the `aztec_utl_getTxEffect` oracle end-to-end.
+/// A contract used to exercise the tx effect oracles end-to-end.
 #[aztec]
 pub contract TxEffectOracleTest {
     use aztec::{
+        ephemeral::EphemeralArray,
         macros::functions::external,
-        oracle::message_processing::get_tx_effect,
+        oracle::message_processing::{get_tx_effect, get_tx_effects},
         protocol::{hash::poseidon2_hash, traits::Serialize},
     };
 
@@ -13,6 +16,16 @@ pub contract TxEffectOracleTest {
     unconstrained fn get_tx_effect_hash(tx_hash: Field) -> Field {
         let e = get_tx_effect(tx_hash).unwrap();
         poseidon2_hash(e.serialize())
+    }
+
+    #[external("utility")]
+    unconstrained fn get_tx_effects_hashes(tx_hashes: [Field; 2]) -> [Field; 2] {
+        let ephemeral_tx_hashes: EphemeralArray<Field> = EphemeralArray::empty();
+        ephemeral_tx_hashes.push(tx_hashes[0]);
+        ephemeral_tx_hashes.push(tx_hashes[1]);
+
+        let tx_effects = get_tx_effects(ephemeral_tx_hashes);
+        [poseidon2_hash(tx_effects.get(0).unwrap().serialize()), poseidon2_hash(tx_effects.get(1).unwrap().serialize())]
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/test.nr
@@ -1,0 +1,23 @@
+use crate::TxEffectOracleTest;
+use aztec::test::helpers::{test_environment::TestEnvironment, txe_oracles};
+
+#[test]
+unconstrained fn batch_tx_effects_match_singular_tx_effects() {
+    let mut env = TestEnvironment::new();
+    let contract_address = env.deploy("TxEffectOracleTest").without_initializer();
+    let first_deployment_tx_hash = txe_oracles::get_last_tx_effects().tx_hash;
+    let _ = env.deploy("TxEffectOracleTest").without_initializer();
+    let second_deployment_tx_hash = txe_oracles::get_last_tx_effects().tx_hash;
+
+    let first_singular_hash =
+        env.execute_utility(TxEffectOracleTest::at(contract_address).get_tx_effect_hash(first_deployment_tx_hash));
+    let second_singular_hash =
+        env.execute_utility(TxEffectOracleTest::at(contract_address).get_tx_effect_hash(second_deployment_tx_hash));
+
+    let batch_hashes = env.execute_utility(TxEffectOracleTest::at(contract_address).get_tx_effects_hashes([
+        first_deployment_tx_hash,
+        second_deployment_tx_hash,
+    ]));
+
+    assert_eq(batch_hashes, [first_singular_hash, second_singular_hash]);
+}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/tx_effect.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/tx_effect.nr
@@ -8,10 +8,10 @@ use crate::{
         MAX_NULLIFIERS_PER_TX, MAX_PRIVATE_LOGS_PER_TX,
         MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     },
-    traits::{Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize},
 };
 
-#[derive(Eq, Serialize)]
+#[derive(Deserialize, Eq, Serialize)]
 pub struct TxEffect {
     pub revert_code: u8,
     pub tx_hash: Field,


### PR DESCRIPTION
The batch oracle `aztec_utl_getTxEffects`, added by https://github.com/AztecProtocol/aztec-packages/pull/24636 , returned a value that no Noir contract could read.

Its Noir wrapper `get_tx_effects`  handed back an `EphemeralArray<Option<TxEffect>>`, but every method that reads an element out of that array requires the element type to implement `Deserialize`, and `TxEffect` did not . A contract can obtain the array and ask for its length; any attempt to read an element fails to compile.

This PR tags `TxEffect` as `Deserializable`, which makes the oracle usable.