### PR TITLE
chore(release-image): consume only labs toolchain and npm artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,7 @@ yarn-project-benches: yarn-project
 #==============================================================================
 
 # Release Image - Docker image for releases
-release-image: yarn-project
+release-image: yarn-project labs-aztec-toolchain
 	$(call build,$@,release-image)
 
 release-image-tests: release-image

--- a/labs-aztec-toolchain/bootstrap.sh
+++ b/labs-aztec-toolchain/bootstrap.sh
@@ -31,7 +31,11 @@ NOIRUP_URL=${NOIRUP_URL:-https://raw.githubusercontent.com/noir-lang/noirup/324a
 # bbup's artifact name is hardcoded to the plain bb, so the AVM-enabled build is taken
 # straight from the release. The URLs are tried in order: the barretenberg mirror, which
 # bb is also published to first, then aztec-packages.
-BB_AVM_ARTIFACT=barretenberg-avm-amd64-linux.tar.gz
+# Empty on a machine ci3/arch does not recognize, which makes bb_avm_released_here skip bb-avm.
+# Letting arch fail here would abort every command this script offers instead, including the nargo
+# and acvm installs that have nothing to do with bb-avm.
+BB_AVM_ARCH=$(arch 2>/dev/null || true)
+BB_AVM_ARTIFACT=barretenberg-avm-$BB_AVM_ARCH-linux.tar.gz
 BB_AVM_URLS=${BB_AVM_URLS:-"
   https://github.com/AztecProtocol/barretenberg/releases/download/v$BB_VERSION/$BB_AVM_ARTIFACT
   https://github.com/AztecProtocol/aztec-packages/releases/download/v$BB_VERSION/$BB_AVM_ARTIFACT
@@ -153,9 +157,9 @@ function install_bb {
   BB_PATH="$PWD/$TARGET_DIR" "$tmp/bbup" -v "$BB_VERSION" --no-modify-path
 }
 
-# bb-avm is released for amd64 linux only, see build_release_dir in barretenberg/cpp/bootstrap.sh.
+# bb-avm is released for linux only, see build_release_dir in barretenberg/cpp/bootstrap.sh.
 function bb_avm_released_here {
-  [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]
+  [ "$(os)" = linux ] && [ -n "$BB_AVM_ARCH" ]
 }
 
 function install_bb_avm {
@@ -287,8 +291,8 @@ function build_labs {
     if bb_avm_released_here; then
       install_bb_avm "$tmp"
     else
-      # Absence is tolerated: its consumers (AVM proving) only run on amd64 linux anyway.
-      echo "Skipping $BB_AVM_BINARY: released for amd64 linux only."
+      # Absence is tolerated: its consumers (AVM proving) only run on linux anyway.
+      echo "Skipping $BB_AVM_BINARY: released for linux amd64/arm64 only (this is $(os)/$(uname -m))."
       drop_unprovisionable "$BB_AVM_BINARY"
     fi
   else

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -9,9 +9,9 @@ ENV BUILD_METADATA=$BUILD_METADATA
 # Provide paths to bb and acvm for use in yarn-project, also create default working directories for each
 ENV UV_THREADPOOL_SIZE=8
 ENV BB_WORKING_DIRECTORY=/usr/src/bb
-ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb-avm
+ENV BB_BINARY_PATH=/usr/src/labs-aztec-toolchain/bin/bb-avm
 ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+ENV ACVM_BINARY_PATH=/usr/src/labs-aztec-toolchain/bin/acvm
 RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY && chmod 777 $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 WORKDIR "/usr/src/yarn-project"
 

--- a/release-image/Dockerfile.base.dockerignore
+++ b/release-image/Dockerfile.base.dockerignore
@@ -1,13 +1,5 @@
 *
 # These are copied in so we can perform a "production dependency install" in the release base image.
-!/barretenberg/ts/bb.js/package.json
-!/barretenberg/ts/bb-avm-sim/package.json
-!/barretenberg/ts/bb-avm-sim/packages/*/package.json
-!/barretenberg/ts/cdb/package.json
-!/noir/packages/*/package.json
-!/wsdb/ts/package.json
-!/wsdb/ts/packages/*/package.json
-!/ipc-runtime/ts/package.json
 !/yarn-project/package.json
 !/yarn-project/yarn.lock
 !/yarn-project/*/package.json

--- a/release-image/Dockerfile.dockerignore
+++ b/release-image/Dockerfile.dockerignore
@@ -1,25 +1,9 @@
 # We include just what's needed to run the aztec cli (none of the aztec.sh extensions).
 *
 !/.release-please-manifest.json
-!/barretenberg/cpp/build/bin/bb-avm
-!/barretenberg/ts/bb.js/dest/
-!/barretenberg/ts/bb.js/build/
-!/barretenberg/ts/bb.js/package.json
-!/barretenberg/ts/bb-avm-sim/dest/
-!/barretenberg/ts/bb-avm-sim/build/
-!/barretenberg/ts/bb-avm-sim/package.json
-!/barretenberg/ts/bb-avm-sim/packages/
-!/barretenberg/ts/cdb/dest/
-!/barretenberg/ts/cdb/package.json
-!/ipc-runtime/ts/dest/
-!/ipc-runtime/ts/package.json
-!/wsdb/ts/dest/
-!/wsdb/ts/build/
-!/wsdb/ts/package.json
-!/wsdb/ts/packages/
-!/noir/noir-repo/target/release/nargo
-!/noir/noir-repo/target/release/acvm
-!/noir/packages/
+# The two toolchain binaries the image runs, via BB_BINARY_PATH and ACVM_BINARY_PATH.
+!/labs-aztec-toolchain/bin/bb-avm
+!/labs-aztec-toolchain/bin/acvm
 !/yarn-project/package.json
 !/yarn-project/yarn.lock
 !/yarn-project/*/package.json

--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-hash=$(hash_str \
-  $(cache_content_hash ^release-image/Dockerfile ^release-image/Dockerfile.base.dockerignore ^release-image/Dockerfile.dockerignore ^build-images/src/Dockerfile ^ipc-runtime/ts/package.json ^yarn-project/yarn.lock) \
-  $(../wsdb/bootstrap.sh hash) \
-  $(../barretenberg/ts/bootstrap.sh hash))
+hash=$(cache_content_hash ^release-image/Dockerfile ^release-image/Dockerfile.base.dockerignore ^release-image/Dockerfile.dockerignore ^build-images/src/Dockerfile ^labs-aztec-toolchain/bootstrap.sh ^yarn-project/yarn.lock)
 
 function prepare_crs {
   echo_header "prepare crs for prover-agent image"
@@ -44,9 +41,32 @@ function build_prover_agent_image {
 }
 export -f build_prover_agent_image
 
+# The image runs these two, so a missing one fails the build rather than the container. Symlinks
+# are rejected too, since docker copies the link and not its target: even one that resolves here
+# would dangle in the image (build_monorepo provisions bin/ as symlinks).
+function check_toolchain_binaries {
+  local binary path
+  for binary in bb-avm acvm; do
+    path=$root/labs-aztec-toolchain/bin/$binary
+    if [ -L "$path" ]; then
+      echo "labs-aztec-toolchain/bin/$binary is a symlink and would dangle in the image. Run labs-aztec-toolchain/bootstrap.sh first."
+      exit 1
+    fi
+    if [ ! -f "$path" ]; then
+      echo "Missing labs-aztec-toolchain/bin/$binary. Run labs-aztec-toolchain/bootstrap.sh first."
+      if [ "$binary" = acvm ]; then
+        echo "Building acvm requires cargo to be installed."
+      fi
+      exit 1
+    fi
+  done
+}
+export -f check_toolchain_binaries
+
 function build_image {
   set -euo pipefail
   cd ..
+  check_toolchain_binaries
   if semver check $REF_NAME; then
     # We are a tagged release. Use the version from the tag.
     # We strip leading 'v' so that this is a valid semver.


### PR DESCRIPTION
## Summary

- The release image now sources its native binaries from `labs-aztec-toolchain/bin` (`bb-avm`, `acvm`) instead of the foundation build trees, and drops the foundation whitelists from both dockerignores: all TS dependencies (`@aztec/bb.js`, `wsdb`, `ipc-runtime`, `@aztec/l1-artifacts`, ...) already resolve to published npm packages, so the base image's `yarn workspaces focus` pulls them from the registry.
- `bb-avm` provisioning is arch-parametrized via ci3's `arch` (arm64 assets ship since #25120), and `nargo` is no longer copied into the image: nothing in it can invoke it (no `NARGO` set, not on PATH), saving ~51MB.
- `release-image/bootstrap.sh` content-hashes `labs-aztec-toolchain/bootstrap.sh` instead of calling sibling `hash` subcommands (a nested command substitution swallows their failures), and `build_image` gains a preflight that fails the build when a toolchain binary is missing or symlinked (docker copies the link, not its target).

Fixes A-1540