### PR TITLE
feat(p2p): expose p2p connectivity (enabled + connected peer count)

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -97,6 +97,11 @@ describe('P2P Client', () => {
     await kvStore.close();
   });
 
+  it('forwards p2p connectivity from the service', async () => {
+    p2pService.getP2PConnectivity.mockReturnValue({ enabled: true, connectedPeers: 4 });
+    await expect(client.getP2PConnectivity()).resolves.toEqual({ enabled: true, connectedPeers: 4 });
+  });
+
   it('can start & stop', async () => {
     expect(client.isReady()).toEqual(false);
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -25,7 +25,7 @@ import {
 } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
-import { type GetTxByHashOptions, type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
+import { type GetTxByHashOptions, type P2PConnectivity, type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
 import { type BlockProposal, CheckpointAttestation, type CheckpointProposal, type TopicType } from '@aztec/stdlib/p2p';
 import type { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
 import { Attributes, type TelemetryClient, WithTracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
@@ -135,6 +135,10 @@ export class P2PClient extends WithTracer implements P2P {
 
   public getPeers(includePending?: boolean): Promise<PeerInfo[]> {
     return Promise.resolve(this.p2pService.getPeers(includePending));
+  }
+
+  public getP2PConnectivity(): Promise<P2PConnectivity> {
+    return Promise.resolve(this.p2pService.getP2PConnectivity());
   }
 
   public getGossipMeshPeerCount(topicType: TopicType): Promise<number> {

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -1,5 +1,5 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
+import type { P2PConnectivity, PeerInfo } from '@aztec/stdlib/interfaces/server';
 import type { Gossipable, PeerErrorSeverity, TopicType } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
 
@@ -45,6 +45,11 @@ export class DummyP2PService implements P2PService {
   /** Returns an empty array for peers. */
   getPeers(): PeerInfo[] {
     return [];
+  }
+
+  /** Reports p2p as disabled, since this service does not run a p2p stack. */
+  getP2PConnectivity(): P2PConnectivity {
+    return { enabled: false, connectedPeers: 0 };
   }
 
   getGossipMeshPeerCount(_topicType: TopicType): number {

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -318,6 +318,25 @@ describe('LibP2PService', () => {
     });
   });
 
+  describe('getP2PConnectivity', () => {
+    it('reports p2p as enabled and counts only connected peers', () => {
+      mockPeerManager.getPeers.mockReturnValue([
+        { status: 'connected', id: 'a', score: 0 },
+        { status: 'dialing', id: 'b', dialStatus: 'queued', addresses: [] },
+        { status: 'connected', id: 'c', score: 1 },
+        { status: 'cached', id: 'd', addresses: [], enr: 'enr', dialAttempts: 1 },
+      ]);
+
+      expect(service.getP2PConnectivity()).toEqual({ enabled: true, connectedPeers: 2 });
+    });
+
+    it('reports zero connected peers when there are none', () => {
+      mockPeerManager.getPeers.mockReturnValue([]);
+
+      expect(service.getP2PConnectivity()).toEqual({ enabled: true, connectedPeers: 0 });
+    });
+  });
+
   describe('validateTxsReceivedInBlockProposal', () => {
     it('throws with the offending tx hashes and reasons when a tx fails integrity validation', async () => {
       // Carries a zero vk tree root, so it fails the metadata check in the minimum integrity validator.

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -10,7 +10,12 @@ import type { EthAddress, L2BlockSource } from '@aztec/stdlib/block';
 import { DEFAULT_MAX_BLOCKS_PER_CHECKPOINT } from '@aztec/stdlib/config';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { type BlockMinFeesProvider, GasFees, getNetworkTxGasLimits } from '@aztec/stdlib/gas';
-import type { ClientProtocolCircuitVerifier, PeerInfo, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type {
+  ClientProtocolCircuitVerifier,
+  P2PConnectivity,
+  PeerInfo,
+  WorldStateSynchronizer,
+} from '@aztec/stdlib/interfaces/server';
 import {
   BlockProposal,
   CheckpointAttestation,
@@ -728,6 +733,11 @@ export class LibP2PService extends WithTracer implements P2PService {
 
   public getPeers(includePending?: boolean): PeerInfo[] {
     return this.peerManager.getPeers(includePending);
+  }
+
+  public getP2PConnectivity(): P2PConnectivity {
+    const connectedPeers = this.peerManager.getPeers().filter(peer => peer.status === 'connected').length;
+    return { enabled: true, connectedPeers };
   }
 
   public getGossipMeshPeerCount(topicType: TopicType): number {

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -1,6 +1,6 @@
 import type { SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
+import type { P2PConnectivity, PeerInfo } from '@aztec/stdlib/interfaces/server';
 import type {
   BlockProposal,
   CheckpointAttestation,
@@ -139,6 +139,12 @@ export interface P2PService {
   getEnr(): ENR | undefined;
 
   getPeers(includePending?: boolean): PeerInfo[];
+
+  /**
+   * Returns whether this p2p service is a real p2p stack, and how many peers it is currently connected to.
+   * Implementations that do not run p2p at all report `enabled: false`.
+   */
+  getP2PConnectivity(): P2PConnectivity;
 
   /** Returns the number of peers in the GossipSub mesh for a given topic type. */
   getGossipMeshPeerCount(topicType: TopicType): number;

--- a/yarn-project/stdlib/src/interfaces/p2p.test.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.test.ts
@@ -5,7 +5,7 @@ import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
 import { Tx } from '../tx/tx.js';
 import type { TxHash } from '../tx/tx_hash.js';
 import type { GetTxByHashOptions } from './aztec-node.js';
-import { type P2PApi, P2PApiSchema, type PeerInfo } from './p2p.js';
+import { type P2PApi, P2PApiSchema, type P2PConnectivity, type PeerInfo } from './p2p.js';
 
 describe('P2PApiSchema', () => {
   let handler: MockP2P;
@@ -66,6 +66,11 @@ describe('P2PApiSchema', () => {
     const peers = await context.client.getPeers(true);
     expect(peers).toEqual(peers);
   });
+
+  it('getP2PConnectivity', async () => {
+    const connectivity = await context.client.getP2PConnectivity();
+    expect(connectivity).toEqual({ enabled: true, connectedPeers: 3 });
+  });
 });
 
 const peers: PeerInfo[] = [
@@ -100,5 +105,9 @@ class MockP2P implements P2PApi {
   getPeers(includePending?: boolean): Promise<PeerInfo[]> {
     expect(includePending === undefined || includePending === true).toBeTruthy();
     return Promise.resolve(peers);
+  }
+
+  getP2PConnectivity(): Promise<P2PConnectivity> {
+    return Promise.resolve({ enabled: true, connectedPeers: 3 });
   }
 }

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -29,6 +29,19 @@ export const PeerInfoSchema = z.discriminatedUnion('status', [
   }),
 ]);
 
+/** Connectivity of the p2p stack: whether it is enabled at all, and how many peers are currently connected. */
+export type P2PConnectivity = {
+  /** False when the node runs without a p2p stack (eg sandbox or single-node setups). */
+  enabled: boolean;
+  /** Number of peers currently connected. Always zero when p2p is disabled. */
+  connectedPeers: number;
+};
+
+export const P2PConnectivitySchema = z.object({
+  enabled: z.boolean(),
+  connectedPeers: z.number(),
+});
+
 /** Exposed API to the P2P module. */
 export interface P2PApi {
   /**
@@ -53,6 +66,13 @@ export interface P2PApi {
    * Returns info for all connected, dialing, and cached peers.
    */
   getPeers(includePending?: boolean): Promise<PeerInfo[]>;
+
+  /**
+   * Returns whether the p2p stack is enabled on this node, and the number of peers it is connected to.
+   * Nodes running without p2p report `enabled: false`, so consumers can tell a disabled stack apart from a
+   * stack that is enabled but has no peers.
+   */
+  getP2PConnectivity(): Promise<P2PConnectivity>;
 
   /**
    * Queries the Attestation pool for checkpoint attestations for the given slot.
@@ -116,4 +136,5 @@ export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
   getPendingTxCount: z.function({ input: z.tuple([]), output: schemas.Integer }),
   getEncodedEnr: z.function({ input: z.tuple([]), output: z.string().optional() }),
   getPeers: z.function({ input: z.tuple([optional(z.boolean())]), output: z.array(PeerInfoSchema) }),
+  getP2PConnectivity: z.function({ input: z.tuple([]), output: P2PConnectivitySchema }),
 };

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -17,7 +17,7 @@ import type {
   StatusMessage,
 } from '@aztec/p2p';
 import type { EthAddress, L2BlockStreamEvent, L2Tips } from '@aztec/stdlib/block';
-import type { ITxProvider, PeerInfo } from '@aztec/stdlib/interfaces/server';
+import type { ITxProvider, P2PConnectivity, PeerInfo } from '@aztec/stdlib/interfaces/server';
 import type {
   BlockProposal,
   CheckpointAttestation,
@@ -50,6 +50,10 @@ export class DummyP2P implements P2P {
 
   public getGossipMeshPeerCount(_topicType: TopicType): Promise<number> {
     return Promise.resolve(0);
+  }
+
+  public getP2PConnectivity(): Promise<P2PConnectivity> {
+    return Promise.resolve({ enabled: false, connectedPeers: 0 });
   }
 
   public broadcastProposal(_proposal: BlockProposal): Promise<void> {


### PR DESCRIPTION
Adds `getP2PConnectivity()`, returning `{ enabled, connectedPeers }`, so downstream subsystems can tell
whether the libp2p stack is alive and how many peers it is talking to. Until now a node running with a dead
p2p stack (zero peers) looked identical to a healthy one from the outside.

- `P2PService` declares the method synchronously, matching its neighbouring `getPeers` / `getGossipMeshPeerCount`.
- `LibP2PService` returns `enabled: true` and counts peers reported as connected by the peer manager, so
  dialing and cached peers are excluded.
- `DummyP2PService` (and the TXE dummy client) return `enabled: false` with zero peers, encoding "p2p is
  disabled" for sandbox and single-node setups; consumers can treat disabled p2p as vacuously healthy instead
  of as a stack with no peers.
- `P2PClient` forwards to the service, and `P2PApi` exposes it over JSON-RPC with a `P2PConnectivity` zod
  schema, so the node API surfaces it too.

No behavior is gated on this yet; it is the foundation for gating slashing, proposing, and sendTx on p2p
connectivity in follow-up changes.

Part of A-1701.


---

Part of a stacked-PR chain (bottom → top) hardening the node against running with a dead p2p stack; each PR targets the branch below it and the bottom targets `merge-train/spartan-v5`:

1. #25177 — fail node startup when the p2p service fails to start
2. #25178 — expose p2p connectivity (enabled + connected peer count)
3. #25179 — do not file data-withholding offenses while peerless
4. #25180 — skip proposing when the node has no connected peers
5. #25181 — report per-component health with p2p peer count on `GET /status`
6. #25182 — reject `sendTx` when the node has no peers to propagate the tx
7. #25183 — warn periodically while the node has zero connected peers
