### PR TITLE
feat(pxe): speculatively sync the predicted callees of sync_state

### DIFF
--- a/yarn-project/pxe/src/contract/contract_sync_service.test.ts
+++ b/yarn-project/pxe/src/contract/contract_sync_service.test.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { executeTimeout } from '@aztec/foundation/timer';
+import { TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -14,7 +15,7 @@ import type { ContractStore } from '../storage/contract_store/contract_store.js'
 import type { NoteStore } from '../storage/note_store/note_store.js';
 import { type ContractFunction, PREDICTION_THRESHOLD } from './contract_call_graph.js';
 import type { ContractClassService } from './contract_class_service.js';
-import { ContractSyncService, MAX_CONCURRENT_SCOPE_SYNCS } from './contract_sync_service.js';
+import { ContractSyncService, MAX_CONCURRENT_SCOPE_SYNCS, SYNC_STATE_SELECTOR } from './contract_sync_service.js';
 
 describe('ContractSyncService', () => {
   let aztecNode: ReturnType<typeof mock<AztecNode>>;
@@ -737,6 +738,29 @@ describe('ContractSyncService', () => {
       expectSyncedContracts([contractAddress, [scopeA]], [otherContract, [scopeA]], [grandChild, [scopeA]]);
     });
 
+    it('speculatively syncs the dependencies of the contract sync itself', async () => {
+      // `sync_state` is only ever invoked by PXE, so its callees (e.g. most contract syncs query the handshake registry)
+      // are learned and predicted under the universal sync_state selector, not under a requested function.
+      const syncStateFn: ContractFunction = { address: contractAddress, selector: SYNC_STATE_SELECTOR };
+      await learnDependencies({
+        count: PREDICTION_THRESHOLD,
+        calls: [{ caller: syncStateFn, callee: otherFn }],
+      });
+
+      // A direct read syncs the contract without invoking any function, yet sync_state's learned callee still syncs.
+      await service.ensureContractSynced({
+        contract: contractAddress,
+        functionToInvokeAfterSync: null,
+        utilityExecutor,
+        anchorBlockHeader,
+        jobId: 'job-3',
+        scopes: [scopeA],
+        triggeredBy: undefined,
+      });
+      await tick();
+      expectSyncedContracts([contractAddress, [scopeA]], [otherContract, [scopeA]]);
+    });
+
     it('stops recursing when the known calls form a cycle', async () => {
       await learnDependencies({
         count: PREDICTION_THRESHOLD,
@@ -911,6 +935,17 @@ describe('ContractSyncService', () => {
 
   /** Yields to the macrotask queue, draining all pending microtasks (semaphore acquires/releases) in between. */
   const tick = () => new Promise<void>(resolve => setImmediate(resolve));
+});
+
+describe('SYNC_STATE_SELECTOR', () => {
+  // Pins the hardcoded selector to the macro's actual output: if the macro ever changes `sync_state`'s signature,
+  // this fails instead of predictions silently keying on a stale selector.
+  it('matches the selector of a compiled artifact', async () => {
+    const syncState = TestContractArtifact.functions.find(f => f.name === 'sync_state');
+    expect(syncState).toBeDefined();
+    const expected = await FunctionSelector.fromNameAndParameters(syncState!.name, syncState!.parameters);
+    expect(SYNC_STATE_SELECTOR).toEqual(expected);
+  });
 });
 
 /** A direct call observed by a job. */

--- a/yarn-project/pxe/src/contract/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract/contract_sync_service.ts
@@ -22,9 +22,8 @@ import { syncScope } from './helpers.js';
 export const MAX_CONCURRENT_SCOPE_SYNCS = 5;
 
 /**
- * Selector of the macro-generated `sync_state` utility function. It is the same for every contract: the macro fixes
- * the signature to `sync_state(scope: AztecAddress)` and rejects user-defined overrides. Pinned against a compiled
- * artifact in tests, so a macro signature change fails there instead of predictions keying on a stale selector.
+ * Selector of the macro-generated `sync_state` utility function, whichis the same for every contract.
+ * Pinned against a compiled artifact in tests, so a macro signature change fails there.
  */
 export const SYNC_STATE_SELECTOR = FunctionSelector.fromString('0x418ef5da');
 

--- a/yarn-project/pxe/src/contract/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract/contract_sync_service.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@aztec/foundation/log';
 import { Semaphore } from '@aztec/foundation/queue';
 import { isProtocolContract } from '@aztec/protocol-contracts';
-import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
+import { type FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -20,6 +20,13 @@ import { syncScope } from './helpers.js';
  * on non-ACIR work (node RPC, note store reads) against memory pressure from concurrent circuit execution.
  */
 export const MAX_CONCURRENT_SCOPE_SYNCS = 5;
+
+/**
+ * Selector of the macro-generated `sync_state` utility function. It is the same for every contract: the macro fixes
+ * the signature to `sync_state(scope: AztecAddress)` and rejects user-defined overrides. Pinned against a compiled
+ * artifact in tests, so a macro signature change fails there instead of predictions keying on a stale selector.
+ */
+export const SYNC_STATE_SELECTOR = FunctionSelector.fromString('0x418ef5da');
 
 /**
  * Service for syncing the private state of contracts. It uses a cache to avoid redundant sync operations - the cache
@@ -133,8 +140,9 @@ export class ContractSyncService implements StagedStore {
    * For each unsynced scope, creates a promise that waits on:
    *  1. Note nullifier sync (shared, batched across all unsynced scopes).
    *  2. Per-scope sync (individual, semaphore-bounded).
-   * When concurrent contract sync is enabled, the invoked function's predicted direct callees start speculatively
-   * too, once the contract's own syncs have started (see {@link #speculativelySync}).
+   * When concurrent contract sync is enabled, the predicted direct callees of the invoked function and of the
+   * contract's `sync_state` start speculatively too, once the contract's own syncs have started (see
+   * {@link #speculativelySync}).
    * @returns A promise that resolves once every requested scope is synced, including syncs already in flight from
    * concurrent calls. Speculative syncs are not included: those are only awaited by a later request that needs
    * their contract, or by the job's {@link settle}.
@@ -185,6 +193,10 @@ export class ContractSyncService implements StagedStore {
         }
         syncs.push(promise);
       }
+
+      // `sync_state` itself calls other contracts (e.g. most contract syncs query the handshake registry), so its
+      // predicted callees start syncing alongside the contract's own syncs.
+      this.#speculativelySync(contractAddress, SYNC_STATE_SELECTOR, utilityExecutor, anchorBlockHeader, jobId, scopes);
 
       this.#speculativelySync(
         contractAddress,


### PR DESCRIPTION
## Motivation

Every contract sync executes the contract's `sync_state`, whose own nested calls are learned by the call graph from #25126 but were never predicted: `sync_state` is only ever invoked by PXE, so its selector never appears as a sync request's invoked function. Almost all contracts make at least one external call during sync (the handshake registry), so a dependency that always started syncing serially now overlaps — a big win.

## The change

`#startSyncIfNeeded` now also fires the speculative sync of the predicted callees of the contract's own `sync_state`, keyed under a hardcoded `SYNC_STATE_SELECTOR`. The selector is safe to hardcode because the macro fixes `sync_state`'s signature for every contract; a test derives the expected value from a compiled artifact, so a macro signature change fails loudly instead of silently disabling these predictions.