### PR TITLE
fix(ci): label v5 merge-train PRs with the built-in workflow token

### DIFF
--- a/.github/workflows/auto-port-v5-merge-trains.yml
+++ b/.github/workflows/auto-port-v5-merge-trains.yml
@@ -14,12 +14,25 @@ on:
     branches:
       - 'merge-train/*-v5'
 
+permissions: {}
+
 jobs:
   label:
     name: Add port-to-next label
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
+      # Labelling via the REST endpoint on the built-in token, rather than `gh pr
+      # edit`: that command resolves PR metadata over GraphQL, which reads org
+      # teams and so needs a personal token carrying `read:org`. `pull_request_target`
+      # runs against the base repo, so GITHUB_TOKEN can write here. The label it
+      # sets does not fire `labeled` events, which is fine — backport.yml only
+      # ports once the PR is merged.
       - name: Add port-to-next label
         env:
-          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label port-to-next
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+            -f "labels[]=port-to-next"


### PR DESCRIPTION
The auto-forward-port labeller has been failing on every v5 merge-train PR ([example run](https://github.com/AztecProtocol/aztec-packages/actions/runs/31542010040/job/93946342513)), so those PRs silently never get `port-to-next` and are not forward-ported on merge.

`gh pr edit --add-label` does not use the labels REST endpoint — it first resolves PR metadata over GraphQL, which reads org teams and therefore needs a token with `read:org`. `AZTEC_BOT_GITHUB_TOKEN` only carries `repo` and `workflow`, so the step errors out before labelling.

Switch to the REST labels endpoint with the built-in `GITHUB_TOKEN` and a job-scoped `pull-requests: write` grant. That endpoint needs no org-level access, and since the trigger is `pull_request_target` the workflow runs against the base repo, where `GITHUB_TOKEN` can be granted write. No personal token is involved any more, so the workflow cannot break again on PAT scope drift.

Labels applied by `GITHUB_TOKEN` do not fire `labeled` events. That is fine here: `backport.yml` gates its port job on `merged == true` and does the work off the `closed` event.