### PR TITLE
fix(p2p): fail node startup when p2p service fails to start

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -2,6 +2,7 @@ import { MockL2BlockSource } from '@aztec/archiver/test';
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryFastUntil } from '@aztec/foundation/retry';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -104,6 +105,31 @@ describe('P2P Client', () => {
 
     await client.stop();
     expect(client.isReady()).toEqual(false);
+  });
+
+  describe('Service startup while syncing', () => {
+    it('fails to start if the p2p service fails to start', async () => {
+      p2pService.start.mockRejectedValue(new Error('ERR_NO_VALID_ADDRESSES'));
+
+      await expect(client.start()).rejects.toThrow('ERR_NO_VALID_ADDRESSES');
+    });
+
+    it('completes the startup only after the p2p service has started', async () => {
+      const serviceStart = promiseWithResolvers<void>();
+      p2pService.start.mockReturnValue(serviceStart.promise);
+
+      let startCompleted = false;
+      const startPromise = client.start().then(() => {
+        startCompleted = true;
+      });
+
+      await retryFastUntil(() => p2pService.start.mock.calls.length > 0 || undefined, 'p2p service start');
+      expect(startCompleted).toBe(false);
+
+      serviceStart.resolve();
+      await startPromise;
+      expect(startCompleted).toBe(true);
+    });
   });
 
   it('adds txs to pool and propagates it', async () => {

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -6,6 +6,7 @@ import {
   SlotNumber,
 } from '@aztec/foundation/branded-types';
 import { createLogger } from '@aztec/foundation/log';
+import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { AztecAsyncKVStore, AztecAsyncSingleton } from '@aztec/kv-store';
 import { L2TipsKVStore } from '@aztec/kv-store/stores';
@@ -61,7 +62,7 @@ export class P2PClient extends WithTracer implements P2P {
 
   private currentState = P2PClientState.IDLE;
   private syncPromise = Promise.resolve();
-  private syncResolve?: () => void = undefined;
+  private syncResolvers?: PromiseWithResolvers<void> = undefined;
   private latestBlockNumberAtStart = -1;
   private provenBlockNumberAtStart = -1;
   private finalizedBlockNumberAtStart = -1;
@@ -239,9 +240,8 @@ export class P2PClient extends WithTracer implements P2P {
       // this gets resolved on `startServiceIfSynched`
       this.initBlockStream();
       this.setCurrentState(P2PClientState.SYNCHING);
-      this.syncPromise = new Promise(resolve => {
-        this.syncResolve = resolve;
-      });
+      this.syncResolvers = promiseWithResolvers<void>();
+      this.syncPromise = this.syncResolvers.promise;
       this.log.info(`Initiating p2p sync from ${syncedLatestBlock}`, {
         syncedLatestBlock,
         syncedProvenBlock,
@@ -772,9 +772,17 @@ export class P2PClient extends WithTracer implements P2P {
         syncedFinalizedBlock,
       });
       this.setCurrentState(P2PClientState.RUNNING);
-      if (this.syncResolve !== undefined) {
-        this.syncResolve();
-        await this.p2pService.start();
+      if (this.syncResolvers !== undefined) {
+        // A throw here would be swallowed by the block stream event handler, so we reject the promise returned by
+        // start instead, which makes node startup fail rather than run on with a dead p2p stack.
+        try {
+          await this.p2pService.start();
+        } catch (err) {
+          this.log.fatal(`Failed to start p2p service`, { err, syncedLatestBlock });
+          this.syncResolvers.reject(err);
+          return;
+        }
+        this.syncResolvers.resolve();
       }
     }
   }


### PR DESCRIPTION
When the p2p client starts while there are blocks to sync, the libp2p service start is deferred to
`startServiceIfSynched`, which runs inside the block stream event handler. That handler catches and
only logs errors, so a TCP bind failure (e.g. `ERR_NO_VALID_ADDRESSES` after a restart) was swallowed.
On top of that, the sync promise awaited by node creation was resolved before the service was started,
so startup succeeded regardless and the node kept running with a dead p2p stack and zero peers.

The service is now started before the sync promise settles, and a failure logs at fatal level and
rejects the stored sync promise (rather than throwing, which the block stream would eat) so node
creation fails and the process exits, letting the orchestrator restart it.

Part of A-1701.


---

Related PRs from the same incident (all independent, all targeting `merge-train/spartan-v5`): #25177 (fail startup when the p2p service fails to start), #25185 (connectivity signal + slasher/proposer/health/sendTx gates), #25183 (periodic zero-peers warning).
