### PR TITLE
feat(p2p): warn periodically while node has zero connected peers

### DIFF
--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -2134,6 +2134,84 @@ describe('PeerManager', () => {
     });
   });
 
+  describe('zero connected peers warning', () => {
+    // A 1s heartbeat means the once-a-minute throttle spans 60 heartbeats.
+    const peerCheckIntervalMS = 1000;
+    const heartbeatsPerWarning = 60;
+    const zeroPeerHeartbeatsThreshold = 3;
+
+    const createManager = () =>
+      createMockPeerManager('zero-peers', mockLibP2PNode, 3, undefined, undefined, undefined, { peerCheckIntervalMS });
+
+    const runHeartbeats = async (manager: PeerManager, count: number) => {
+      for (let i = 0; i < count; i++) {
+        await manager.heartbeat();
+      }
+    };
+
+    it('does not warn before the threshold of consecutive zero-peer heartbeats', async () => {
+      const manager = createManager();
+      const warnSpy = jest.spyOn((manager as any).logger, 'warn');
+
+      await runHeartbeats(manager, zeroPeerHeartbeatsThreshold - 1);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns once zero peers persists across consecutive heartbeats', async () => {
+      const manager = createManager();
+      const warnSpy = jest.spyOn((manager as any).logger, 'warn');
+
+      await runHeartbeats(manager, zeroPeerHeartbeatsThreshold);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no connected peers'),
+        expect.objectContaining({ zeroPeerHeartbeats: zeroPeerHeartbeatsThreshold }),
+      );
+    });
+
+    it('throttles repeated warnings while peers stay at zero', async () => {
+      const manager = createManager();
+      const warnSpy = jest.spyOn((manager as any).logger, 'warn');
+
+      await runHeartbeats(manager, zeroPeerHeartbeatsThreshold + heartbeatsPerWarning - 1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      await runHeartbeats(manager, 1);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not warn while peers are connected', async () => {
+      const manager = createManager();
+      const warnSpy = jest.spyOn((manager as any).logger, 'warn');
+      mockLibP2PNode.getPeers.mockReturnValue([await createSecp256k1PeerId()]);
+
+      await runHeartbeats(manager, zeroPeerHeartbeatsThreshold + 5);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs once when connectivity is restored after a warning', async () => {
+      const manager = createManager();
+      const warnSpy = jest.spyOn((manager as any).logger, 'warn');
+      const infoSpy = jest.spyOn((manager as any).logger, 'info');
+
+      await runHeartbeats(manager, zeroPeerHeartbeatsThreshold);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      mockLibP2PNode.getPeers.mockReturnValue([await createSecp256k1PeerId(), await createSecp256k1PeerId()]);
+      await runHeartbeats(manager, 3);
+
+      const restoredLogs = infoSpy.mock.calls.filter(([message]) =>
+        (message as string).includes('connectivity restored'),
+      );
+      expect(restoredLogs).toHaveLength(1);
+      expect(restoredLogs[0][1]).toEqual(expect.objectContaining({ connectedPeerCount: 2 }));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   function createMockLibP2PNode(peers?: PeerId[], connections?: any[]): any {
     return {
       addEventListener: jest.fn(),

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -36,6 +36,8 @@ const MAX_CACHED_PEER_AGE_MS = 5 * 60 * 1000; // 5 minutes
 const DEFAULT_FAILED_PEER_BAN_TIME_MS = 5 * 60 * 1000; // 5 minutes timeout after failing MAX_DIAL_ATTEMPTS
 const GOODBYE_DIAL_TIMEOUT_MS = 1000;
 const FAILED_AUTH_HANDSHAKE_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+const ZERO_PEER_WARNING_THRESHOLD_HEARTBEATS = 3; // tolerate transient dips, such as at startup
+const ZERO_PEER_WARNING_REPEAT_INTERVAL_MS = 60 * 1000;
 
 type CachedPeer = {
   peerId: PeerId;
@@ -71,6 +73,10 @@ export class PeerManager implements PeerManagerInterface {
   private failedAuthHandshakes: Map<string, FailedAuthHandshakeEntry> = new Map();
   private validatorAddresses: EthAddress[] = [];
   private initializedPreferredPeers: boolean = false;
+  private consecutiveZeroPeerHeartbeats: number = 0;
+  private zeroPeerWarningHeartbeats: number = 0;
+  private zeroPeerWarningIssued: boolean = false;
+  private lastConnectedPeerAtMs: number | undefined;
 
   private metrics: PeerManagerMetrics;
   private handlers: {
@@ -115,6 +121,10 @@ export class PeerManager implements PeerManagerInterface {
 
     // Display peer counts every 60 seconds
     this.displayPeerCountsPeerHeartbeat = Math.floor(60_000 / this.config.peerCheckIntervalMS);
+    this.zeroPeerWarningHeartbeats = Math.max(
+      1,
+      Math.floor(ZERO_PEER_WARNING_REPEAT_INTERVAL_MS / this.config.peerCheckIntervalMS),
+    );
   }
   /**
    * Initializes the trusted peers.
@@ -173,6 +183,45 @@ export class PeerManager implements PeerManagerInterface {
     await this.processScheduledDisconnects();
 
     this.discover();
+    this.checkPeerConnectivity();
+  }
+
+  /**
+   * Flags a node that has been left without any connected peers, since it can neither gossip nor propagate txs.
+   *
+   * Warnings only start after a few consecutive zero-peer heartbeats so that startup or a transient dip stays quiet,
+   * and then repeat roughly once a minute instead of on every heartbeat. Recovery is logged once.
+   */
+  private checkPeerConnectivity() {
+    const connectedPeerCount = this.libP2PNode.getPeers().length;
+    const now = this.dateProvider.now();
+
+    if (connectedPeerCount > 0) {
+      if (this.zeroPeerWarningIssued) {
+        this.logger.info(`Peer connectivity restored with ${connectedPeerCount} connected peers`, {
+          connectedPeerCount,
+          zeroPeerHeartbeats: this.consecutiveZeroPeerHeartbeats,
+        });
+      }
+      this.consecutiveZeroPeerHeartbeats = 0;
+      this.zeroPeerWarningIssued = false;
+      this.lastConnectedPeerAtMs = now;
+      return;
+    }
+
+    this.consecutiveZeroPeerHeartbeats++;
+    const heartbeatsSinceThreshold = this.consecutiveZeroPeerHeartbeats - ZERO_PEER_WARNING_THRESHOLD_HEARTBEATS;
+    if (heartbeatsSinceThreshold < 0 || heartbeatsSinceThreshold % this.zeroPeerWarningHeartbeats !== 0) {
+      return;
+    }
+
+    this.zeroPeerWarningIssued = true;
+    this.logger.warn('Node has no connected peers; gossip and tx propagation are unavailable', {
+      zeroPeerHeartbeats: this.consecutiveZeroPeerHeartbeats,
+      peerCheckIntervalMS: this.config.peerCheckIntervalMS,
+      msSinceLastConnectedPeer: this.lastConnectedPeerAtMs === undefined ? undefined : now - this.lastConnectedPeerAtMs,
+      cachedPeers: this.cachedPeers.size,
+    });
   }
 
   /*


### PR DESCRIPTION
A validator could run for hours with a dead libp2p stack - zero peers and zero
gossip - without anything in its logs flagging the condition. The failure was
only reconstructable after the fact from the absence of activity, rather than
from any explicit signal.

The peer manager heartbeat now tracks consecutive zero-peer heartbeats. After 3
of them (so startup and transient dips stay quiet) it logs a warning that the
node has no connected peers and can neither gossip nor propagate txs, with the
zero-peer heartbeat count, the heartbeat interval, time since a peer was last
connected, and the cached peer count. The warning then repeats about once a
minute, derived from peerCheckIntervalMS, instead of on every heartbeat. When
peers come back, a single info log reports connectivity restored and the new
peer count.

Connected peers are counted via libp2p getPeers(), matching what
getP2PConnectivity reports. A peer count gauge already existed
(PEER_MANAGER_PEER_COUNT, recorded in discover()), so no metric was added -
this change is logs only.

Part of A-1701.


---

Related PRs from the same incident (all independent, all targeting `merge-train/spartan-v5`): #25177 (fail startup when the p2p service fails to start), #25185 (connectivity signal + slasher/proposer/health/sendTx gates), #25183 (periodic zero-peers warning).
