### PR TITLE
fix: block stream sync can resolve against a pass that predates it

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -2555,7 +2555,7 @@ describe('Archiver Sync', () => {
       archiver.events.off(L2BlockSourceEvents.L2BlockSourceUpdated, updateSpy);
     });
 
-    it('emits a single aggregate event carrying fromTips, toTips and blocksAdded for a checkpoint sync', async () => {
+    it('emits a single aggregate event carrying fromTips and toTips for a checkpoint sync', async () => {
       const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,
         messagesL1BlockNumber: 60n,
@@ -2572,7 +2572,6 @@ describe('Archiver Sync', () => {
       expect(event.fromTips.proposed.number).toEqual(BlockNumber(0));
       expect(event.toTips.proposed.number).toEqual(lastBlock);
       expect(event.toTips.checkpointed.checkpoint.number).toEqual(CheckpointNumber(1));
-      expect(event.blocksAdded.map(b => b.number)).toEqual(cp1.blocks.map(b => b.number));
     });
 
     it('emits no aggregate event on a fully-synced no-op pass', async () => {
@@ -2613,18 +2612,15 @@ describe('Archiver Sync', () => {
       updateSpy.mockClear();
       await archiver.syncImmediate();
 
-      // The conflicting local blocks are pruned and replaced by the L1 chain. The aggregate event carries the
-      // newly-fetched L1 blocks (the prune itself is reflected by the moved tips, not by the delta).
+      // The conflicting local blocks are pruned and replaced by the L1 chain, which the single aggregate event
+      // reports through its moved tips.
       expect(updateSpy).toHaveBeenCalledTimes(1);
       const event = updateSpy.mock.calls[0][0] as L2BlockSourceUpdatedEvent;
-      expect(event.blocksAdded.map(b => b.number)).toEqual(
-        expect.arrayContaining(differentCp2.blocks.map(b => b.number)),
-      );
       expect(event.toTips.checkpointed.checkpoint.number).toEqual(CheckpointNumber(2));
       expect(event.toTips.proposed.number).toEqual(differentCp2.blocks.at(-1)!.number);
     }, 15_000);
 
-    it('emits an aggregate event with no blocks added when only the proven tip advances', async () => {
+    it('emits an aggregate event when only the proven tip advances', async () => {
       const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), { l1BlockNumber: 70n });
       fake.setL1BlockNumber(100n);
       await archiver.syncImmediate();
@@ -2640,7 +2636,6 @@ describe('Archiver Sync', () => {
       expect(updateSpy).toHaveBeenCalledTimes(1);
       const event = updateSpy.mock.calls[0][0] as L2BlockSourceUpdatedEvent;
       // No blocks were added; the event still fires because the proven tip moved (proposed/checkpointed unchanged).
-      expect(event.blocksAdded).toEqual([]);
       expect(event.fromTips.proven.checkpoint.number).toEqual(CheckpointNumber(0));
       expect(event.toTips.proven.checkpoint.number).toEqual(CheckpointNumber(1));
       expect(event.fromTips.proposed.number).toEqual(event.toTips.proposed.number);

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -435,7 +435,6 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
         type: L2BlockSourceEvents.L2BlockSourceUpdated,
         fromTips,
         toTips,
-        blocksAdded,
       });
     }
   }

--- a/yarn-project/foundation/src/promise/running-promise.test.ts
+++ b/yarn-project/foundation/src/promise/running-promise.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 import { type Logger, createLogger } from '../log/pino-logger.js';
 import { type ErrorHandler, RunningPromise } from './running-promise.js';
+import { promiseWithResolvers } from './utils.js';
 
 jest.useFakeTimers();
 
@@ -48,6 +49,107 @@ describe('RunningPromise', () => {
       const promise = runningPromise.trigger();
       expect(counter).toEqual(1);
       await promise;
+      expect(counter).toEqual(2);
+    });
+
+    it('resolves only after a run that started after the call, even during a request-serving pass', async () => {
+      const gates = [promiseWithResolvers<void>(), promiseWithResolvers<void>()];
+      const log: string[] = [];
+      fn.mockImplementation(async () => {
+        const gate = gates[counter];
+        counter++;
+        const run = counter;
+        log.push(`start:${run}`);
+        await gate?.promise;
+        log.push(`end:${run}`);
+      });
+
+      runningPromise.start();
+      expect(counter).toEqual(1);
+
+      // The first trigger is served by the pass that starts once the initial (gated) pass returns.
+      const first = runningPromise.trigger().then(() => log.push('first'));
+      gates[0].resolve();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(counter).toEqual(2);
+      expect(log).not.toContain('first');
+
+      // The second trigger arrives while the pass serving the first one is in flight, so it must wait for a fresh
+      // third pass rather than resolving off the pass that was already running.
+      const second = runningPromise.trigger().then(() => log.push('second'));
+      gates[1].resolve();
+      await jest.advanceTimersByTimeAsync(0);
+      await Promise.all([first, second]);
+
+      expect(counter).toEqual(3);
+      expect(log.indexOf('first')).toBeGreaterThan(log.indexOf('end:2'));
+      expect(log.indexOf('second')).toBeGreaterThan(log.indexOf('end:3'));
+    });
+
+    it('rejects a pending trigger when stopped mid-pass', async () => {
+      const gate = promiseWithResolvers<void>();
+      fn.mockImplementation(() => {
+        counter++;
+        return counter === 1 ? gate.promise : Promise.resolve();
+      });
+
+      runningPromise.start();
+      expect(counter).toEqual(1);
+
+      const rejected = expect(runningPromise.trigger()).rejects.toThrow(
+        'RunningPromise stopped before serving trigger',
+      );
+      const stopped = runningPromise.stop();
+      gate.resolve();
+      await stopped;
+
+      await rejected;
+      expect(counter).toEqual(1);
+    });
+
+    it('rejects a pending trigger when the error handler requests an exit', async () => {
+      const gate = promiseWithResolvers<void>();
+      fn.mockImplementation(async () => {
+        counter++;
+        await gate.promise;
+        throw new Error('ouch');
+      });
+      errorHandler.mockReturnValue(RunningPromise.EXIT);
+
+      runningPromise.start();
+      expect(counter).toEqual(1);
+
+      const rejected = expect(runningPromise.trigger()).rejects.toThrow(
+        'RunningPromise stopped before serving trigger',
+      );
+      gate.resolve();
+      await jest.advanceTimersByTimeAsync(0);
+
+      await rejected;
+      expect(runningPromise.isRunning()).toBe(false);
+      expect(counter).toEqual(1);
+    });
+
+    it('resolves a trigger served by the pass in flight when stopped during that pass', async () => {
+      const gate = promiseWithResolvers<void>();
+      fn.mockImplementation(() => {
+        counter++;
+        return counter === 2 ? gate.promise : Promise.resolve();
+      });
+
+      runningPromise.start();
+      expect(counter).toEqual(1);
+
+      // The pass serving this trigger is already running when stop() is called, so the request is still served.
+      const pending = runningPromise.trigger();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(counter).toEqual(2);
+
+      const stopped = runningPromise.stop();
+      gate.resolve();
+      await stopped;
+
+      await expect(pending).resolves.toBeUndefined();
       expect(counter).toEqual(2);
     });
   });

--- a/yarn-project/foundation/src/promise/running-promise.ts
+++ b/yarn-project/foundation/src/promise/running-promise.ts
@@ -1,3 +1,4 @@
+import { InterruptError } from '../error/index.js';
 import { type Logger, createLogger } from '../log/pino-logger.js';
 import { InterruptibleSleep } from '../sleep/index.js';
 import { type PromiseWithResolvers, promiseWithResolvers } from './utils.js';
@@ -22,17 +23,16 @@ export function makeLoggingErrorHandler(
  * at a specified polling interval. It allows starting, stopping, and checking the status of the
  * internally managed promise. The class also supports interrupting the polling process when stopped.
  */
-export class RunningPromise<T = void> {
+export class RunningPromise {
   private running = false;
   private runningPromise = Promise.resolve();
   private interruptibleSleep = new InterruptibleSleep();
   private requested: PromiseWithResolvers<void> | undefined = undefined;
-  private requestedArg: T | undefined = undefined;
 
   public static readonly EXIT: typeof EXIT = EXIT;
 
   constructor(
-    private fn: (arg?: T) => void | Promise<void>,
+    private fn: () => void | Promise<void>,
     private logger = createLogger('running-promise'),
     private pollingIntervalMS = 10000,
     private handleError: ErrorHandler = makeLoggingErrorHandler(logger),
@@ -50,9 +50,10 @@ export class RunningPromise<T = void> {
 
     const poll = async () => {
       while (this.running) {
-        const hasRequested = this.requested !== undefined;
+        const requested = this.requested;
+        this.requested = undefined;
         try {
-          await this.fn(this.requestedArg);
+          await this.fn();
         } catch (err) {
           const code = await this.handleError(err);
           if (code === RunningPromise.EXIT) {
@@ -62,10 +63,8 @@ export class RunningPromise<T = void> {
         }
 
         // If an immediate run had been requested *before* the function started running, resolve the request.
-        if (hasRequested) {
-          this.requested!.resolve();
-          this.requested = undefined;
-          this.requestedArg = undefined;
+        if (requested) {
+          requested.resolve();
         }
 
         // If no immediate run was requested, sleep for the polling interval.
@@ -73,6 +72,12 @@ export class RunningPromise<T = void> {
           await this.interruptibleSleep.sleep(this.pollingIntervalMS);
         }
       }
+
+      // A trigger that arrived after the final pass started will never be served by any pass, so settle it as
+      // failed rather than leaving its caller waiting forever.
+      const unserved = this.requested;
+      this.requested = undefined;
+      unserved?.reject(new InterruptError('RunningPromise stopped before serving trigger'));
     };
     this.runningPromise = poll();
     return this;
@@ -101,21 +106,26 @@ export class RunningPromise<T = void> {
 
   /**
    * Triggers an immediate run of the function, bypassing the polling interval.
-   * If the function is currently running, it will be allowed to continue and then called again immediately.
+   *
+   * Resolves only after a complete run of the function that *started after* this call: a run already in flight is
+   * allowed to finish first, and the function is then called again. Concurrent callers coalesce onto a single such
+   * run. Rejects if the loop stops (via `stop()` or an error handler requesting exit) before that run happens.
+   *
+   * Calling this from inside the function itself and awaiting the result deadlocks, since the awaited run cannot
+   * start until the current one returns. That usage is not supported.
    */
-  public async trigger(arg?: T): Promise<void> {
+  public async trigger(): Promise<void> {
     if (!this.running) {
-      return this.fn(arg);
+      return this.fn();
     }
 
     let requested = this.requested;
     if (!requested) {
       requested = promiseWithResolvers<void>();
       this.requested = requested;
-      this.requestedArg = arg;
       this.interruptibleSleep.interrupt();
     }
-    await requested!.promise;
+    await requested.promise;
   }
 
   /**

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -457,19 +457,16 @@ export enum L2BlockSourceEvents {
 
 /**
  * Aggregate event emitted once per committed archiver sync pass that mutated local state. Carries the chain tips
- * before and after the pass, and the blocks added during it. Consumers compare `fromTips` and `toTips` to learn what
- * moved; there is no separate `changed` section.
+ * before and after the pass; consumers compare `fromTips` and `toTips` to learn what moved, and read any data they
+ * need from the source itself.
  *
  * This is an optimization signal that lets a block stream reconcile immediately on an archiver update rather than
  * waiting for its next poll. Polling remains the correctness fallback, so a missed event only affects latency.
- * `blocksAdded` are hydrated blocks already in hand from the sync pass, so a triggered sync that is caught up to
- * `fromTips` can reuse them (and `toTips`) instead of re-reading the store.
  */
 export type L2BlockSourceUpdatedEvent = {
   type: 'l2BlockSourceUpdated';
   fromTips: L2Tips;
   toTips: L2Tips;
-  blocksAdded: readonly L2Block[];
 };
 
 export type L2BlockProvenEvent = {

--- a/yarn-project/stdlib/src/block/l2_block_stream/event_driven_l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/event_driven_l2_block_stream.test.ts
@@ -104,12 +104,11 @@ describe('EventDrivenL2BlockStream', () => {
     getL2Tips.mockResolvedValue(makeTips(proposed));
   };
 
-  const emitUpdate = (fromProposed: number, toProposed: number, blocksAdded: L2Block[]) => {
+  const emitUpdate = (fromProposed: number, toProposed: number) => {
     const event: L2BlockSourceUpdatedEvent = {
       type: 'l2BlockSourceUpdated',
       fromTips: makeTips(fromProposed),
       toTips: makeTips(toProposed),
-      blocksAdded,
     };
     events.emit(L2BlockSourceEvents.L2BlockSourceUpdated, event);
   };
@@ -155,71 +154,46 @@ describe('EventDrivenL2BlockStream', () => {
     expect(handler.addedBlockNumbers()).toEqual([1, 2, 3, 4, 5]);
   });
 
-  it('serves a fully-covered block range from the hot cache without hitting the source', async () => {
+  it('runs a pass reading from the source as soon as an event arrives', async () => {
     // Start fully synced so start()'s immediate pass is a no-op (no getBlocks).
     setSourceTips(3);
     local.proposedNumber = BlockNumber(3);
     wrapper.start();
     await waitFor(() => getL2Tips.mock.calls.length > 0);
 
-    // Source advances to 6; the aggregate event begins at the stream's local tip (3) and carries the three new
-    // blocks 4-6, so the stream is caught up to its `fromTips` and the fast path is armed.
+    // The source advances to 6. The event carries no block data, so the triggered pass reads tips and blocks from
+    // the source itself.
     setSourceTips(6);
     getBlocks.mockClear();
     getL2Tips.mockClear();
     handler.events.length = 0;
-    emitUpdate(3, 6, [makeBlock(4), makeBlock(5), makeBlock(6)]);
+    emitUpdate(3, 6);
 
     await waitFor(() => handler.events.some(e => e.type === 'blocks-added'));
 
-    // The full 4-6 range was served from the cache and `toTips` short-circuits the tips read, so neither the
-    // source's getBlocks nor getL2Tips was called.
-    expect(getBlocks).not.toHaveBeenCalled();
-    expect(getL2Tips).not.toHaveBeenCalled();
-    expect(handler.addedBlockNumbers()).toEqual([4, 5, 6]);
-  });
-
-  it('delegates to the source when the cache only partially covers the requested range', async () => {
-    setSourceTips(3);
-    local.proposedNumber = BlockNumber(3);
-    wrapper.start();
-    await waitFor(() => getL2Tips.mock.calls.length > 0);
-
-    setSourceTips(6);
-    getBlocks.mockClear();
-    handler.events.length = 0;
-    // Event begins at the local tip (3) but only carries blocks 4-5, while the stream needs through block 6.
-    emitUpdate(3, 6, [makeBlock(4), makeBlock(5)]);
-
-    await waitFor(() => handler.events.some(e => e.type === 'blocks-added'));
-
+    expect(getL2Tips).toHaveBeenCalled();
     expect(getBlocks).toHaveBeenCalled();
     expect(handler.addedBlockNumbers()).toEqual([4, 5, 6]);
   });
 
-  it('delegates fully to the source when not caught up to the event start', async () => {
+  it('catches up even when the event begins ahead of the local tip', async () => {
     setSourceTips(3);
     local.proposedNumber = BlockNumber(3);
     wrapper.start();
     await waitFor(() => getL2Tips.mock.calls.length > 0);
 
     // The source has moved to 6, but the event began at proposed 5: the stream (local tip 3) missed intervening
-    // updates and is not caught up to the event's `fromTips`, so its blocks cannot be applied directly.
+    // updates. Reading from the source makes the pass catch up regardless of what the event reports.
     setSourceTips(6);
-    getBlocks.mockClear();
-    getL2Tips.mockClear();
     handler.events.length = 0;
-    emitUpdate(5, 6, [makeBlock(6)]);
+    emitUpdate(5, 6);
 
     await waitFor(() => handler.events.some(e => e.type === 'blocks-added'));
 
-    // Not caught up: the fast path is not armed, so the source is queried for both tips and blocks.
-    expect(getL2Tips).toHaveBeenCalled();
-    expect(getBlocks).toHaveBeenCalled();
     expect(handler.addedBlockNumbers()).toEqual([4, 5, 6]);
   });
 
-  it('coalesces several events arriving during a sync into a single follow-up pass', async () => {
+  it('runs a follow-up pass for an event arriving while a pass is in flight', async () => {
     // No-op passes (local == source) so each pass only reads getL2Tips.
     setSourceTips(3);
     local.proposedNumber = BlockNumber(3);
@@ -228,7 +202,7 @@ describe('EventDrivenL2BlockStream', () => {
     let calls = 0;
     getL2Tips.mockImplementation(() => {
       calls++;
-      // Block only the first pass so the events fired during it coalesce into one follow-up.
+      // Block only the first pass, so the event fired during it cannot be served by that same pass.
       return (calls === 1 ? gate.promise : Promise.resolve()).then(() => makeTips(3));
     });
 
@@ -236,11 +210,31 @@ describe('EventDrivenL2BlockStream', () => {
     wrapper.start();
     expect(calls).toBe(1);
 
-    // Three events arrive while the first pass is in flight. They begin at proposed 2 (≠ local 3) so each would
-    // take the source-backed slow path; the point is that they coalesce into a single follow-up pass regardless.
-    emitUpdate(2, 3, []);
-    emitUpdate(2, 3, []);
-    emitUpdate(2, 3, []);
+    emitUpdate(3, 3);
+    gate.resolve();
+
+    await waitFor(() => calls >= 2);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('coalesces several events arriving during a sync into a single follow-up pass', async () => {
+    setSourceTips(3);
+    local.proposedNumber = BlockNumber(3);
+
+    const gate = promiseWithResolvers<void>();
+    let calls = 0;
+    getL2Tips.mockImplementation(() => {
+      calls++;
+      return (calls === 1 ? gate.promise : Promise.resolve()).then(() => makeTips(3));
+    });
+
+    wrapper.start();
+    expect(calls).toBe(1);
+
+    // Three events arrive while the first pass is in flight; they must coalesce into a single follow-up pass.
+    emitUpdate(3, 3);
+    emitUpdate(3, 3);
+    emitUpdate(3, 3);
 
     gate.resolve();
     await waitFor(() => calls >= 2);
@@ -271,5 +265,21 @@ describe('EventDrivenL2BlockStream', () => {
     }
 
     expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('stops listening to source events once stopped', async () => {
+    setSourceTips(3);
+    local.proposedNumber = BlockNumber(3);
+    wrapper.start();
+    await waitFor(() => getL2Tips.mock.calls.length > 0);
+
+    await wrapper.stop();
+    expect(wrapper.isRunning()).toBe(false);
+
+    getL2Tips.mockClear();
+    emitUpdate(3, 6);
+    await sleep(30);
+
+    expect(getL2Tips).not.toHaveBeenCalled();
   });
 });

--- a/yarn-project/stdlib/src/block/l2_block_stream/event_driven_l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/event_driven_l2_block_stream.ts
@@ -1,156 +1,51 @@
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
-import type { BlockData } from '../block_data.js';
-import type { L2Block } from '../l2_block.js';
 import {
   type ArchiverEmitter,
-  type BlockQuery,
-  type BlocksQuery,
   type L2BlockSource,
   type L2BlockSourceEventEmitter,
   L2BlockSourceEvents,
-  type L2BlockSourceUpdatedEvent,
-  type L2Tips,
 } from '../l2_block_source.js';
-import { type L2BlockStreamEventHandler, type L2BlockStreamLocalDataProvider, localTipsMatch } from './interfaces.js';
-import { L2BlockStream, type L2BlockStreamOptions, type L2BlockStreamSource } from './l2_block_stream.js';
-
-/** Derives the metadata-only {@link BlockData} view of a hydrated {@link L2Block}. */
-async function l2BlockToBlockData(block: L2Block): Promise<BlockData> {
-  return {
-    header: block.header,
-    archive: block.archive,
-    blockHash: await block.hash(),
-    checkpointNumber: block.checkpointNumber,
-    indexWithinCheckpoint: block.indexWithinCheckpoint,
-  };
-}
+import type { L2BlockStreamEventHandler, L2BlockStreamLocalDataProvider } from './interfaces.js';
+import { L2BlockStream, type L2BlockStreamOptions } from './l2_block_stream.js';
 
 /** Returns the event emitter of a source that exposes one, or undefined for plain (e.g. RPC-backed) sources. */
 function getEmitter(source: L2BlockSource | L2BlockSourceEventEmitter): ArchiverEmitter | undefined {
   return 'events' in source ? source.events : undefined;
 }
 
-/** Fast-path context for a single sync pass: blocks to serve by number, plus the tips to report as the source's. */
-type ActiveUpdate = { byNumber: Map<number, L2Block>; toTips: L2Tips };
-
-/**
- * Wraps a block source so a single sync pass can be served from blocks delivered by an aggregate update event,
- * avoiding round-trips to archiver storage. The fast path is only armed (via {@link activate}) for a pass that is
- * confirmed caught up to the event's pre-pass tips: in that case the event's `blocksAdded` contiguously cover the
- * pass's download range and `toTips` is the exact post-pass tip, so `getL2Tips` can report it without querying the
- * source. When the fast path is not armed, every read delegates to the source, so a stale or partial cache never
- * changes the sync outcome.
- */
-class HotBlockSourceAdapter implements L2BlockStreamSource {
-  /** Set for the duration of one fast-path pass; undefined when reads must delegate to the source. */
-  private active: ActiveUpdate | undefined;
-
-  constructor(
-    private readonly source: L2BlockStreamSource,
-    private readonly log: Logger,
-  ) {}
-
-  /** Arms the fast path for the current pass: serve these blocks and report `toTips` as the source tips. */
-  public activate(blocks: readonly L2Block[], toTips: L2Tips): void {
-    const byNumber = new Map<number, L2Block>();
-    for (const block of blocks) {
-      byNumber.set(block.number, block);
-    }
-    this.active = { byNumber, toTips };
-    this.log.trace(`Armed hot-block fast path`, { blocks: byNumber.size, toTips });
-  }
-
-  /** Disarms the fast path so subsequent reads delegate to the source again. */
-  public deactivate(): void {
-    this.active = undefined;
-  }
-
-  public getL2Tips(): Promise<L2Tips> {
-    return this.active ? Promise.resolve(this.active.toTips) : this.source.getL2Tips();
-  }
-
-  public getBlocks(query: BlocksQuery): Promise<L2Block[]> {
-    const served = this.active ? this.tryServeBlocksFromCache(query) : undefined;
-    return served ? Promise.resolve(served) : this.source.getBlocks(query);
-  }
-
-  public getBlockData(query: BlockQuery): Promise<BlockData | undefined> {
-    if (this.active && 'number' in query) {
-      const block = this.active.byNumber.get(query.number);
-      if (block) {
-        return l2BlockToBlockData(block);
-      }
-    }
-    return this.source.getBlockData(query);
-  }
-
-  /** Serves a block range from the cache only when it is fully covered by contiguous cached blocks. */
-  private tryServeBlocksFromCache(query: BlocksQuery): L2Block[] | undefined {
-    // Only the by-range form is cacheable, and only for the full (not checkpointed-only) chain: the cache may hold
-    // uncheckpointed blocks that an onlyCheckpointed query must not receive.
-    if (!this.active || !('from' in query) || query.onlyCheckpointed) {
-      return undefined;
-    }
-    const from = query.from;
-    const to = from + query.limit - 1;
-    const blocks: L2Block[] = [];
-    for (let n = from; n <= to; n++) {
-      const block = this.active.byNumber.get(n);
-      if (!block) {
-        // A gap inside the requested range: bail out and let the source serve the whole range.
-        return undefined;
-      }
-      blocks.push(block);
-    }
-    return blocks;
-  }
-}
-
 /**
  * Event-driven wrapper around {@link L2BlockStream}. Subscribes to the source's aggregate `l2BlockSourceUpdated`
- * event (when the source exposes one) to trigger an immediate reconciliation, while keeping the periodic poll as
- * the correctness fallback. Subsystems keep consuming the same {@link L2BlockStreamEvent}s; the archiver aggregate
- * event is handled entirely here.
- *
- * The event is passed through to the sync pass via {@link RunningPromise.trigger}. If, at the time the pass runs,
- * the stream's local tips match the event's `fromTips` (it is caught up to where the event began), the event's
- * hydrated blocks are served back through a hot-block cache and the event's `toTips` is reported as the source tips
- * — so the triggered sync re-reads neither block bodies nor tips from the archiver. Otherwise the pass delegates
- * entirely to the source, and the periodic poll guarantees eventual catch-up.
+ * event (when the source exposes one) and uses it purely as a doorbell: each event triggers an immediate
+ * reconciliation pass instead of waiting for the next tick, while the periodic poll remains the correctness
+ * fallback. Every pass reads tips and blocks authoritatively from the source, so a missed, stale, or duplicated
+ * event only affects latency. Subsystems keep consuming the same {@link L2BlockStreamEvent}s; the archiver
+ * aggregate event is handled entirely here.
  */
 export class EventDrivenL2BlockStream {
-  private readonly adapter: HotBlockSourceAdapter;
   private readonly blockStream: L2BlockStream;
-  private readonly runningPromise: RunningPromise<L2BlockSourceUpdatedEvent>;
+  private readonly runningPromise: RunningPromise;
   private readonly emitter: ArchiverEmitter | undefined;
   private started = false;
 
-  private readonly onSourceUpdated = (event: L2BlockSourceUpdatedEvent) => {
+  private readonly onSourceUpdated = () => {
     // Fire-and-forget: trigger coalesces with any in-flight or periodic pass (see RunningPromise.trigger), so a
     // burst of events does not run passes concurrently. Errors are swallowed by the inner stream's own handler.
-    void this.runningPromise
-      .trigger(event)
-      .catch(err => this.log.error(`Error in event-triggered block stream sync`, err));
+    void this.runningPromise.trigger().catch(err => this.log.error(`Error in event-triggered block stream sync`, err));
   };
 
   constructor(
     source: L2BlockSource | L2BlockSourceEventEmitter,
-    private readonly localData: L2BlockStreamLocalDataProvider,
+    localData: L2BlockStreamLocalDataProvider,
     handler: L2BlockStreamEventHandler,
     private readonly log = createLogger('types:event_driven_block_stream'),
     opts: L2BlockStreamOptions = {},
   ) {
-    this.adapter = new HotBlockSourceAdapter(source, log);
     // The inner stream's own RunningPromise is never started; this wrapper owns the polling loop and drives the
     // stream through `sync()` (which runs `work()` directly when the inner loop is stopped).
-    this.blockStream = new L2BlockStream(this.adapter, localData, handler, log, opts);
-    this.runningPromise = new RunningPromise<L2BlockSourceUpdatedEvent>(
-      this.runPass.bind(this),
-      log,
-      opts.pollIntervalMS ?? 1000,
-    );
+    this.blockStream = new L2BlockStream(source, localData, handler, log, opts);
+    this.runningPromise = new RunningPromise(() => this.blockStream.sync(), log, opts.pollIntervalMS ?? 1000);
     this.emitter = getEmitter(source);
   }
 
@@ -176,32 +71,11 @@ export class EventDrivenL2BlockStream {
   }
 
   /**
-   * Runs a synchronization pass now, bypassing the poll interval, and resolves once that pass completes. Concurrent
-   * callers and periodic ticks coalesce onto a single pass; a caller that coalesces onto an already in-flight pass
-   * can resolve against a pass that began just before it, so this guarantees freshness only up to that coalescing
-   * window. The periodic poll and per-pass reorg handling make the gap a latency effect, never a correctness one.
+   * Runs a synchronization pass now, bypassing the poll interval. Resolves once a pass that started after this call
+   * completes, so the caller observes state at least as fresh as the moment it asked. Concurrent callers coalesce
+   * onto a single such pass. Rejects if the stream is stopped before that pass runs.
    */
   public sync(): Promise<void> {
     return this.runningPromise.trigger();
-  }
-
-  /**
-   * Runs a single pass over the underlying block stream. When triggered by an aggregate event and the stream is
-   * caught up to the event's pre-pass tips, the event's blocks and tips serve the pass directly; the fast path is
-   * always disarmed afterwards so a subsequent poll-driven pass reads from the source.
-   */
-  private async runPass(event?: L2BlockSourceUpdatedEvent): Promise<void> {
-    if (event) {
-      const localTips = await this.localData.getL2Tips();
-      if (localTipsMatch(localTips, event.fromTips)) {
-        this.adapter.activate(event.blocksAdded, event.toTips);
-      }
-    }
-
-    try {
-      await this.blockStream.sync();
-    } finally {
-      this.adapter.deactivate();
-    }
   }
 }


### PR DESCRIPTION
Fixes a race where `worldState.syncImmediate(N)` failed with `block_not_available` even though the archiver had block N, alerting `Eviction rule FeePayerBalanceEviction failed` on production nodes.

## Context

`EventDrivenL2BlockStream.sync()` goes through `RunningPromise.trigger()`, whose pending-request slot was only cleared after the pass serving it completed. Since the world-state stream is event-driven, nearly every block-processing pass serves a request, so a `sync()` arriving mid-pass attached to a pass that started before the archiver committed the target block and resolved at N-1. Additionally, a trigger coalescing onto a pending request silently dropped its event payload, so the next pass could run armed with an older event's hot-block cache, which capped `getL2Tips()` below the archiver's real tip. Both mechanisms produce the observed error; the 100ms fallback poll self-healed right after.

## Approach

- `RunningPromise` now captures and clears the request slot when a pass starts, so `trigger()` resolves only after a full run that started after the call; unserved requests are rejected when the loop exits instead of hanging; the per-trigger argument is removed entirely.
- `EventDrivenL2BlockStream` is reduced to a doorbell: the archiver's aggregate event just triggers an immediate reconciliation pass, and every pass reads tips and blocks authoritatively from the source. The `HotBlockSourceAdapter` fast path and the event's `blocksAdded` payload are deleted — their arming conditions were the source of the race, and their only real saving was block-body re-hydration on event-triggered passes.
- The latency win that motivated the event-driven stream (#24317) is preserved; if the removed body-read saving ever shows up in profiles, it should be recovered inside the archiver with a content-addressed block cache instead (tracked separately).

Fixes A-1659