### PR TITLE
fix(aztec-nr)!: domain-separate account entrypoint authorization from generic authwits

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,20 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [aztec-nr / Aztec.js] Account entrypoint authorization is now domain-separated from generic authwits
+
+The account entrypoint previously wrapped its payload hash with the generic authwit outer hash
+(`compute_authwit_message_hash` / `computeOuterAuthWitHash`). That placed the authorized message in the image of the
+generic authwit path: a `createAuthWit` over `{ consumer: account, innerHash: <entrypoint payload hash> }` produces
+exactly the message the entrypoint validates, so anyone able to request a generic authwit from the account could mint
+an entrypoint authorization for a call list of their choosing. The entrypoint now wraps the payload hash with a
+dedicated `entrypoint_message` domain separator, so the message can no longer be produced through the generic path.
+
+This changes the authorized message preimage again, so it is a breaking change with the same upgrade requirements as
+above: client and account bytecode must be upgraded together. **Third-party wallets or tooling** that build the
+entrypoint authorization witness themselves must wrap the payload hash with the new `entrypoint_message` domain
+separator instead of the generic outer authwit hash.
+
 ### [aztec-nr / Aztec.js] Account entrypoint authorization now binds the fee-payment method and cancellation flag
 
 The account entrypoint (`AccountActions::entrypoint`) previously authorized only the app payload hash. It now

--- a/noir-projects/labs/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/authwit/account.nr
@@ -1,6 +1,6 @@
 use crate::context::PrivateContext;
 
-use crate::protocol::{hash::poseidon2_hash_with_separator, traits::Hash};
+use crate::protocol::{address::AztecAddress, hash::poseidon2_hash_with_separator, traits::{Hash, ToField}};
 
 use crate::authwit::auth::{compute_authwit_message_hash, IS_VALID_SELECTOR};
 use crate::authwit::entrypoint::app::AppPayload;
@@ -16,6 +16,15 @@ pub(crate) global DOM_SEP__TX_NULLIFIER: u32 = 1025801951;
 /// them together.
 pub(crate) global DOM_SEP__ENTRYPOINT_PAYLOAD: u32 = 3045079954;
 
+/// Domain separator for the account entrypoint authorization message.
+///
+/// The entrypoint authorizes `compute_entrypoint_message_hash`, which wraps the payload hash with this separator
+/// rather than the generic authwit outer separator. Sharing the generic separator would place the entrypoint
+/// message in the image of the generic authwit path (`compute_authwit_message_hash` over an attacker-chosen inner
+/// hash), letting anyone able to request a generic authwit from the account mint an entrypoint authorization for a
+/// call list of their choosing.
+pub(crate) global DOM_SEP__ENTRYPOINT_MESSAGE: u32 = 3858756027;
+
 /// Computes the inner hash the account authorizes when invoked through its entrypoint.
 ///
 /// Binds the app payload together with the fee-payment selector and cancellation flag. Both drive fee-payer and
@@ -27,6 +36,22 @@ fn compute_entrypoint_payload_hash(app_payload: AppPayload, fee_payment_method: 
     poseidon2_hash_with_separator(
         [app_payload.hash(), fee_payment_method as Field, cancellable as Field],
         DOM_SEP__ENTRYPOINT_PAYLOAD,
+    )
+}
+
+/// Computes the message the account authorizes when invoked through its entrypoint.
+///
+/// Mirrors `compute_authwit_message_hash` but uses `DOM_SEP__ENTRYPOINT_MESSAGE`, so reproducing the entrypoint
+/// message through the generic authwit path would require a Poseidon2 collision.
+fn compute_entrypoint_message_hash(
+    consumer: AztecAddress,
+    chain_id: Field,
+    version: Field,
+    inner_hash: Field,
+) -> Field {
+    poseidon2_hash_with_separator(
+        [consumer.to_field(), chain_id, version, inner_hash],
+        DOM_SEP__ENTRYPOINT_MESSAGE,
     )
 }
 
@@ -62,7 +87,9 @@ impl AccountActions<&mut PrivateContext> {
     /// Verifies that the entrypoint payload is authorized and executes the `app_payload`.
     ///
     /// The authorized message binds the app payload together with `fee_payment_method` and `cancellable`, so the
-    /// account's approval covers the fee-payer and cancellation side effects rather than the call list alone.
+    /// account's approval covers the fee-payer and cancellation side effects rather than the call list alone. It is
+    /// domain-separated from generic authwits (see `DOM_SEP__ENTRYPOINT_MESSAGE`) so it cannot be minted through
+    /// the generic authwit path.
     ///
     /// @param app_payload The payload that contains the calls to be executed in the app phase.
     ///
@@ -84,7 +111,7 @@ impl AccountActions<&mut PrivateContext> {
         let valid_fn = self.is_valid_impl;
 
         let inner_hash = compute_entrypoint_payload_hash(app_payload, fee_payment_method, cancellable);
-        let message_hash = compute_authwit_message_hash(
+        let message_hash = compute_entrypoint_message_hash(
             self.context.this_address(),
             self.context.chain_id(),
             self.context.version(),

--- a/noir-projects/labs/aztec-nr/aztec/src/authwit/auth.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/authwit/auth.nr
@@ -19,8 +19,12 @@ pub(crate) global DOM_SEP__AUTHWIT_NULLIFIER: u32 = 1239150694;
 
 /// Authentication witness helper library
 ///
-/// Authentication Witness is a scheme for authenticating actions on Aztec, so users can allow third-parties (e.g.
-/// protocols or other users) to execute an action on their behalf.
+/// Authentication Witness is a scheme for authorizing application-level actions on Aztec, so users can allow
+/// third-parties (e.g. protocols or other users) to perform an action that a consuming contract checks.
+///
+/// A witness authorizes one action against one consumer. It does not authorize originating a transaction as the
+/// account: an account's entrypoint message uses its own domain separator (see `DOM_SEP__ENTRYPOINT_MESSAGE` in
+/// `crate::authwit::account`).
 ///
 /// This library provides helper functions to manage such witnesses. The authentication witness, is some "witness"
 /// (data) that authenticates a `message_hash`. The simplest example of an authentication witness, is a signature. The

--- a/noir-projects/labs/aztec-nr/aztec/src/test/domain_separators.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/test/domain_separators.nr
@@ -8,7 +8,7 @@
 //! that the whole set (every aztec-nr separator plus every protocol separator) is collision-free. The protocol enforces
 //! the same for its own separators in its own tests.
 
-use crate::authwit::account::{DOM_SEP__ENTRYPOINT_PAYLOAD, DOM_SEP__TX_NULLIFIER};
+use crate::authwit::account::{DOM_SEP__ENTRYPOINT_MESSAGE, DOM_SEP__ENTRYPOINT_PAYLOAD, DOM_SEP__TX_NULLIFIER};
 use crate::authwit::auth::DOM_SEP__AUTHWIT_NULLIFIER;
 use crate::keys::ecdh_shared_secret::{DOM_SEP__ECDH_FIELD_MASK, DOM_SEP__ECDH_SUBKEY};
 use crate::macros::functions::initialization_utils::DOM_SEP__INITIALIZATION_NULLIFIER;
@@ -124,6 +124,7 @@ unconstrained fn domain_separators_are_valid() {
         );
     all = all.push_back(derived(DOM_SEP__TX_NULLIFIER, "tx_nullifier"));
     all = all.push_back(derived(DOM_SEP__ENTRYPOINT_PAYLOAD, "entrypoint_payload"));
+    all = all.push_back(derived(DOM_SEP__ENTRYPOINT_MESSAGE, "entrypoint_message"));
     all = all.push_back(derived(DOM_SEP__AUTHWIT_NULLIFIER, "authwit_nullifier"));
     all = all.push_back(derived(DOM_SEP__ECDH_SUBKEY, "ecdh_subkey"));
     all = all.push_back(derived(DOM_SEP__ECDH_FIELD_MASK, "ecdh_field_mask"));

--- a/yarn-project/entrypoints/src/account_entrypoint.test.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.test.ts
@@ -1,6 +1,6 @@
 import { poseidon2HashBytes } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { AuthWitness } from '@aztec/stdlib/auth-witness';
+import { AuthWitness, computeOuterAuthWitHash } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GasSettings } from '@aztec/stdlib/gas';
 import { ExecutionPayload } from '@aztec/stdlib/tx';
@@ -9,8 +9,12 @@ import {
   AccountFeePaymentMethodOptions,
   DefaultAccountEntrypoint,
   type DefaultAccountEntrypointOptions,
+  ENTRYPOINT_MESSAGE_DOMAIN_SEPARATOR,
   ENTRYPOINT_PAYLOAD_DOMAIN_SEPARATOR,
+  computeEntrypointMessageHash,
+  computeEntrypointPayloadHash,
 } from './account_entrypoint.js';
+import { EncodedAppEntrypointCalls } from './encoding.js';
 import type { AuthWitnessProvider, ChainInfo } from './interfaces.js';
 
 describe('DefaultAccountEntrypoint', () => {
@@ -80,5 +84,37 @@ describe('DefaultAccountEntrypoint', () => {
       (await poseidon2HashBytes(Buffer.from('az_dom_sep__entrypoint_payload'))).toBigInt() & 0xffffffffn,
     );
     expect(ENTRYPOINT_PAYLOAD_DOMAIN_SEPARATOR).toEqual(derived);
+  });
+
+  it('mirrors the Noir entrypoint message domain separator', async () => {
+    const derived = Number(
+      (await poseidon2HashBytes(Buffer.from('az_dom_sep__entrypoint_message'))).toBigInt() & 0xffffffffn,
+    );
+    expect(ENTRYPOINT_MESSAGE_DOMAIN_SEPARATOR).toEqual(derived);
+  });
+
+  // The entrypoint must authorize a message the generic authwit path cannot reproduce. Otherwise a party able to
+  // request a generic authwit from the account (a createAuthWit over { consumer: account, innerHash }) could mint an
+  // entrypoint authorization for a call list of its choosing.
+  it('domain-separates the entrypoint message from the generic authwit hash', async () => {
+    const hash = await getPayloadAuthWitnessHash(baseOptions);
+
+    const encodedCalls = await EncodedAppEntrypointCalls.create(ExecutionPayload.empty().calls, baseOptions.txNonce);
+    const payloadHash = await computeEntrypointPayloadHash(
+      encodedCalls,
+      baseOptions.feePaymentMethodOptions,
+      !!baseOptions.cancellable,
+    );
+
+    const entrypointMessage = await computeEntrypointMessageHash(
+      address,
+      chainInfo.chainId,
+      chainInfo.version,
+      payloadHash,
+    );
+    const genericAuthwit = await computeOuterAuthWitHash(address, chainInfo.chainId, chainInfo.version, payloadHash);
+
+    expect(hash.equals(entrypointMessage)).toBe(true);
+    expect(hash.equals(genericAuthwit)).toBe(false);
   });
 });

--- a/yarn-project/entrypoints/src/account_entrypoint.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.ts
@@ -7,7 +7,6 @@ import {
   encodeArguments,
   getFunctionReturnType,
 } from '@aztec/stdlib/abi';
-import { computeOuterAuthWitHash } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { GasSettings } from '@aztec/stdlib/gas';
 import { ExecutionPayload, HashedValues, TxContext, TxExecutionRequest } from '@aztec/stdlib/tx';
@@ -36,6 +35,31 @@ export async function computeEntrypointPayloadHash(
   return poseidon2HashWithSeparator(
     [await encodedCalls.hash(), new Fr(feePaymentMethod), new Fr(cancellable)],
     ENTRYPOINT_PAYLOAD_DOMAIN_SEPARATOR,
+  );
+}
+
+/**
+ * Domain separator for the account entrypoint authorization message. Mirrors DOM_SEP__ENTRYPOINT_MESSAGE in
+ * noir-projects/labs/aztec-nr/aztec/src/authwit/account.nr. Derived from the poseidon hash of
+ * "az_dom_sep__entrypoint_message" truncated to a u32; kept in TypeScript by hand because the generated constants
+ * package only carries protocol-circuit constants, and pinned by a drift test that re-derives it.
+ */
+export const ENTRYPOINT_MESSAGE_DOMAIN_SEPARATOR = 3858756027;
+
+/**
+ * Computes the message the account authorizes when invoked through its entrypoint. Wraps the entrypoint payload hash
+ * with a dedicated domain separator rather than the generic authwit outer hash, so the message cannot be reproduced
+ * through the generic authwit path (a `createAuthWit` over `{ consumer: account, innerHash }`).
+ */
+export function computeEntrypointMessageHash(
+  consumer: AztecAddress,
+  chainId: Fr,
+  version: Fr,
+  payloadHash: Fr,
+): Promise<Fr> {
+  return poseidon2HashWithSeparator(
+    [consumer.toField(), chainId, version, payloadHash],
+    ENTRYPOINT_MESSAGE_DOMAIN_SEPARATOR,
   );
 }
 
@@ -168,7 +192,12 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
     const functionSelector = await FunctionSelector.fromNameAndParameters(abi.name, abi.parameters);
 
     const payloadHash = await computeEntrypointPayloadHash(encodedCalls, feePaymentMethodOptions, !!cancellable);
-    const messageHash = await computeOuterAuthWitHash(this.address, chainInfo.chainId, chainInfo.version, payloadHash);
+    const messageHash = await computeEntrypointMessageHash(
+      this.address,
+      chainInfo.chainId,
+      chainInfo.version,
+      payloadHash,
+    );
     const payloadAuthWitness = await this.auth.createAuthWit(messageHash);
 
     return {


### PR DESCRIPTION
Stacked on #25157 (F-841). Breaking: changes the entrypoint authorization preimage.

**Bug:** a wallet displays and authorizes a permit-like message, but because the permit and the account transaction message share a domain separator, that same message authorizes a transaction: not one scoped action against one consumer, but a whole call list executed as the account, chosen by whoever requested the permit. The wallet cannot catch this at display time: the requester supplies the inner hash as an opaque field (`IntentInnerHash`, `authwit.ts:94`) with no preimage to render. Concretely: the entrypoint wrapped its payload hash with the generic authwit outer hash, so `createAuthWit({ consumer: account, innerHash })` mints the exact message the entrypoint validates, forging an entrypoint authorization for any calls.

**Exploit (pre-fix):**
1. dApp precomputes offline (all public): `payload = AppPayload{ calls: [Token.transfer(victim → attacker, ALL)] }`, then `X = poseidon2([payload.hash(), EXTERNAL, false], ENTRYPOINT_PAYLOAD_SEP)`.
2. dApp calls `wallet.createAuthWit({ consumer: victimAccount, innerHash: X })`. To the wallet this reads as "authorize consumer=self over opaque hash `0x…`" — a self-authwit, not a transaction.
3. Wallet signs. Via the `IntentInnerHash` branch (`authwit.ts:96`) the message = `computeOuterAuthWitHash(victimAccount, chainId, version, X)` — exactly what the pre-fix entrypoint validates.
4. Attacker submits `victimAccount.entrypoint(payload, EXTERNAL, false)` with that witness. `is_valid_impl` finds the signature over `message_hash` → passes.
5. Victim drained. No dApp authwit reused, no signature forged — the wallet legitimately signed one ambiguous message.

**Fix:** wrap with a dedicated `entrypoint_message` domain separator, so the generic authwit path can no longer produce the entrypoint message.

**Likelihood & design:** Low likelihood — a wallet talking to a dApp usually already trusts it, and the only gate is the *sign* step (step 2): the attacker submits the `entrypoint` tx himself, so there is no second prompt to catch it. The value is making the capability boundary explicit. The dApp-facing `createAuthWit` accepts no bare message hash (`IntentInnerHash | CallIntent`, `wallet.ts:306`), so post-fix every authwit it can request is `AUTHWIT_OUTER`-wrapped and disjoint from the entrypoint message; a wallet that scopes `createAuthWit` below `sendTx` now actually gets that separation. The structured `CallIntent` branch could never reach the entrypoint message anyway, since F-841 gave the payload its own inner separator, so the opaque `IntentInnerHash` branch was the whole exposure. That branch remains unrenderable to a wallet even post-fix; whether it belongs on the dApp-facing API at all is a separate question, left as a follow-up. Posture: keep structured authwits narrowly scoped, treat raw opaque signing as high privilege (the fix cannot help a bare-field signer), domain-separate entrypoint authorization so the scopes cannot collapse cryptographically. If authwits instead stayed opaque and unscoped, equating the two capabilities would be the conservative alternative.

**Root cause — scope collapse, not delegation:** a structured authwit delegates one scoped action to one consumer; signing an opaque hash siloed to your own account is account authority. Pre-fix both went through the same outer hash, so requesting the narrow capability produced the bytes granting the maximal one.

The value is therefore conditional on one threat-model choice: that `createAuthWit` is meant to be grantable at a *lower* trust tier than `sendTx`. If we commit to that, this is required for the boundary to hold. If any authwit signer is considered fully trusted with the account, it is defense in depth. The library docs already frame authwits as scoped, consumer-checked permits and never as account origination, so the intent was there; it was just never enforced, and the one-line summary in `auth.nr` invited the loose reading. This PR enforces it and rewords that line.

**Change:**
1. Noir: new `DOM_SEP__ENTRYPOINT_MESSAGE`; `AccountActions::entrypoint` uses `compute_entrypoint_message_hash`.
2. TS: mirror in `DefaultAccountEntrypoint` (`computeEntrypointMessageHash`).
3. `compute_authwit_message_hash` / `verify_private_authwit` untouched, so no AuthRegistry re-pin.
4. Account contracts inherit it via `AccountActions` on recompile.
5. Docs: the `auth.nr` library doc now says a witness authorizes one action against one consumer, and points at the entrypoint separator for account origination.

**Exposure (ranked):**
1. Session-wide / unattended `createAuthWit` gated weaker than `sendTx`: directly exposed pre-fix; closed post-fix (structured authwits can no longer reach the entrypoint message).
2. Compromised or malicious frontend with direct `createAuthWit`: credible.
3. Default `BaseWallet` today: `requestCapabilities` throws, no capability boundary, so little added authority yet. Latent until capabilities ship.

**Tests:** red/green (entrypoint message == new hash, != generic hash for the same payload); TS drift test + Noir collision test.
