### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/create-rollup-upgrade-payload.yml
+++ b/.github/workflows/create-rollup-upgrade-payload.yml
@@ -55,6 +55,7 @@ jobs:
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           NETWORK: ${{ inputs.network }}
+          REGISTRY_ADDRESS: ${{ inputs.registry_address }}
           NO_SPOT: 1
         run: |
-          ./.github/ci3.sh deploy-rollup-upgrade "${{ inputs.registry_address }}"
+          ./.github/ci3.sh deploy-rollup-upgrade "$REGISTRY_ADDRESS"

--- a/.github/workflows/deploy-irm.yml
+++ b/.github/workflows/deploy-irm.yml
@@ -103,22 +103,27 @@ jobs:
           echo "IMAGE_TAG=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Validate inputs
+        env:
+          L1_NETWORK: ${{ inputs.l1_network }}
+          INPUT_NAMESPACE: ${{ inputs.namespace }}
+          INPUT_NETWORK: ${{ inputs.network }}
+          INPUT_MONITORING_NAMESPACE: ${{ inputs.monitoring_namespace }}
         run: |
           # Validate l1_network
-          if [[ "${{ inputs.l1_network }}" != "sepolia" && "${{ inputs.l1_network }}" != "mainnet" ]]; then
-            echo "Error: L1 network must be 'sepolia' or 'mainnet', got '${{ inputs.l1_network }}'"
+          if [[ "$L1_NETWORK" != "sepolia" && "$L1_NETWORK" != "mainnet" ]]; then
+            echo "Error: L1 network must be 'sepolia' or 'mainnet', got '${L1_NETWORK}'"
             exit 1
           fi
 
           # Validate namespace to monitor
           # Determine namespace to monitor (defaults to network when not provided)
-          NAMESPACE_TO_MONITOR="${{ inputs.namespace }}"
+          NAMESPACE_TO_MONITOR="${INPUT_NAMESPACE}"
           if [[ -z "$NAMESPACE_TO_MONITOR" ]]; then
-            NAMESPACE_TO_MONITOR="${{ inputs.network }}"
+            NAMESPACE_TO_MONITOR="${INPUT_NETWORK}"
           fi
 
           # Determine IRM namespace (defaults to {namespace}-irm when not provided)
-          EFFECTIVE_MONITORING_NAMESPACE="${{ inputs.monitoring_namespace }}"
+          EFFECTIVE_MONITORING_NAMESPACE="${INPUT_MONITORING_NAMESPACE}"
           if [[ -z "$EFFECTIVE_MONITORING_NAMESPACE" ]]; then
             EFFECTIVE_MONITORING_NAMESPACE="${NAMESPACE_TO_MONITOR}-irm"
           fi
@@ -143,11 +148,13 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          INPUT_NETWORK: ${{ inputs.network }}
+          L1_NETWORK: ${{ inputs.l1_network }}
         run: |
-          echo "Deploying IRM to network: ${{ inputs.network }}"
+          echo "Deploying IRM to network: ${INPUT_NETWORK}"
           echo "Namespace to monitor: ${NAMESPACE}"
           echo "Monitoring namespace: ${MONITORING_NAMESPACE}"
-          echo "L1 network: ${{ inputs.l1_network }}"
+          echo "L1 network: ${L1_NETWORK}"
           echo "Image tag: ${IMAGE_TAG}"
 
-          ./spartan/metrics/irm-monitor/scripts/update-monitoring.sh $NAMESPACE $MONITORING_NAMESPACE ${{ inputs.network }} $ETHEREUM_HOSTS_SECRET_NAME
+          ./spartan/metrics/irm-monitor/scripts/update-monitoring.sh $NAMESPACE $MONITORING_NAMESPACE "$INPUT_NETWORK" $ETHEREUM_HOSTS_SECRET_NAME

--- a/.github/workflows/network-healthcheck.yml
+++ b/.github/workflows/network-healthcheck.yml
@@ -21,11 +21,11 @@ jobs:
 
       - name: Run healthcheck
         env:
+          NETWORKS: ${{ inputs.networks || 'next-net,staging-public,staging-internal,testnet,mainnet' }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           CI: "1"
         run: |
-          NETWORKS="${{ inputs.networks || 'next-net,staging-public,staging-internal,testnet,mainnet' }}"
 
           PROMPT="Run a network healthcheck for: ${NETWORKS}.
 

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Run
         env:
+          SEVERITY: ${{ inputs.severity || 'high' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
@@ -51,4 +52,4 @@ jobs:
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-        run: ./.github/ci3.sh socket-fix ${{ inputs.severity || 'high' }}
+        run: ./.github/ci3.sh socket-fix "$SEVERITY"


### PR DESCRIPTION
## Summary
- Bind `inputs.severity` through `env:` before `socket-fix` shell.
- Bind `inputs.registry_address` through `env:` before rollup upgrade deploy shell.
- Bind `inputs.networks` through `env:` before network healthcheck shell.
- Bind IRM `l1_network` / `namespace` / `network` / `monitoring_namespace` through `env:` before validate/deploy shell.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] socket-fix still runs with configured severity (default high)
- [ ] rollup upgrade deploy still receives registry address
- [ ] healthcheck still expands the networks list
- [ ] IRM validate/deploy still resolves namespace defaults


Made with [Cursor](https://cursor.com)