### PR TITLE
fix: include standard-contracts historical artifacts in release image

### DIFF
--- a/release-image/Dockerfile.dockerignore
+++ b/release-image/Dockerfile.dockerignore
@@ -18,6 +18,7 @@
 !/yarn-project/noir-protocol-circuits-types/artifacts/
 !/yarn-project/protocol-contracts/artifacts/
 !/yarn-project/standard-contracts/artifacts/
+!/yarn-project/standard-contracts/artifacts-historical/
 !/yarn-project/noir-contracts.js/artifacts/
 !/yarn-project/noir-test-contracts.js/artifacts/
 !/yarn-project/simulator/artifacts/


### PR DESCRIPTION
Since #25032, `@aztec/standard-contracts` has a top-level import of historical artifact JSONs from `standard-contracts/artifacts-historical/`. The release image dockerignore ignores everything and then whitelists specific paths, and it only whitelisted `standard-contracts/artifacts/` — so the historical artifacts never made it into the image.

- Every node built from a v5-next release image crash-loops on startup at ESM link time with `ERR_MODULE_NOT_FOUND` for `HandshakeRegistry-5.0.1.json`.
- This has broken all spartan deploys from this line since 2026-07-29.
- The fix is a single whitelist entry: `!/yarn-project/standard-contracts/artifacts-historical/`.

Split out from #25148 so the deploy fix can land independently of that PR's review. Once this merges, #25148 will be rebased and its duplicate commit will drop out.
