### PR TITLE
fix(validator): do not turn stale proposal re-validation into slashable offenses

### DIFF
--- a/yarn-project/p2p/src/msg_validators/proposal_validator/README.md
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/README.md
@@ -38,7 +38,7 @@ Only runs on validator nodes. Non-validator nodes use a default handler that tri
 | # | Rule | Failure Reason |
 |---|------|----------------|
 | 12 | Signature re-check | `invalid_proposal` |
-| 13 | ProposalValidator re-run | `invalid_proposal` |
+| 13 | ProposalValidator re-run, via `validateStableFields` (rules 2-8; the rule 1 receive-window check is deliberately *not* repeated, since its outcome depends on the wall clock when it runs rather than on the proposal) | `proposal_revalidation_failed` |
 | 14 | Self-proposal filter | Ignored silently |
 | 15 | Parent block exists (`lastArchive.root` matches known block or genesis) | `parent_block_not_found` |
 | 16 | Parent block slot <= proposal slot | `parent_block_wrong_slot` |
@@ -55,7 +55,7 @@ Only runs on validator nodes. Non-validator nodes use a default handler that tri
 
 **Conditional re-execution**: rules 22-24 only run when at least one condition is true: `fishermanMode` enabled, `slashBroadcastedInvalidBlockPenalty > 0`, committee membership, `alwaysReexecuteBlockProposals`, or `blobClient.canUpload()`.
 
-**Slashing**: only `state_mismatch` and `failed_txs` trigger on-chain slashing (`OffenseType.BROADCASTED_INVALID_BLOCK_PROPOSAL`, gated by `slashBroadcastedInvalidBlockPenalty > 0`). Unknown errors during re-execution do NOT slash.
+**Slashing**: only `state_mismatch` and `failed_txs` trigger on-chain slashing (`OffenseType.BROADCASTED_INVALID_BLOCK_PROPOSAL`, gated by `slashBroadcastedInvalidBlockPenalty > 0`). Unknown errors during re-execution do NOT slash. `proposal_revalidation_failed` is likewise never slashable: this node already accepted the same signed proposal at Stage 1, so a re-check that now disagrees points at a changed local view (committee, clock, config), not at the proposer.
 
 **Embedded tx validation**: txs in `signedTxs` are validated via `createTxValidatorForBlockProposalReceivedTxs` (well-formedness only) when stored in the tx pool. Invalid embedded txs are rejected from the pool but do not cause the block proposal itself to be rejected at gossipsub level.
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
@@ -1,8 +1,8 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import type { BlockProposal, CoordinationSignatureContext, P2PValidator, ValidationResult } from '@aztec/stdlib/p2p';
+import type { BlockProposal, CoordinationSignatureContext, P2PValidator } from '@aztec/stdlib/p2p';
 import type { ConsensusTimetable } from '@aztec/stdlib/timetable';
 
-import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
+import { type ProposalValidationResult, ProposalValidator } from '../proposal_validator/proposal_validator.js';
 
 export class BlockProposalValidator implements P2PValidator<BlockProposal> {
   private proposalValidator: ProposalValidator;
@@ -22,8 +22,23 @@ export class BlockProposalValidator implements P2PValidator<BlockProposal> {
     this.proposalValidator = new ProposalValidator(epochCache, timetable, opts, 'p2p:block_proposal_validator');
   }
 
-  async validate(proposal: BlockProposal): Promise<ValidationResult> {
+  async validate(proposal: BlockProposal): Promise<ProposalValidationResult> {
     const headerResult = await this.proposalValidator.validate(proposal);
+    if (headerResult.result !== 'accept') {
+      return headerResult;
+    }
+    return this.proposalValidator.validateTxs(proposal);
+  }
+
+  /**
+   * Runs every check `validate` runs except whether the proposal arrived inside its receive window. Intended
+   * for callers that already accepted this exact proposal on arrival and are re-checking it later: the
+   * receive-window check depends on the wall clock at evaluation time, so repeating it would fail an on-time
+   * proposal purely because processing started late. Every other check, including the full transaction-field
+   * validation, is a property of the signed payload and still applies.
+   */
+  async validateStableFields(proposal: BlockProposal): Promise<ProposalValidationResult> {
+    const headerResult = await this.proposalValidator.validateStableFields(proposal);
     if (headerResult.result !== 'accept') {
       return headerResult;
     }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
@@ -1,13 +1,8 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import type {
-  CheckpointProposal,
-  CoordinationSignatureContext,
-  P2PValidator,
-  ValidationResult,
-} from '@aztec/stdlib/p2p';
+import type { CheckpointProposal, CoordinationSignatureContext, P2PValidator } from '@aztec/stdlib/p2p';
 import type { ConsensusTimetable } from '@aztec/stdlib/timetable';
 
-import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
+import { type ProposalValidationResult, ProposalValidator } from '../proposal_validator/proposal_validator.js';
 
 export class CheckpointProposalValidator implements P2PValidator<CheckpointProposal> {
   private proposalValidator: ProposalValidator;
@@ -27,7 +22,7 @@ export class CheckpointProposalValidator implements P2PValidator<CheckpointPropo
     this.proposalValidator = new ProposalValidator(epochCache, timetable, opts, 'p2p:checkpoint_proposal_validator');
   }
 
-  async validate(proposal: CheckpointProposal): Promise<ValidationResult> {
+  async validate(proposal: CheckpointProposal): Promise<ProposalValidationResult> {
     const headerResult = await this.proposalValidator.validate(proposal);
     if (headerResult.result !== 'accept') {
       return headerResult;

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -125,7 +125,11 @@ describe('ProposalValidator', () => {
       const proposal = await factory(currentSlot, Secp256k1Signer.random(), foreignSignatureContext);
 
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.LowToleranceError,
+        code: 'foreign_signature_context',
+      });
     });
 
     it('rejects with high tolerance error if slot is outside its receive window', async () => {
@@ -142,7 +146,11 @@ describe('ProposalValidator', () => {
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(EthAddress.random());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
+      });
       expect(epochCache.getProposerAttesterAddressInSlot).not.toHaveBeenCalled();
     });
 
@@ -172,7 +180,11 @@ describe('ProposalValidator', () => {
 
       mockGetProposer(signer.address, EthAddress.random());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'invalid_signature',
+      });
       expect(epochCache.getProposerAttesterAddressInSlot).not.toHaveBeenCalled();
     });
 
@@ -181,7 +193,11 @@ describe('ProposalValidator', () => {
 
       mockGetProposer(EthAddress.random(), EthAddress.random());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'wrong_proposer',
+      });
     });
 
     it('rejects with mid tolerance error if proposer is wrong for next slot', async () => {
@@ -197,7 +213,11 @@ describe('ProposalValidator', () => {
       });
       mockGetProposer(EthAddress.random(), EthAddress.random());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'wrong_proposer',
+      });
     });
 
     it('rejects with mid tolerance error if current proposer sends for next slot', async () => {
@@ -212,7 +232,11 @@ describe('ProposalValidator', () => {
       });
       mockGetProposer(currentProposer.address, EthAddress.random());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'wrong_proposer',
+      });
     });
 
     it('rejects with high tolerance error when proposer is undefined (open committee)', async () => {
@@ -220,7 +244,11 @@ describe('ProposalValidator', () => {
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(undefined);
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.HighToleranceError,
+        code: 'no_expected_proposer',
+      });
     });
 
     it('rejects with low tolerance error on NoCommitteeError', async () => {
@@ -228,7 +256,11 @@ describe('ProposalValidator', () => {
 
       epochCache.getProposerAttesterAddressInSlot.mockRejectedValue(new NoCommitteeError());
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.LowToleranceError,
+        code: 'no_committee',
+      });
     });
 
     it('accepts valid proposal for current slot', async () => {
@@ -303,7 +335,11 @@ describe('ProposalValidator', () => {
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
+      });
     });
   });
 
@@ -332,7 +368,11 @@ describe('ProposalValidator', () => {
       });
 
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
+      });
     });
 
     it('accepts a checkpoint proposal for the target slot arriving within the receive window', async () => {
@@ -369,7 +409,11 @@ describe('ProposalValidator', () => {
       });
 
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
+      });
     });
   });
 
@@ -407,6 +451,7 @@ describe('ProposalValidator', () => {
       expect(await validateAt(buildFrameStart - deltaSeconds - 0.001)).toEqual({
         result: 'reject',
         severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
       });
     });
 
@@ -418,6 +463,7 @@ describe('ProposalValidator', () => {
       expect(await validateAt(proposalDeadline + deltaSeconds + 0.001)).toEqual({
         result: 'reject',
         severity: PeerErrorSeverity.HighToleranceError,
+        code: 'outside_receive_window',
       });
     });
   });
@@ -439,7 +485,11 @@ describe('ProposalValidator', () => {
 
         const proposal = await makeBlockProposal({ txHashes: [TxHash.random(), TxHash.random()] });
         const result = await validator.validateTxs(proposal);
-        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+        expect(result).toEqual({
+          result: 'reject',
+          severity: PeerErrorSeverity.MidToleranceError,
+          code: 'txs_not_permitted',
+        });
       });
 
       it('accepts proposal with no txHashes when txs not permitted', async () => {
@@ -476,7 +526,11 @@ describe('ProposalValidator', () => {
         Object.defineProperty(proposal, 'txs', { get: () => [fakeTx], configurable: true });
 
         const result = await validator.validateTxs(proposal);
-        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+        expect(result).toEqual({
+          result: 'reject',
+          severity: PeerErrorSeverity.MidToleranceError,
+          code: 'embedded_tx_not_listed',
+        });
       });
 
       it('rejects if embedded tx has invalid tx hash', async () => {
@@ -487,7 +541,11 @@ describe('ProposalValidator', () => {
         Object.defineProperty(proposal, 'txs', { get: () => [fakeTx], configurable: true });
 
         const result = await validator.validateTxs(proposal);
-        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+        expect(result).toEqual({
+          result: 'reject',
+          severity: PeerErrorSeverity.LowToleranceError,
+          code: 'invalid_embedded_tx_hash',
+        });
       });
     });
 
@@ -507,7 +565,11 @@ describe('ProposalValidator', () => {
 
         const proposal = await makeBlockProposal({ txHashes: Array.from({ length: 3 }, () => TxHash.random()) });
         const result = await validator.validateTxs(proposal);
-        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+        expect(result).toEqual({
+          result: 'reject',
+          severity: PeerErrorSeverity.MidToleranceError,
+          code: 'too_many_txs',
+        });
       });
 
       it('accepts when txHashes count equals maxTxsPerBlock', async () => {
@@ -583,7 +645,11 @@ describe('ProposalValidator', () => {
         signer,
       });
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'index_beyond_attestable_ceiling',
+      });
     });
 
     it('accepts a block proposal whose indexWithinCheckpoint is below the cap (4 < 5)', async () => {
@@ -623,7 +689,11 @@ describe('ProposalValidator', () => {
         signer,
       });
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'index_beyond_attestable_ceiling',
+      });
     });
 
     it('accepts the last block within the attestable limit', async () => {
@@ -663,7 +733,11 @@ describe('ProposalValidator', () => {
         },
       });
       const result = await checkpointValidator.validate(proposal);
-      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      expect(result).toEqual({
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'index_beyond_attestable_ceiling',
+      });
     });
 
     it('accepts when the embedded last block is within the attestable limit', async () => {

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -1,5 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { NoCommitteeError } from '@aztec/ethereum/contracts';
+import type { SlotNumber } from '@aztec/foundation/branded-types';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '@aztec/stdlib/deserialization';
 import {
@@ -11,6 +12,26 @@ import {
   hasValidSignatureContext,
 } from '@aztec/stdlib/p2p';
 import type { ConsensusTimetable } from '@aztec/stdlib/timetable';
+
+/** Identifies which sub-check of proposal validation rejected a proposal. */
+export type ProposalRejectionCode =
+  | 'foreign_signature_context'
+  | 'outside_receive_window'
+  | 'invalid_signature'
+  | 'no_expected_proposer'
+  | 'wrong_proposer'
+  | 'index_beyond_attestable_ceiling'
+  | 'no_committee'
+  | 'txs_not_permitted'
+  | 'too_many_txs'
+  | 'embedded_tx_not_listed'
+  | 'invalid_embedded_tx_hash';
+
+/**
+ * A `ValidationResult` from proposal validation, annotated with the sub-check that produced it so callers
+ * can log or attribute a rejection without re-deriving it.
+ */
+export type ProposalValidationResult = ValidationResult & { code?: ProposalRejectionCode };
 
 /** Validates header-level and tx-level fields of block and checkpoint proposals. */
 export class ProposalValidator {
@@ -46,67 +67,114 @@ export class ProposalValidator {
     this.logger = createLogger(loggerName);
   }
 
-  /** Validates header-level fields: slot, signature, and proposer. */
-  public async validate(proposal: BlockProposal | CheckpointProposalCore): Promise<ValidationResult> {
+  /**
+   * Validates header-level fields for a proposal arriving from the network: signature context, arrival
+   * inside the receive window, signature, proposer, and block index.
+   */
+  public validate(proposal: BlockProposal | CheckpointProposalCore): Promise<ProposalValidationResult> {
+    const contextResult = this.validateSignatureContext(proposal);
+    if (contextResult.result !== 'accept') {
+      return Promise.resolve(contextResult);
+    }
+
+    const windowResult = this.validateReceiveWindow(proposal.slotNumber);
+    if (windowResult.result !== 'accept') {
+      return Promise.resolve(windowResult);
+    }
+
+    return this.validateSignerAndIndex(proposal);
+  }
+
+  /**
+   * Validates every header-level field except arrival inside the receive window: signature context,
+   * signature, proposer, and block index. All of these are properties of the signed payload, so they give
+   * the same answer no matter when they run — unlike the receive-window check, whose outcome depends on the
+   * wall clock at the moment of evaluation. Callers that already accepted a proposal on arrival use this so
+   * a slow local pipeline cannot turn an on-time proposal into an invalid one.
+   */
+  public validateStableFields(proposal: BlockProposal | CheckpointProposalCore): Promise<ProposalValidationResult> {
+    const contextResult = this.validateSignatureContext(proposal);
+    if (contextResult.result !== 'accept') {
+      return Promise.resolve(contextResult);
+    }
+
+    return this.validateSignerAndIndex(proposal);
+  }
+
+  /** Cross-chain replay check: rejects proposals that carry a foreign signing domain. */
+  private validateSignatureContext(proposal: BlockProposal | CheckpointProposalCore): ProposalValidationResult {
+    if (!hasValidSignatureContext(proposal, this.signatureContext)) {
+      this.logger.warn(`Penalizing peer for proposal with foreign signature context`, {
+        chainId: proposal.signatureContext.chainId,
+        rollupAddress: proposal.signatureContext.rollupAddress.toString(),
+        expectedChainId: this.signatureContext.chainId,
+        expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
+      });
+      return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError, code: 'foreign_signature_context' };
+    }
+    return { result: 'accept' };
+  }
+
+  /**
+   * Slot check: the tight checkpoint proposal receive window (`[receiveStart - δ, target_slot_start - E - D
+   * + δ]`) is the sole acceptance gate, applied to both block and checkpoint proposals. The window itself
+   * bounds which slots are valid, so far/wrong slots fall outside it. Every block proposal for slot N is
+   * sent before the checkpoint proposal for slot N, so nothing legitimate can arrive after the checkpoint
+   * receive deadline; gating block proposals on the same window rejects late block proposals at p2p
+   * ingress. The attestation deadline remains their re-execution/validation deadline downstream, not their
+   * arrival gate.
+   *
+   * This is the only time-of-check-sensitive part of proposal validation: it answers "did this arrive on
+   * time", not "is this proposal well-formed", so it belongs to arrival handling alone.
+   */
+  private validateReceiveWindow(slotNumber: SlotNumber): ProposalValidationResult {
+    if (this.skipSlotValidation) {
+      return { result: 'accept' };
+    }
+
+    // Proposal receive window: [checkpoint_proposal_receive_start, checkpoint_proposal_receive_deadline],
+    // widened by the configured clock-disparity tolerance on both ends.
+    const startSeconds = this.timetable.getCheckpointProposalReceiveStart(slotNumber);
+    const deadlineSeconds = this.timetable.getCheckpointProposalReceiveDeadline(slotNumber);
+    const nowMs = Number(this.epochCache.getEpochAndSlotNow().nowMs);
+    if (nowMs < startSeconds * 1000 - this.clockDisparityMs || nowMs > deadlineSeconds * 1000 + this.clockDisparityMs) {
+      this.logger.warn(`Penalizing peer for invalid slot number ${slotNumber}`, {
+        slotNumber,
+        nowMs,
+        windowStartSeconds: startSeconds,
+        windowDeadlineSeconds: deadlineSeconds,
+      });
+      return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError, code: 'outside_receive_window' };
+    }
+
+    return { result: 'accept' };
+  }
+
+  /** Validates the proposal signature, the expected proposer for the slot, and the block index. */
+  private async validateSignerAndIndex(
+    proposal: BlockProposal | CheckpointProposalCore,
+  ): Promise<ProposalValidationResult> {
+    const slotNumber = proposal.slotNumber;
     try {
-      // Cross-chain replay check: reject proposals that carry a foreign signing domain.
-      if (!hasValidSignatureContext(proposal, this.signatureContext)) {
-        this.logger.warn(`Penalizing peer for proposal with foreign signature context`, {
-          chainId: proposal.signatureContext.chainId,
-          rollupAddress: proposal.signatureContext.rollupAddress.toString(),
-          expectedChainId: this.signatureContext.chainId,
-          expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
-        });
-        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
-      }
-
-      // Slot check: the tight checkpoint proposal receive window (`[receiveStart - δ, target_slot_start -
-      // E - D + δ]`) is the sole acceptance gate, applied to both block and checkpoint proposals. The
-      // window itself bounds which slots are valid, so far/wrong slots fall outside it. Every block
-      // proposal for slot N is sent before the checkpoint proposal for slot N, so nothing legitimate can
-      // arrive after the checkpoint receive deadline; gating block proposals on the same window rejects
-      // late block proposals at p2p ingress. The attestation deadline remains their re-execution/
-      // validation deadline downstream, not their arrival gate.
-      const slotNumber = proposal.slotNumber;
-      if (!this.skipSlotValidation) {
-        // Proposal receive window: [checkpoint_proposal_receive_start, checkpoint_proposal_receive_deadline],
-        // widened by the configured clock-disparity tolerance on both ends.
-        const startSeconds = this.timetable.getCheckpointProposalReceiveStart(slotNumber);
-        const deadlineSeconds = this.timetable.getCheckpointProposalReceiveDeadline(slotNumber);
-        const nowMs = Number(this.epochCache.getEpochAndSlotNow().nowMs);
-        if (
-          nowMs < startSeconds * 1000 - this.clockDisparityMs ||
-          nowMs > deadlineSeconds * 1000 + this.clockDisparityMs
-        ) {
-          this.logger.warn(`Penalizing peer for invalid slot number ${slotNumber}`, {
-            slotNumber,
-            nowMs,
-            windowStartSeconds: startSeconds,
-            windowDeadlineSeconds: deadlineSeconds,
-          });
-          return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
-        }
-      }
-
       // Signature validity
       const proposer = proposal.getSender();
       if (!proposer) {
         this.logger.warn(`Penalizing peer for proposal with invalid signature`);
-        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError, code: 'invalid_signature' };
       }
 
       // Proposer check
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
       if (expectedProposer === undefined) {
         this.logger.warn(`Penalizing peer for proposal with no expected proposer for current slot ${slotNumber}`);
-        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError, code: 'no_expected_proposer' };
       }
       if (!proposer.equals(expectedProposer)) {
         this.logger.warn(`Penalizing peer for invalid proposer for current slot ${slotNumber}`, {
           expectedProposer,
           proposer: proposer.toString(),
         });
-        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError, code: 'wrong_proposer' };
       }
 
       // A block proposal whose index lands at or beyond the hard attestable ceiling is structurally
@@ -125,7 +193,7 @@ export class ProposalValidator {
       return { result: 'accept' };
     } catch (e) {
       if (e instanceof NoCommitteeError) {
-        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError, code: 'no_committee' };
       }
       throw e;
     }
@@ -143,25 +211,29 @@ export class ProposalValidator {
    * proposal per (slot, proposer) as slashing evidence and skips processing it. Applies to standalone
    * block proposals and to the terminal block embedded in a checkpoint proposal.
    */
-  public validateBlockIndexWithinCheckpoint(proposal: BlockProposal): ValidationResult {
+  public validateBlockIndexWithinCheckpoint(proposal: BlockProposal): ProposalValidationResult {
     if (proposal.indexWithinCheckpoint >= MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT) {
       this.logger.warn(
         `Penalizing peer for proposal with indexWithinCheckpoint ${proposal.indexWithinCheckpoint} >= attestable ceiling ${MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT}`,
       );
-      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+      return {
+        result: 'reject',
+        severity: PeerErrorSeverity.MidToleranceError,
+        code: 'index_beyond_attestable_ceiling',
+      };
     }
     return { result: 'accept' };
   }
 
   /** Validates transaction-related fields of a block proposal. */
-  public async validateTxs(proposal: BlockProposal): Promise<ValidationResult> {
+  public async validateTxs(proposal: BlockProposal): Promise<ProposalValidationResult> {
     // Transactions permitted check
     const embeddedTxCount = proposal.txs?.length ?? 0;
     if (!this.txsPermitted && (proposal.txHashes.length > 0 || embeddedTxCount > 0)) {
       this.logger.warn(
         `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when transactions are not permitted`,
       );
-      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError, code: 'txs_not_permitted' };
     }
 
     // Max txs per block check
@@ -169,7 +241,7 @@ export class ProposalValidator {
       this.logger.warn(
         `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when max is ${this.maxTxsPerBlock}`,
       );
-      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError, code: 'too_many_txs' };
     }
 
     // Embedded txs must be listed in txHashes
@@ -184,13 +256,13 @@ export class ProposalValidator {
         txHashesLength: proposal.txHashes.length,
         missingTxHashes,
       });
-      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError, code: 'embedded_tx_not_listed' };
     }
 
     // Validate tx hashes for all txs embedded in the proposal
     if (!(await Promise.all(proposal.txs?.map(tx => tx.validateTxHash()) ?? [])).every(v => v)) {
       this.logger.warn(`Penalizing peer for invalid tx hashes in proposal`);
-      return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
+      return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError, code: 'invalid_embedded_tx_hash' };
     }
 
     return { result: 'accept' };

--- a/yarn-project/validator-client/src/metrics.ts
+++ b/yarn-project/validator-client/src/metrics.ts
@@ -67,6 +67,7 @@ export class ValidatorMetrics {
           'txs_not_available',
           'timeout',
           'unknown_error',
+          'proposal_revalidation_failed',
         ],
         [Attributes.IS_COMMITTEE_MEMBER]: [true, false],
       },

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -2,14 +2,14 @@ import type { Archiver } from '@aztec/archiver';
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
-import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS, NoCommitteeError } from '@aztec/ethereum/contracts';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { type FieldsOf, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
-import type { BlockProposalValidator } from '@aztec/p2p/msg_validators';
+import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import { type Checkpoint, CheckpointReexecutionTracker, type ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
@@ -729,6 +729,7 @@ describe('ProposalHandler checkpoint validation', () => {
 
     const blockProposalValidator = mock<BlockProposalValidator>();
     blockProposalValidator.validate.mockResolvedValue({ result: 'accept' } as any);
+    blockProposalValidator.validateStableFields.mockResolvedValue({ result: 'accept' } as any);
 
     const txProvider = mock<ITxProvider>();
     txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
@@ -865,6 +866,105 @@ describe('ProposalHandler checkpoint validation', () => {
         blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
         reason: 'block_number_already_exists',
       });
+    });
+  });
+
+  describe('handleBlockProposal downstream re-validation', () => {
+    /**
+     * Builds a genesis-parent proposal wired to a real p2p validator (rather than a mock), so the
+     * downstream re-validation exercises the same checks the p2p ingress layer runs.
+     */
+    async function setupWithRealValidator(signer: Secp256k1Signer) {
+      const proposal = await makeBlockProposal({
+        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
+        archiveRoot: Fr.random(),
+        signer,
+      });
+
+      blockSource.getGenesisValues.mockResolvedValue({
+        genesisArchiveRoot: proposal.blockHeader.lastArchive.root,
+      } as any);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+
+      const txProvider = mock<ITxProvider>();
+      txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
+
+      const blockProposalValidator = new BlockProposalValidator(epochCache, consensusTimetable, {
+        txsPermitted: true,
+        signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+        clockDisparityMs: 0,
+      });
+
+      const blockHandler = new ProposalHandler(
+        checkpointsBuilder,
+        mock<WorldStateSynchronizer>(),
+        blockSource,
+        l1ToL2MessageSource,
+        txProvider,
+        blockProposalValidator,
+        epochCache,
+        consensusTimetable,
+        config,
+        mock<BlobClientInterface>(),
+        new CheckpointReexecutionTracker(),
+        metrics,
+        dateProvider,
+      );
+      return { proposal, blockHandler };
+    }
+
+    /** Sets the wall clock the p2p receive-window check reads (the epoch cache, not the date provider). */
+    function setValidatorClock(nowMs: number) {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: EpochNumber(0),
+        slot: SlotNumber(1),
+        ts: BigInt(Math.floor(nowMs / 1000)),
+        nowMs: BigInt(nowMs),
+      });
+    }
+
+    // The proposal was accepted at p2p ingress while its receive window was still open; the window having
+    // since closed says nothing about the proposal itself, so processing must not reject it on that basis.
+    it('processes a proposal whose receive window closed while it waited to be processed', async () => {
+      const signer = Secp256k1Signer.random();
+      const { proposal, blockHandler } = await setupWithRealValidator(signer);
+      // Slot 1's proposal receive window is [-4s, 17s]; 30s is well past its close.
+      setValidatorClock(30_000);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: true, blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
+    });
+
+    it('reports proposal_revalidation_failed when the committee view is unavailable at processing time', async () => {
+      const signer = Secp256k1Signer.random();
+      const { proposal, blockHandler } = await setupWithRealValidator(signer);
+      setValidatorClock(10_000);
+      epochCache.getProposerAttesterAddressInSlot.mockRejectedValue(new NoCommitteeError());
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: false, reason: 'proposal_revalidation_failed' });
+    });
+
+    it('reports proposal_revalidation_failed when no expected proposer is known at processing time', async () => {
+      const signer = Secp256k1Signer.random();
+      const { proposal, blockHandler } = await setupWithRealValidator(signer);
+      setValidatorClock(10_000);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(undefined);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: false, reason: 'proposal_revalidation_failed' });
+    });
+
+    // Stable fields must still be re-checked downstream, so a proposal that does not match the expected
+    // proposer is rejected even though the arrival-window check no longer applies.
+    it('still rejects a proposal signed by the wrong proposer', async () => {
+      const signer = Secp256k1Signer.random();
+      const { proposal, blockHandler } = await setupWithRealValidator(signer);
+      setValidatorClock(10_000);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(Secp256k1Signer.random().address);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: false, reason: 'proposal_revalidation_failed' });
     });
   });
 });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -57,6 +57,7 @@ import type { ValidatorMetrics } from './metrics.js';
 export type BlockProposalValidationFailureReason =
   | 'invalid_signature'
   | 'invalid_proposal'
+  | 'proposal_revalidation_failed'
   | 'parent_block_not_found'
   | 'parent_block_wrong_slot'
   | 'in_hash_mismatch'
@@ -168,7 +169,14 @@ type BlockProposalSlotValidationResult =
 
 const MAX_TRACKED_INVALID_PROPOSAL_SLOTS = 1000;
 
-/** Block-proposal validation failures that constitute a slashable invalid-block offense. */
+/**
+ * Block-proposal validation failures that constitute a slashable invalid-block offense.
+ *
+ * `proposal_revalidation_failed` is deliberately absent: this node already accepted the exact signed payload
+ * when it arrived, so a contradictory answer on re-validation is a local consistency failure, not evidence
+ * against the proposer. `invalid_proposal` remains slashable because it now only comes from the structural
+ * checkpoint-consistency checks in `computeCheckpointNumber`, which are properties of the payload itself.
+ */
 export const SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT: BlockProposalValidationFailureReason[] = [
   'state_mismatch',
   'failed_txs',
@@ -472,12 +480,23 @@ export class ProposalHandler {
       txHashes: proposal.txHashes.map(t => t.toString()),
     });
 
-    // Check that the proposal is from the current proposer, or the next proposer
-    // This should have been handled by the p2p layer, but we double check here out of caution
-    const validationResult = await this.blockProposalValidator.validate(proposal);
+    // Defense in depth over the p2p ingress checks: re-verify the signed payload's stable fields (signature
+    // context, signature, expected proposer, block index, transaction fields). Deliberately excludes the
+    // arrival-window check, which p2p already applied when this proposal was accepted; its outcome depends
+    // on the wall clock at evaluation time, so repeating it here would reject an on-time proposal purely
+    // because this node started processing it late.
+    //
+    // Since the same node already accepted this exact signed payload on arrival, a contradictory answer now
+    // is a local consistency failure (clock, epoch-cache view, or option drift), not fresh evidence of
+    // proposer misconduct — hence a non-slashable reason.
+    const validationResult = await this.blockProposalValidator.validateStableFields(proposal);
     if (validationResult.result !== 'accept') {
-      this.log.warn(`Proposal is not valid, skipping processing`, proposalInfo);
-      return { isValid: false, reason: 'invalid_proposal' };
+      this.log.warn(`Proposal is not valid, skipping processing`, {
+        ...proposalInfo,
+        validationResult: validationResult.result,
+        validationCode: validationResult.code,
+      });
+      return { isValid: false, reason: 'proposal_revalidation_failed' };
     }
 
     // A tx can only appear once in a block: the second copy would emit nullifiers already emitted by the

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -1,7 +1,7 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
+import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS, NoCommitteeError } from '@aztec/ethereum/contracts';
 import {
   BlockNumber,
   CheckpointNumber,
@@ -1430,6 +1430,31 @@ describe('ValidatorClient', () => {
       expect(mockCheckpointBuilder.buildBlock).not.toHaveBeenCalled();
     });
 
+    // The p2p layer already accepted this exact signed proposal on arrival, so a re-validation that now
+    // disagrees reflects a local view that changed (committee lookup, clock, config), not proposer
+    // misbehavior. Slashing on it would punish an honest proposer for this node's own inconsistency.
+    it('does not slash when downstream re-validation contradicts the accepted proposal', async () => {
+      epochCache.getProposerAttesterAddressInSlot.mockRejectedValue(new NoCommitteeError());
+      const emitSpy = jest.spyOn(validatorClient, 'emit');
+
+      const isValid = await validatorClient.validateBlockProposal(proposal, sender);
+
+      expect(isValid).toBe(false);
+      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
+      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
+    });
+
+    it('does not slash when no expected proposer is known at re-validation time', async () => {
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(undefined);
+      const emitSpy = jest.spyOn(validatorClient, 'emit');
+
+      const isValid = await validatorClient.validateBlockProposal(proposal, sender);
+
+      expect(isValid).toBe(false);
+      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
+      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
+    });
+
     // A tx collection failure that is not proposer misbehavior (pool error, network error) must not be
     // classified as an invalid proposal, so it keeps propagating to the p2p caller.
     it('propagates generic tx collection errors without slashing', async () => {
@@ -1470,37 +1495,32 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(true);
     });
 
-    it('should return false if the proposal is not for the current or next slot', async () => {
+    // Whether a proposal arrived in time is decided once, at p2p ingress (covered by the p2p proposal
+    // validator's receive-window tests). Re-applying that gate here would make the verdict depend on how
+    // long this node took to get around to the proposal, so validation past the window is expected to
+    // succeed and must never be treated as a proposer offense.
+    it('validates a proposal without slashing even once its receive window has closed', async () => {
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
+      const staleSlot = SlotNumber(proposal.slotNumber + 20);
       epochCache.getTargetAndNextSlot.mockReturnValue({
-        targetSlot: SlotNumber(proposal.slotNumber + 20),
+        targetSlot: staleSlot,
         nextSlot: SlotNumber(proposal.slotNumber + 21),
       });
       epochCache.getEpochAndSlotNow.mockReturnValue({
         epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 20),
+        slot: staleSlot,
         ts: 0n,
-        nowMs: 0n,
+        nowMs: BigInt(staleSlot) * 24_000n,
       });
-      // Keep the wall-clock slot consistent with the "now" set above so the always-on pipelining
-      // acceptance window correctly treats the proposal's slot as stale (not the current slot).
-      epochCache.getSlotNow.mockReturnValue(SlotNumber(proposal.slotNumber + 20));
-      epochCache.getEpochAndSlotInNextL1Slot.mockReturnValue({
-        epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 20),
-        ts: 0n,
-        nowSeconds: 0n,
-      });
-      epochCache.getTargetSlot.mockReturnValue(SlotNumber(proposal.slotNumber + 20));
-      epochCache.getTargetEpochAndSlotInNextL1Slot.mockReturnValue({
-        epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 21),
-        ts: 0n,
-        nowSeconds: 0n,
-      });
+      epochCache.getSlotNow.mockReturnValue(staleSlot);
+      epochCache.getTargetSlot.mockReturnValue(staleSlot);
+      const emitSpy = jest.spyOn(validatorClient, 'emit');
 
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-      expect(isValid).toBe(false);
+
+      expect(isValid).toBe(true);
+      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
+      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
     });
 
     it('should return false if messages do not match', async () => {


### PR DESCRIPTION
On mainnet (2026-08-11, slot 50415) a validator falsely accused an honest proposer of broadcasting an invalid block proposal, and the slot-wide invalid marker then implicated every attester of the slot. The block was canonical.

This was caused by a massive delay (already fixed) between the time we first validated the proposal on the p2p boundary, and we revalidated on the validator. The defense-in-depth revalidation (which we could remove in a future PR) now skips time-dependent checks.

## Context

Block proposals are gated at p2p ingress on a wall-clock receive window, but the validator client re-ran the exact same validation downstream before re-execution. On the incident node, processing stalled ~50s behind the tx-pool serial queue held by epoch finalization (A-1656, fixed separately in #25148), so an on-time proposal failed the repeated window check purely because processing started late — and that rejection was collapsed into `invalid_proposal`, a slashable offense. Local latency must never convert into slashing evidence against other validators.

## Approach

- Split `ProposalValidator` into `validate()` (ingress behavior unchanged, including the receive-window check and peer penalization for genuinely-late proposals) and `validateStableFields()`, which runs every check that is a property of the signed payload (signature context, signature, expected proposer, block index, transaction fields) and omits the time-of-check-sensitive window. The proposal handler now calls the stable variant, so arrival gating cannot be repeated after the fact.
- Downstream re-validation failures return a new `proposal_revalidation_failed` reason that is absent from the slashable set and counted as a node issue in metrics: once this node accepted the exact signed payload at ingress, a contradictory re-check reflects a changed local view (clock, epoch-cache state, or option drift), never proposer misconduct. This also removes a latent false-slash path where a `NoCommitteeError` at processing time produced a slashable rejection. `invalid_proposal` stays slashable and now only comes from the structural checkpoint-consistency checks.
- Reject results carry a machine-readable code for the failing sub-check, logged when a proposal is skipped, so any rejection can be traced to its cause.

The remaining attester-side issue (offenses keyed only by slot rather than by the signed checkpoint payload) is tracked in A-1711.

Fixes A-1703

---

Review guide with context, change summary, and pointers into the diff: https://claude.ai/code/artifact/e64d378d-1d4d-43f8-aa25-1de6e118ada3
