### PR TITLE
refactor(txe): return TxEffects as a struct from the oracle

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/test/helpers/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/test/helpers/mod.nr
@@ -3,7 +3,6 @@ use crate::macros::oracle_testing::generate_oracle_tests_excluding;
 pub mod test_environment;
 #[generate_oracle_tests_excluding(
     @[
-        quote { get_last_tx_effects_oracle }, // TODO: implement once we support more complex types
         quote { deploy_oracle }, // TODO: implement once we support more complex types
         quote { set_tagging_secret_strategies }, // TODO: implement once we support more complex types
     ],

--- a/noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -21,7 +21,7 @@ use crate::protocol::{
 /// [`oracle::version`](crate::oracle::version), which covers oracles used during contract execution by PXE.
 ///
 /// The TypeScript counterparts are in `yarn-project/txe/src/oracle/txe_oracle_version.ts`.
-pub global TXE_ORACLE_VERSION_MAJOR: Field = 6;
+pub global TXE_ORACLE_VERSION_MAJOR: Field = 7;
 pub global TXE_ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the TXE oracle interface version is compatible.
@@ -145,6 +145,7 @@ pub type TxPrivateLog = BoundedVec<Field, PRIVATE_LOG_SIZE_IN_FIELDS>;
 pub type TxPrivateLogs = BoundedVec<TxPrivateLog, MAX_PRIVATE_LOGS_PER_TX>;
 
 /// The side effects of a single transaction, as surfaced by [`get_last_tx_effects`].
+#[derive(Eq)]
 pub struct TxEffects {
     pub tx_hash: Field,
     pub note_hashes: TxNoteHashes,
@@ -153,19 +154,8 @@ pub struct TxEffects {
 }
 
 /// Returns the effects of the last transaction included by the TXE.
-pub unconstrained fn get_last_tx_effects() -> TxEffects {
-    let (tx_hash, note_hashes, nullifiers, raw_log_storage, log_lengths, log_count) = get_last_tx_effects_oracle();
-
-    let mut private_logs = BoundedVec::new();
-    for i in 0..log_count {
-        private_logs.push(BoundedVec::from_parts(raw_log_storage[i], log_lengths[i]));
-    }
-
-    TxEffects { tx_hash, note_hashes, nullifiers, private_logs }
-}
-
 #[oracle(aztec_txe_getLastTxEffects)]
-unconstrained fn get_last_tx_effects_oracle() -> (Field, TxNoteHashes, TxNullifiers, [[Field; PRIVATE_LOG_SIZE_IN_FIELDS]; MAX_PRIVATE_LOGS_PER_TX], [u32; MAX_PRIVATE_LOGS_PER_TX], u32) {}
+pub unconstrained fn get_last_tx_effects() -> TxEffects {}
 
 /// Returns the raw offchain effect payloads emitted by the last top-level call into TXE.
 /// Each effect is a variable-length field array (e.g. offchain messages have a different size

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -42,6 +42,7 @@ export {
   SLOT_NUMBER,
   STR,
   STRUCT,
+  TX_HASH,
   U32,
   U64,
   U128,

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -1,5 +1,4 @@
 import { CompleteAddress } from '@aztec/aztec.js/addresses';
-import { TxHash } from '@aztec/aztec.js/tx';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -8,8 +7,9 @@ import type { Option } from '@aztec/pxe/simulator';
 import type { EventSelector, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { GasSettings } from '@aztec/stdlib/gas';
-import type { PrivateLog } from '@aztec/stdlib/logs';
 import type { UInt64 } from '@aztec/stdlib/types';
+
+import type { TxEffectsData } from './noir-structs/tx_effects_data.js';
 
 // These interfaces complement the ones defined in PXE, and combined with those contain the full list of oracles used by
 // aztec-nr. In particular, these include the ones needed to run Brillig code associated to #[external("public")] functions that has
@@ -86,12 +86,7 @@ export interface ITxeExecutionOracle {
    */
   setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void;
   getLastBlockTimestamp(): Promise<bigint>;
-  getLastTxEffects(): Promise<{
-    txHash: TxHash;
-    noteHashes: Fr[];
-    nullifiers: Fr[];
-    privateLogs: PrivateLog[];
-  }>;
+  getLastTxEffects(): Promise<TxEffectsData>;
   getPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
   privateCallNewFlow(
     from: AztecAddress | undefined,

--- a/yarn-project/txe/src/oracle/noir-structs/tx_effects_data.ts
+++ b/yarn-project/txe/src/oracle/noir-structs/tx_effects_data.ts
@@ -1,0 +1,11 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { TxHash } from '@aztec/stdlib/tx';
+
+type TxPrivateLog = Fr[];
+
+export type TxEffectsData = {
+  txHash: TxHash;
+  noteHashes: Fr[];
+  nullifiers: Fr[];
+  privateLogs: TxPrivateLog[];
+};

--- a/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
+++ b/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
@@ -20,6 +20,7 @@ import {
   type OracleRegistryEntry,
   SLOT_NUMBER,
   type StructMapping,
+  TX_HASH,
   type TypeMapping,
   U8,
   U32,
@@ -36,6 +37,7 @@ import {
 import { EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { BlockHash } from '@aztec/stdlib/block';
 import { AppTaggingSecretKind } from '@aztec/stdlib/logs';
+import { TxHash } from '@aztec/stdlib/tx';
 
 import { EVENT_SELECTOR } from '../txe_oracle_registry.js';
 import type { OracleTestScenario } from './resolver.js';
@@ -81,6 +83,7 @@ const SCALAR_IMPLS: ScalarImpl[] = [
   scalar(NOTE_SELECTOR, seed => NoteSelector.fromField(new Fr(seed))),
   scalar(BLOCK_HASH, seed => new BlockHash(new Fr(seed))),
   scalar(SLOT_NUMBER, seed => SlotNumber(seed)),
+  scalar(TX_HASH, seed => TxHash.fromField(new Fr(seed))),
   // Only two delivery modes are valid for tagging, so the seed alternates between them, matching the Noir impl.
   scalar(DELIVERY_MODE, seed =>
     seed % 2 === 0 ? AppTaggingSecretKind.UNCONSTRAINED : AppTaggingSecretKind.CONSTRAINED,

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -34,6 +34,7 @@ import {
   SCALAR,
   STR,
   STRUCT,
+  TX_HASH,
   type TypeMapping,
   U32,
   U64,
@@ -43,8 +44,7 @@ import {
 import { EventSelector } from '@aztec/stdlib/abi';
 import { CompleteAddress } from '@aztec/stdlib/contract';
 import type { PrivateContextInputs } from '@aztec/stdlib/kernel';
-import type { PrivateLog } from '@aztec/stdlib/logs';
-import type { CallContext, TxContext, TxHash } from '@aztec/stdlib/tx';
+import type { CallContext, TxContext } from '@aztec/stdlib/tx';
 
 import {
   MAX_OFFCHAIN_EFFECTS_PER_TXE_QUERY,
@@ -54,6 +54,7 @@ import {
 } from '../constants.js';
 import type { ForeignCallArgs, ForeignCallResult } from '../utils/encoding.js';
 import type { GasData, GasSettingsData } from './noir-structs/gas_settings_data.js';
+import type { TxEffectsData } from './noir-structs/tx_effects_data.js';
 
 // Spreading `ORACLE_REGISTRY` re-materializes its entries into `TXE_ORACLE_REGISTRY`'s inferred type, which names the
 // protocol types below. Re-exporting them gives tsc a portable path to each instead of falling back to a deep
@@ -146,52 +147,15 @@ const COMPLETE_ADDRESS: TypeMapping<CompleteAddress> = STRUCT([
   { name: 'publicKeys', type: PUBLIC_KEYS },
 ]);
 
-const TXE_TX_EFFECTS: TypeMapping<{
-  txHash: TxHash;
-  noteHashes: Fr[];
-  nullifiers: Fr[];
-  privateLogs: PrivateLog[];
-}> = LEAF({
-  kind: 'txe-tx-effects',
-  serialization: {
-    fn: ({ txHash, noteHashes, nullifiers, privateLogs }) => {
-      const emittedLogs = privateLogs.map(log => log.getEmittedFields());
-      const rawLogStorage = emittedLogs
-        .map(fields => fields.concat(Array(PRIVATE_LOG_SIZE_IN_FIELDS - fields.length).fill(Fr.ZERO)))
-        .concat(
-          Array(MAX_PRIVATE_LOGS_PER_TX - emittedLogs.length).fill(Array(PRIVATE_LOG_SIZE_IN_FIELDS).fill(Fr.ZERO)),
-        )
-        .flat();
-      const logLengths = emittedLogs
-        .map(fields => new Fr(fields.length))
-        .concat(Array(MAX_PRIVATE_LOGS_PER_TX - emittedLogs.length).fill(Fr.ZERO));
-      const paddedNoteHashes = noteHashes.concat(Array(MAX_NOTE_HASHES_PER_TX - noteHashes.length).fill(Fr.ZERO));
-      const paddedNullifiers = nullifiers.concat(Array(MAX_NULLIFIERS_PER_TX - nullifiers.length).fill(Fr.ZERO));
-
-      return [
-        txHash.hash,
-        paddedNoteHashes,
-        new Fr(noteHashes.length),
-        paddedNullifiers,
-        new Fr(nullifiers.length),
-        rawLogStorage,
-        logLengths,
-        new Fr(emittedLogs.length),
-      ] as (Fr | Fr[])[];
-    },
+const TXE_TX_EFFECTS: TypeMapping<TxEffectsData> = STRUCT([
+  { name: 'txHash', type: TX_HASH },
+  { name: 'noteHashes', type: FIXED_BOUNDED_VEC(FIELD, MAX_NOTE_HASHES_PER_TX) },
+  { name: 'nullifiers', type: FIXED_BOUNDED_VEC(FIELD, MAX_NULLIFIERS_PER_TX) },
+  {
+    name: 'privateLogs',
+    type: FIXED_BOUNDED_VEC(FIXED_BOUNDED_VEC(FIELD, PRIVATE_LOG_SIZE_IN_FIELDS), MAX_PRIVATE_LOGS_PER_TX),
   },
-  // txHash, padded note hashes + count, padded nullifiers + count, flattened private-log storage + lengths + count.
-  shape: [
-    'scalar',
-    { len: MAX_NOTE_HASHES_PER_TX },
-    'scalar',
-    { len: MAX_NULLIFIERS_PER_TX },
-    'scalar',
-    { len: MAX_PRIVATE_LOGS_PER_TX * PRIVATE_LOG_SIZE_IN_FIELDS },
-    { len: MAX_PRIVATE_LOGS_PER_TX },
-    'scalar',
-  ],
-});
+]);
 
 const TXE_OFFCHAIN_EFFECTS: TypeMapping<Fr[][]> = FIXED_BOUNDED_VEC(
   FIXED_BOUNDED_VEC(FIELD, MAX_OFFCHAIN_EFFECT_LEN),

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -1,8 +1,4 @@
-import {
-  CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
-  MAX_PRIVATE_LOGS_PER_TX,
-  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-} from '@aztec/constants';
+import { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Schnorr } from '@aztec/foundation/crypto/schnorr';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -72,7 +68,6 @@ import {
   PublicCallRequest,
 } from '@aztec/stdlib/kernel';
 import { deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
-import type { PrivateLog } from '@aztec/stdlib/logs';
 import { AppTaggingSecretKind } from '@aztec/stdlib/logs';
 import { L1Actor, L1ToL2Message, L2Actor } from '@aztec/stdlib/messaging';
 import { ChonkProof } from '@aztec/stdlib/proofs';
@@ -100,6 +95,7 @@ import type { TXEAccountStore } from '../utils/txe_account_store.js';
 import type { TXEArtifactResolver } from '../utils/txe_artifact_resolver.js';
 import { TXEPublicContractDataSource } from '../utils/txe_public_contract_data_source.js';
 import type { ITxeExecutionOracle } from './interfaces.js';
+import type { TxEffectsData } from './noir-structs/tx_effects_data.js';
 import { type TXETaggingSecretStrategies, makeResolveTaggingSecretStrategyHook } from './tagging_secret_strategy.js';
 
 export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracle {
@@ -188,7 +184,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return (await this.stateMachine.node.getBlockData('latest'))!.header.globalVariables.timestamp;
   }
 
-  async getLastTxEffects(): Promise<{ txHash: TxHash; noteHashes: Fr[]; nullifiers: Fr[]; privateLogs: PrivateLog[] }> {
+  async getLastTxEffects(): Promise<TxEffectsData> {
     const latestBlockNumber = await this.stateMachine.archiver.getBlockNumber();
     const block = await this.stateMachine.archiver.getBlock({ number: latestBlockNumber });
 
@@ -199,16 +195,11 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const txEffects = block!.body.txEffects[0];
 
-    const privateLogs = txEffects.privateLogs;
-    if (privateLogs.length > MAX_PRIVATE_LOGS_PER_TX) {
-      throw new Error(`${privateLogs.length} private logs exceed max ${MAX_PRIVATE_LOGS_PER_TX}`);
-    }
-
     return {
       txHash: txEffects.txHash,
       noteHashes: txEffects.noteHashes,
       nullifiers: txEffects.nullifiers,
-      privateLogs,
+      privateLogs: txEffects.privateLogs.map(log => log.getEmittedFields()),
     };
   }
 

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -5,7 +5,7 @@
  *
  * The Noir counterparts are in `noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
-export const TXE_ORACLE_VERSION_MAJOR = 6;
+export const TXE_ORACLE_VERSION_MAJOR = 7;
 export const TXE_ORACLE_VERSION_MINOR = 0;
 
 /**
@@ -14,4 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 0;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-export const TXE_ORACLE_INTERFACE_HASH = 'df1e60d80159d05ba98ad1e7a427e3f2dfe33195f8f09c79d8062841ea022036';
+export const TXE_ORACLE_INTERFACE_HASH = 'd062900c87e89ac162a7a1759be638facdd14f4a43c886bd70871240b6b1a1a1';


### PR DESCRIPTION
## Summary

Same treatment as #25174 and #25173: `get_last_tx_effects` returned a 6-element tuple that Noir
reassembled by hand, so the TS side had to be a hand-rolled `LEAF` that flattened note hashes,
nullifiers and private logs itself. It now returns a `TxEffects` struct described by a compositional
`STRUCT`, dropping both the manual serialization and the reassembly wrapper.

Being compositional is also what lets the generated oracle tests cover it: a hand-rolled `LEAF` has
no test-value implementation, so the oracle had to sit on `mod.nr`'s exclusion list. It comes off
that list here, and `__oracle_test__get_last_tx_effects` now runs with the rest.

The wire format changed, so `TXE_ORACLE_VERSION_MAJOR` goes to 7.