### PR TITLE
chore(docs): drop stale doc references to deleted l1-contracts

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
@@ -3,7 +3,7 @@ title: Understanding Function Context
 sidebar_position: 3
 tags: [functions, context]
 description: Learn about the execution context available to Aztec contract functions, including caller information and block data.
-references: ["noir-projects/labs/aztec-nr/aztec/src/context/*", "noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/*"]
+references: ["noir-projects/labs/aztec-nr/aztec/src/context/*"]
 ---
 
 import Image from '@theme/IdealImage';

--- a/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
@@ -2,7 +2,6 @@
 title: Global Variables
 description: Access chain ID, block number, timestamps, and gas information in your Aztec contracts
 sidebar_position: 10
-references: ["noir-projects/fnd/noir-protocol-circuits/crates/types/src/abis/*"]
 ---
 
 # Global Variables

--- a/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/data_structures.md
+++ b/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/data_structures.md
@@ -1,7 +1,6 @@
 ---
 title: Data Structures
 description: Learn about the data structures used in Aztec portals for L1-L2 communication.
-references: ["l1-contracts/src/core/libraries/DataStructures.sol"]
 ---
 
 This page documents the Solidity structs used for L1-L2 message passing in the Aztec protocol.

--- a/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/inbox.md
+++ b/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/inbox.md
@@ -2,7 +2,6 @@
 title: Inbox
 description: Learn about the inbox mechanism in Aztec portals for receiving messages from L1.
 tags: [portals, contracts]
-references: ["l1-contracts/src/core/interfaces/messagebridge/IInbox.sol"]
 ---
 
 The `Inbox` is a contract deployed on L1 that handles message passing from L1 to L2.

--- a/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/outbox.md
+++ b/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/outbox.md
@@ -2,7 +2,6 @@
 title: Outbox
 description: Learn about the outbox mechanism in Aztec portals for sending messages to L1.
 tags: [portals, contracts]
-references: ["l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol"]
 ---
 
 The `Outbox` is a contract deployed on L1 that handles message passing from L2 to L1. Portal contracts call `consume()` to receive and process messages that were sent from L2 contracts. The Rollup contract inserts message roots via `insert()` as proofs land. A proof can cover a prefix of an epoch's checkpoints (a partial proof), so an epoch can have several roots, one per number of checkpoints covered.

--- a/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/registry.md
+++ b/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/registry.md
@@ -2,7 +2,6 @@
 title: Registry
 description: Learn about the portal registry and how it manages L1-L2 contract mappings.
 tags: [portals, contracts]
-references: ["l1-contracts/src/governance/interfaces/IRegistry.sol"]
 ---
 
 The Registry is a contract deployed on L1 that tracks canonical and historical rollup instances. It allows you to query the current rollup contract and look up prior deployments by version.

--- a/docs/docs-developers/docs/foundational-topics/fees.md
+++ b/docs/docs-developers/docs/foundational-topics/fees.md
@@ -6,8 +6,6 @@ description: Understand Aztec's fee system including mana-based transaction pric
 references:
   [
     "yarn-project/stdlib/src/gas/gas_settings.ts",
-    "l1-contracts/src/core/messagebridge/FeeJuicePortal.sol",
-    "noir-projects/fnd/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr",
     "yarn-project/aztec.js/src/ethereum/portal_manager.ts",
     "yarn-project/aztec.js/src/fee/fee_juice_payment_method_with_claim.ts",
   ]


### PR DESCRIPTION
Mentioned in another pr, didn't push there to not reset CI