### PR TITLE
fix(node): reject sendTx when node has no peers to propagate the tx

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -158,6 +158,7 @@ describe('aztec node', () => {
     const feePayerBalance = 10n ** 20n;
 
     p2p = mock<P2P>();
+    p2p.getP2PConnectivity.mockResolvedValue({ enabled: false, connectedPeers: 0 });
 
     globalVariablesBuilder = mock<GlobalVariableBuilder>();
     feeProvider = mock<FeeProvider>();
@@ -392,6 +393,32 @@ describe('aztec node', () => {
       });
       // Tx with expiration timestamp >= current block number should be valid
       expect(await node.isValidTx(validExpirationTimestampMetadata)).toEqual({ result: 'valid' });
+    });
+  });
+
+  describe('sendTx', () => {
+    it('rejects the tx when p2p is enabled but has no connected peers', async () => {
+      p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 0 });
+      const tx = await mockTxForRollup(0x10000);
+
+      await expect(node.sendTx(tx)).rejects.toThrow('no connected peers');
+      expect(p2p.sendTx).not.toHaveBeenCalled();
+    });
+
+    it('accepts the tx when p2p is enabled and has connected peers', async () => {
+      p2p.getP2PConnectivity.mockResolvedValue({ enabled: true, connectedPeers: 1 });
+      const tx = await mockTxForRollup(0x10000);
+
+      await node.sendTx(tx);
+      expect(p2p.sendTx).toHaveBeenCalledWith(tx);
+    });
+
+    it('accepts the tx when p2p is disabled', async () => {
+      p2p.getP2PConnectivity.mockResolvedValue({ enabled: false, connectedPeers: 0 });
+      const tx = await mockTxForRollup(0x10000);
+
+      await node.sendTx(tx);
+      expect(p2p.sendTx).toHaveBeenCalledWith(tx);
     });
   });
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -523,6 +523,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     const timer = new Timer();
     const txHash = tx.getTxHash().toString();
 
+    const connectivity = await this.p2pClient.getP2PConnectivity();
+    if (connectivity.enabled && connectivity.connectedPeers === 0) {
+      this.metrics.receivedTx(timer.ms(), false);
+      this.log.warn(`Rejecting tx ${txHash}: node has no connected peers`, { txHash });
+      throw new Error('Cannot accept tx: node has no connected peers to propagate it');
+    }
+
     const valid = await this.isValidTx(tx);
     if (valid.result !== 'valid') {
       const reason = valid.reason.join(', ');

--- a/yarn-project/end-to-end/src/single-node/misc/missed_l1_slot.test.ts
+++ b/yarn-project/end-to-end/src/single-node/misc/missed_l1_slot.test.ts
@@ -3,6 +3,7 @@ import { Fr } from '@aztec/aztec.js/fields';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { sleep } from '@aztec/foundation/sleep';
 import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
+import { registerPhantomGossipPeer } from '@aztec/p2p/test-helpers';
 import { SequencerState } from '@aztec/sequencer-client';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
@@ -102,6 +103,10 @@ describe('single-node/misc/missed_l1_slot', () => {
       // to verify against.
       perBlockAllocationMultiplier: 8,
     });
+
+    // This node is the only member of the mock gossip bus, so it would otherwise count zero connected peers:
+    // the node would reject the txs sent below and the proposer would skip its slots under minPeersToPropose.
+    await registerPhantomGossipPeer(test.context.mockGossipSubNetwork!);
 
     from = test.context.accounts[0];
     contract = await test.registerTestContract(test.context.wallet);

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -17,6 +17,7 @@ import {
   type TopicValidatorResult,
   TypedEventEmitter,
 } from '@libp2p/interface';
+import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
 
 import type { P2PConfig } from '../config.js';
 import type { MemPools } from '../mem_pools/interface.js';
@@ -308,4 +309,18 @@ export class MockGossipSubNetwork {
       }
     }
   }
+}
+
+/**
+ * Registers an extra peer on the mock gossip network that subscribes to nothing and drops every message
+ * delivered to it, and returns its peer id.
+ *
+ * Exists for single-node tests that run on a mock gossip bus: with a single member the node counts zero
+ * connected peers, and connectivity-gated behavior then kicks in even though the topology is intentional
+ * (the node rejects incoming txs since it has nobody to propagate them to, and a proposer under
+ * `minPeersToPropose` skips its slot). Registering one phantom peer keeps those gates satisfied.
+ */
+export async function registerPhantomGossipPeer(network: MockGossipSubNetwork): Promise<PeerId> {
+  const service = new MockGossipSubService(await createSecp256k1PeerId(), network);
+  return service.peerId;
 }


### PR DESCRIPTION
A node whose p2p stack is up but has zero connected peers used to accept txs
over RPC and "gossip" them to nobody: the tx sat in the local pool forever
while the caller believed it had been submitted. The failure was silent — no
error, no receipt, nothing actionable.

`#sendTx` now checks p2p connectivity before doing any work and rejects with a
clear error when p2p is enabled and no peers are connected, so callers fail
immediately and can retry against a healthy node. The check runs ahead of
`isValidTx` so a peerless node does not pay for full tx validation before
rejecting, and the rejection is counted in the received-tx metric like the
other failure paths.

Nodes running without a p2p stack (sandbox, single-node setups) report
`enabled: false` and are unaffected — they keep accepting txs, since their
local sequencer mines straight from the local pool.



Also includes a test-infra commit: `registerPhantomGossipPeer` in the p2p test helpers, so the one single-node e2e test that runs on the in-memory mock gossip bus (`missed_l1_slot`) presents one connected peer to the connectivity gates instead of looking peerless.

Part of A-1701.

---

Part of a stacked-PR chain (bottom → top) hardening the node against running with a dead p2p stack; each PR targets the branch below it and the bottom targets `merge-train/spartan-v5`:

1. #25177 — fail node startup when the p2p service fails to start
2. #25178 — expose p2p connectivity (enabled + connected peer count)
3. #25179 — do not file data-withholding offenses while peerless
4. #25180 — skip proposing when the node has no connected peers
5. #25181 — report per-component health with p2p peer count on `GET /status`
6. #25182 — reject `sendTx` when the node has no peers to propagate the tx
7. #25183 — warn periodically while the node has zero connected peers
