### PR TITLE
chore: point repo references at aztec-labs-eng/aztec-node

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,6 +1,6 @@
 # `.claude/`
 
-Project-level Claude Code configuration for aztec-packages. This file documents layout decisions; the filesystem describes the contents.
+Project-level Claude Code configuration for aztec-node. This file documents layout decisions; the filesystem describes the contents.
 
 ## Layout rules
 

--- a/.claude/agents/identify-ci-failures.md
+++ b/.claude/agents/identify-ci-failures.md
@@ -55,12 +55,12 @@ Do NOT:
 
 **If given PR number**:
 ```bash
-gh pr view <PR> --repo AztecProtocol/aztec-packages --json headRefName,baseRefName,statusCheckRollup
+gh pr view <PR> --repo aztec-labs-eng/aztec-node --json headRefName,baseRefName,statusCheckRollup
 ```
 Extract the `ci` job's `detailsUrl` and get the run ID (number after `runs/`).
 
 ```bash
-gh run view <RUN_ID> --repo AztecProtocol/aztec-packages --log 2>&1 | grep -i "CI run log id"
+gh run view <RUN_ID> --repo aztec-labs-eng/aztec-node --log 2>&1 | grep -i "CI run log id"
 ```
 
 **If given CI URL or hash**: Extract the hash directly.

--- a/.claude/claudebox/backport.md
+++ b/.claude/claudebox/backport.md
@@ -28,7 +28,7 @@ commits will leak into the PR. **Always verify your branch before calling `creat
 ### 1. Validate PR State
 
 ```
-github_api(method="GET", path="repos/AztecProtocol/aztec-packages/pulls/<PR_NUMBER>")
+github_api(method="GET", path="repos/aztec-labs-eng/aztec-node/pulls/<PR_NUMBER>")
 ```
 
 Confirm `state` is `closed` and `merged` is `true`. Extract `merge_commit_sha`.
@@ -81,7 +81,7 @@ When the cherry-pick fails:
 1. Check `git status` and `git diff` to understand the conflict state
 2. Get the full PR diff for reference:
    ```
-   github_api(method="GET", path="repos/AztecProtocol/aztec-packages/pulls/<PR_NUMBER>",
+   github_api(method="GET", path="repos/aztec-labs-eng/aztec-node/pulls/<PR_NUMBER>",
               accept="application/vnd.github.v3.diff")
    ```
 3. For each conflicted file:
@@ -125,7 +125,7 @@ Then create the PR:
 create_pr(
   title="<PR_TITLE> (backport #<PR_NUMBER>)",
   body="## Summary
-Backport of https://github.com/AztecProtocol/aztec-packages/pull/<PR_NUMBER> to <TARGET_BRANCH>.
+Backport of https://github.com/aztec-labs-eng/aztec-node/pull/<PR_NUMBER> to <TARGET_BRANCH>.
 
 <Brief description of what was backported and any conflicts resolved>
 

--- a/.claude/claudebox/deploy-investigation.md
+++ b/.claude/claudebox/deploy-investigation.md
@@ -31,7 +31,7 @@ Use MCP tools instead: `github_api`, `respond_to_user`.
 ### 1. Fetch the Failed Job
 
 ```
-github_api(method="GET", path="repos/AztecProtocol/aztec-packages/actions/runs/<RUN_ID>/jobs")
+github_api(method="GET", path="repos/aztec-labs-eng/aztec-node/actions/runs/<RUN_ID>/jobs")
 ```
 
 Find the job with `conclusion: "failure"`. Extract its `id` and note which step failed
@@ -40,7 +40,7 @@ Find the job with `conclusion: "failure"`. Extract its `id` and note which step 
 ### 2. Download GitHub Actions Job Logs
 
 ```
-github_api(method="GET", path="repos/AztecProtocol/aztec-packages/actions/jobs/<JOB_ID>/logs")
+github_api(method="GET", path="repos/aztec-labs-eng/aztec-node/actions/jobs/<JOB_ID>/logs")
 ```
 
 The GitHub Actions logs are a wrapper. The **actual detailed logs** are on

--- a/.claude/skills/backport/SKILL.md
+++ b/.claude/skills/backport/SKILL.md
@@ -33,7 +33,7 @@ Supported target branches:
 ### Step 2: Validate PR State
 
 ```bash
-gh pr view <PR> --repo AztecProtocol/aztec-packages --json state,title
+gh pr view <PR> --repo aztec-labs-eng/aztec-node --json state,title
 ```
 
 **Abort if:**

--- a/.claude/skills/merge-trains/SKILL.md
+++ b/.claude/skills/merge-trains/SKILL.md
@@ -49,7 +49,7 @@ A merge train is an automated batching system (inspired by [Rust rollups](https:
 
 ### When CI Fails on the Merge-Train PR
 
-Two options from the [merge-train-readme.md](https://github.com/AztecProtocol/aztec-packages/blob/next/.github/workflows/merge-train-readme.md):
+Two options from the [merge-train-readme.md](https://github.com/aztec-labs-eng/aztec-node/blob/main/.github/workflows/merge-train-readme.md):
 
 **Option 1: Direct Fix** -- Merge-train branches are protected, so you cannot push directly. Instead, create a PR targeting the merge-train branch with your fix, add the `ci-skip` label to skip CI, and use GitHub's "Merge without waiting for requirements to be met" button (bypass merge) to force-merge it. All users have bypass merge permission. **Important**: If your fix resolves a conflict from a `next` merge, use the **merge commit** method (not squash) to preserve the merge resolution.
 

--- a/.claude/skills/update-doc-references/SKILL.md
+++ b/.claude/skills/update-doc-references/SKILL.md
@@ -20,12 +20,12 @@ Extract from the dispatch prompt:
 ### Step 2: Get PR Details
 
 ```bash
-gh pr view <PR_NUMBER> --repo AztecProtocol/aztec-packages --json title,body,baseRefName,files,url
+gh pr view <PR_NUMBER> --repo aztec-labs-eng/aztec-node --json title,body,baseRefName,files,url
 ```
 
 Get the diff for each changed source file:
 ```bash
-gh pr diff <PR_NUMBER> --repo AztecProtocol/aztec-packages
+gh pr diff <PR_NUMBER> --repo aztec-labs-eng/aztec-node
 ```
 
 ### Step 3: Identify Affected Documentation
@@ -79,7 +79,7 @@ If changes were made, create a PR:
 
 ```bash
 BRANCH="docs/update-refs-pr-<PR_NUMBER>"
-BASE_BRANCH=$(gh pr view <PR_NUMBER> --repo AztecProtocol/aztec-packages --json baseRefName -q .baseRefName)
+BASE_BRANCH=$(gh pr view <PR_NUMBER> --repo aztec-labs-eng/aztec-node --json baseRefName -q .baseRefName)
 git checkout -b "$BRANCH"
 git add -A
 git commit -m "docs: update references for PR #<PR_NUMBER>

--- a/.github/workflows/auto-close-stale-drafts.yml
+++ b/.github/workflows/auto-close-stale-drafts.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   close-stale-drafts:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/avm-circuit-inputs.yml
+++ b/.github/workflows/avm-circuit-inputs.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   collect-avm-circuit-inputs:
-    if: ${{ github.repository != 'AztecProtocol/aztec-packages-private' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+    if: ${{ github.repository != 'AztecProtocol/aztec-packages-private' && (github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,7 +65,7 @@ jobs:
 
   avm-check-circuit:
     needs: collect-avm-circuit-inputs
-    if: ${{ github.repository != 'AztecProtocol/aztec-packages-private' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+    if: ${{ github.repository != 'AztecProtocol/aztec-packages-private' && (github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -218,7 +218,7 @@ jobs:
       && (
         (
           needs.validate-nightly-tag.outputs.is_current == 'true'
-          && github.repository == 'AztecProtocol/aztec-packages'
+          && github.repository == 'aztec-labs-eng/aztec-node'
           && startsWith(github.ref_name, 'v6.')
         )
         || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario')

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   get-image-tag:
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.determine_tag.outputs.TAG }}
@@ -58,7 +58,7 @@ jobs:
 
   wait-for-ci3:
     needs: get-image-tag
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -75,7 +75,7 @@ jobs:
 
   deploy-next-net:
     needs: [get-image-tag, wait-for-ci3]
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     uses: ./.github/workflows/deploy-network.yml
     with:
       network: next-net

--- a/.github/workflows/deploy-staging-public.yml
+++ b/.github/workflows/deploy-staging-public.yml
@@ -29,7 +29,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule') &&
       (github.event_name != 'schedule' ||
-      github.repository == 'AztecProtocol/aztec-packages')
+      github.repository == 'aztec-labs-eng/aztec-node')
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       semver: ${{ steps.resolve.outputs.semver }}
@@ -63,7 +63,7 @@ jobs:
 
   wait-for-ci3:
     needs: determine-tag
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +81,7 @@ jobs:
 
   deploy:
     needs: [determine-tag, wait-for-ci3]
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     uses: ./.github/workflows/deploy-network.yml
     with:
       network: staging-public

--- a/.github/workflows/docs-typesense.yml
+++ b/.github/workflows/docs-typesense.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   docs-scraper:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ensure-funded-environments.yml
+++ b/.github/workflows/ensure-funded-environments.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   discover:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -65,7 +65,7 @@ jobs:
 
   fund:
     needs: discover
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     strategy:
       # we can only run one funding operation at a time because all jobs fund from the same address
       max-parallel: 1

--- a/.github/workflows/merge-train-auto-merge.yml
+++ b/.github/workflows/merge-train-auto-merge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   auto-merge-inactive:
     name: Auto-merge inactive PRs
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/merge-train-stale-check.yml
+++ b/.github/workflows/merge-train-stale-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   spartan:
     name: Check merge-train/spartan
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/network-healthcheck.yml
+++ b/.github/workflows/network-healthcheck.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   healthcheck:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-bench-inclusion-sweep.yml
+++ b/.github/workflows/nightly-bench-inclusion-sweep.yml
@@ -37,7 +37,7 @@ jobs:
   select-image:
     # Scheduled runs only fire on the public repo; on the private mirror this is a no-op
     # (matches the guard the prior nightly-bench-10tps.yml workflow carried on this line).
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     outputs:
       docker_image: ${{ steps.docker-image.outputs.docker_image }}

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   nightly-release-tag:
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   select-image:
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     outputs:
       nightly_tag: ${{ steps.nightly-tag.outputs.nightly_tag }}
@@ -74,7 +74,7 @@ jobs:
   # so the deploys below don't race the build and hit ImagePullBackOff.
   wait-for-ci3:
     needs: select-image
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -95,7 +95,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-proving-network:
     needs: [select-image, wait-for-ci3]
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     uses: ./.github/workflows/deploy-network.yml
     with:
       network: prove-n-tps-fake
@@ -110,7 +110,7 @@ jobs:
     needs:
       - select-image
       - deploy-proving-network
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -141,7 +141,7 @@ jobs:
     needs:
       - select-image
       - wait-proving-l2-block
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -180,7 +180,7 @@ jobs:
           ./.github/ci3.sh network-proving-bench prove-n-tps-fake prove-n-tps-fake "${{ needs.select-image.outputs.docker_image }}"
 
   cleanup-proving:
-    if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.repository == 'aztec-labs-eng/aztec-node' }}
     needs:
       - select-image
       - deploy-proving-network
@@ -211,7 +211,7 @@ jobs:
           gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-proving:
-    if: ${{ always() && github.event_name != 'workflow_dispatch' && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.event_name != 'workflow_dispatch' && github.repository == 'aztec-labs-eng/aztec-node' }}
     needs:
       - select-image
       - deploy-proving-network
@@ -255,7 +255,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-block-capacity-network:
     needs: [select-image, wait-for-ci3]
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     uses: ./.github/workflows/deploy-network.yml
     with:
       network: block-capacity
@@ -270,7 +270,7 @@ jobs:
     needs:
       - select-image
       - deploy-block-capacity-network
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -301,7 +301,7 @@ jobs:
     needs:
       - select-image
       - wait-block-capacity-l2-block
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -339,7 +339,7 @@ jobs:
           ./.github/ci3.sh network-block-capacity-bench block-capacity nightly-block-capacity "${{ needs.select-image.outputs.docker_image }}"
 
   cleanup-block-capacity:
-    if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.repository == 'aztec-labs-eng/aztec-node' }}
     needs:
       - select-image
       - deploy-block-capacity-network
@@ -370,7 +370,7 @@ jobs:
           gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-block-capacity:
-    if: ${{ always() && github.event_name != 'workflow_dispatch' && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.event_name != 'workflow_dispatch' && github.repository == 'aztec-labs-eng/aztec-node' }}
     needs:
       - select-image
       - deploy-block-capacity-network
@@ -412,7 +412,7 @@ jobs:
   status:
     runs-on: ubuntu-latest
     needs: [proving-benchmark, block-capacity-benchmark]
-    if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.repository == 'aztec-labs-eng/aztec-node' }}
     steps:
       - name: Check benchmark results
         run: |

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   socket-fix:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   select-image:
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     outputs:
       nightly_tag: ${{ steps.nightly-tag.outputs.nightly_tag }}
@@ -67,7 +67,7 @@ jobs:
 
   deploy-real-proving-network:
     needs: select-image
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     uses: ./.github/workflows/deploy-network.yml
     with:
       network: prove-n-tps-real
@@ -81,7 +81,7 @@ jobs:
     needs:
       - select-image
       - deploy-real-proving-network
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -111,7 +111,7 @@ jobs:
     needs:
       - select-image
       - wait-for-first-l2-block
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ github.repository == 'aztec-labs-eng/aztec-node' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -142,7 +142,7 @@ jobs:
           ./.github/ci3.sh network-proving-bench prove-n-tps-real prove-n-tps-real
 
   cleanup:
-    if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
+    if: ${{ always() && github.repository == 'aztec-labs-eng/aztec-node' }}
     needs:
       - select-image
       - deploy-real-proving-network
@@ -167,7 +167,7 @@ jobs:
         run: ./.github/ci3.sh network-teardown prove-n-tps-real prove-n-tps-real
 
   notify:
-    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && github.repository == 'AztecProtocol/aztec-packages'
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && github.repository == 'aztec-labs-eng/aztec-node'
     needs:
       - select-image
       - deploy-real-proving-network

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# aztec-packages
+# aztec-node
 
 All paths below are relative to the git root. When working inside a component, also read that component's `CLAUDE.md` — each is self-contained and covers its own build, style, and test conventions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before opening an issue, be sure to search through the existing open and closed 
 
 When requesting a new feature, include as many details as you can, especially around the use cases that motivate it. Features are prioritized according to the impact they may have on the ecosystem, so we appreciate information showing that the impact could be high.
 
-[open an issue]: https://github.com/AztecProtocol/aztec-packages/issues/new
+[open an issue]: https://github.com/aztec-labs-eng/aztec-node/issues/new
 
 ## Submitting a pull request
 
@@ -22,7 +22,7 @@ If you would like to contribute code or documentation you may do so by forking t
 
 For non-trivial changes, start an issue first and discuss it with maintainers (see [Opening an issue](#opening-an-issue)).
 
-If you're looking for a good place to start, look for issues labeled ["good first issue"](https://github.com/AztecProtocol/aztec-packages/labels/good%20first%20issue). Please first communicate that you wish to take it on.
+If you're looking for a good place to start, look for issues labeled ["good first issue"](https://github.com/aztec-labs-eng/aztec-node/labels/good%20first%20issue). Please first communicate that you wish to take it on.
 
 ## Pull request checklist:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Please use [Aztec Network Bug Bounty](https://cantina.xyz/bounties/80e74370-10d8
 
 **Do not** open public GitHub issues or pull requests for suspected security vulnerabilities.
 
-Instead, please use the [Private Vulnerability Reporting](https://github.com/AztecProtocol/aztec-packages/security/advisories/new) process on GitHub.
+Instead, please use the [Private Vulnerability Reporting](https://github.com/aztec-labs-eng/aztec-node/security/advisories/new) process on GitHub.
 
 - Navigate to the "Security" tab of this repository.
 - Click "Report a vulnerability" on the left sidebar.

--- a/aztec-up/scripts/run_isolated_test.sh
+++ b/aztec-up/scripts/run_isolated_test.sh
@@ -32,7 +32,7 @@ function install_node {
   # Install required node version.
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
   source ~/.nvm/nvm.sh
-  node_version=$(grep node aztec-packages/aztec-up/bin/0.0.1/versions | cut -d' ' -f2)
+  node_version=$(grep node aztec-node/aztec-up/bin/0.0.1/versions | cut -d' ' -f2)
   echo $node_version
   nvm install $node_version
   nvm alias default $node_version
@@ -87,7 +87,7 @@ EOF
 
   # Install aztec.
   export NO_NEW_SHELL=1
-  export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
+  export INSTALL_URI=file:///home/ubuntu/aztec-node/aztec-up/bin
   if [ -t 0 ]; then
     bash_args="-i"
   else
@@ -109,7 +109,7 @@ EOF
 }
 
 # We want to use the locally built nargo, via the labs toolchain.
-export NARGO=/home/ubuntu/aztec-packages/labs-aztec-toolchain/bin/nargo
+export NARGO=/home/ubuntu/aztec-node/labs-aztec-toolchain/bin/nargo
 
 retry install_node
 source ~/.nvm/nvm.sh
@@ -118,4 +118,4 @@ start_verdaccio
 install_aztec
 
 # Run test. Force interactive to parse .bashrc.
-bash -i aztec-packages/aztec-up/test/$1.sh
+bash -i aztec-node/aztec-up/test/$1.sh

--- a/aztec-up/scripts/run_test.sh
+++ b/aztec-up/scripts/run_test.sh
@@ -18,13 +18,13 @@ function run {
     --name $name \
     --tmpfs /home/ubuntu/.nvm:exec,size=4g \
     --tmpfs /home/ubuntu/.npm:exec,size=2g \
-    -v$(git rev-parse --show-toplevel):/home/ubuntu/aztec-packages:ro \
+    -v$(git rev-parse --show-toplevel):/home/ubuntu/aztec-node:ro \
     -v$HOME/.bb-crs:/home/ubuntu/.bb-crs \
     -w/home/ubuntu \
     --user ubuntu:ubuntu \
     aztecprotocol/aztec-up-test \
     bash -c "
-      aztec-packages/aztec-up/scripts/run_isolated_test.sh $name ${fail_shell:-}
+      aztec-node/aztec-up/scripts/run_isolated_test.sh $name ${fail_shell:-}
     "
 }
 

--- a/aztec-up/test/counter_contract.sh
+++ b/aztec-up/test/counter_contract.sh
@@ -27,9 +27,9 @@ if [ "$(stat -c %U counter)" != "ubuntu" ]; then
 fi
 
 # "Write" our contract over the scaffold.
-cp -Rf ./aztec-packages/noir-projects/labs/noir-contracts/contracts/test/counter/* counter/
+cp -Rf ./aztec-node/noir-projects/labs/noir-contracts/contracts/test/counter/* counter/
 cd counter
-sed -i 's|\.\./\.\./\.\./\.\./\.\./|/home/ubuntu/aztec-packages/noir-projects/labs/|g' counter_contract/Nargo.toml counter_test/Nargo.toml
+sed -i 's|\.\./\.\./\.\./\.\./\.\./|/home/ubuntu/aztec-node/noir-projects/labs/|g' counter_contract/Nargo.toml counter_test/Nargo.toml
 
 # Compile the contract.
 aztec compile

--- a/aztec-up/test/default_scaffold.sh
+++ b/aztec-up/test/default_scaffold.sh
@@ -32,8 +32,8 @@ fi
 # This is unfortunate as it makes the test worse but in CI setting the aztec version is 0.0.1 which doesn't exist as
 # a remote git tag, so we need to rewrite dependencies to use local aztec-nr.
 sed -i \
-  -e 's|aztec = .*git.*AztecProtocol/aztec-nr.*|aztec = { path="/home/ubuntu/aztec-packages/noir-projects/labs/aztec-nr/aztec" }|' \
-  -e 's|balance_set = .*git.*AztecProtocol/aztec-nr.*|balance_set = { path="/home/ubuntu/aztec-packages/noir-projects/labs/aztec-nr/balance-set" }|' \
+  -e 's|aztec = .*git.*AztecProtocol/aztec-nr.*|aztec = { path="/home/ubuntu/aztec-node/noir-projects/labs/aztec-nr/aztec" }|' \
+  -e 's|balance_set = .*git.*AztecProtocol/aztec-nr.*|balance_set = { path="/home/ubuntu/aztec-node/noir-projects/labs/aztec-nr/balance-set" }|' \
   my_workspace_contract/Nargo.toml my_workspace_test/Nargo.toml
 
 # Compile the Counter contract.
@@ -72,7 +72,7 @@ fi
 
 # Rewrite aztec deps for token crates too.
 sed -i \
-  's|aztec = .*git.*AztecProtocol/aztec-nr.*|aztec = { path="/home/ubuntu/aztec-packages/noir-projects/labs/aztec-nr/aztec" }|' \
+  's|aztec = .*git.*AztecProtocol/aztec-nr.*|aztec = { path="/home/ubuntu/aztec-node/noir-projects/labs/aztec-nr/aztec" }|' \
   token_contract/Nargo.toml token_test/Nargo.toml
 
 # Compile and test the full workspace (both contracts).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1081,7 +1081,7 @@ case "$cmd" in
     set -e
     if [ "$compat_rc" -ne 0 ]; then
       if [[ "${REF_NAME:-}" == *-nightly.* ]]; then
-        run_url="https://github.com/${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}/actions/runs/${RUN_ID:-unknown}"
+        run_url="https://github.com/${GITHUB_REPOSITORY:-aztec-labs-eng/aztec-node}/actions/runs/${RUN_ID:-unknown}"
         "$ci3/slack_notify" "Backwards compatibility e2e tests FAILED on nightly tag <${run_url}|${REF_NAME}>" "#team-fairies" || true
         echo "Compat e2e failed on nightly tag — continuing (non-blocking)."
       else

--- a/build-images/README.md
+++ b/build-images/README.md
@@ -8,17 +8,17 @@ If you use vscode, the simplest thing to do is install the "Dev Containers" plug
 You'll be prompted to reload in a dev container, at which point you can open a terminal and bootstrap.
 You can connect to your container from outside vscode with e.g.: `docker exec -ti <container_id> /bin/zsh`
 
-Your repo will be mounted at `/workspaces/aztec-packages`, and your home directory is persisted in a docker volume.
+Your repo will be mounted at `/workspaces/aztec-node`, and your home directory is persisted in a docker volume.
 
 ## Running Independently
 
 If you don't use vscode, you can simply run `./run.sh` to create and drop into the container.
 
-Your repo will be mounted at `/workspaces/aztec-packages`, and your home directory is persisted in a docker volume.
+Your repo will be mounted at `/workspaces/aztec-node`, and your home directory is persisted in a docker volume.
 
 ## GitHub Codespaces
 
-This is also compatible with GitHub codespaces. Visit the repo at `https://github.com/aztecprotocol/aztec-packages`.
+This is also compatible with GitHub codespaces. Visit the repo at `https://github.com/aztec-labs-eng/aztec-node`.
 Press `.`, and open a terminal window. You will be prompted to create a new machine.
 You can then continue to work within the browser, or reopen the codespace in your local vscode.
 

--- a/build-images/bootstrap.sh
+++ b/build-images/bootstrap.sh
@@ -54,10 +54,10 @@ function build_ec2 {
   ssh -F $ci3/aws/build_instance_ssh_config ubuntu@$ip "
     set -euo pipefail
     export DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD
-    mkdir aztec-packages
-    cd aztec-packages
+    mkdir aztec-node
+    cd aztec-node
     git init . &>/dev/null
-    git remote add origin https://github.com/aztecprotocol/aztec-packages
+    git remote add origin https://github.com/aztec-labs-eng/aztec-node
     git fetch --depth 1 origin $current_commit
     git checkout FETCH_HEAD
     ./build-images/bootstrap.sh

--- a/build-images/run.sh
+++ b/build-images/run.sh
@@ -35,8 +35,8 @@ else
     -e SSH_CONNECTION=' ' \
     -e DOCKER_CONFIG=/home/aztec-dev/.docker-devbox \
     ${ID_ARGS:-} \
-    -w/workspaces/aztec-packages \
-    -v$PWD/..:/workspaces/aztec-packages \
+    -w/workspaces/aztec-node \
+    -v$PWD/..:/workspaces/aztec-node \
     -vdevbox-home:/home/aztec-dev \
     -vdevbox-var-lib-docker:/var/lib/docker \
     -v$HOME/.ssh/id_rsa:/home/aztec-dev/.ssh/id_rsa:ro \

--- a/build-images/src/home/.gitconfig
+++ b/build-images/src/home/.gitconfig
@@ -1,5 +1,5 @@
 [safe]
-	directory = /workspaces/aztec-packages
-	directory = /root/aztec-packages
+	directory = /workspaces/aztec-node
+	directory = /root/aztec-node
 [advice]
 	detachedHead = false

--- a/ci3/aws_instance_name
+++ b/ci3/aws_instance_name
@@ -8,7 +8,7 @@
 #   arch    default $ARCH, else amd64. Normalised: x86_64->amd64, aarch64|arm64->arm64.
 #   postfix default $INSTANCE_POSTFIX (the per-job suffix, e.g. x-fast, bench); optional.
 #
-# The repo prefix is $GITHUB_REPOSITORY's basename (default aztec-packages) so that
+# The repo prefix is $GITHUB_REPOSITORY's basename (default aztec-node) so that
 # aztec-packages and aztec-packages-private don't collide on names.
 set -eu
 
@@ -22,7 +22,7 @@ case "$arch" in
   aarch64 | arm64) arch=arm64 ;;
 esac
 
-repo=${GITHUB_REPOSITORY:-aztec-packages}
+repo=${GITHUB_REPOSITORY:-aztec-node}
 repo=${repo##*/}
 
 # Merge-queue refs look like gh-readonly-queue/<target>/pr-<N>-<sha>; key on pr-<N>

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -176,11 +176,11 @@ container_script=$(
   # Note we use the "ci-started" file to determine if we're running on a CI machine in some cases (e.g. npm cache).
   while [ -f ci-started ]; do sleep 999; done
   touch ci-started
-  sudo chown aztec-dev:aztec-dev aztec-packages
+  sudo chown aztec-dev:aztec-dev aztec-node
   # Set up preferred commit attribution (used during releases).
   git config --global user.email "tech@aztecprotocol.com"
   git config --global user.name "AztecBot"
-  cd aztec-packages
+  cd aztec-node
   git config --global advice.detachedHead false
   git init .
   if [ -n "\${GITHUB_TOKEN:-}" ]; then
@@ -344,7 +344,7 @@ start_build() {
     --name aztec_build \
     --hostname $docker_hostname \
     -v bootstrap_ci_local_docker:/var/lib/docker \
-    -v bootstrap_ci_repo:/home/aztec-dev/aztec-packages \
+    -v bootstrap_ci_repo:/home/aztec-dev/aztec-node \
     -v \$HOME/.ssh:/home/aztec-dev/.ssh:ro \
     -v \$HOME/.bb-crs:/home/aztec-dev/.bb-crs \
     -v /dev/kmsg:/dev/kmsg \

--- a/ci3/clean_remote_tags
+++ b/ci3/clean_remote_tags
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Set your GitHub repository info and token if needed
-GH_OWNER="aztecprotocol"
-GH_REPO="aztec-packages"
+GH_OWNER="aztec-labs-eng"
+GH_REPO="aztec-node"
 
 # Fetch all releases with pagination
 page=1

--- a/ci3/dashboard/Dockerfile
+++ b/ci3/dashboard/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt gunicorn
 COPY ci-metrics/requirements.txt ci-metrics/requirements.txt
 RUN pip install --no-cache-dir -r ci-metrics/requirements.txt
 
-RUN git config --global --add safe.directory /aztec-packages
+RUN git config --global --add safe.directory /aztec-node
 COPY . .
 EXPOSE 8080 8081
 CMD ["gunicorn", "-w", "4", "--threads", "12", "-b", "0.0.0.0:8080", "rk:app"]

--- a/ci3/dashboard/chonk-breakdowns/README.md
+++ b/ci3/dashboard/chonk-breakdowns/README.md
@@ -41,7 +41,7 @@ Data comes from CI benchmark runs and is stored in `/logs-disk/bench/bb-breakdow
 4. **Test in browser:**
    - Open: http://localhost:8080/chonk-breakdowns
    - Enter credentials when prompted
-   - The SHA field will auto-populate with the latest commit from `aztec-packages` `next` branch
+   - The SHA field will auto-populate with the latest commit from `aztec-node` `main` branch
    - Select Runtime: `native` or `wasm`
    - The Flow dropdown will dynamically show flows available for the selected runtime and SHA
    - Click "Load Breakdown"

--- a/ci3/dashboard/chonk-breakdowns/breakdown-viewer.html
+++ b/ci3/dashboard/chonk-breakdowns/breakdown-viewer.html
@@ -712,10 +712,10 @@
       }
     });
 
-    // Fetch latest commit SHA from aztec-packages next branch
+    // Fetch latest commit SHA from aztec-node main branch
     async function fetchLatestNextSha() {
       try {
-        const response = await fetch('https://api.github.com/repos/AztecProtocol/aztec-packages/commits/next');
+        const response = await fetch('https://api.github.com/repos/aztec-labs-eng/aztec-node/commits/main');
         if (!response.ok) throw new Error('Failed to fetch latest commit');
         const data = await response.json();
         return data.sha.substring(0, 7);

--- a/ci3/dashboard/ci-metrics/Dockerfile
+++ b/ci3/dashboard/ci-metrics/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y jq redis-tools && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
-RUN git config --global --add safe.directory /aztec-packages
+RUN git config --global --add safe.directory /aztec-node
 COPY . .
 EXPOSE 8081
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8081", "app:app"]

--- a/ci3/dashboard/ci-metrics/github_data.py
+++ b/ci3/dashboard/ci-metrics/github_data.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 
 import db as _db
 
-REPO = 'AztecProtocol/aztec-packages'
+REPO = 'aztec-labs-eng/aztec-node'
 _GH_API = 'https://api.github.com'
 
 BRANCH_PAIRS = [

--- a/ci3/dashboard/ci-metrics/views/commits.html
+++ b/ci3/dashboard/ci-metrics/views/commits.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Commits — aztec-packages</title>
+  <title>Commits — aztec-node</title>
   <style>
     * { box-sizing: border-box; }
     body { background: #0d1117; color: #e6edf3; font-family: monospace; font-size: 13px; padding: 16px; margin: 0; }
@@ -139,7 +139,7 @@
   </div>
 
 <script>
-  const REPO = 'AztecProtocol/aztec-packages';
+  const REPO = 'aztec-labs-eng/aztec-node';
   const BASE  = `https://github.com/${REPO}`;
 
   let allCommits  = [];   // page's commits (before filter)

--- a/ci3/dashboard/ci-metrics/views/flake-prs.html
+++ b/ci3/dashboard/ci-metrics/views/flake-prs.html
@@ -103,7 +103,7 @@
     const sortedKeys = Object.keys(groups).sort().reverse();
     container.innerHTML = sortedKeys.map(key => {
       const rows = groups[key].map(pr => {
-        const ghUrl = `https://github.com/AztecProtocol/aztec-packages/pull/${pr.pr_number}`;
+        const ghUrl = `https://github.com/aztec-labs-eng/aztec-node/pull/${pr.pr_number}`;
         const adds = pr.additions != null ? `<span class="add">+${pr.additions}</span>` : '';
         const dels = pr.deletions != null ? `<span class="del">-${pr.deletions}</span>` : '';
         const diff = (adds || dels) ? `<span class="pr-diff">${adds} ${dels}</span>` : '';

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -31,7 +31,7 @@ if [ -n "${PARENT_LOG_ID:-}" ]; then
 fi
 cat <<EOF
 Command: $full_cmd
-Commit: https://github.com/AztecProtocol/aztec-packages/commit/${COMMIT_HASH:-HEAD}
+Commit: https://github.com/aztec-labs-eng/aztec-node/commit/${COMMIT_HASH:-HEAD}
 Env: REF_NAME=${REF_NAME:-} CURRENT_VERSION=${CURRENT_VERSION:-} CI_FULL=${CI_FULL:-} NO_FLAKE=${NO_FLAKE:-}
 Date: $(date)
 System: ARCH=$(arch) CPUS=$(nproc --all) MEM=$(free -h | awk '/^Mem:/{print $2}') HOSTNAME=$(hostname)

--- a/ci3/merge_train_stale_check
+++ b/ci3/merge_train_stale_check
@@ -23,7 +23,7 @@ CHANNEL="${2:?Usage: $0 <merge-train-branch> <slack-channel>}"
 STALE_HOURS="${STALE_HOURS:-24}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
 
-pr_json=$(gh api "repos/AztecProtocol/aztec-packages/pulls?head=AztecProtocol:${REF_NAME}&state=open&base=${BASE_BRANCH}" --jq '.[0] // empty')
+pr_json=$(gh api "repos/aztec-labs-eng/aztec-node/pulls?head=aztec-labs-eng:${REF_NAME}&state=open&base=${BASE_BRANCH}" --jq '.[0] // empty')
 
 if [[ -z "$pr_json" ]]; then
   echo "$REF_NAME: no open PR targeting $BASE_BRANCH — nothing to alert."
@@ -45,7 +45,7 @@ if (( age_hours < STALE_HOURS )); then
   exit 0
 fi
 
-mergeable_state=$(gh api "repos/AztecProtocol/aztec-packages/pulls/$pr_number" --jq '.mergeable_state // "unknown"')
+mergeable_state=$(gh api "repos/aztec-labs-eng/aztec-node/pulls/$pr_number" --jq '.mergeable_state // "unknown"')
 days=$(( age_hours / 24 ))
 
 message=$(printf ':warning: `%s` has not merged into `%s` in %d day(s). <%s|PR #%d> is in state `%s`.' \

--- a/ci3/npm_install_deps
+++ b/ci3/npm_install_deps
@@ -7,7 +7,7 @@ NO_CD=1 source ${root:-$(git rev-parse --show-toplevel)}/ci3/source
 # We assume that `yarn.lock` sits within the root directory of the git repository we're currently in.
 #
 # We cannot assume that this is equal to `$root` as we may be within a nested repository
-# whereas `$root` points to the root of the aztec-packages monorepo.
+# whereas `$root` points to the root of the aztec-node repo.
 REPO_PATH=$(git rev-parse --show-toplevel)
 
 if [ ! -f yarn.lock ]; then

--- a/ci3/post_github_status
+++ b/ci3/post_github_status
@@ -11,7 +11,7 @@
 # Environment:
 #   CI             - must be 1 (otherwise no-op)
 #   GITHUB_TOKEN   - GitHub API token
-#   GITHUB_REPOSITORY - owner/repo (e.g. AztecProtocol/aztec-packages)
+#   GITHUB_REPOSITORY - owner/repo (e.g. aztec-labs-eng/aztec-node)
 #   COMMIT_HASH    - the SHA to post status on
 set -euo pipefail
 

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -352,7 +352,7 @@ function flake_slack_channel {
   if [[ "$head_branch" =~ ^gh-readonly-queue/.+/pr-([0-9]+)- ]] \
       && [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
     head_branch=$(GH_TOKEN="$GITHUB_TOKEN" gh pr view "${BASH_REMATCH[1]}" \
-      --repo AztecProtocol/aztec-packages --json headRefName -q '.headRefName' 2>/dev/null || true)
+      --repo aztec-labs-eng/aztec-node --json headRefName -q '.headRefName' 2>/dev/null || true)
   fi
   local channel=""
   case "$head_branch" in

--- a/ci3/slack_notify_with_claudebox_kickoff
+++ b/ci3/slack_notify_with_claudebox_kickoff
@@ -11,7 +11,7 @@ set -eu
 #         it, work aimed at a private repo dead-ends in a public-mode session.
 #
 # Requires: SLACK_BOT_TOKEN
-# Optional: CLAUDEBOX_REPO (default: AztecProtocol/aztec-packages) -- the repo
+# Optional: CLAUDEBOX_REPO (default: aztec-labs-eng/aztec-node) -- the repo
 #           whose claudebox.yml is dispatched (holds the CLAUDEBOX_API_SECRET).
 
 NO_CD=1 source "$(git rev-parse --show-toplevel)/ci3/source_base"
@@ -40,7 +40,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-REPO="${CLAUDEBOX_REPO:-AztecProtocol/aztec-packages}"
+REPO="${CLAUDEBOX_REPO:-aztec-labs-eng/aztec-node}"
 
 # Post to Slack (inline rather than via ci3/slack_notify because we need the response for permalink)
 if [[ -n "${SLACK_BOT_TOKEN:-}" ]]; then

--- a/ci3/source_stdlib
+++ b/ci3/source_stdlib
@@ -66,7 +66,7 @@ function pr_link {
   local line=$1
   if [[ $line =~ \(#([0-9]+)\) ]]; then
     pr_number="${BASH_REMATCH[1]}"
-    link=$(term_link https://github.com/aztecprotocol/aztec-packages/pull/$pr_number $pr_number)
+    link=$(term_link https://github.com/aztec-labs-eng/aztec-node/pull/$pr_number $pr_number)
     echo -e "${line/\(#${pr_number}\)/(#${link})}"
   else
     echo -e "$line"

--- a/ci3/upload_benchmarks
+++ b/ci3/upload_benchmarks
@@ -17,7 +17,7 @@ set -euo pipefail
 #   GITHUB_TOKEN      Token with push access to the data repo (required unless BENCH_REPO_URL).
 #   BENCH_REPO        Data repo slug (default: AztecProtocol/benchmark-page-data).
 #   BENCH_REPO_URL    Full clone URL override; bypasses token auth (used by tests).
-#   SOURCE_REPO_URL   Repo the commit sha belongs to (default: https://github.com/AztecProtocol/aztec-packages).
+#   SOURCE_REPO_URL   Repo the commit sha belongs to (default: https://github.com/aztec-labs-eng/aztec-node).
 #   MAX_ITEMS         Datapoints kept per entry series (default: 100).
 #   RETRY_SLEEP       Base seconds between push retries (default: 5; tests set 0).
 
@@ -28,7 +28,7 @@ commit_sha=$4
 
 bench_repo=${BENCH_REPO:-AztecProtocol/benchmark-page-data}
 repo_url=${BENCH_REPO_URL:-https://x-access-token:${GITHUB_TOKEN:-}@github.com/$bench_repo}
-source_repo_url=${SOURCE_REPO_URL:-https://github.com/AztecProtocol/aztec-packages}
+source_repo_url=${SOURCE_REPO_URL:-https://github.com/aztec-labs-eng/aztec-node}
 max_items=${MAX_ITEMS:-100}
 retry_sleep=${RETRY_SLEEP:-5}
 

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -25,7 +25,7 @@ function resolveSnippetSource(relativeCodeFilePath, rootDir, defaultTag) {
   );
   if (!published) {
     return {
-      repoUrl: "https://github.com/AztecProtocol/aztec-packages",
+      repoUrl: "https://github.com/aztec-labs-eng/aztec-node",
       ref: defaultTag,
       displayPath: relativeCodeFilePath,
     };

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     mem_limit: 8G
     tty: true
     volumes:
-      - ../:/root/aztec-packages
-    working_dir: /root/aztec-packages/yarn-project/aztec
+      - ../:/root/aztec-node
+    working_dir: /root/aztec-node/yarn-project/aztec
     command: 'node ./dest/bin start --local-network'
     environment:
       ETHEREUM_HOSTS: http://ethereum:8545
@@ -42,8 +42,8 @@ services:
     mem_limit: 8G
     tty: true
     volumes:
-      - ../:/root/aztec-packages
-    working_dir: /root/aztec-packages/playground
+      - ../:/root/aztec-node
+    working_dir: /root/aztec-node/playground
     command: 'yarn workspace @aztec/playground test --project=$BROWSER'
     environment:
       HARDWARE_CONCURRENCY: 4

--- a/scripts/auto_close_issues.py
+++ b/scripts/auto_close_issues.py
@@ -133,7 +133,7 @@ def main():
         print("   or: auto_close_issues.py <commit_sha>", file=sys.stderr)
         sys.exit(1)
 
-    repo = os.environ.get('GITHUB_REPOSITORY', 'AztecProtocol/aztec-packages')
+    repo = os.environ.get('GITHUB_REPOSITORY', 'aztec-labs-eng/aztec-node')
     dry_run = os.environ.get('DRY_RUN', '0') == '1'
 
     # Get commits to process

--- a/scripts/commits
+++ b/scripts/commits
@@ -264,7 +264,7 @@ def process_commit(commit: str, indent: str = "", message: str = "",
     pr_num = get_pr_number(message)
     pr_link = ""
     if pr_num:
-        pr_url = f"https://github.com/AztecProtocol/aztec-packages/pull/{pr_num}"
+        pr_url = f"https://github.com/aztec-labs-eng/aztec-node/pull/{pr_num}"
         pr_link = f" ({term_link(pr_url, f'#{YELLOW}{pr_num}{RESET}')})"
 
     # Clean message (remove PR number from display)
@@ -290,7 +290,7 @@ def process_commit(commit: str, indent: str = "", message: str = "",
         commit_part = f"{DARK_GRAY}{visible_part}{RESET}{' ' * (8 - len(visible_part))}"
     else:
         # Make commit hash a clickable link
-        commit_url = f"https://github.com/AztecProtocol/aztec-packages/commit/{commit}"
+        commit_url = f"https://github.com/aztec-labs-eng/aztec-node/commit/{commit}"
         commit_part = f"{term_link(commit_url, f'{YELLOW}{commit[:7]}{RESET}')} "
 
     # Build the left part of the line
@@ -310,12 +310,12 @@ def process_commit_markdown(commit: str, indent: str = "", message: str = "",
     pr_num = get_pr_number(message)
     pr_md = ""
     if pr_num:
-        pr_url = f"https://github.com/AztecProtocol/aztec-packages/pull/{pr_num}"
+        pr_url = f"https://github.com/aztec-labs-eng/aztec-node/pull/{pr_num}"
         pr_md = f" ([#{pr_num}]({pr_url}))"
 
     clean_message = re.sub(r' \(#\d+\)$', '', message)
 
-    commit_url = f"https://github.com/AztecProtocol/aztec-packages/commit/{commit}"
+    commit_url = f"https://github.com/aztec-labs-eng/aztec-node/commit/{commit}"
     commit_md = md_link(commit_url, commit[:7])
 
     prefix = ""
@@ -486,9 +486,9 @@ Examples:
                     if args.markdown:
                         pr_md = ""
                         if pr_num:
-                            pr_url = f"https://github.com/AztecProtocol/aztec-packages/pull/{pr_num}"
+                            pr_url = f"https://github.com/aztec-labs-eng/aztec-node/pull/{pr_num}"
                             pr_md = f" ([#{pr_num}]({pr_url}))"
-                        commit_url = f"https://github.com/AztecProtocol/aztec-packages/commit/{commit}"
+                        commit_url = f"https://github.com/aztec-labs-eng/aztec-node/commit/{commit}"
                         commit_link = md_link(commit_url, commit[:7])
                         print(f"* {commit_link} merge-train{pr_md}")
                         for (train_commit, train_message, train_author, train_date) in filtered_children:
@@ -496,9 +496,9 @@ Examples:
                     else:
                         pr_link = ""
                         if pr_num:
-                            pr_url = f"https://github.com/AztecProtocol/aztec-packages/pull/{pr_num}"
+                            pr_url = f"https://github.com/aztec-labs-eng/aztec-node/pull/{pr_num}"
                             pr_link = f" ({term_link(pr_url, f'#{YELLOW}{pr_num}{RESET}')})"
-                        commit_url = f"https://github.com/AztecProtocol/aztec-packages/commit/{commit}"
+                        commit_url = f"https://github.com/aztec-labs-eng/aztec-node/commit/{commit}"
                         commit_link = term_link(commit_url, f'{YELLOW}{commit[:7]}{RESET}')
                         print(f"* {commit_link} {DIM}merge-train{RESET}{pr_link}")
                         for (train_commit, train_message, train_author, train_date) in filtered_children:

--- a/scripts/find_missing_backports.sh
+++ b/scripts/find_missing_backports.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #
 # Requires: gh, jq
 
-REPO="AztecProtocol/aztec-packages"
+REPO="aztec-labs-eng/aztec-node"
 SINCE="2026-02-22"
 TARGET_BRANCH="v4"
 

--- a/scripts/find_orphaned_issues_in_prs.py
+++ b/scripts/find_orphaned_issues_in_prs.py
@@ -127,8 +127,8 @@ def main():
     )
     parser.add_argument(
         '--repo',
-        default='AztecProtocol/aztec-packages',
-        help='Repository in format owner/repo (default: AztecProtocol/aztec-packages)'
+        default='aztec-labs-eng/aztec-node',
+        help='Repository in format owner/repo (default: aztec-labs-eng/aztec-node)'
     )
 
     args = parser.parse_args()

--- a/scripts/redo-typo-pr
+++ b/scripts/redo-typo-pr
@@ -4,7 +4,7 @@ set -eux
 
 # Configuration
 ORIGINAL_PR_NUMBER=$1
-REPO='AztecProtocol/aztec-packages'
+REPO='aztec-labs-eng/aztec-node'
 NEW_BRANCH="chore/typo-redo-$ORIGINAL_PR_NUMBER"
 AUTHOR=`gh pr view $ORIGINAL_PR_NUMBER --json author --jq '.author.login'`
 

--- a/scripts/socket-fix-ci.sh
+++ b/scripts/socket-fix-ci.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 SEVERITY="${1:-critical}"
 BRANCH_NAME="chore/socket-fix-updates"
-REPO="${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}"
+REPO="${GITHUB_REPOSITORY:-aztec-labs-eng/aztec-node}"
 
 # --- Install socket CLI ---
 echo "Installing socket CLI..."

--- a/spartan/README.md
+++ b/spartan/README.md
@@ -33,7 +33,7 @@ If you are new to Kubernetes, the following resources may also be helpful:
 
 Aztec has two permanent network deployments: `staging` and `production`. These networks are intended to be long running and are not tied to activities and testing happening within CI.
 
-Aztec's `staging` and `production` networks rely on a continuous delivery workflow (CD) and are configured to automatically refresh when node container images are released to the general public ([Github Action](https://github.com/AztecProtocol/aztec-packages/blob/master/.github/workflows/network-deploy.yml)). The following diagram shows a high-level topology of the two environments. Note that number of each node type may be changed over time. All nodes, with the exception of the transaction bot, are exposed to the public internet using a Kubernetes load balancer.
+Aztec's `staging` and `production` networks rely on a continuous delivery workflow (CD) and are configured to automatically refresh when node container images are released to the general public ([Github Action](https://github.com/aztec-labs-eng/aztec-node/blob/main/.github/workflows/network-deploy.yml)). The following diagram shows a high-level topology of the two environments. Note that number of each node type may be changed over time. All nodes, with the exception of the transaction bot, are exposed to the public internet using a Kubernetes load balancer.
 
 ![Aztec network deployment](./img/aztec_staging.svg)
 

--- a/spartan/benchmarks/README.md
+++ b/spartan/benchmarks/README.md
@@ -38,7 +38,7 @@ Every benchmark follows the same phases:
 7. **Notify** `#alerts-next-scenario` on Slack. Failures on scheduled runs also dispatch a ClaudeBox
    investigation; `workflow_dispatch` runs stay silent.
 
-All four workflows are guarded on `github.repository == 'AztecProtocol/aztec-packages'` so they only
+All four workflows are guarded on `github.repository == 'aztec-labs-eng/aztec-node'` so they only
 run there, and all use `concurrency` with `cancel-in-progress`.
 
 ### From workflow to test

--- a/spartan/scripts/bench_10tps/bench_output.schema.json
+++ b/spartan/scripts/bench_10tps/bench_output.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/AztecProtocol/aztec-packages/benchmark-design/benchmark-output.schema.json",
+  "$id": "https://github.com/aztec-labs-eng/aztec-node/benchmark-design/benchmark-output.schema.json",
   "title": "Aztec 10 TPS benchmark — per-run output",
   "description": "One JSON per benchmark run, self-contained. Produced by bench_scrape.ts after a run finishes. Two scrape paths, run independently so one failing does not prevent the other from populating: (a) PromQL query_range for continuous time-series; (b) gcloud log scrape for per-block records and discrete events.",
   "type": "object",

--- a/spartan/scripts/wait_for_ci3.ts
+++ b/spartan/scripts/wait_for_ci3.ts
@@ -8,7 +8,7 @@
  *
  * Arguments:
  *   tag  - The git tag to wait for (e.g., v4.0.0-devnet.1-patch.0)
- *   repo - Optional GitHub repo (default: GITHUB_REPOSITORY or 'AztecProtocol/aztec-packages')
+ *   repo - Optional GitHub repo (default: GITHUB_REPOSITORY or 'aztec-labs-eng/aztec-node')
  *
  * The script resolves the tag's commit, finds the ci3.yml run for it, then
  * polls that run's `ci` job and exits 0 as soon as it completes successfully.
@@ -35,7 +35,7 @@ if (!tag) {
 const repo =
   positional[1] ||
   process.env.GITHUB_REPOSITORY ||
-  "AztecProtocol/aztec-packages";
+  "aztec-labs-eng/aztec-node";
 
 const gh = (args: string): string =>
   execSync(`gh ${args}`, { encoding: "utf-8" }).trim();

--- a/yarn-project/.claude/skills/fix-pr/SKILL.md
+++ b/yarn-project/.claude/skills/fix-pr/SKILL.md
@@ -21,7 +21,7 @@ Autonomous workflow to fix CI failures for a PR. Delegates failure identificatio
 Before doing anything, verify the PR is valid:
 
 ```bash
-gh pr view <PR> --repo AztecProtocol/aztec-packages --json state,baseRefName,headRefName
+gh pr view <PR> --repo aztec-labs-eng/aztec-node --json state,baseRefName,headRefName
 ```
 
 **Abort if:**

--- a/yarn-project/.claude/skills/monitor-pr/check-pr.sh
+++ b/yarn-project/.claude/skills/monitor-pr/check-pr.sh
@@ -14,7 +14,7 @@
 
 set -uo pipefail
 
-REPO="${MONITOR_PR_REPO:-AztecProtocol/aztec-packages}"
+REPO="${MONITOR_PR_REPO:-aztec-labs-eng/aztec-node}"
 PR="${1:-}"
 
 die() { echo "ERROR=$*"; exit 1; }

--- a/yarn-project/.claude/skills/network-deployed-version/SKILL.md
+++ b/yarn-project/.claude/skills/network-deployed-version/SKILL.md
@@ -5,7 +5,7 @@ description: Determine which git commit an Aztec network (next-net, devnet, stag
 
 # Determine an Aztec network's deployed commit
 
-Aztec networks deploy via **scheduled GitHub Actions workflows**. Depending on the network, the run history lives in **either** the PRIVATE repo `AztecProtocol/aztec-packages-private` **or** the PUBLIC repo `AztecProtocol/aztec-packages` — see the table below for which repo each network deploys from (`gh` needs auth with access to both). The commit a network runs at time T is the **headSha of the last *successful* deploy run at or before T** — failed runs leave the previous commit live, so a string of failed nightlies can keep a network on a days-old commit.
+Aztec networks deploy via **scheduled GitHub Actions workflows**. Depending on the network, the run history lives in **either** the PRIVATE repo `AztecProtocol/aztec-packages-private` **or** the PUBLIC repo `aztec-labs-eng/aztec-node` — see the table below for which repo each network deploys from (`gh` needs auth with access to both). The commit a network runs at time T is the **headSha of the last *successful* deploy run at or before T** — failed runs leave the previous commit live, so a string of failed nightlies can keep a network on a days-old commit.
 
 > The local working clone is usually the **public mirror** (`aztec-packages`), which has *different commits and PR numbers*. Do not infer deployed code from local `origin/next`.
 
@@ -30,13 +30,13 @@ If the optional live cross-check (step 4) is needed, the subagent can itself del
 | staging (public) | Deploy to staging public | 244296513 | aztec-packages (PUBLIC) | `next` → `v5.0.0-nightly.<date>` tag | nightly, cron `0 6 * * *` UTC |
 | staging (internal) | Deploy to staging internal | 292462388 | aztec-packages-private | `next` → `v5.0.0-nightly.<date>` tag | nightly, cron `0 6 * * *` UTC |
 
-> Watch the repo column. The scheduled "Deploy to staging public" run is gated to `github.repository == 'AztecProtocol/aztec-packages'`, so in the **private** repo those runs show as `skipped` — its real run history lives in the **public** `aztec-packages` repo. The other three deploy from the private repo.
+> Watch the repo column. The scheduled "Deploy to staging public" run is gated to `github.repository == 'aztec-labs-eng/aztec-node'`, so in the **private** repo those runs show as `skipped` — its real run history lives in the **public** `aztec-packages` repo. The other three deploy from the private repo.
 
 Re-confirm ids/branches with `gh workflow list -R AztecProtocol/aztec-packages-private --all` and the YAML under `.github/workflows/`.
 
 ## Procedure
 
-The subagent runs these steps. Use the repo from the table above for each network — private for most, public (`AztecProtocol/aztec-packages`) for staging-public — substituting it for `-R AztecProtocol/aztec-packages-private` in the commands below.
+The subagent runs these steps. Use the repo from the table above for each network — private for most, public (`aztec-labs-eng/aztec-node`) for staging-public — substituting it for `-R AztecProtocol/aztec-packages-private` in the commands below.
 
 1. **Find the live commit at time T.** Use the repo from the table above (either private or public):
    ```bash


### PR DESCRIPTION
Stacked on #25192. Points the labs repo's self-identity references at `aztec-labs-eng/aztec-node`.

Part of A-1463 .

Self-identity references only: `github.repository` guards, `gh`/API paths, generated PR/commit/run URLs, the EC2 bootstrap clone dir and `GITHUB_REPOSITORY` defaults, `aws_instance_name`, dashboard `REPO` constants and page titles, container mount paths (build-images, playground compose, dashboard Dockerfiles, aztec-up tests), CONTRIBUTING/SECURITY links, `.claude` agent/skill commands, and stale branch components inside those links (`commits/next`, `blob/next`, `blob/master`).

Deliberately NOT renamed:

- `labs-aztec-toolchain` download URLs — they fetch foundation-released binaries from `AztecProtocol/aztec-packages` / `AztecProtocol/barretenberg`, which keep their names. Playground's pinned artifacts likewise.
- Historical issue/commit/PR links in code comments, CHANGELOG, `.test_patterns.yml`, and the ci-health report — that content lives in the old repo and a new repo gets no redirects.
- All `aztec-packages-private` references (release safety gates, `private-fork-release.yml`, `deploy-staging-internal` guards) — the private-fork story for this repo is undecided; `private-fork-release.yml` belongs with the deleted sync machinery if the answer is "no fork".
- `docs/` content links (~140 files, many into foundation-only paths) — needs a content-aware pass, as do the merge-trains skill body and root CLAUDE.md body.

The renamed guards assume the new repo is exactly `aztec-labs-eng/aztec-node`; if the final name differs it's a one-line sed.
