### PR TITLE
refactor: run compat tests on committed legacy artifacts

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -57,11 +57,6 @@ function main {
     echo "NO_FAIL_FAST=1" >> $GITHUB_ENV
   fi
 
-  # Handle skip-compat-e2e label (escape hatch for backwards compat test failures on release PRs)
-  if has_label "ci-skip-compat-e2e"; then
-    echo "SKIP_COMPAT_E2E=1" >> $GITHUB_ENV
-  fi
-
   local chonk_input_update=0
   local chonk_input_update_requested=0
   if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && { has_label "ci-refresh-chonk" || head_commit_has_marker "--ci-refresh-chonk"; }; then
@@ -163,7 +158,6 @@ function main {
   if [ "$ci_mode" = "release" ] &&
      [ "$(printf '%s' "${GITHUB_REPOSITORY:-}" | tr 'A-Z' 'a-z')" = "aztecprotocol/aztec-packages-private" ]; then
     echo "PRIVATE_RELEASE=1" >> $GITHUB_ENV
-    echo "SKIP_COMPAT_E2E=1" >> $GITHUB_ENV
   fi
 
   # Determine if benchmarks should be uploaded (merge-queue, full, or full-no-test-cache modes)

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -127,7 +127,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_ACTOR: ${{ github.actor }}
-          # Forwarded to EC2 so release_compat_e2e's nightly-failure Slack alert can build a real run URL.
+          # Groups this workflow's CI dashboard entries under the GitHub run id (stable across re-runs).
           RUN_ID: ${{ github.run_id }}
           CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
           CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -642,94 +642,48 @@ function private_release {
   done
 }
 
-function release_compat_e2e {
-  # Runs e2e tests with contract artifacts from every prior stable release since 4.2.0 (the version
-  # where we committed to backwards compatibility). Validates that old contract artifacts work on the
-  # current release. Blocking for stable/RC releases; observational (non-blocking) for nightlies.
-  # Set SKIP_COMPAT_E2E=1 to bypass (escape hatch via the ci-skip-compat-e2e label).
-  if [ "${SKIP_COMPAT_E2E:-0}" = "1" ]; then
-    echo "SKIP_COMPAT_E2E=1, skipping backwards compatibility e2e tests."
-    return 0
-  fi
-
-  # Compat e2e only runs on amd64 — the arm64 release job just builds and publishes release-image.
-  if [ "$(arch)" == arm64 ]; then
-    echo "Skipping backwards compatibility e2e tests on arm64 (amd64 only)."
-    return 0
-  fi
-
-  # TODO: bump when v5 commits to backwards-compatible contract artifacts.
-  #   compat_major:       major version that has compat guarantees today.
-  #   compat_min_version: earliest stable tag of that major to test against
-  #                       (artifacts before this are incompatible due to oracle interface changes).
-  local compat_major="4"
-  local compat_min_version="4.2.0"
+function check_compat_artifacts_tracked {
+  # The backwards-compat e2e sweep runs as part of the normal e2e suite, driven by the artifact
+  # tarballs committed under yarn-project/end-to-end/legacy-contracts/ (see its README). This check
+  # guards the history: cutting a release while a prior stable's artifacts are missing there would
+  # silently shrink compat coverage for every future run.
+  #   compat_major:       major version line with a backwards-compatibility guarantee.
+  #   compat_min_version: earliest stable release covered by that guarantee.
+  local compat_major="5"
+  local compat_min_version="5.0.1"
 
   local current_version major
   current_version=$(jq -r '."."' .release-please-manifest.json)
   major=$(semver major "$current_version")
   if [ "$major" != "$compat_major" ]; then
-    echo "Compat e2e tests only apply to v${compat_major}. Current major: v${major}. Skipping."
+    echo "Compat artifact tracking only applies to v${compat_major}. Current major: v${major}. Skipping."
     return 0
   fi
 
   # Fetch tags (EC2 clone may not have them). Fail loud: a silent fetch failure plus an empty
-  # tag list would publish a real release with zero compat coverage.
+  # tag list would vacuously pass the check.
   if ! git fetch origin 'refs/tags/v*:refs/tags/v*'; then
     echo "ERROR: failed to fetch release tags." >&2
     return 1
   fi
 
-  # Discover stable tags for this major version (no prerelease suffixes).
-  local versions=()
+  local missing=()
   local tag ver
   while IFS= read -r tag; do
     ver=${tag#v}
     # Include only versions >= compat_min_version (sort -V puts smaller first).
-    if [ "$(printf '%s\n%s' "$compat_min_version" "$ver" | sort -V | head -1)" = "$compat_min_version" ]; then
-      versions+=("$ver")
-    fi
-  done < <(git tag -l "v${major}.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V)
+    [ "$(printf '%s\n%s' "$compat_min_version" "$ver" | sort -V | head -1)" = "$compat_min_version" ] || continue
+    # The tag being released right now can't have artifacts yet — they're published by this release.
+    [ "v$ver" = "${REF_NAME:-}" ] && continue
+    [ -f "yarn-project/end-to-end/legacy-contracts/$ver.tar.gz" ] || missing+=("$ver")
+  done < <(git tag -l "v${compat_major}.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V)
 
-  # Exclude the current tag when running on a release tag push.
-  if [[ "${REF_NAME:-}" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-    local current_tag="${BASH_REMATCH[1]}"
-    local filtered=()
-    local v
-    for v in "${versions[@]}"; do
-      [ "$v" != "$current_tag" ] && filtered+=("$v")
-    done
-    versions=("${filtered[@]}")
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: stable release(s) missing committed compat artifacts: ${missing[*]}" >&2
+    echo "Add yarn-project/end-to-end/legacy-contracts/<version>.tar.gz for each (see that README), then re-tag." >&2
+    return 1
   fi
-
-  if [ ${#versions[@]} -eq 0 ]; then
-    echo "No prior stable versions found for v${major}.x (>= $compat_min_version). Skipping compat tests."
-    return 0
-  fi
-
-  echo_header "Backwards compatibility e2e tests"
-  echo "Testing against ${#versions[@]} prior stable version(s): ${versions[*]}"
-
-  # Pre-populate the legacy contract cache on the host. Test containers run with --net=none, so the
-  # jest resolver's on-demand npm install would fail with EAI_AGAIN. Install here where we have network.
-  for ver in "${versions[@]}"; do
-    node yarn-project/end-to-end/src/install_legacy_contracts.cjs "$ver"
-  done
-
-  # Build and run the compat test commands in an isolated subshell so the bespoke test settings
-  # (no test cache, no fast-fail short-circuit) don't leak into the release build/publish that follows.
-  # set -e re-enables errexit inside this subshell: the caller invokes release_compat_e2e with errexit
-  # disabled (to capture its exit code), so without this a failed build/install would be masked.
-  (
-    set -e
-    export USE_TEST_CACHE=0
-    export CI_FULL=0
-    export NO_FAIL_FAST=1
-    build
-    for ver in "${versions[@]}"; do
-      yarn-project/end-to-end/bootstrap.sh compat_test_cmds "$ver"
-    done | filter_test_cmds | parallelize
-  )
+  echo "Compat artifacts tracked for all prior stable v${compat_major} releases."
 }
 
 ### SELF TESTING #######################################################################################################
@@ -1061,8 +1015,7 @@ case "$cmd" in
   # RELEASES #
   ############
   "ci-release")
-    # Single command that tests and publishes a release. Runs the backwards-compatibility e2e
-    # checks (blocking for stable/RC, observational for nightlies), then builds and publishes.
+    # Single command that tests and publishes a release.
     # DRY_RUN=1 exercises the whole flow without publishing — this is how releases are tested in CI.
     export CI=1
     export USE_TEST_CACHE=1
@@ -1070,25 +1023,7 @@ case "$cmd" in
       exit 1
     fi
 
-    # Backwards-compatibility e2e checks. A failure blocks stable/RC releases, but only warns on
-    # nightlies (where compat coverage is observational) so the nightly publish still proceeds.
-    # Toggle errexit explicitly rather than `release_compat_e2e || compat_rc=$?`: calling under `||`
-    # suspends errexit for the whole function (and its subshell), masking build/setup failures there.
-    compat_rc=0
-    set +e
-    release_compat_e2e
-    compat_rc=$?
-    set -e
-    if [ "$compat_rc" -ne 0 ]; then
-      if [[ "${REF_NAME:-}" == *-nightly.* ]]; then
-        run_url="https://github.com/${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}/actions/runs/${RUN_ID:-unknown}"
-        "$ci3/slack_notify" "Backwards compatibility e2e tests FAILED on nightly tag <${run_url}|${REF_NAME}>" "#team-fairies" || true
-        echo "Compat e2e failed on nightly tag — continuing (non-blocking)."
-      else
-        echo "ERROR: backwards compatibility e2e tests failed — blocking release." >&2
-        exit 1
-      fi
-    fi
+    check_compat_artifacts_tracked
 
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -645,8 +645,11 @@ function private_release {
 function check_compat_artifacts_tracked {
   # The backwards-compat e2e sweep runs as part of the normal e2e suite, driven by the artifact
   # tarballs committed under yarn-project/end-to-end/legacy-contracts/ (see its README). This check
-  # guards the history: cutting a release while a prior stable's artifacts are missing there would
-  # silently shrink compat coverage for every future run.
+  # runs on every full CI run and fails while any stable release of the compat major is missing its
+  # tarball, so the set can't silently fall behind. Releases deliberately don't run it: the release
+  # cutting X.Y.Z is what publishes the packages the X.Y.Z artifacts are built from, so they can't
+  # be vendored beforehand — instead the first full run after a stable release goes red until
+  # someone commits the new tarball.
   #   compat_major:       major version line with a backwards-compatibility guarantee.
   #   compat_min_version: earliest stable release covered by that guarantee.
   local compat_major="5"
@@ -673,14 +676,12 @@ function check_compat_artifacts_tracked {
     ver=${tag#v}
     # Include only versions >= compat_min_version (sort -V puts smaller first).
     [ "$(printf '%s\n%s' "$compat_min_version" "$ver" | sort -V | head -1)" = "$compat_min_version" ] || continue
-    # The tag being released right now can't have artifacts yet — they're published by this release.
-    [ "v$ver" = "${REF_NAME:-}" ] && continue
     [ -f "yarn-project/end-to-end/legacy-contracts/$ver.tar.gz" ] || missing+=("$ver")
   done < <(git tag -l "v${compat_major}.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V)
 
   if [ ${#missing[@]} -gt 0 ]; then
     echo "ERROR: stable release(s) missing committed compat artifacts: ${missing[*]}" >&2
-    echo "Add yarn-project/end-to-end/legacy-contracts/<version>.tar.gz for each (see that README), then re-tag." >&2
+    echo "Add yarn-project/end-to-end/legacy-contracts/<version>.tar.gz for each (see that README)." >&2
     return 1
   fi
   echo "Compat artifacts tracked for all prior stable v${compat_major} releases."
@@ -783,6 +784,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=1
+    check_compat_artifacts_tracked
     build_and_test full
     bench
     ;;
@@ -790,6 +792,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=0
     export CI_FULL=1
+    check_compat_artifacts_tracked
     build_and_test full
     bench
     ;;
@@ -1022,8 +1025,6 @@ case "$cmd" in
     if ! semver check $REF_NAME; then
       exit 1
     fi
-
-    check_compat_artifacts_tracked
 
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -643,13 +643,12 @@ function private_release {
 }
 
 function check_compat_artifacts_tracked {
-  # The backwards-compat e2e sweep runs as part of the normal e2e suite, driven by the artifact
-  # tarballs committed under yarn-project/end-to-end/legacy-contracts/ (see its README). This check
-  # runs on every full CI run and fails while any stable release of the compat major is missing its
+  # The backwards-compat e2e tests run as part of the normal e2e suite, driven by the artifact
+  # tarballs committed under yarn-project/end-to-end/legacy-contracts/. This check runs on
+  # every full CI run and fails while any stable release of the compat major is missing its
   # tarball, so the set can't silently fall behind. Releases deliberately don't run it: the release
-  # cutting X.Y.Z is what publishes the packages the X.Y.Z artifacts are built from, so they can't
-  # be vendored beforehand — instead the first full run after a stable release goes red until
-  # someone commits the new tarball.
+  # cutting X.Y.Z is what publishes the packages the X.Y.Z artifacts are built from, so the first
+  # full CI run after a stable release goes red until someone commits the new tarball.
   #   compat_major:       major version line with a backwards-compatibility guarantee.
   #   compat_min_version: earliest stable release covered by that guarantee.
   local compat_major="5"
@@ -664,7 +663,7 @@ function check_compat_artifacts_tracked {
   fi
 
   # Fetch tags (EC2 clone may not have them). Fail loud: a silent fetch failure plus an empty
-  # tag list would vacuously pass the check.
+  # tag list would incorrectly pass the check.
   if ! git fetch origin 'refs/tags/v*:refs/tags/v*'; then
     echo "ERROR: failed to fetch release tags." >&2
     return 1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -681,7 +681,7 @@ function check_compat_artifacts_tracked {
 
   if [ ${#missing[@]} -gt 0 ]; then
     echo "ERROR: stable release(s) missing committed compat artifacts: ${missing[*]}" >&2
-    echo "Add yarn-project/end-to-end/legacy-contracts/<version>.tar.gz for each (see that README)." >&2
+    echo "Run yarn-project/end-to-end/legacy-contracts/add_version.sh <version> for each and commit the result." >&2
     return 1
   fi
   echo "Compat artifacts tracked for all prior stable v${compat_major} releases."

--- a/ci.sh
+++ b/ci.sh
@@ -131,7 +131,10 @@ case "$cmd" in
   full|full-no-test-cache)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
-    export AWS_SHUTDOWN_TIME=75
+    # Sized for the arm's heaviest workload: full runs include the backwards-compat e2e sweep
+    # (yarn-project/end-to-end test_cmds under CI_FULL). The timer is a runaway backstop, so the
+    # headroom is free for runs that finish sooner.
+    export AWS_SHUTDOWN_TIME=90
     bootstrap_ec2 "./bootstrap.sh ci-$cmd"
     ;;
   chonk-input-update)

--- a/ci.sh
+++ b/ci.sh
@@ -131,9 +131,6 @@ case "$cmd" in
   full|full-no-test-cache)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
-    # Sized for the arm's heaviest workload: full runs include the backwards-compat e2e sweep
-    # (yarn-project/end-to-end test_cmds under CI_FULL). The timer is a runaway backstop, so the
-    # headroom is free for runs that finish sooner.
     export AWS_SHUTDOWN_TIME=90
     bootstrap_ec2 "./bootstrap.sh ci-$cmd"
     ;;

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -402,7 +402,6 @@ start_build() {
     -e DRY_RUN=${DRY_RUN:-} \
     -e PRIVATE_RELEASE=${PRIVATE_RELEASE:-} \
     -e INTERNAL_DOCKER_REGISTRY=${INTERNAL_DOCKER_REGISTRY:-} \
-    -e SKIP_COMPAT_E2E=${SKIP_COMPAT_E2E:-} \
     --pids-limit=65536 \
     --shm-size=2g \
     --ulimit nofile=1048576:1048576 \

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -151,10 +151,7 @@ or it **won't run in CI**:
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of
   the function (real proofs and custom resources under `CI_FULL`, `FAKE_PROOFS=1` otherwise) and
   `avm_simulator` (below).
-- The backwards-compat sweep (a subset, emitted only under `CI_FULL` via `compat_test_cmds`): reruns the
-  artifact-consuming tests once per prior stable release committed under `legacy-contracts/` (see that
-  directory's README), with `CONTRACT_ARTIFACTS_VERSION` set so the jest resolver swaps in the historical
-  artifact JSON. This one enumerates **single-level leaf globs** (e.g. `src/automine/token/*.test.ts`), so
+- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf globs** (e.g. `src/automine/token/*.test.ts`), so
   a new sub-folder whose tests should run against legacy contract artifacts needs its own line here.
 
 Bespoke handling to be aware of:

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -142,26 +142,28 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 
 ### CI test discovery — `bootstrap.sh`
 
-`end-to-end/bootstrap.sh` enumerates tests in two arrays, and a test must resolve through the relevant one
-or it **won't run in CI**:
+`end-to-end/bootstrap.sh` enumerates tests in two arrays inside `test_cmds`, and a test must resolve
+through the relevant one or it **won't run in CI**:
 
-- `test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
+- The standard run. Covers each category with a recursive glob (e.g.
   `src/automine/!(simulation)/**/*.test.ts`, `src/multi-node/**/*.test.ts`), so a new file or sub-folder
   inside an existing category is picked up automatically; only a new top-level category needs its own glob
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of
   the function (real proofs and custom resources under `CI_FULL`, `FAKE_PROOFS=1` otherwise) and
   `avm_simulator` (below).
-- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf
-  globs** (e.g. `src/automine/token/*.test.ts`), so a new sub-folder whose tests should run against legacy
-  contract artifacts needs its own line here.
+- The backwards-compat sweep (`compat_tests`, a subset, emitted only under `CI_FULL`): reruns the
+  artifact-consuming tests once per prior stable release committed under `legacy-contracts/` (see that
+  directory's README), with `CONTRACT_ARTIFACTS_VERSION` set so the jest resolver swaps in the historical
+  artifact JSON. This one enumerates **single-level leaf globs** (e.g. `src/automine/token/*.test.ts`), so
+  a new sub-folder whose tests should run against legacy contract artifacts needs its own line here.
 
 Bespoke handling to be aware of:
 
-- **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in `test_cmds`
-  that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
-  excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In `compat_test_cmds` it runs
+- **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in the standard
+  run that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
+  excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In the compat sweep it runs
   as a regular test (no dump line), so it is **not** excluded there.
-- **`kernelless_simulation`** is excluded from `compat_test_cmds` only.
+- **`kernelless_simulation`** is excluded from the compat sweep only.
 
 After editing the arrays, confirm every `*.test.ts` resolves through exactly one line (no duplicate, no
 omission — anything excluded via `!(...)` must be matched by its dedicated line). Per-test bash `TIMEOUT`

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -145,7 +145,7 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 `end-to-end/bootstrap.sh` enumerates tests in two arrays, and a test must resolve through the relevant one
 or it **won't run in CI**:
 
-`- test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
+- `test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
   `src/automine/!(simulation)/**/*.test.ts`, `src/multi-node/**/*.test.ts`), so a new file or sub-folder
   inside an existing category is picked up automatically; only a new top-level category needs its own glob
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -160,6 +160,7 @@ Bespoke handling to be aware of:
 - **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in `test_cmds`
   that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
   excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In `compat_test_cmds` it runs
+    as a regular test (no dump line), so it is **not** excluded there.
 - **`kernelless_simulation`** is excluded from `compat_test_cmds` only.
 
 After editing the arrays, confirm every `*.test.ts` resolves through exactly one line (no duplicate, no

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -151,8 +151,9 @@ or it **won't run in CI**:
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of
   the function (real proofs and custom resources under `CI_FULL`, `FAKE_PROOFS=1` otherwise) and
   `avm_simulator` (below).
-- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf globs** (e.g. `src/automine/token/*.test.ts`), so
-  a new sub-folder whose tests should run against legacy contract artifacts needs its own line here.
+- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf 
+globs** (e.g. `src/automine/token/*.test.ts`), so a new sub-folder whose tests should run against legacy
+contract artifacts needs its own line here.
 
 Bespoke handling to be aware of:
 

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -145,7 +145,7 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 `end-to-end/bootstrap.sh` enumerates tests in two arrays, and a test must resolve through the relevant one
 or it **won't run in CI**:
 
-`test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
+`- test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
   `src/automine/!(simulation)/**/*.test.ts`, `src/multi-node/**/*.test.ts`), so a new file or sub-folder
   inside an existing category is picked up automatically; only a new top-level category needs its own glob
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -146,7 +146,7 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 compat sweep's in `compat_per_version_test_cmds` — and a test must resolve through the relevant one
 or it **won't run in CI**:
 
-- The standard run. Covers each category with a recursive glob (e.g.
+`test_cmds` — the standard run. Covers each category with a recursive glob (e.g.
   `src/automine/!(simulation)/**/*.test.ts`, `src/multi-node/**/*.test.ts`), so a new file or sub-folder
   inside an existing category is picked up automatically; only a new top-level category needs its own glob
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -151,9 +151,9 @@ or it **won't run in CI**:
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of
   the function (real proofs and custom resources under `CI_FULL`, `FAKE_PROOFS=1` otherwise) and
   `avm_simulator` (below).
-- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf 
-globs** (e.g. `src/automine/token/*.test.ts`), so a new sub-folder whose tests should run against legacy
-contract artifacts needs its own line here.
+- `compat_test_cmds` — the forward/legacy-compat run (a subset). This one enumerates **single-level leaf
+  globs** (e.g. `src/automine/token/*.test.ts`), so a new sub-folder whose tests should run against legacy
+  contract artifacts needs its own line here.
 
 Bespoke handling to be aware of:
 

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -142,8 +142,7 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 
 ### CI test discovery — `bootstrap.sh`
 
-`end-to-end/bootstrap.sh` enumerates tests in two arrays — the standard run's in `test_cmds`, the
-compat sweep's in `compat_per_version_test_cmds` — and a test must resolve through the relevant one
+`end-to-end/bootstrap.sh` enumerates tests in two arrays, and a test must resolve through the relevant one
 or it **won't run in CI**:
 
 `test_cmds` — the standard run. Covers each category with a recursive glob (e.g.

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -160,7 +160,7 @@ Bespoke handling to be aware of:
 - **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in `test_cmds`
   that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
   excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In `compat_test_cmds` it runs
-    as a regular test (no dump line), so it is **not** excluded there.
+  as a regular test (no dump line), so it is **not** excluded there.
 - **`kernelless_simulation`** is excluded from `compat_test_cmds` only.
 
 After editing the arrays, confirm every `*.test.ts` resolves through exactly one line (no duplicate, no

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -142,8 +142,9 @@ CI splits each `it` in a `.parallel.test.ts` file into its own docker job, runni
 
 ### CI test discovery — `bootstrap.sh`
 
-`end-to-end/bootstrap.sh` enumerates tests in two arrays inside `test_cmds`, and a test must resolve
-through the relevant one or it **won't run in CI**:
+`end-to-end/bootstrap.sh` enumerates tests in two arrays — the standard run's in `test_cmds`, the
+compat sweep's in `compat_per_version_test_cmds` — and a test must resolve through the relevant one
+or it **won't run in CI**:
 
 - The standard run. Covers each category with a recursive glob (e.g.
   `src/automine/!(simulation)/**/*.test.ts`, `src/multi-node/**/*.test.ts`), so a new file or sub-folder
@@ -151,7 +152,7 @@ through the relevant one or it **won't run in CI**:
   line. Tests with bespoke handling sit outside the globs: the `single-node/prover/` lanes at the top of
   the function (real proofs and custom resources under `CI_FULL`, `FAKE_PROOFS=1` otherwise) and
   `avm_simulator` (below).
-- The backwards-compat sweep (`compat_tests`, a subset, emitted only under `CI_FULL`): reruns the
+- The backwards-compat sweep (a subset, emitted only under `CI_FULL` via `compat_test_cmds`): reruns the
   artifact-consuming tests once per prior stable release committed under `legacy-contracts/` (see that
   directory's README), with `CONTRACT_ARTIFACTS_VERSION` set so the jest resolver swaps in the historical
   artifact JSON. This one enumerates **single-level leaf globs** (e.g. `src/automine/token/*.test.ts`), so

--- a/yarn-project/end-to-end/README.md
+++ b/yarn-project/end-to-end/README.md
@@ -157,11 +157,10 @@ or it **won't run in CI**:
 
 Bespoke handling to be aware of:
 
-- **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in the standard
-  run that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
-  excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In the compat sweep it runs
-  as a regular test (no dump line), so it is **not** excluded there.
-- **`kernelless_simulation`** is excluded from the compat sweep only.
+- **`avm_simulator`** (`automine/simulation/avm_simulator.test.ts`) has a dedicated line in `test_cmds`
+  that sets `DUMP_AVM_INPUTS_TO_DIR` (feeds the downstream `avm_check_circuit` job) and is therefore
+  excluded from the generic `simulation/` glob there (`!(avm_simulator)`). In `compat_test_cmds` it runs
+- **`kernelless_simulation`** is excluded from `compat_test_cmds` only.
 
 After editing the arrays, confirm every `*.test.ts` resolves through exactly one line (no duplicate, no
 omission — anything excluded via `!(...)` must be matched by its dedicated line). Per-test bash `TIMEOUT`

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -165,22 +165,7 @@ function test_cmds {
     echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=verbose $run_test_script compose $flow"
   done
 
-  # Backwards-compat sweep: rerun the artifact-consuming tests against each prior stable release's
-  # contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
-  # No tarballs (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies
-  # e2e cost per version, and the merge queue's full run is the enforcement point.
-  if [ "${CI_FULL:-0}" -eq 1 ]; then
-    local version tarball
-    for tarball in legacy-contracts/*.tar.gz; do
-      [ -e "$tarball" ] || continue
-      version=$(basename "$tarball" .tar.gz)
-      # Unpack on the host now: the isolated test containers share this checkout, so extracting once
-      # here saves every container doing it lazily. Status goes to stderr — stdout is the command
-      # stream.
-      node src/install_legacy_contracts.cjs "$version" 1>&2
-      compat_test_cmds "$version"
-    done
-  fi
+  compat_sweep_test_cmds
 }
 
 function test {
@@ -373,6 +358,24 @@ function compat_test_cmds {
     else
       echo "$prefix:NAME=compat_${version}_${name} $compat_env $run_test_script simple $test"
     fi
+  done
+}
+
+# Backwards-compat sweep: rerun the artifact-consuming tests against each prior stable release's
+# contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
+# No tarballs (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies
+# e2e cost per version, and the merge queue's full run is the enforcement point.
+function compat_sweep_test_cmds {
+  [ "${CI_FULL:-0}" -eq 1 ] || return 0
+  local version tarball
+  for tarball in legacy-contracts/*.tar.gz; do
+    [ -e "$tarball" ] || continue
+    version=$(basename "$tarball" .tar.gz)
+    # Unpack on the host now: the isolated test containers share this checkout, so extracting once
+    # here saves every container doing it lazily. Status goes to stderr — stdout is the command
+    # stream.
+    node src/install_legacy_contracts.cjs "$version" 1>&2
+    compat_test_cmds "$version"
   done
 }
 

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -165,7 +165,7 @@ function test_cmds {
     echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=verbose $run_test_script compose $flow"
   done
 
-  compat_sweep_test_cmds
+  compat_test_cmds
 }
 
 function test {
@@ -311,7 +311,7 @@ function avm_check_circuit {
 # Excludes kernelless_simulation, which asserts on the exact number of nullifiers emitted and breaks
 # whenever contracts add/remove nullifier emissions across versions (unrelated to the compat contract
 # surface).
-function compat_test_cmds {
+function compat_per_version_test_cmds {
   local version=${1:?version is required}
   local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
   local prefix="$hash:ISOLATE=1:TIMEOUT=20m"
@@ -365,7 +365,7 @@ function compat_test_cmds {
 # contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
 # No tarballs (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies
 # e2e cost per version, and the merge queue's full run is the enforcement point.
-function compat_sweep_test_cmds {
+function compat_test_cmds {
   [ "${CI_FULL:-0}" -eq 1 ] || return 0
   local version tarball
   for tarball in legacy-contracts/*.tar.gz; do
@@ -375,7 +375,7 @@ function compat_sweep_test_cmds {
     # here saves every container doing it lazily. Status goes to stderr — stdout is the command
     # stream.
     node src/install_legacy_contracts.cjs "$version" 1>&2
-    compat_test_cmds "$version"
+    compat_per_version_test_cmds "$version"
   done
 }
 

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -361,19 +361,15 @@ function compat_per_version_test_cmds {
   done
 }
 
-# Backwards-compat sweep: rerun the artifact-consuming tests against each prior stable release's
+# Backwards-compat testing: rerun the artifact-consuming tests against each prior stable release's
 # contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
-# No tarballs (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies
-# e2e cost per version, and the merge queue's full run is the enforcement point.
+# Full CI only: each stable release tested here increases e2e running time by around 5 minutes.
 function compat_test_cmds {
   [ "${CI_FULL:-0}" -eq 1 ] || return 0
   local version tarball
   for tarball in legacy-contracts/*.tar.gz; do
     [ -e "$tarball" ] || continue
     version=$(basename "$tarball" .tar.gz)
-    # Unpack on the host now: the isolated test containers share this checkout, so extracting once
-    # here saves every container doing it lazily. Status goes to stderr — stdout is the command
-    # stream.
     node src/install_legacy_contracts.cjs "$version" 1>&2
     compat_per_version_test_cmds "$version"
   done

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -164,6 +164,68 @@ function test_cmds {
     # Run at LOG_LEVEL=verbose so the captured local-network logs are detailed enough for diagnostics.
     echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=verbose $run_test_script compose $flow"
   done
+
+  # Backwards-compat sweep: rerun the artifact-consuming tests against each prior stable release's
+  # contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
+  # The jest resolver swaps artifact JSON imports when CONTRACT_ARTIFACTS_VERSION is set. No tarballs
+  # (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies e2e cost
+  # per version, and the merge queue's full run is the enforcement point.
+  # Only simple (jest-based) tests, since compose/docker tests don't use the legacy jest resolver.
+  # Excludes kernelless_simulation, which asserts on the exact number of nullifiers emitted and breaks
+  # whenever contracts add/remove nullifier emissions across versions (unrelated to the compat contract
+  # surface).
+  if [ "${CI_FULL:-0}" -eq 1 ]; then
+    local compat_tests=(
+      src/automine/*.test.ts
+      src/automine/contracts/*.test.ts
+      src/automine/contracts/deploy/*.test.ts
+      src/automine/contracts/nested/*.test.ts
+      src/automine/token/*.test.ts
+      src/automine/accounts/*.test.ts
+      src/automine/effects/*.test.ts
+      src/automine/simulation/!(kernelless_simulation).test.ts
+      src/single-node/fees/*.test.ts
+      src/single-node/cross-chain/*.test.ts
+      src/single-node/bot/*.test.ts
+      src/infra/*.test.ts
+      src/p2p/*.test.ts
+      src/p2p/reqresp/*.test.ts
+    )
+    local version tarball
+    for tarball in legacy-contracts/*.tar.gz; do
+      [ -e "$tarball" ] || continue
+      version=$(basename "$tarball" .tar.gz)
+      # Unpack on the host now: the isolated test containers share this checkout, so extracting once
+      # here saves every container doing it lazily. Status goes to stderr — stdout is the command
+      # stream.
+      node src/install_legacy_contracts.cjs "$version" 1>&2
+      for test in "${compat_tests[@]}"; do
+        local name
+        if [[ "$test" == src/p2p/* || "$test" == src/automine/* ]]; then
+          # The p2p/ and automine/ folders have no `e2e_` prefix to strip; flatten their path into an
+          # e2e_<path> name (matching the historical e2e_p2p/<file> names) by dropping "src/",
+          # ".test.ts", and slashes.
+          name=${test#src/}
+          name=e2e_${name%.test.ts}
+          name=${name//\//_}
+        else
+          name=${test#*e2e_}
+          name=e2e_${name%.test.ts}
+        fi
+
+        if [[ "$test" == *.parallel.test.ts ]]; then
+          while IFS= read -r test_name; do
+            # See the matching note near the top of test_cmds: collapse docker-illegal characters so
+            # NAME is a valid container name for docker_isolate.
+            local safe_test_name=$(echo "$test_name" | sed 's/[^a-zA-Z0-9_.-]/_/g')
+            echo "$prefix:NAME=compat_${version}_${name}_${safe_test_name} CONTRACT_ARTIFACTS_VERSION=$version $run_test_script simple $test \"$test_name\""
+          done < <(extract_test_names "$test")
+        else
+          echo "$prefix:NAME=compat_${version}_${name} CONTRACT_ARTIFACTS_VERSION=$version $run_test_script simple $test"
+        fi
+      done
+    done
+  fi
 }
 
 function test {
@@ -301,61 +363,6 @@ function avm_check_circuit {
 
   # Run check-circuit
   avm_check_circuit_cmds | parallelize
-}
-
-# Generates e2e test commands using contract artifacts from a prior release version.
-# Only includes simple (jest-based) tests since compose/docker tests don't use the legacy jest resolver.
-# Excludes kernelless_simulation, which asserts on the exact number of nullifiers emitted and breaks
-# whenever contracts add/remove nullifier emissions across versions (unrelated to the compat contract
-# surface).
-function compat_test_cmds {
-  local version=${1:?version is required}
-  local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
-  local prefix="$hash:ISOLATE=1"
-  local compat_env="CONTRACT_ARTIFACTS_VERSION=$version"
-
-  local tests=(
-    src/automine/*.test.ts
-    src/automine/contracts/*.test.ts
-    src/automine/contracts/deploy/*.test.ts
-    src/automine/contracts/nested/*.test.ts
-    src/automine/token/*.test.ts
-    src/automine/accounts/*.test.ts
-    src/automine/effects/*.test.ts
-    src/automine/simulation/!(kernelless_simulation).test.ts
-    src/single-node/fees/*.test.ts
-    src/single-node/cross-chain/*.test.ts
-    src/single-node/bot/*.test.ts
-    src/infra/*.test.ts
-    src/p2p/*.test.ts
-    src/p2p/reqresp/*.test.ts
-  )
-  for test in "${tests[@]}"; do
-    local name
-    if [[ "$test" == src/p2p/* || "$test" == src/automine/* ]]; then
-      # The p2p/ and automine/ folders have no `e2e_` prefix to strip; flatten their path into an
-      # e2e_<path> name (matching the historical e2e_p2p/<file> names) by dropping "src/", ".test.ts",
-      # and slashes.
-      name=${test#src/}
-      name=e2e_${name%.test.ts}
-      name=${name//\//_}
-    else
-      name=${test#*e2e_}
-      name=e2e_${name%.test.ts}
-    fi
-
-    if [[ "$test" == *.parallel.test.ts ]]; then
-      while IFS= read -r test_name; do
-        # See the matching note in test_cmds: collapse docker-illegal characters so NAME is a valid
-        # container name for docker_isolate.
-        local safe_test_name=$(echo "$test_name" | sed 's/[^a-zA-Z0-9_.-]/_/g')
-        local full_name="compat_${version}_${name}_${safe_test_name}"
-        echo "$prefix:NAME=$full_name $compat_env $run_test_script simple $test \"$test_name\""
-      done < <(extract_test_names "$test")
-    else
-      echo "$prefix:NAME=compat_${version}_${name} $compat_env $run_test_script simple $test"
-    fi
-  done
 }
 
 case "$cmd" in

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -167,30 +167,9 @@ function test_cmds {
 
   # Backwards-compat sweep: rerun the artifact-consuming tests against each prior stable release's
   # contract artifacts, committed as legacy-contracts/<version>.tar.gz (see legacy-contracts/README.md).
-  # The jest resolver swaps artifact JSON imports when CONTRACT_ARTIFACTS_VERSION is set. No tarballs
-  # (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies e2e cost
-  # per version, and the merge queue's full run is the enforcement point.
-  # Only simple (jest-based) tests, since compose/docker tests don't use the legacy jest resolver.
-  # Excludes kernelless_simulation, which asserts on the exact number of nullifiers emitted and breaks
-  # whenever contracts add/remove nullifier emissions across versions (unrelated to the compat contract
-  # surface).
+  # No tarballs (a line with no stable releases yet) means no sweep. Full CI only: the sweep multiplies
+  # e2e cost per version, and the merge queue's full run is the enforcement point.
   if [ "${CI_FULL:-0}" -eq 1 ]; then
-    local compat_tests=(
-      src/automine/*.test.ts
-      src/automine/contracts/*.test.ts
-      src/automine/contracts/deploy/*.test.ts
-      src/automine/contracts/nested/*.test.ts
-      src/automine/token/*.test.ts
-      src/automine/accounts/*.test.ts
-      src/automine/effects/*.test.ts
-      src/automine/simulation/!(kernelless_simulation).test.ts
-      src/single-node/fees/*.test.ts
-      src/single-node/cross-chain/*.test.ts
-      src/single-node/bot/*.test.ts
-      src/infra/*.test.ts
-      src/p2p/*.test.ts
-      src/p2p/reqresp/*.test.ts
-    )
     local version tarball
     for tarball in legacy-contracts/*.tar.gz; do
       [ -e "$tarball" ] || continue
@@ -199,31 +178,7 @@ function test_cmds {
       # here saves every container doing it lazily. Status goes to stderr — stdout is the command
       # stream.
       node src/install_legacy_contracts.cjs "$version" 1>&2
-      for test in "${compat_tests[@]}"; do
-        local name
-        if [[ "$test" == src/p2p/* || "$test" == src/automine/* ]]; then
-          # The p2p/ and automine/ folders have no `e2e_` prefix to strip; flatten their path into an
-          # e2e_<path> name (matching the historical e2e_p2p/<file> names) by dropping "src/",
-          # ".test.ts", and slashes.
-          name=${test#src/}
-          name=e2e_${name%.test.ts}
-          name=${name//\//_}
-        else
-          name=${test#*e2e_}
-          name=e2e_${name%.test.ts}
-        fi
-
-        if [[ "$test" == *.parallel.test.ts ]]; then
-          while IFS= read -r test_name; do
-            # See the matching note near the top of test_cmds: collapse docker-illegal characters so
-            # NAME is a valid container name for docker_isolate.
-            local safe_test_name=$(echo "$test_name" | sed 's/[^a-zA-Z0-9_.-]/_/g')
-            echo "$prefix:NAME=compat_${version}_${name}_${safe_test_name} CONTRACT_ARTIFACTS_VERSION=$version $run_test_script simple $test \"$test_name\""
-          done < <(extract_test_names "$test")
-        else
-          echo "$prefix:NAME=compat_${version}_${name} CONTRACT_ARTIFACTS_VERSION=$version $run_test_script simple $test"
-        fi
-      done
+      compat_test_cmds "$version"
     done
   fi
 }
@@ -363,6 +318,62 @@ function avm_check_circuit {
 
   # Run check-circuit
   avm_check_circuit_cmds | parallelize
+}
+
+# Generates e2e test commands using contract artifacts from a prior release version: the jest resolver
+# swaps artifact JSON imports when CONTRACT_ARTIFACTS_VERSION is set.
+# Only includes simple (jest-based) tests since compose/docker tests don't use the legacy jest resolver.
+# Excludes kernelless_simulation, which asserts on the exact number of nullifiers emitted and breaks
+# whenever contracts add/remove nullifier emissions across versions (unrelated to the compat contract
+# surface).
+function compat_test_cmds {
+  local version=${1:?version is required}
+  local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
+  local prefix="$hash:ISOLATE=1:TIMEOUT=20m"
+  local compat_env="CONTRACT_ARTIFACTS_VERSION=$version"
+
+  local tests=(
+    src/automine/*.test.ts
+    src/automine/contracts/*.test.ts
+    src/automine/contracts/deploy/*.test.ts
+    src/automine/contracts/nested/*.test.ts
+    src/automine/token/*.test.ts
+    src/automine/accounts/*.test.ts
+    src/automine/effects/*.test.ts
+    src/automine/simulation/!(kernelless_simulation).test.ts
+    src/single-node/fees/*.test.ts
+    src/single-node/cross-chain/*.test.ts
+    src/single-node/bot/*.test.ts
+    src/infra/*.test.ts
+    src/p2p/*.test.ts
+    src/p2p/reqresp/*.test.ts
+  )
+  for test in "${tests[@]}"; do
+    local name
+    if [[ "$test" == src/p2p/* || "$test" == src/automine/* ]]; then
+      # The p2p/ and automine/ folders have no `e2e_` prefix to strip; flatten their path into an
+      # e2e_<path> name (matching the historical e2e_p2p/<file> names) by dropping "src/", ".test.ts",
+      # and slashes.
+      name=${test#src/}
+      name=e2e_${name%.test.ts}
+      name=${name//\//_}
+    else
+      name=${test#*e2e_}
+      name=e2e_${name%.test.ts}
+    fi
+
+    if [[ "$test" == *.parallel.test.ts ]]; then
+      while IFS= read -r test_name; do
+        # See the matching note in test_cmds: collapse docker-illegal characters so NAME is a valid
+        # container name for docker_isolate.
+        local safe_test_name=$(echo "$test_name" | sed 's/[^a-zA-Z0-9_.-]/_/g')
+        local full_name="compat_${version}_${name}_${safe_test_name}"
+        echo "$prefix:NAME=$full_name $compat_env $run_test_script simple $test \"$test_name\""
+      done < <(extract_test_names "$test")
+    else
+      echo "$prefix:NAME=compat_${version}_${name} $compat_env $run_test_script simple $test"
+    fi
+  done
 }
 
 case "$cmd" in

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -370,7 +370,6 @@ function compat_test_cmds {
   for tarball in legacy-contracts/*.tar.gz; do
     [ -e "$tarball" ] || continue
     version=$(basename "$tarball" .tar.gz)
-    node src/install_legacy_contracts.cjs "$version" 1>&2
     compat_per_version_test_cmds "$version"
   done
 }

--- a/yarn-project/end-to-end/legacy-contracts/README.md
+++ b/yarn-project/end-to-end/legacy-contracts/README.md
@@ -1,8 +1,8 @@
 # Legacy contract artifacts
 
-One tarball per prior stable release of the current major, holding the contract artifact JSON of
+Each tarball, holds the contract artifact JSON's of
 `@aztec/noir-contracts.js`, `@aztec/noir-test-contracts.js`, and `@aztec/accounts` as published at
-that version:
+a specific version:
 
 ```
 <version>.tar.gz
@@ -12,22 +12,10 @@ that version:
     └── accounts/artifacts/*.json
 ```
 
-These drive the backwards-compatibility sweep: `test_cmds` (in `../bootstrap.sh`) emits, for every
-version present here, a run of the artifact-consuming e2e tests with `CONTRACT_ARTIFACTS_VERSION`
-set, and the jest resolver (`../src/legacy-jest-resolver.cjs`) swaps artifact JSON imports to the
-matching historical files, unpacked on demand into the gitignored `../.legacy-contracts/` cache by
-`../src/install_legacy_contracts.cjs`. An empty directory (a line with no stable releases yet)
-means no sweep — delete the tarballs to disable compat testing on a line, add one to extend it.
-
-Every full CI run (`bootstrap.sh ci-full*` at the repo root) fails while any stable release of the
-major is missing here, so the set can't silently fall behind. Releases themselves aren't gated:
-the release cutting `X.Y.Z` is what publishes the packages the `X.Y.Z` artifacts are built from,
-so they can't be vendored beforehand — the first full run after a stable release goes red until
-the new tarball lands.
+These artifacts are used to test for backwards-compatibility during CI. 
 
 ## Adding a version
 
-After a stable release `X.Y.Z` is published to npm:
 
 ```bash
 cd $(mktemp -d)

--- a/yarn-project/end-to-end/legacy-contracts/README.md
+++ b/yarn-project/end-to-end/legacy-contracts/README.md
@@ -16,19 +16,11 @@ These artifacts are used to test for backwards-compatibility during CI.
 
 ## Adding a version
 
+After a stable release `X.Y.Z` is published to npm, run:
 
 ```bash
-cd $(mktemp -d)
-for p in noir-contracts.js noir-test-contracts.js accounts; do
-  npm pack "@aztec/$p@X.Y.Z"
-  mkdir -p "X.Y.Z/$p"
-  tar -xzf aztec-$p-X.Y.Z.tgz
-  cp -r package/artifacts "X.Y.Z/$p/artifacts" && rm -rf package
-done
-find X.Y.Z -type f ! -name '*.json' -delete
-tar --sort=name --owner=0 --group=0 --numeric-owner --mtime='2000-01-01 00:00:00Z' \
-    -cf - X.Y.Z | gzip -n -9 > X.Y.Z.tar.gz
+./add_version.sh X.Y.Z
 ```
 
-Commit the resulting `X.Y.Z.tar.gz` in this directory. The tar/gzip flags make the output
-deterministic, so regenerating from the same npm packages yields a byte-identical file.
+and commit the resulting `X.Y.Z.tar.gz`. The script builds the tarball with deterministic tar/gzip
+flags, so regenerating from the same npm packages yields a byte-identical file.

--- a/yarn-project/end-to-end/legacy-contracts/README.md
+++ b/yarn-project/end-to-end/legacy-contracts/README.md
@@ -19,8 +19,11 @@ matching historical files, unpacked on demand into the gitignored `../.legacy-co
 `../src/install_legacy_contracts.cjs`. An empty directory (a line with no stable releases yet)
 means no sweep — delete the tarballs to disable compat testing on a line, add one to extend it.
 
-The release flow (`bootstrap.sh ci-release` at the repo root) refuses to cut a release while any
-prior stable of the major is missing here, so the set can't silently fall behind.
+Every full CI run (`bootstrap.sh ci-full*` at the repo root) fails while any stable release of the
+major is missing here, so the set can't silently fall behind. Releases themselves aren't gated:
+the release cutting `X.Y.Z` is what publishes the packages the `X.Y.Z` artifacts are built from,
+so they can't be vendored beforehand — the first full run after a stable release goes red until
+the new tarball lands.
 
 ## Adding a version
 

--- a/yarn-project/end-to-end/legacy-contracts/README.md
+++ b/yarn-project/end-to-end/legacy-contracts/README.md
@@ -1,0 +1,43 @@
+# Legacy contract artifacts
+
+One tarball per prior stable release of the current major, holding the contract artifact JSON of
+`@aztec/noir-contracts.js`, `@aztec/noir-test-contracts.js`, and `@aztec/accounts` as published at
+that version:
+
+```
+<version>.tar.gz
+└── <version>/
+    ├── noir-contracts.js/artifacts/*.json
+    ├── noir-test-contracts.js/artifacts/*.json
+    └── accounts/artifacts/*.json
+```
+
+These drive the backwards-compatibility sweep: `test_cmds` (in `../bootstrap.sh`) emits, for every
+version present here, a run of the artifact-consuming e2e tests with `CONTRACT_ARTIFACTS_VERSION`
+set, and the jest resolver (`../src/legacy-jest-resolver.cjs`) swaps artifact JSON imports to the
+matching historical files, unpacked on demand into the gitignored `../.legacy-contracts/` cache by
+`../src/install_legacy_contracts.cjs`. An empty directory (a line with no stable releases yet)
+means no sweep — delete the tarballs to disable compat testing on a line, add one to extend it.
+
+The release flow (`bootstrap.sh ci-release` at the repo root) refuses to cut a release while any
+prior stable of the major is missing here, so the set can't silently fall behind.
+
+## Adding a version
+
+After a stable release `X.Y.Z` is published to npm:
+
+```bash
+cd $(mktemp -d)
+for p in noir-contracts.js noir-test-contracts.js accounts; do
+  npm pack "@aztec/$p@X.Y.Z"
+  mkdir -p "X.Y.Z/$p"
+  tar -xzf aztec-$p-X.Y.Z.tgz
+  cp -r package/artifacts "X.Y.Z/$p/artifacts" && rm -rf package
+done
+find X.Y.Z -type f ! -name '*.json' -delete
+tar --sort=name --owner=0 --group=0 --numeric-owner --mtime='2000-01-01 00:00:00Z' \
+    -cf - X.Y.Z | gzip -n -9 > X.Y.Z.tar.gz
+```
+
+Commit the resulting `X.Y.Z.tar.gz` in this directory. The tar/gzip flags make the output
+deterministic, so regenerating from the same npm packages yields a byte-identical file.

--- a/yarn-project/end-to-end/legacy-contracts/add_version.sh
+++ b/yarn-project/end-to-end/legacy-contracts/add_version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Builds <version>.tar.gz in this directory from the @aztec packages published on npm, enabling the
+# backwards-compat sweep for that version once committed.
+# Usage: ./add_version.sh <version>   e.g. ./add_version.sh 5.2.0
+set -euo pipefail
+
+version=${1:?usage: $0 <version> (e.g. 5.2.0)}
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: '$version' is not a stable X.Y.Z version." >&2
+  exit 1
+fi
+
+out_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+out="$out_dir/$version.tar.gz"
+
+# The deterministic flags below are GNU tar's; macOS ships BSD tar (brew install gnu-tar).
+tar_bin=tar
+if ! tar --version 2>/dev/null | grep -q GNU; then
+  tar_bin=gtar
+  command -v gtar >/dev/null || { echo "ERROR: GNU tar required (brew install gnu-tar)." >&2; exit 1; }
+fi
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+cd "$workdir"
+
+for p in noir-contracts.js noir-test-contracts.js accounts; do
+  # Force the public registry: some environments (e.g. CI) point the @aztec scope elsewhere.
+  npm pack "@aztec/$p@$version" --@aztec:registry=https://registry.npmjs.org/ --quiet
+  mkdir -p "$version/$p"
+  tar -xzf "aztec-$p-$version.tgz"
+  cp -r package/artifacts "$version/$p/artifacts"
+  rm -rf package
+done
+find "$version" -type f ! -name '*.json' -delete
+
+# Deterministic output: regenerating from the same npm packages yields a byte-identical file.
+$tar_bin --sort=name --owner=0 --group=0 --numeric-owner --mtime='2000-01-01 00:00:00Z' \
+    -cf - "$version" | gzip -n -9 > "$version.tar.gz"
+
+if [ -f "$out" ]; then
+  if cmp -s "$version.tar.gz" "$out"; then
+    echo "$out already exists and is byte-identical. Nothing to do."
+    exit 0
+  fi
+  echo "ERROR: $out exists but differs from the freshly built tarball." >&2
+  exit 1
+fi
+mv "$version.tar.gz" "$out"
+echo "Created $out. Commit it to enable the compat sweep for $version."

--- a/yarn-project/end-to-end/src/install_legacy_contracts.cjs
+++ b/yarn-project/end-to-end/src/install_legacy_contracts.cjs
@@ -3,14 +3,11 @@
 // gitignored .legacy-contracts/<version>/ cache. See legacy-contracts/README.md for the tarball
 // layout and how versions are added.
 //
-// Called from two places:
-//   - bootstrap.sh test_cmds: unpacks on the host while emitting the compat sweep commands, so the
-//     isolated test containers (which share the checkout) don't each pay the extraction.
-//   - legacy-jest-resolver.cjs: on-demand unpack for local dev.
+// Called from legacy-jest-resolver.cjs, which unpacks on demand at first use — both locally and in
+// the isolated CI test containers (which bind-mount the checkout read-write).
 //
 // Idempotent and concurrency-safe: extraction goes to a temp dir and is renamed into place, so
-// parallel callers race benignly. Writes status to stderr only — test_cmds' stdout is the command
-// stream consumed by the test engine.
+// parallel callers (e.g. compat test containers starting together) race benignly.
 /* eslint-disable @typescript-eslint/no-require-imports */
 
 const path = require('path');

--- a/yarn-project/end-to-end/src/install_legacy_contracts.cjs
+++ b/yarn-project/end-to-end/src/install_legacy_contracts.cjs
@@ -1,74 +1,83 @@
 #!/usr/bin/env node
-// Installs pinned legacy @aztec/* contract-artifact packages into .legacy-contracts/<version>/.
+// Unpacks the committed legacy artifact tarballs (legacy-contracts/<version>.tar.gz) into the
+// gitignored .legacy-contracts/<version>/ cache. See legacy-contracts/README.md for the tarball
+// layout and how versions are added.
 //
 // Called from two places:
-//   - bootstrap.sh ci-compat-e2e: pre-populates the cache on the host before hermetic test
-//     containers launch. The containers run with --net=none (see ci3/docker_isolate), so on-demand
-//     installs from inside them fail with EAI_AGAIN.
-//   - legacy-jest-resolver.cjs: on-demand install for local dev, where jest runs with network.
+//   - bootstrap.sh test_cmds: unpacks on the host while emitting the compat sweep commands, so the
+//     isolated test containers (which share the checkout) don't each pay the extraction.
+//   - legacy-jest-resolver.cjs: on-demand unpack for local dev.
 //
-// Idempotent: no-op when all packages are already present.
+// Idempotent and concurrency-safe: extraction goes to a temp dir and is renamed into place, so
+// parallel callers race benignly. Writes status to stderr only — test_cmds' stdout is the command
+// stream consumed by the test engine.
 /* eslint-disable @typescript-eslint/no-require-imports */
 
 const path = require('path');
 const fs = require('fs');
 const { execFileSync } = require('child_process');
 
-const REDIRECTED = ['@aztec/noir-contracts.js', '@aztec/noir-test-contracts.js', '@aztec/accounts'];
+// Package dir names whose artifacts/*.json the jest resolver redirects to historical versions.
+const REDIRECTED = ['noir-contracts.js', 'noir-test-contracts.js', 'accounts'];
 
 const e2eRoot = path.resolve(__dirname, '..');
+const tarballDir = path.join(e2eRoot, 'legacy-contracts');
+const cacheBase = path.join(e2eRoot, '.legacy-contracts');
 
 function cacheRoot(version) {
-  return path.join(e2eRoot, '.legacy-contracts', version);
+  return path.join(cacheBase, version);
 }
 
-function pkgJsonPath(version, pkg) {
-  return path.join(cacheRoot(version), 'node_modules', pkg, 'package.json');
+/** Versions with committed artifacts, derived from the tarballs present. */
+function listVersions() {
+  if (!fs.existsSync(tarballDir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(tarballDir)
+    .filter(f => f.endsWith('.tar.gz'))
+    .map(f => f.slice(0, -'.tar.gz'.length))
+    .sort();
 }
 
 function installLegacyContracts(version) {
   if (!version) {
     throw new Error('installLegacyContracts: version is required');
   }
-  if (REDIRECTED.every(pkg => fs.existsSync(pkgJsonPath(version, pkg)))) {
+  const dest = cacheRoot(version);
+  if (fs.existsSync(dest)) {
     return;
   }
-
-  const cacheDir = cacheRoot(version);
-  fs.mkdirSync(cacheDir, { recursive: true });
-
-  // Seed a standalone package.json so `npm install --prefix` treats cacheRoot as its own project. Without this, npm
-  // walks up and finds the yarn-project workspace root, which breaks on `workspace:` protocol deps and risks
-  // clobbering the monorepo's node_modules.
-  const seed = path.join(cacheDir, 'package.json');
-  if (!fs.existsSync(seed)) {
-    fs.writeFileSync(seed, JSON.stringify({ name: 'legacy-contracts-cache', private: true }));
+  const tarball = path.join(tarballDir, `${version}.tar.gz`);
+  if (!fs.existsSync(tarball)) {
+    throw new Error(`[legacy-contracts] no committed artifacts for ${version} (expected ${tarball})`);
   }
 
-  const specs = REDIRECTED.map(pkg => `${pkg}@${version}`);
-  process.stderr.write(`[legacy-contracts] installing ${specs.join(' ')} into ${cacheDir}\n`);
-  // --prefix: install into cacheRoot instead of cwd, so the cache is isolated from the monorepo.
-  // --no-save: don't write the installed packages back to the seeded package.json.
-  // --ignore-scripts: skip lifecycle scripts (preinstall/postinstall) of the legacy packages and their transitive
-  //   deps; we only want the files on disk, not to run any build steps.
-  // --legacy-peer-deps: tolerate peer-dependency mismatches between the pinned legacy @aztec/* graph and whatever
-  //   current versions npm would otherwise try to reconcile.
-  execFileSync(
-    'npm',
-    ['install', '--prefix', cacheDir, '--no-save', '--ignore-scripts', '--legacy-peer-deps', ...specs],
-    { stdio: 'inherit' },
-  );
-
-  // Verify versions on disk match the requested version.
-  for (const pkg of REDIRECTED) {
-    const onDisk = JSON.parse(fs.readFileSync(pkgJsonPath(version, pkg), 'utf8')).version;
-    if (onDisk !== version) {
-      throw new Error(`[legacy-contracts] ${pkg} on disk is ${onDisk}, expected ${version}`);
+  fs.mkdirSync(cacheBase, { recursive: true });
+  // Extract to a temp sibling and rename into place: rename is atomic on the same filesystem, so a
+  // concurrent caller either sees the complete cache or none of it.
+  const tmp = fs.mkdtempSync(path.join(cacheBase, `.${version}.tmp-`));
+  try {
+    process.stderr.write(`[legacy-contracts] unpacking ${path.basename(tarball)} -> ${dest}\n`);
+    execFileSync('tar', ['-xzf', tarball, '-C', tmp], { stdio: ['ignore', 'ignore', 'inherit'] });
+    for (const pkg of REDIRECTED) {
+      if (!fs.existsSync(path.join(tmp, version, pkg, 'artifacts'))) {
+        throw new Error(`[legacy-contracts] ${path.basename(tarball)} is missing ${pkg}/artifacts`);
+      }
     }
+    try {
+      fs.renameSync(path.join(tmp, version), dest);
+    } catch (err) {
+      if (!fs.existsSync(dest)) {
+        throw err;
+      }
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
   }
 }
 
-module.exports = { installLegacyContracts, REDIRECTED, cacheRoot };
+module.exports = { installLegacyContracts, listVersions, cacheRoot, REDIRECTED };
 
 if (require.main === module) {
   installLegacyContracts(process.argv[2]);

--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -1,22 +1,19 @@
 // Custom Jest resolver. When CONTRACT_ARTIFACTS_VERSION is set, redirects *only* JSON artifact files under
-// @aztec/noir-contracts.js/artifacts/, @aztec/noir-test-contracts.js/artifacts/, and @aztec/accounts/artifacts/ to a local cache of the pinned
-// legacy versions. TypeScript wrapper classes (e.g. Token.ts) continue to load from the current workspace and use the
-// current @aztec/aztec.js — only the artifact JSON (the deployed-contract ABI / bytecode / notes surface) is swapped.
+// @aztec/noir-contracts.js/artifacts/, @aztec/noir-test-contracts.js/artifacts/, and @aztec/accounts/artifacts/ to
+// that version's historical artifacts, committed as legacy-contracts/<version>.tar.gz and unpacked on demand into
+// .legacy-contracts/<version>/ by install_legacy_contracts.cjs.
 //
 // Why JSON-only: the JSON artifact is the actual interchange surface a "deployed contract" exposes. The TS wrapper is
 // generated client-side ergonomics that's tightly coupled to the current @aztec/aztec.js API. Redirecting the wrapper
 // would couple this test to a moving aztec.js surface and break at import time on unrelated breaking changes; we want
 // to fail only on actual artifact-compat regressions.
 //
-// Cache population lives in install_legacy_contracts.cjs — invoked lazily here for local dev, and eagerly
-// by bootstrap.sh ci-compat-e2e before hermetic test containers (which run with --net=none) launch.
-//
-// Missing artifacts: legacy version directories are immutable, so an artifact missing from the cache means the
-// contract was added after the pinned release — there's nothing to compat-test. Rather than failing or silently
-// falling back to the workspace artifact (which would turn the compat run into a regular e2e run that always
-// passes), we log the miss and exit the process cleanly with code 0. The test never runs, but the per-test CI
-// log captures the explanatory line so the reason is auditable. This keeps the change scoped to this resolver,
-// avoiding a new exit-code contract in the shared ci3 test runner.
+// Missing artifacts: legacy version tarballs are immutable, so an artifact missing from the unpacked cache means the
+// contract was added after that release — there's nothing to compat-test. Rather than failing or silently falling
+// back to the workspace artifact (which would turn the compat run into a regular e2e run that always passes), we log
+// the miss and exit the process cleanly with code 0. The test never runs, but the per-test CI log captures the
+// explanatory line so the reason is auditable. This keeps the change scoped to this resolver, avoiding a new
+// exit-code contract in the shared ci3 test runner.
 //
 // Activated by env var; passthrough otherwise.
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -28,14 +25,8 @@ const { installLegacyContracts, REDIRECTED, cacheRoot } = require('./install_leg
 const version = process.env.CONTRACT_ARTIFACTS_VERSION;
 const cacheDir = version ? cacheRoot(version) : null;
 
-function pkgJsonPath(name) {
-  return path.join(cacheDir, 'node_modules', name, 'package.json');
-}
-
-// Kept in a separate module (not inlined) because bootstrap.sh ci-compat-e2e also calls it directly
-// via `node .../install_legacy_contracts.cjs <version>` to pre-populate the cache on the host before
-// hermetic --net=none test containers launch. Inlining here would force us to duplicate the logic
-// in bash or re-run jest just to trigger the install.
+// bootstrap.sh test_cmds normally pre-unpacks on the host before the hermetic test containers launch;
+// this lazy call covers local dev runs. Both are idempotent.
 if (version) {
   installLegacyContracts(version);
 }
@@ -49,12 +40,8 @@ function printBannerOnce() {
   }
   bannerPrinted = true;
   const lines = ['='.repeat(60), `[legacy-contracts][jest] CONTRACT_ARTIFACTS_VERSION=${version}`];
-  for (const p of REDIRECTED) {
-    const v = JSON.parse(fs.readFileSync(pkgJsonPath(p), 'utf8')).version;
-    if (v !== version) {
-      throw new Error(`[legacy-contracts] ${p} on disk is ${v}, expected ${version}`);
-    }
-    lines.push(`[legacy-contracts][jest] redirecting ${p}/artifacts/*.json -> .legacy-contracts/${version}/...`);
+  for (const pkg of REDIRECTED) {
+    lines.push(`[legacy-contracts][jest] redirecting ${pkg}/artifacts/*.json -> .legacy-contracts/${version}/...`);
   }
   lines.push('='.repeat(60));
   process.stderr.write(lines.join('\n') + '\n');
@@ -67,15 +54,14 @@ function legacyArtifactPath(resolved) {
     return null;
   }
   for (const pkg of REDIRECTED) {
-    // pkg = '@aztec/noir-contracts.js' -> match '/noir-contracts.js/artifacts/'
-    const dirName = pkg.split('/')[1];
-    const marker = `/${dirName}/artifacts/`;
+    // pkg = 'noir-contracts.js' -> match '/noir-contracts.js/artifacts/'
+    const marker = `/${pkg}/artifacts/`;
     const idx = resolved.indexOf(marker);
     if (idx === -1) {
       continue;
     }
     const basename = resolved.slice(idx + marker.length);
-    return path.join(cacheDir, 'node_modules', pkg, 'artifacts', basename);
+    return path.join(cacheDir, pkg, 'artifacts', basename);
   }
   return null;
 }

--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -25,8 +25,8 @@ const { installLegacyContracts, REDIRECTED, cacheRoot } = require('./install_leg
 const version = process.env.CONTRACT_ARTIFACTS_VERSION;
 const cacheDir = version ? cacheRoot(version) : null;
 
-// bootstrap.sh test_cmds normally pre-unpacks on the host before the hermetic test containers launch;
-// this lazy call covers local dev runs. Both are idempotent.
+// Unpack on demand at first use. Idempotent and concurrency-safe, so parallel jest workers and
+// isolated test containers (which share the checkout) race benignly.
 if (version) {
   installLegacyContracts(version);
 }


### PR DESCRIPTION
- Removes specific workflows, labels, and modes that we originally had introduced to test backwards compatibility. Instead, compat tests are enumerated via `compat_test_cmds` based on what is found in the `legacy-contracts` folder.

- The `legacy-contracts` folder, by convention, holds legacy contract artifacts of historical versions we're interested in running compat ci against. It's up to each branch to determine that: after this PR is merged, `v5-next` will run compat tests on v5.0.1 and v5.1.0, which are the stable releases of the stack under protocol v5. `next` (after porting this PR), will keep `legacy-contracts` empty until a stable version of the stack is released under protocol v6.

- Compat tests only run in `ci-full` mode, and according to my measurements they increase `ci-full` running time by ~10 minutes. For two stable versions (v5.0.1, v5.1.0), that comes down to around 5 minutes per stable release. Once we release v5.2.0, we can expect the overhead to be ~15 minutes. This is why I increased the AWS shutdown limit.

- `ci-fast` runs are unaffected by these changes.

-  In `ci-full` mode, adds a check to enforce that the expected artifact tars are in the `legacy-contracts` folder. Note this will cause the first `ci-full` run **after** a stable release to fail with a hopefully clear enough message that artifacts for the new release need to be committed moving forward. This is purposedly designed not to block or interfere with releases.
