### PR TITLE
feat(bb): release bb-avm for arm64-linux

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -807,7 +807,7 @@
       "name": "arm64-linux",
       "configurePreset": "arm64-linux",
       "inheritConfigureEnvironment": true,
-      "targets": ["bb", "nodejs_module", "bb-external", "aztec-wsdb", "bb-avm-sim"]
+      "targets": ["bb", "bb-avm", "nodejs_module", "bb-external", "aztec-wsdb", "bb-avm-sim"]
     },
     {
       "name": "amd64-macos",

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -225,6 +225,7 @@ function build_release_dir {
 
   # bb cross-compiles.
   tar -czf build-release/barretenberg-arm64-linux.tar.gz -C build-arm64-linux/bin bb
+  tar -czf build-release/barretenberg-avm-arm64-linux.tar.gz -C build-arm64-linux/bin bb-avm
   tar -czf build-release/barretenberg-arm64-darwin.tar.gz -C build-arm64-macos/bin bb
   tar -czf build-release/barretenberg-amd64-darwin.tar.gz -C build-amd64-macos/bin bb
   tar -czf build-release/barretenberg-amd64-windows.tar.gz -C build-amd64-windows/bin bb.exe


### PR DESCRIPTION
## Motivation

After the monorepo split the labs repo cannot build C++, so `labs-aztec-toolchain` downloads `bb-avm` from the barretenberg release. Only `barretenberg-avm-amd64-linux.tar.gz` is published today, while the aztec Docker images ship for both amd64 and arm64 - once the in-repo native build is gone, the arm64 image has no `bb-avm`.

## The change

- Add `bb-avm` to the `arm64-linux` cross build preset (the configure preset already wires the aarch64 `avm_transpiler` lib).
- Package `barretenberg-avm-arm64-linux.tar.gz` in `build_release_dir`. `release` uploads `build-release/*` wholesale, so the asset reaches the barretenberg mirror and aztec-packages releases with no further change.

Verified locally: the arm64-linux cross build compiles the full `vm2` proving module under zig for the first time and links an AArch64 `bb-avm`.