### PR TITLE
fix(slasher): do not file data-withholding offenses while peerless

### DIFF
--- a/yarn-project/slasher/src/watchers/data_withholding_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/data_withholding_watcher.test.ts
@@ -33,7 +33,7 @@ describe('DataWithholdingWatcher', () => {
   let epochCache: MockProxy<EpochCache>;
   let l2BlockSource: MockProxy<Pick<L2BlockSource, 'getCheckpoint' | 'getSyncedL2SlotNumber'>>;
   let txProvider: MockProxy<Pick<ITxProvider, 'hasTxs'>>;
-  let p2p: MockProxy<Pick<P2PApi, 'getCheckpointAttestationsForSlot'>>;
+  let p2p: MockProxy<Pick<P2PApi, 'getCheckpointAttestationsForSlot' | 'getP2PConnectivity'>>;
   let reexecutionTracker: MockProxy<Pick<CheckpointReexecutionTracker, 'getTxsCollectedRecord'>>;
   let watcher: TestDataWithholdingWatcher;
   let l1Constants: L1RollupConstants;
@@ -42,8 +42,9 @@ describe('DataWithholdingWatcher', () => {
     epochCache = mock<EpochCache>();
     l2BlockSource = mock<Pick<L2BlockSource, 'getCheckpoint' | 'getSyncedL2SlotNumber'>>();
     txProvider = mock<Pick<ITxProvider, 'hasTxs'>>();
-    p2p = mock<Pick<P2PApi, 'getCheckpointAttestationsForSlot'>>();
+    p2p = mock<Pick<P2PApi, 'getCheckpointAttestationsForSlot' | 'getP2PConnectivity'>>();
     p2p.getCheckpointAttestationsForSlot.mockResolvedValue([]);
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 5 });
     reexecutionTracker = mock<Pick<CheckpointReexecutionTracker, 'getTxsCollectedRecord'>>();
     reexecutionTracker.getTxsCollectedRecord.mockReturnValue(undefined);
 
@@ -334,6 +335,83 @@ describe('DataWithholdingWatcher', () => {
     await watcher.work();
 
     expect(captured).toHaveLength(0);
+  });
+
+  it('does not probe or slash while p2p is enabled with no connected peers', async () => {
+    await startAtSlot(10);
+    setSyncedSlot(11 + TOLERANCE + 1);
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 0 });
+
+    const slot = 11;
+    const published = makePublished(slot, 1);
+    const missing = published.checkpoint.blocks[0].body.txEffects[0].txHash;
+    l2BlockSource.getCheckpoint.mockResolvedValue(published);
+    mockMissing([missing]);
+    watcher.attestersBySlot.set(slot, [EthAddress.random()]);
+    const captured = captureEmits();
+
+    await watcher.work();
+
+    expect(l2BlockSource.getCheckpoint).not.toHaveBeenCalled();
+    expect(txProvider.hasTxs).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+
+    // The skipped slots are marked as checked, so a later tick does not reprocess them.
+    await watcher.work();
+    expect(l2BlockSource.getCheckpoint).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+
+  it('does not revisit slots skipped while peerless, but processes slots after recovery', async () => {
+    await startAtSlot(10);
+    setSyncedSlot(11 + TOLERANCE + 1);
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 0 });
+
+    const skippedCheckpoint = makePublished(11, 1);
+    const laterCheckpoint = makePublished(12, 1);
+    l2BlockSource.getCheckpoint.mockImplementation(query =>
+      Promise.resolve('slot' in query ? { 11: skippedCheckpoint, 12: laterCheckpoint }[Number(query.slot)] : undefined),
+    );
+    mockMissing([
+      skippedCheckpoint.checkpoint.blocks[0].body.txEffects[0].txHash,
+      laterCheckpoint.checkpoint.blocks[0].body.txEffects[0].txHash,
+    ]);
+    watcher.attestersBySlot.set(11, [EthAddress.random()]);
+    watcher.attestersBySlot.set(12, [EthAddress.random()]);
+    const captured = captureEmits();
+
+    await watcher.work();
+    expect(captured).toHaveLength(0);
+
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 4 });
+    setSyncedSlot(12 + TOLERANCE + 1);
+    await watcher.work();
+
+    expect(l2BlockSource.getCheckpoint).toHaveBeenCalledTimes(1);
+    expect(l2BlockSource.getCheckpoint).toHaveBeenCalledWith({ slot: SlotNumber(12) });
+    expect(captured).toHaveLength(1);
+    expect(captured[0][0].epochOrSlot).toEqual(BigInt(12));
+  });
+
+  it('still slashes when p2p is disabled by configuration', async () => {
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: false, connectedPeers: 0 });
+    await startAtSlot(10);
+    setSyncedSlot(11 + TOLERANCE + 1);
+
+    const slot = 11;
+    const published = makePublished(slot, 1);
+    const missing = published.checkpoint.blocks[0].body.txEffects[0].txHash;
+    const attester = EthAddress.random();
+    l2BlockSource.getCheckpoint.mockResolvedValue(published);
+    mockMissing([missing]);
+    watcher.attestersBySlot.set(slot, [attester]);
+    const captured = captureEmits();
+
+    await watcher.work();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0][0].validator).toEqual(attester);
+    expect(captured[0][0].offenseType).toBe(OffenseType.DATA_WITHHOLDING);
   });
 
   it('sets epochOrSlot to the checkpoint slot, not its epoch (slot-keyed offense)', async () => {

--- a/yarn-project/slasher/src/watchers/data_withholding_watcher.ts
+++ b/yarn-project/slasher/src/watchers/data_withholding_watcher.ts
@@ -33,18 +33,23 @@ type DataWithholdingWatcherConfig = Pick<SlasherConfig, (typeof DataWithholdingW
  * The watcher ticks at quarter-eth-slot cadence (matching the Sentinel template). On boot it
  * floors processing at the current slot — restart-time gaps are accepted and not back-filled,
  * matching the Sentinel approach.
+ *
+ * Since the evidence for an offense is the absence of txs in the local pool, the probe is gated on
+ * p2p connectivity: while p2p is enabled but has no connected peers, slots are skipped instead of
+ * probed, since missing txs then say nothing about the attesters.
  */
 export class DataWithholdingWatcher extends (EventEmitter as new () => WatcherEmitter) implements Watcher {
   private runningPromise: RunningPromise;
   private initialSlot: SlotNumber | undefined;
   private lastCheckedSlot: SlotNumber | undefined;
   private config: DataWithholdingWatcherConfig;
+  private gossipDegraded = false;
 
   constructor(
     private readonly epochCache: EpochCache,
     private readonly l2BlockSource: Pick<L2BlockSource, 'getCheckpoint' | 'getSyncedL2SlotNumber'>,
     private readonly txProvider: Pick<ITxProvider, 'hasTxs'>,
-    private readonly p2p: Pick<P2PApi, 'getCheckpointAttestationsForSlot'>,
+    private readonly p2p: Pick<P2PApi, 'getCheckpointAttestationsForSlot' | 'getP2PConnectivity'>,
     private readonly reexecutionTracker: Pick<CheckpointReexecutionTracker, 'getTxsCollectedRecord'>,
     private readonly signatureContext: CoordinationSignatureContext,
     config: DataWithholdingWatcherConfig,
@@ -99,6 +104,31 @@ export class DataWithholdingWatcher extends (EventEmitter as new () => WatcherEm
     const targetSlot = SlotNumber(currentSlot - tolerance - 1);
     if (targetSlot <= this.initialSlot) {
       return;
+    }
+
+    // Missing txs are only evidence of withholding if we could have received them. Slots probed
+    // while gossip is down are skipped for good rather than deferred: once peers return, txs from
+    // those checkpoints may already have been evicted from the pool as mined, so a late probe would
+    // still report them missing. An unknown must not turn into an offense.
+    const connectivity = await this.p2p.getP2PConnectivity();
+    if (connectivity.enabled && connectivity.connectedPeers === 0) {
+      if (!this.gossipDegraded) {
+        this.gossipDegraded = true;
+        this.log.warn(`Skipping data-withholding checks while no peers are connected`, {
+          targetSlot,
+          lastCheckedSlot: this.lastCheckedSlot,
+        });
+      }
+      this.lastCheckedSlot = targetSlot;
+      return;
+    }
+
+    if (this.gossipDegraded) {
+      this.gossipDegraded = false;
+      this.log.info(`Resuming data-withholding checks now that peers are connected`, {
+        targetSlot,
+        connectedPeers: connectivity.connectedPeers,
+      });
     }
 
     const startSlot = this.lastCheckedSlot === undefined ? this.initialSlot : this.lastCheckedSlot;


### PR DESCRIPTION
The data-withholding watcher infers an offense from the absence of a
checkpoint's txs in the local pool. That is only valid evidence if the node
could have received those txs in the first place: a node whose p2p stack is
down sees every checkpoint's txs as missing and accuses entire committees of
withholding data.

The watcher now checks p2p connectivity once per tick, and while p2p is
enabled with zero connected peers it skips the slots that would otherwise be
probed. The skip is permanent — those slots are marked as checked and never
backfilled — because after peers return, txs from those checkpoints may
already have been evicted from the pool as mined, so a late probe would still
report them missing. An unknown must not become an offense.

The gate is vacuous when p2p is disabled by configuration (sandbox and
single-node setups report `enabled: false`), so behavior there is unchanged.
The degraded-state warning is logged only on the transition into and out of
the state, since the watcher ticks several times per slot.

Part of A-1701.


---

Part of a stacked-PR chain (bottom → top) hardening the node against running with a dead p2p stack; each PR targets the branch below it and the bottom targets `merge-train/spartan-v5`:

1. #25177 — fail node startup when the p2p service fails to start
2. #25178 — expose p2p connectivity (enabled + connected peer count)
3. #25179 — do not file data-withholding offenses while peerless
4. #25180 — skip proposing when the node has no connected peers
5. #25181 — report per-component health with p2p peer count on `GET /status`
6. #25182 — reject `sendTx` when the node has no peers to propagate the tx
7. #25183 — warn periodically while the node has zero connected peers
