### PR TITLE
fix: spurious insufficient-funds rejection when simulating L1 calls

### DIFF
--- a/yarn-project/ethereum/src/client.ts
+++ b/yarn-project/ethereum/src/client.ts
@@ -10,6 +10,7 @@ import {
   type HttpTransport,
   type LocalAccount,
   type PrivateKeyAccount,
+  RpcRequestError,
   createPublicClient,
   createWalletClient,
   fallback,
@@ -56,6 +57,11 @@ export function getL1RpcHttpStatus(err: unknown): number | undefined {
 /** Returns true when an L1 RPC error's cause chain contains the given HTTP status. */
 export function isL1RpcHttpStatus(err: unknown, status: number): boolean {
   return getL1RpcHttpStatus(err) === status;
+}
+
+/** Returns the JSON-RPC error code reported by the L1 node, if the error's cause chain carries one. */
+export function getL1RpcErrorCode(err: unknown): number | undefined {
+  return getErrorCause(err, RpcRequestError)?.code;
 }
 
 function wrapL1RpcTransport(transport: FallbackTransport<HttpTransport[]>): FallbackTransport<HttpTransport[]> {

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -1589,6 +1589,19 @@ describe('L1TxUtils', () => {
       }
     });
 
+    it('omits fee fields from the simulated call', async () => {
+      // Fee fields on a simulated call make the node enforce balance >= gas * maxFeePerGas, which rejects the
+      // whole eth_simulateV1 request when the sender cannot afford the worst-case gas cap.
+      using simulateBlocksSpy = jest.spyOn(l1Client, 'simulateBlocks');
+
+      await gasUtils.simulate(request);
+
+      const call = simulateBlocksSpy.mock.calls[0][0].blocks[0].calls[0];
+      expect(call).toHaveProperty('gas', MAX_L1_TX_LIMIT);
+      expect(call).not.toHaveProperty('maxFeePerGas');
+      expect(call).not.toHaveProperty('maxPriorityFeePerGas');
+    });
+
     it('transitions from sent to not-mined when tx drops without cancellation', async () => {
       await cheatCodes.setAutomine(false);
       await cheatCodes.setIntervalMining(0);
@@ -1914,6 +1927,24 @@ describe('L1TxUtils', () => {
           { fallbackGasEstimate: 123n },
         ),
       ).resolves.toEqual({ gasUsed: 123n, result: '0x' });
+    });
+
+    it('throws a descriptive error when the node rejects the simulation for insufficient funds', async () => {
+      const from: Hex = '0x1111111111111111111111111111111111111111';
+      const readOnlyUtils = new ReadOnlyL1TxUtils(publicClient, logger, dateProvider);
+      using _simulateBlocksSpy = jest.spyOn(publicClient, 'simulateBlocks').mockRejectedValue(
+        new L1RpcError('L1 RPC request failed', {
+          cause: new RpcRequestError({
+            body: {},
+            error: { code: -38014, message: 'insufficient funds for gas * price + value' },
+            url: rpcUrl,
+          }),
+        }),
+      );
+
+      await expect(
+        readOnlyUtils.simulate({ to: '0x1234567890123456789012345678901234567890', data: '0xabcdef', value: 0n, from }),
+      ).rejects.toThrow(new RegExp(`rejected the eth_simulateV1 request with insufficient funds.*${from}`, 'is'));
     });
 
     it('L1TxUtils can be instantiated with wallet client and has write methods', () => {

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -22,6 +22,7 @@ import {
   TransactionNotFoundError,
   type TransactionSerializable,
   createPublicClient,
+  encodeErrorResult,
   encodeFunctionData,
   http,
 } from 'viem';
@@ -1944,7 +1945,49 @@ describe('L1TxUtils', () => {
 
       await expect(
         readOnlyUtils.simulate({ to: '0x1234567890123456789012345678901234567890', data: '0xabcdef', value: 0n, from }),
-      ).rejects.toThrow(new RegExp(`rejected the eth_simulateV1 request with insufficient funds.*${from}`, 'is'));
+      ).rejects.toThrow(new RegExp(`insufficient funds error before executing it \\(sender ${from}\\)`, 'i'));
+    });
+
+    it('classifies an insufficient funds rejection reported without the dedicated error code', async () => {
+      const readOnlyUtils = new ReadOnlyL1TxUtils(publicClient, logger, dateProvider);
+      using _simulateBlocksSpy = jest.spyOn(publicClient, 'simulateBlocks').mockRejectedValue(
+        new L1RpcError('L1 RPC request failed', {
+          cause: new RpcRequestError({
+            body: {},
+            error: { code: -32000, message: 'insufficient funds for gas * price + value: have 1 want 2' },
+            url: rpcUrl,
+          }),
+        }),
+      );
+
+      await expect(
+        readOnlyUtils.simulate({ to: '0x1234567890123456789012345678901234567890', data: '0xabcdef', value: 0n }),
+      ).rejects.toThrow(/insufficient funds error before executing it.*have 1 want 2/s);
+    });
+
+    it('reports an execution revert mentioning insufficient funds as a simulation failure', async () => {
+      const readOnlyUtils = new ReadOnlyL1TxUtils(publicClient, logger, dateProvider);
+      const data = encodeErrorResult({
+        abi: [{ type: 'error', name: 'Error', inputs: [{ type: 'string', name: 'message' }] }],
+        errorName: 'Error',
+        args: ['insufficient funds for fee'],
+      });
+      // Only the fields _simulate reads; the full viem return type carries every block field.
+      const failedSimulation = [
+        { gasUsed: 1_000n, calls: [{ status: 'failure', error: undefined, data }] },
+      ] as unknown as Awaited<ReturnType<typeof publicClient.simulateBlocks>>;
+      using _simulateBlocksSpy = jest.spyOn(publicClient, 'simulateBlocks').mockResolvedValue(failedSimulation);
+
+      const promise = readOnlyUtils.simulate({
+        to: '0x1234567890123456789012345678901234567890',
+        data: '0xabcdef',
+        value: 0n,
+      });
+
+      await expect(promise).rejects.toThrow(
+        'L1 transaction simulation failed with error Error(insufficient funds for fee)',
+      );
+      await expect(promise).rejects.not.toThrow(/rejected the eth_simulateV1 request/);
     });
 
     it('L1TxUtils can be instantiated with wallet client and has write methods', () => {

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -701,7 +701,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       blockOverrides.gasLimit = MAX_L1_TX_LIMIT;
     }
 
-    return this._simulate(call, blockOverrides, stateOverrides, gasConfig, abi);
+    return await this._simulate(call, blockOverrides, stateOverrides, gasConfig, abi);
   }
 
   /**

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -685,14 +685,14 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
   ): Promise<{ gasUsed: bigint; result: `0x${string}` }> {
     const blockOverrides = { ..._blockOverrides };
     const gasConfig = merge(this.config, _gasConfig);
-    const gasPrice = await this.getGasPrice(gasConfig, false);
 
+    // Fee fields are deliberately omitted. Supplying them makes the node apply the EIP-1559 upfront funds
+    // check (sender balance >= gas * maxFeePerGas) against the worst-case gas cap below, which rejects the
+    // whole simulation request before any execution. Omitted fee fields default to a zero gas price.
     const call: any = {
       to: request.to!,
       data: request.data,
       from: request.from ?? this.getSenderAddress().toString(),
-      maxFeePerGas: gasPrice.maxFeePerGas,
-      maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
       gas: request.gas ?? MAX_L1_TX_LIMIT,
     };
 

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -46,9 +46,10 @@ const CurrentStrategy: PriorityFeeStrategy = P75AllTxsPriorityFeeStrategy;
 const INSUFFICIENT_FUNDS_RPC_ERROR_CODE = -38014;
 
 /**
- * Returns true when a simulation was rejected by the node's upfront funds check
- * (sender balance >= gasLimit * maxFeePerGas) rather than failing during execution. Matches on the message
- * as well as the error code, since RPC gateways differ in how they wrap node errors.
+ * Returns true when an RPC transport error reports the node's upfront funds check
+ * (sender balance >= gasLimit * maxFeePerGas) rejecting the request. Matches on the message as well as on the
+ * error code, since RPC gateways differ in how they wrap node errors. Apply this only to transport errors: an
+ * execution revert string can mention insufficient funds without being this kind of rejection.
  */
 function isInsufficientFundsRpcError(err: unknown): boolean {
   if (getL1RpcErrorCode(err) === INSUFFICIENT_FUNDS_RPC_ERROR_CODE) {
@@ -391,8 +392,8 @@ export class ReadOnlyL1TxUtils {
     gasConfig: L1TxUtilsConfig & { fallbackGasEstimate?: bigint },
     abi: Abi,
   ) {
-    try {
-      const result = await this.client.simulateBlocks({
+    const simulateBlocks = () =>
+      this.client.simulateBlocks({
         validation: false,
         blocks: [
           {
@@ -403,16 +404,11 @@ export class ReadOnlyL1TxUtils {
         ],
       });
 
-      if (result[0].calls[0].status === 'failure') {
-        this.logger?.error('L1 transaction simulation failed', result[0].calls[0].error);
-        const decodedError = decodeErrorResult({ abi, data: result[0].calls[0].data });
-
-        throw new Error(
-          `L1 transaction simulation failed with error ${decodedError.errorName}(${decodedError.args?.join(',')})`,
-        );
-      }
-      this.logger?.debug(`L1 transaction simulation succeeded`, { ...result[0].calls[0] });
-      return { gasUsed: result[0].gasUsed, result: result[0].calls[0].data as `0x${string}` };
+    // Only the request itself is wrapped, so that transport-level rejections are never confused with an
+    // execution revert (whose decoded revert string could well mention insufficient funds too).
+    let result: Awaited<ReturnType<typeof simulateBlocks>>;
+    try {
+      result = await simulateBlocks();
     } catch (err) {
       if (getErrorCause(err, MethodNotFoundRpcError) || getErrorCause(err, MethodNotSupportedRpcError)) {
         if (gasConfig.fallbackGasEstimate) {
@@ -424,15 +420,28 @@ export class ReadOnlyL1TxUtils {
         this.logger?.error('Node does not support eth_simulateV1 API');
       }
       if (isInsufficientFundsRpcError(err)) {
+        const rpcError = getErrorCause(err, RpcRequestError);
+        const providerMessage = rpcError?.details ?? (err instanceof Error ? err.message : String(err));
+        const gas = call?.gas !== undefined ? `, gas ${call.gas}` : '';
         throw new Error(
-          `L1 node rejected the eth_simulateV1 request with insufficient funds: the balance of sender ` +
-            `${call?.from ?? 'unknown'} does not cover gas ${call?.gas ?? 'unset'} times maxFeePerGas, even after ` +
-            `state overrides. Simulated calls should omit fee fields so that this check is vacuous.`,
+          `L1 node rejected the eth_simulateV1 request with an insufficient funds error before executing it ` +
+            `(sender ${call?.from ?? 'unknown'}${gas}): ${providerMessage}`,
           { cause: err },
         );
       }
       throw err;
     }
+
+    if (result[0].calls[0].status === 'failure') {
+      this.logger?.error('L1 transaction simulation failed', result[0].calls[0].error);
+      const decodedError = decodeErrorResult({ abi, data: result[0].calls[0].data });
+
+      throw new Error(
+        `L1 transaction simulation failed with error ${decodedError.errorName}(${decodedError.args?.join(',')})`,
+      );
+    }
+    this.logger?.debug(`L1 transaction simulation succeeded`, { ...result[0].calls[0] });
+    return { gasUsed: result[0].gasUsed, result: result[0].calls[0].data as `0x${string}` };
   }
 
   public bumpGasLimit(gasLimit: bigint, _gasConfig?: L1TxUtilsConfig): bigint {

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -17,6 +17,7 @@ import {
   type Hex,
   MethodNotFoundRpcError,
   MethodNotSupportedRpcError,
+  RpcRequestError,
   type StateOverride,
   decodeErrorResult,
   formatGwei,
@@ -24,6 +25,7 @@ import {
   hexToBytes,
 } from 'viem';
 
+import { getL1RpcErrorCode } from '../client.js';
 import type { ViemClient } from '../types.js';
 import { type L1TxUtilsConfig, defaultL1TxUtilsConfig, l1TxUtilsConfigMappings } from './config.js';
 import {
@@ -39,6 +41,22 @@ import { getCalldataGasUsage, tryGetCustomErrorNameContractFunction } from './ut
 
 // Change this to the current strategy we want to use
 const CurrentStrategy: PriorityFeeStrategy = P75AllTxsPriorityFeeStrategy;
+
+/** Error code returned by eth_simulateV1 for `insufficient funds for gas * price + value`. */
+const INSUFFICIENT_FUNDS_RPC_ERROR_CODE = -38014;
+
+/**
+ * Returns true when a simulation was rejected by the node's upfront funds check
+ * (sender balance >= gasLimit * maxFeePerGas) rather than failing during execution. Matches on the message
+ * as well as the error code, since RPC gateways differ in how they wrap node errors.
+ */
+function isInsufficientFundsRpcError(err: unknown): boolean {
+  if (getL1RpcErrorCode(err) === INSUFFICIENT_FUNDS_RPC_ERROR_CODE) {
+    return true;
+  }
+  const messages = [err, getErrorCause(err, RpcRequestError)].map(e => (e instanceof Error ? e.message : '')).join(' ');
+  return /insufficient funds/i.test(messages);
+}
 
 export class ReadOnlyL1TxUtils {
   public config: Required<L1TxUtilsConfig>;
@@ -404,6 +422,14 @@ export class ReadOnlyL1TxUtils {
           return { gasUsed: gasConfig.fallbackGasEstimate, result: '0x' as `0x${string}` };
         }
         this.logger?.error('Node does not support eth_simulateV1 API');
+      }
+      if (isInsufficientFundsRpcError(err)) {
+        throw new Error(
+          `L1 node rejected the eth_simulateV1 request with insufficient funds: the balance of sender ` +
+            `${call?.from ?? 'unknown'} does not cover gas ${call?.gas ?? 'unset'} times maxFeePerGas, even after ` +
+            `state overrides. Simulated calls should omit fee fields so that this check is vacuous.`,
+          { cause: err },
+        );
       }
       throw err;
     }

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -739,7 +739,7 @@ describe('L1Publisher integration', () => {
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
-      await publisher.validateBlockHeader(checkpoint.header);
+      await publisher.validateCheckpointHeader(checkpoint.header);
 
       const proposerSigner = validators.find(v => v.address.equals(proposer!));
 
@@ -760,7 +760,7 @@ describe('L1Publisher integration', () => {
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
-      await publisher.validateBlockHeader(checkpoint.header);
+      await publisher.validateCheckpointHeader(checkpoint.header);
 
       // Enqueue no longer simulates — the bundle simulate at send time drops the failing propose
       // and sendRequests returns undefined (no surviving actions). The drop is reported via a
@@ -789,7 +789,7 @@ describe('L1Publisher integration', () => {
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
-      await publisher.validateBlockHeader(checkpoint.header);
+      await publisher.validateCheckpointHeader(checkpoint.header);
 
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(
@@ -826,7 +826,7 @@ describe('L1Publisher integration', () => {
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
-      await publisher.validateBlockHeader(checkpoint.header);
+      await publisher.validateCheckpointHeader(checkpoint.header);
 
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(
@@ -913,9 +913,9 @@ describe('L1Publisher integration', () => {
       expect(canPropose?.slot).toEqual(block.header.getSlot());
 
       // Same for validation
-      logger.warn('Checking validate block header');
-      await expect(publisher.validateBlockHeader(checkpoint.header)).rejects.toThrow(/Rollup__InvalidArchive/);
-      await publisher.validateBlockHeader(checkpoint.header, invalidationSimulationOverridesPlan);
+      logger.warn('Checking validate checkpoint header');
+      await expect(publisher.validateCheckpointHeader(checkpoint.header)).rejects.toThrow(/Rollup__InvalidArchive/);
+      await publisher.validateCheckpointHeader(checkpoint.header, invalidationSimulationOverridesPlan);
 
       // At this point I'm gonna need to propose the correct signature ye? So confused actually here.
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -556,7 +556,7 @@ describe('SequencerPublisher', () => {
     expect(l1TxUtils.simulate).toHaveBeenCalledTimes(1);
   });
 
-  it('validates block headers when L1 head is already at the L2 slot boundary', async () => {
+  it('validates checkpoint headers when L1 head is already at the L2 slot boundary', async () => {
     epochCache.getL1Constants.mockReturnValue({
       ...EmptyL1RollupConstants,
       l1GenesisTime: 1000n,
@@ -572,7 +572,7 @@ describe('SequencerPublisher', () => {
     });
 
     await expect(
-      publisher.validateBlockHeader(CheckpointHeader.random({ slotNumber: SlotNumber(5) })),
+      publisher.validateCheckpointHeader(CheckpointHeader.random({ slotNumber: SlotNumber(5) })),
     ).resolves.toBeUndefined();
   });
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -761,13 +761,13 @@ export class SequencerPublisher {
   }
 
   /**
-   * @notice  Will simulate `validateHeader` to make sure that the block header is valid
-   * @dev     This is a convenience function that can be used by the sequencer to validate a "partial" header.
-   *          It will throw if the block header is invalid.
-   * @param header - The block header to validate
+   * @notice  Will simulate the rollup's `validateHeaderWithAttestations` to make sure the checkpoint header is valid
+   * @dev     This is a convenience function that can be used by the sequencer to validate a "partial" header,
+   *          skipping the DA and signature checks. It will throw if the checkpoint header is invalid.
+   * @param header - The checkpoint header to validate
    */
-  @trackSpan('SequencerPublisher.validateBlockHeader')
-  public async validateBlockHeader(
+  @trackSpan('SequencerPublisher.validateCheckpointHeader')
+  public async validateCheckpointHeader(
     header: CheckpointHeader,
     simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<void> {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -786,8 +786,7 @@ export class SequencerPublisher {
     const l1Constants = this.epochCache.getL1Constants();
     const ts = getLastL1SlotTimestampForL2Slot(header.slotNumber, l1Constants);
     const stateOverrides = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
-    // The simulated call carries no gas price, so no funds are actually needed; the ample balance override
-    // keeps the simulation working on providers that still apply an upfront funds check.
+    // Balance override for compatibility with providers that apply an upfront funds check to simulated calls.
     stateOverrides.push({
       address: MULTI_CALL_3_ADDRESS,
       balance: 10n * WEI_CONST * WEI_CONST, // 10 ETH

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -786,17 +786,11 @@ export class SequencerPublisher {
     const l1Constants = this.epochCache.getL1Constants();
     const ts = getLastL1SlotTimestampForL2Slot(header.slotNumber, l1Constants);
     const stateOverrides = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
-    let balance = 0n;
-    if (this.config.fishermanMode) {
-      // In fisherman mode, we can't know where the proposer is publishing from
-      // so we just add sufficient balance to the multicall3 address
-      balance = 10n * WEI_CONST * WEI_CONST; // 10 ETH
-    } else {
-      balance = await this.l1TxUtils.getSenderBalance();
-    }
+    // The simulated call carries no gas price, so no funds are actually needed; the ample balance override
+    // keeps the simulation working on providers that still apply an upfront funds check.
     stateOverrides.push({
       address: MULTI_CALL_3_ADDRESS,
-      balance,
+      balance: 10n * WEI_CONST * WEI_CONST, // 10 ETH
     });
 
     await this.l1TxUtils.simulate(

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -114,7 +114,7 @@ export class CheckpointProposalJob implements Traceable {
    * Chain state overrides built once per slot in proposeCheckpoint after the checkpoint is
    * complete. Carries the pending parent override (archive + slot + fee header) for pipelining,
    * or the invalidation pending override when rolling back. Consumed by
-   * publisher.validateBlockHeader before broadcast.
+   * publisher.validateCheckpointHeader before broadcast.
    */
   private checkpointSimulationOverridesPlan?: SimulationOverridesPlan;
 
@@ -592,7 +592,7 @@ export class CheckpointProposalJob implements Traceable {
       // Build the simulation plan for this slot. When pipelining, this overrides L1's view of
       // pending/archive/fee-header to "as if the proposed parent had landed", so both the
       // mana-min-fee simulation (in the globals builder) and the pre-broadcast
-      // validateBlockHeader see the chain tip the eventual L1 send will see.
+      // validateCheckpointHeader see the chain tip the eventual L1 send will see.
       this.checkpointSimulationOverridesPlan = await buildCheckpointSimulationOverridesPlan({
         checkpointNumber: this.checkpointNumber,
         proposedCheckpointData: this.proposedCheckpointData,
@@ -794,7 +794,7 @@ export class CheckpointProposalJob implements Traceable {
       // If this fails the slot is aborted before any gossip work; state drift between here
       // and the eventual L1 send is caught by the bundle simulate at send time.
       try {
-        await this.publisher.validateBlockHeader(checkpoint.header, this.checkpointSimulationOverridesPlan);
+        await this.publisher.validateCheckpointHeader(checkpoint.header, this.checkpointSimulationOverridesPlan);
       } catch (err) {
         this.log.error(`Pre-broadcast header validation failed for slot ${this.targetSlot}; aborting`, err, {
           slot: this.targetSlot,

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -61,7 +61,7 @@ export type SequencerEvents = {
   }) => void;
   ['checkpoint-empty']: (args: { slot: SlotNumber }) => void;
   /**
-   * Emitted when the proposer's pre-broadcast `validateBlockHeader` simulation fails. This is a
+   * Emitted when the proposer's pre-broadcast `validateCheckpointHeader` simulation fails. This is a
    * last-chance check before we gossip a checkpoint proposal: a failure here means the header
    * would not be accepted by L1 (e.g. archive mismatch, stale chain tip, or some other state
    * drift between when we built the checkpoint and when we are about to broadcast it).

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -230,7 +230,7 @@ describe('sequencer', () => {
     publisher = mockDeep<SequencerPublisher>();
     publisher.epochCache = epochCache;
     publisher.getSenderAddress.mockImplementation(() => EthAddress.random());
-    publisher.validateBlockHeader.mockResolvedValue();
+    publisher.validateCheckpointHeader.mockResolvedValue();
     publisher.enqueueProposeCheckpoint.mockResolvedValue(undefined);
     publisher.enqueueGovernanceCastSignal.mockResolvedValue(true);
     publisher.enqueueSlashingActions.mockResolvedValue(true);
@@ -708,12 +708,12 @@ describe('sequencer', () => {
       expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
     });
 
-    // TODO(palla/mbps): Reinstante the validateBlockHeader call
+    // TODO(palla/mbps): Reinstante the validateCheckpointHeader call
     it.skip('aborts building a block if the chain moves underneath it', async () => {
       await setupSingleTxBlock();
 
       // This could practically be for any reason, e.g., could also be that we have entered a new slot.
-      publisher.validateBlockHeader.mockRejectedValueOnce(new Error('No block for you'));
+      publisher.validateCheckpointHeader.mockRejectedValueOnce(new Error('No block for you'));
 
       await sequencer.work();
 
@@ -764,7 +764,7 @@ describe('sequencer', () => {
         const pub = mockDeep<SequencerPublisher>();
         pub.epochCache = epochCache;
         pub.getSenderAddress.mockImplementation(() => EthAddress.random());
-        pub.validateBlockHeader.mockResolvedValue();
+        pub.validateCheckpointHeader.mockResolvedValue();
         pub.enqueueProposeCheckpoint.mockResolvedValue(undefined);
         pub.enqueueGovernanceCastSignal.mockResolvedValue(true);
         pub.enqueueSlashingActions.mockResolvedValue(true);

--- a/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
+++ b/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
@@ -45,7 +45,7 @@ type CheckpointSimulationOverridesPlanInput = {
 /**
  * Builds the SimulationOverridesPlan describing the simulated L1 rollup state for a checkpoint's
  * enqueue-time simulations: `canProposeAt` (in Sequencer.doWork) and the propose-related sims
- * (validateBlockHeader, simulateProposeTx). The plan reflects "as if our pipelined parent
+ * (validateCheckpointHeader, simulateProposeTx). The plan reflects "as if our pipelined parent
  * checkpoint has landed and any required invalidation has executed" — the gap that needs to be
  * bridged at enqueue time.
  *
@@ -81,7 +81,7 @@ export async function buildCheckpointSimulationOverridesPlan(
     // `getEffectivePendingCheckpointNumber` silently collapses pending back to proven — producing
     // a spurious `Rollup__InvalidArchive` against the on-chain genesis archive. The other fields
     // (headerHash, outHash, payloadDigest) are not strictly load-bearing for `canProposeAt` /
-    // `validateBlockHeader`, but mirroring the full cell keeps the simulation byte-faithful with
+    // `validateCheckpointHeader`, but mirroring the full cell keeps the simulation byte-faithful with
     // what the actual `propose()` send will observe, which is a defense against future reads
     // taking dependencies on them.
     builder.withPendingTempCheckpointLogFields({


### PR DESCRIPTION
Validators were aborting checkpoint proposals on eth-mainnet with a generic `L1RpcError: L1 RPC request failed` during pre-broadcast header validation, e.g. `insufficient funds for gas * price + value: have 169461140054989709 want 432138191814787072`.

With this PR we now skip any balance checks during simulate calls for header validation by removing fee-per-gas settings, and also just in case we fake a lot of ETH as balance. Created A-1712 to gate block-building on publisher balance.

## Context

`L1TxUtils.simulate` attached production fee fields (competitive P75 priority fee, ~26 gwei during the incident) together with the worst-case `MAX_L1_TX_LIMIT` gas cap (16.7M) to every `eth_simulateV1` call, and `validateBlockHeader` overrode the multicall3 sender's balance with the validator's real balance. Supplying fee fields makes the node enforce the EIP-1559 upfront funds check (balance >= gasLimit x maxFeePerGas, ~0.43 ETH at those numbers) before executing anything, so any validator holding less than that failed header validation and skipped its proposal — even though the actual publish tx costs a small fraction of that. With fee fields omitted, the node defaults them to zero, so the check only fired because we supplied them.

## Approach

- Omit `maxFeePerGas`/`maxPriorityFeePerGas` from simulated calls entirely, making the upfront check vacuous for all `simulate()` callers.
- `validateBlockHeader` now always uses the ample 10 ETH multicall3 balance override (previously fisherman-mode only) instead of the real sender balance, as compatibility with providers that still apply an upfront check.
- While at it, the third commit renames `SequencerPublisher.validateBlockHeader` to `validateCheckpointHeader`: it takes a `CheckpointHeader` and simulates the rollup's `validateHeaderWithAttestations`, so it never validated a *block* header. Mechanical rename of the method, its `trackSpan` label, and all call sites and doc references; contract-side names, the `header-validation-failed` event key, and metric labels are untouched.
- An insufficient-funds rejection of the simulation request (code -38014, with a message-match fallback for clients and gateways that report it differently) now surfaces as a descriptive error carrying the sender and the provider's have/want message, instead of a generic RPC error.
- `_simulate` is restructured so only the `simulateBlocks` transport call sits inside the classifying try/catch; decoding of failed calls and the success path happen after it.

## What to review

- **The core semantic claim**, verified against client and library sources: viem 2.38.2's `simulateBlocks` forwards call objects verbatim (no fee filling, no type inference — unlike `simulateCalls`/`sendTransaction`, so re-verify on a viem bump), and geth, reth, anvil (>= v1.1.0), and nethermind all default omitted fee fields to a zero gas price and zero the block base fee under `validation: false`. The upfront funds check still runs in all four but degenerates to `balance >= value`; every call we simulate is zero-value, so it passes regardless of sender balance. Nothing in the simulated paths reads `tx.gasprice`. All four production `simulate()` callers were audited (`validateCheckpointHeader`, `simulateInvalidateCheckpoint`, the multicall aggregate helper, L1 contract deploy simulations): they consume only `gasUsed`/return data, both unaffected by gas price.
- **The insufficient-funds classifier keeps a message fallback deliberately**: geth reports the rejection as spec code -38014, but reth uses -32003 (TransactionRejected) and anvil did too before its spec-conformance fixes, so matching on the code alone would miss those clients.
- **The catch boundary in `readonly_l1_tx_utils.ts`** (second commit): only the RPC request is inside the try, so an execution revert whose message mentions "insufficient funds" (e.g. a plain `Error("insufficient funds")` revert string) can no longer be misclassified as an RPC rejection — this was a real bug in the first commit, caught in review and pinned by the new regression test. Also check the `MethodNotFound`/`fallbackGasEstimate` early-return path survived the restructure unchanged.
- **Loss of signal**: dropping the real-balance override removes an (unintentional) affordability check. It never carried a real signal — wrong sender (multicall3), worst-case gas cap, inflated fees — and no other affordability check exists today: publisher selection only requires balance > 0, with the optional funding loop and balance metrics covering the rest operationally. An explicit post-simulation cost-vs-balance warning is a candidate follow-up.
- **Tests are correct by inspection only** — this branch has not been built or run locally; CI is the first real execution.

A port to `next` will follow; it needs the `getGasPrice` -> `getFeesPerGas` rename accounted for.

Fixes A-1706
