### PR TITLE
feat(l1): conditional sequencer checkpoint rewards (PoC)

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -114,7 +114,10 @@ library EpochProofLib {
     // Verify attestations for the last checkpoint in the epoch
     // -> This serves as training wheels for the public part of the system (proving systems used in public and AVM)
     // ensuring committee agreement on the epoch's validity alongside the cryptographic proof verification below.
-    verifyLastCheckpointAttestationsAndOutHash(_args.end, _args.attestations, _args.args.outHash);
+    // The committee reconstructed from the attestations is reused below to derive each
+    // checkpoint's proposer for the reward eligibility check, so it is not re-sampled.
+    address[] memory committee =
+      verifyLastCheckpointAttestationsAndOutHash(_args.end, _args.attestations, _args.args.outHash);
 
     require(verifyEpochRootProof(_args), Errors.Rollup__InvalidProof());
 
@@ -138,7 +141,7 @@ library EpochProofLib {
       }
     }
 
-    RewardLib.handleRewardsAndFees(_args, endEpoch);
+    RewardLib.handleRewardsAndFees(_args, endEpoch, committee);
 
     emit IRollupCore.L2ProofVerified(_args.end, _args.args.proverId);
   }
@@ -298,7 +301,7 @@ library EpochProofLib {
     uint256 _endCheckpointNumber,
     CommitteeAttestations memory _attestations,
     bytes32 _outHash
-  ) private {
+  ) private returns (address[] memory) {
     // Get the stored attestation hash and payload digest for the last checkpoint
     CompressedTempCheckpointLog storage checkpointLog = STFLib.getStorageTempCheckpointLog(_endCheckpointNumber);
 
@@ -323,12 +326,12 @@ library EpochProofLib {
         (bool isOpen,) = escapeHatch.isHatchOpen(epoch);
         if (isOpen) {
           // Skip attestation verification for escape hatch epochs
-          return;
+          return new address[](0);
         }
       }
     }
 
-    ValidatorSelectionLib.verifyAttestations(epoch, _attestations, checkpointLog.payloadDigest);
+    return ValidatorSelectionLib.verifyAttestations(epoch, _attestations, checkpointLog.payloadDigest);
   }
 
   /**

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -5,7 +5,9 @@ pragma solidity >=0.8.27;
 import {RollupStore, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {CompressedFeeHeader, FeeHeaderLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {StakingLib} from "@aztec/core/libraries/rollup/StakingLib.sol";
 import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
+import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelectionLib.sol";
 import {Epoch, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
@@ -89,7 +91,7 @@ library RewardLib {
   address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
 
   /// @dev Enough for a getter behind a proxy (2 cold account accesses + a few SLOADs), while
-  ///      bounding how much gas a hostile coinbase can burn per checkpoint during proof submission.
+  ///      bounding how much gas a hostile withdrawer can burn per checkpoint during proof submission.
   uint256 private constant ELIGIBILITY_PROBE_GAS = 50_000;
 
   /// @notice One-shot writer used during rollup construction. Writes every field of
@@ -197,7 +199,7 @@ library RewardLib {
         uint256 added = length - $er.longestProvenLength;
         uint256 eligibleCount = 0;
         for (uint256 i = $er.longestProvenLength; i < length; i++) {
-          eligible[i] = isEligible(_args.headers[i].coinbase);
+          eligible[i] = isWithdrawerEligible(_args.start + i);
           if (eligible[i]) {
             eligibleCount++;
           }
@@ -207,8 +209,9 @@ library RewardLib {
         uint256 sequencerShare = BpsLib.mul(getCheckpointReward(), rewardStorage.config.sequencerBps);
 
         // Only claim what is owed from the distributor: the prover share for every added
-        // checkpoint, plus the sequencer share for checkpoints with an eligible coinbase.
-        // The sequencer share of ineligible checkpoints never leaves the distributor.
+        // checkpoint, plus the sequencer share for checkpoints proposed by a validator with an
+        // eligible withdrawer. The sequencer share of ineligible checkpoints never leaves the
+        // distributor.
         uint256 checkpointRewardsDesired = added * getCheckpointReward() - (added - eligibleCount) * sequencerShare;
         uint256 checkpointRewardsAvailable = 0;
 
@@ -280,14 +283,26 @@ library RewardLib {
     }
   }
 
-  /// @dev Placeholder eligibility test for the checkpoint reward: the coinbase qualifies only if
-  ///      it is a contract answering true to {IEligible.isEligible}. The coinbase is an arbitrary
-  ///      proposer-chosen address, so the probe is a gas-capped staticcall whose failure modes
-  ///      (no code, revert, wrong return shape) all read as ineligible -- it must never revert,
-  ///      or a hostile coinbase could block epoch proof submission.
-  function isEligible(address _coinbase) private view returns (bool) {
+  /// @dev Placeholder eligibility test for the checkpoint reward: the proposer of the checkpoint
+  ///      is recomputed from the checkpoint's slot, its withdrawer looked up in the GSE, and the
+  ///      checkpoint qualifies only if the withdrawer is a contract answering true to
+  ///      {IEligible.isEligible}. The withdrawer is an arbitrary staker-chosen address, so the
+  ///      probe is a gas-capped staticcall whose failure modes (no code, revert, wrong return
+  ///      shape) all read as ineligible -- it must never revert, or a hostile withdrawer could
+  ///      block epoch proof submission.
+  function isWithdrawerEligible(uint256 _checkpointNumber) private returns (bool) {
+    (address proposer,) = ValidatorSelectionLib.getProposerAt(STFLib.getSlotNumber(_checkpointNumber));
+    if (proposer == address(0)) {
+      return false;
+    }
+
+    address withdrawer = StakingLib.getStorage().gse.getWithdrawer(proposer);
+    if (withdrawer == address(0)) {
+      return false;
+    }
+
     (bool success, bytes memory returnData) =
-      _coinbase.staticcall{gas: ELIGIBILITY_PROBE_GAS}(abi.encodeCall(IEligible.isEligible, ()));
+      withdrawer.staticcall{gas: ELIGIBILITY_PROBE_GAS}(abi.encodeCall(IEligible.isEligible, ()));
     return success && returnData.length == 32 && uint256(bytes32(returnData)) == 1;
   }
 

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -17,6 +17,10 @@ import {BitMaps} from "@oz/utils/structs/BitMaps.sol";
 
 type Bps is uint32;
 
+interface IEligible {
+  function isEligible() external view returns (bool);
+}
+
 library BpsLib {
   function mul(uint256 _a, Bps _b) internal pure returns (uint256) {
     return _a * uint256(Bps.unwrap(_b)) / 10_000;
@@ -83,6 +87,10 @@ library RewardLib {
   // offerings,
   // such as sacrificial hearts, during rituals performed within temples.
   address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
+
+  /// @dev Enough for a getter behind a proxy (2 cold account accesses + a few SLOADs), while
+  ///      bounding how much gas a hostile coinbase can burn per checkpoint during proof submission.
+  uint256 private constant ELIGIBILITY_PROBE_GAS = 50_000;
 
   /// @notice One-shot writer used during rollup construction. Writes every field of
   ///         {RewardConfig}, including the immutable `rewardDistributor` and `booster`.
@@ -183,9 +191,25 @@ library RewardLib {
       Values memory v;
       Totals memory t;
 
+      bool[] memory eligible = new bool[](length);
+
       {
         uint256 added = length - $er.longestProvenLength;
-        uint256 checkpointRewardsDesired = added * getCheckpointReward();
+        uint256 eligibleCount = 0;
+        for (uint256 i = $er.longestProvenLength; i < length; i++) {
+          eligible[i] = isEligible(_args.headers[i].coinbase);
+          if (eligible[i]) {
+            eligibleCount++;
+          }
+        }
+
+        // Per-checkpoint sequencer share of the checkpoint reward; the rest goes to the provers.
+        uint256 sequencerShare = BpsLib.mul(getCheckpointReward(), rewardStorage.config.sequencerBps);
+
+        // Only claim what is owed from the distributor: the prover share for every added
+        // checkpoint, plus the sequencer share for checkpoints with an eligible coinbase.
+        // The sequencer share of ineligible checkpoints never leaves the distributor.
+        uint256 checkpointRewardsDesired = added * getCheckpointReward() - (added - eligibleCount) * sequencerShare;
         uint256 checkpointRewardsAvailable = 0;
 
         if (checkpointRewardsDesired > 0) {
@@ -200,11 +224,14 @@ library RewardLib {
           }
         }
 
-        uint256 sequenceCheckpointRewards = BpsLib.mul(checkpointRewardsAvailable, rewardStorage.config.sequencerBps);
-        v.sequencerCheckpointReward = sequenceCheckpointRewards / added;
+        // If the distributor could not cover the full amount, both pots scale proportionally.
+        uint256 sequencerCheckpointRewards = checkpointRewardsDesired == 0
+          ? 0
+          : checkpointRewardsAvailable * (eligibleCount * sequencerShare) / checkpointRewardsDesired;
+        v.sequencerCheckpointReward = eligibleCount == 0 ? 0 : sequencerCheckpointRewards / eligibleCount;
 
-        uint256 dust = sequenceCheckpointRewards - (v.sequencerCheckpointReward * added);
-        uint256 proverCheckpointRewards = checkpointRewardsAvailable - sequenceCheckpointRewards + dust;
+        // Rounding dust from the sequencer pot lands with the provers.
+        uint256 proverCheckpointRewards = checkpointRewardsAvailable - v.sequencerCheckpointReward * eligibleCount;
         if (proverCheckpointRewards > 0) {
           $er.rewards += proverCheckpointRewards.toUint128();
         }
@@ -231,7 +258,10 @@ library RewardLib {
 
         {
           v.sequencer = _args.headers[i].coinbase;
-          uint256 toSequencer = v.sequencerCheckpointReward + v.sequencerFee;
+          uint256 toSequencer = v.sequencerFee;
+          if (eligible[i]) {
+            toSequencer += v.sequencerCheckpointReward;
+          }
           if (toSequencer > 0) {
             rewardStorage.sequencerRewards[v.sequencer] += toSequencer;
           }
@@ -248,6 +278,17 @@ library RewardLib {
         rollupStore.config.feeAsset.safeTransfer(BURN_ADDRESS, t.totalBurn);
       }
     }
+  }
+
+  /// @dev Placeholder eligibility test for the checkpoint reward: the coinbase qualifies only if
+  ///      it is a contract answering true to {IEligible.isEligible}. The coinbase is an arbitrary
+  ///      proposer-chosen address, so the probe is a gas-capped staticcall whose failure modes
+  ///      (no code, revert, wrong return shape) all read as ineligible -- it must never revert,
+  ///      or a hostile coinbase could block epoch proof submission.
+  function isEligible(address _coinbase) private view returns (bool) {
+    (bool success, bytes memory returnData) =
+      _coinbase.staticcall{gas: ELIGIBILITY_PROBE_GAS}(abi.encodeCall(IEligible.isEligible, ()));
+    return success && returnData.length == 32 && uint256(bytes32(returnData)) == 1;
   }
 
   function getSharesFor(address _prover) internal view returns (uint256) {

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -91,7 +91,7 @@ library RewardLib {
   address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
 
   /// @dev Enough for a getter behind a proxy (2 cold account accesses + a few SLOADs), while
-  ///      bounding how much gas a hostile withdrawer can burn per checkpoint during proof submission.
+  ///      bounding how much gas a hostile withdrawer can burn during proposal.
   uint256 private constant ELIGIBILITY_PROBE_GAS = 50_000;
 
   /// @notice One-shot writer used during rollup construction. Writes every field of
@@ -161,7 +161,9 @@ library RewardLib {
     return accumulatedRewards;
   }
 
-  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) internal {
+  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch, address[] memory _committee)
+    internal
+  {
     RollupStore storage rollupStore = STFLib.getStorage();
     RewardStorage storage rewardStorage = getStorage();
 
@@ -193,17 +195,11 @@ library RewardLib {
       Values memory v;
       Totals memory t;
 
-      bool[] memory eligible = new bool[](length);
+      (bool[] memory eligible, uint256 eligibleCount) =
+        computeEligibility(_args, _endEpoch, _committee, $er.longestProvenLength, length);
 
       {
         uint256 added = length - $er.longestProvenLength;
-        uint256 eligibleCount = 0;
-        for (uint256 i = $er.longestProvenLength; i < length; i++) {
-          eligible[i] = isWithdrawerEligible(_args.start + i);
-          if (eligible[i]) {
-            eligibleCount++;
-          }
-        }
 
         // Per-checkpoint sequencer share of the checkpoint reward; the rest goes to the provers.
         uint256 sequencerShare = BpsLib.mul(getCheckpointReward(), rewardStorage.config.sequencerBps);
@@ -283,20 +279,53 @@ library RewardLib {
     }
   }
 
-  /// @dev Placeholder eligibility test for the checkpoint reward: the proposer of the checkpoint
-  ///      is recomputed from the checkpoint's slot, its withdrawer looked up in the GSE, and the
-  ///      checkpoint qualifies only if the withdrawer is a contract answering true to
-  ///      {IEligible.isEligible}. The withdrawer is an arbitrary staker-chosen address, so the
-  ///      probe is a gas-capped staticcall whose failure modes (no code, revert, wrong return
-  ///      shape) all read as ineligible -- it must never revert, or a hostile withdrawer could
-  ///      block epoch proof submission.
-  function isWithdrawerEligible(uint256 _checkpointNumber) private returns (bool) {
-    (address proposer,) = ValidatorSelectionLib.getProposerAt(STFLib.getSlotNumber(_checkpointNumber));
-    if (proposer == address(0)) {
+  /// @notice Derives the proposer of every newly proven checkpoint from the committee and
+  ///         evaluates the checkpoint-reward eligibility of each proposer's withdrawer.
+  /// @dev The committee was already reconstructed from calldata and checked against the stored
+  ///      commitment during attestation verification, so each checkpoint's proposer is one index
+  ///      computation away -- no committee sampling and no extra storage reads. An empty
+  ///      committee (target committee size 0 or escape hatch) marks everything ineligible.
+  function computeEligibility(
+    SubmitEpochRootProofArgs calldata _args,
+    Epoch _endEpoch,
+    address[] memory _committee,
+    uint256 _from,
+    uint256 _to
+  ) private view returns (bool[] memory, uint256) {
+    bool[] memory eligible = new bool[](_to);
+    uint256 eligibleCount = 0;
+
+    if (_committee.length == 0) {
+      return (eligible, eligibleCount);
+    }
+
+    uint256 sampleSeed = ValidatorSelectionLib.getSampleSeed(_endEpoch);
+    for (uint256 i = _from; i < _to; i++) {
+      uint256 proposerIndex = ValidatorSelectionLib.computeProposerIndex(
+        _endEpoch, _args.headers[i].slotNumber, sampleSeed, _committee.length
+      );
+      eligible[i] = isWithdrawerEligible(_committee[proposerIndex]);
+      if (eligible[i]) {
+        eligibleCount++;
+      }
+    }
+
+    return (eligible, eligibleCount);
+  }
+
+  /// @notice Placeholder eligibility test for the checkpoint reward: the proposer's withdrawer is
+  ///         looked up in the GSE, and the checkpoint qualifies only if the withdrawer is a
+  ///         contract answering true to {IEligible.isEligible}.
+  /// @dev The withdrawer is an arbitrary staker-chosen address, so the probe is a gas-capped
+  ///      staticcall whose failure modes (no code, revert, wrong return shape) all read as
+  ///      ineligible -- it must never revert, or a hostile withdrawer could block proof
+  ///      submission.
+  function isWithdrawerEligible(address _proposer) internal view returns (bool) {
+    if (_proposer == address(0)) {
       return false;
     }
 
-    address withdrawer = StakingLib.getStorage().gse.getWithdrawer(proposer);
+    address withdrawer = StakingLib.getStorage().gse.getWithdrawer(_proposer);
     if (withdrawer == address(0)) {
       return false;
     }

--- a/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
@@ -328,6 +328,7 @@ library ValidatorSelectionLib {
    */
   function verifyAttestations(Epoch _epochNumber, CommitteeAttestations memory _attestations, bytes32 _digest)
     internal
+    returns (address[] memory)
   {
     (bytes32 committeeCommitment, uint256 targetCommitteeSize) = getCommitteeCommitmentAt(_epochNumber);
 
@@ -335,7 +336,7 @@ library ValidatorSelectionLib {
     // Note: This generally only happens in test setups; In production, the target committee is non-zero,
     // and one can see in `sampleValidators` that we will revert if the target committee size is not met.
     if (targetCommitteeSize == 0) {
-      return;
+      return new address[](0);
     }
 
     VerifyStack memory stack = VerifyStack({
@@ -392,6 +393,8 @@ library ValidatorSelectionLib {
     if (reconstructedCommitment != committeeCommitment) {
       revert Errors.ValidatorSelection__InvalidCommitteeCommitment(reconstructedCommitment, committeeCommitment);
     }
+
+    return stack.reconstructedCommittee;
   }
 
   /**

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -126,7 +126,7 @@ contract RewardLibWrapper {
   }
 
   function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) external {
-    RewardLib.handleRewardsAndFees(_args, _endEpoch);
+    RewardLib.handleRewardsAndFees(_args, _endEpoch, new address[](0));
   }
 
   function getSequencerRewards(address _sequencer) external view returns (uint256) {


### PR DESCRIPTION
Proof of concept for making the sequencer's checkpoint reward conditional on a property of the validator that proposed the checkpoint. The condition is evaluated on the **withdrawer** of the proposer (looked up in the GSE), matching how ATP stakers register validators: the attester key is arbitrary, but the withdrawer is the ATP's staker contract.

## Approach

At proof time, `submitEpochRootProof` already reconstructs the full committee from the end checkpoint's attestations and checks it against the stored per-epoch committee commitment. Since the committee is stable for the whole epoch, each checkpoint's proposer is derived from that same in-memory committee with one `computeProposerIndex` keccak — no committee sampling, no extra calldata, and no stored state. `verifyAttestations` now returns the committee it already built, and `RewardLib` uses it to compute per-checkpoint eligibility.

The eligibility test itself is a placeholder: the proposer's withdrawer must be a contract answering `true` to `isEligible()`. The probe is a gas-capped staticcall where no code, revert, or a malformed return all read as ineligible, so a hostile withdrawer cannot block proof submission.

Only what is owed is claimed from the reward distributor: the prover share for every checkpoint plus the sequencer share for eligible ones. Ineligible sequencers' shares never leave the distributor; prover rewards are unaffected. If the distributor cannot cover the full amount, both pots scale proportionally.

## Gas

Measured with `test/benchmark/happy.t.sol::test_100_validators` (32-slot epochs, target committee size 48, 100 validators, forge gas-report averages). Baseline: `propose` 324,981, `submitEpochRootProof` 1,581,276.

| Variant | propose Δ (each) | proof Δ | Total Δ per epoch (32 proposes + 1 proof) |
|---|---|---|---|
| Re-sample committee per checkpoint at proof time | 0 | +5,396k | +5,396k |
| Check at propose time, persist a bit per checkpoint | +16.0k | +116k / −290k¹ | +629k / +215k |
| **Derive proposers from the attestation committee (this PR)** | ±0 | +279k / −136k¹ | **+279k / −136k** |

¹ all-eligible / all-ineligible. All-ineligible epochs are cheaper than baseline because the 32 sequencer-reward SSTOREs are skipped.

The benchmark's validators share a single withdrawer; with 32 distinct withdrawers the all-eligible proof delta grows by roughly 2.6–5k per checkpoint (cold account + storage per withdrawer), i.e. ~+400k total.

## Caveats

- Escape-hatch epochs skip attestation verification, so no committee is available and all their checkpoints read as ineligible.
- Existing reward tests that expect unconditional sequencer rewards fail by design; no tests were added since this is a PoC.