### PR TITLE
refactor(pxe): make FIXED_BOUNDED_VEC two-slot like BOUNDED_VEC

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -741,8 +741,10 @@ export function BOUNDED_VEC<T>(inner: TypeMapping<T>): BoundedVecMapping<T> {
 }
 
 /**
- * Noir's `BoundedVec<T, MaxLen>` in its padded form (one fixed-width slot): `maxLength * elementWidth` storage fields
- * (zero-padded) followed by the actual length, with no length prefix, so the width is statically known. Serialize-only.
+ * Noir's `BoundedVec<T, MaxLen>` with the capacity fixed at construction.
+ *
+ * Two slots (zero-padded storage, then the length) whose widths are statically known from the fixed capacity.
+ *
  * Throws if the input exceeds `maxLength`.
  */
 export function FIXED_BOUNDED_VEC<T>(element: TypeMapping<T>, maxLength: number): FixedBoundedVecMapping<T> {
@@ -759,11 +761,11 @@ export function FIXED_BOUNDED_VEC<T>(element: TypeMapping<T>, maxLength: number)
               throw new Error(`Got ${values.length} items, but maxLength is ${maxLength}`);
             }
             const flat = padArrayEnd(packElements(element, values), Fr.ZERO, maxLength * width);
-            return [[...flat, new Fr(values.length)]];
+            return [flat, new Fr(values.length)];
           },
         }
       : undefined,
-    shape: [{ len: maxLength * width + 1 }],
+    shape: [{ len: maxLength * width }, 'scalar'],
   };
 }
 

--- a/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
+++ b/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
@@ -107,7 +107,7 @@ const COMPOSITE_IMPLS: CompositeImpl[] = [
   // DEFAULT_ARRAY_LENGTH.
   composite(isFixedArrayMapping, (type, seed) => [unnamed(collectionData(type.inner, seed, type.length))]),
   // Same for a fixed-capacity bounded vec: real capacity, DEFAULT_ARRAY_LENGTH elements (its value type is a plain
-  // element array, unlike the two-slot BOUNDED_VEC), clamped to the capacity so small vecs stay valid.
+  // element array, unlike BOUNDED_VEC), clamped to the capacity so small vecs stay valid.
   composite(isFixedBoundedVecMapping, (type, seed) => [
     unnamed(collectionData(type.inner, seed, Math.min(DEFAULT_ARRAY_LENGTH, type.maxLength))),
   ]),


### PR DESCRIPTION
## Summary

- `FIXED_BOUNDED_VEC` now declares the same two slots as `BOUNDED_VEC` (padded storage, then the length scalar) instead of pre-flattening both into a single slot. The flattening is contextual, and the containers that need it (e.g. ephemeral-array rows) already flatten all slots generically, so baking it into the leaf only made the mapping wrong for any future top-level use, where Noir passes a `BoundedVec` as separate storage and length foreign-call params.
- The wire is unchanged: every current use sits inside an ephemeral-array row, where the two slots concatenate to the exact bytes the single slot produced. The TS value stays a plain `T[]`.