### PR TITLE
chore: remove RPC client

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -83,7 +83,6 @@ locals {
     "mainnet-rpc-consumer-client8",
     "mainnet-rpc-consumer-client9",
     "mainnet-rpc-consumer-client10",
-    "mainnet-rpc-consumer-client11",
     "mainnet-rpc-consumer-client12",
     "mainnet-rpc-consumer-client13",
     "mainnet-rpc-consumer-client14"


### PR DESCRIPTION
Removes `client11` from the mainnet RPC consumers. The Terraform removal was already applied with a guarded plan of 0 added, 0 changed, and 2 destroyed (KongConsumer and ExternalSecret). The GCP secret was deleted after verifying the Kubernetes resources were gone.