### PR TITLE
fix(validator): remove duplicate time-sensitive validation of block proposals

### DIFF
--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -2,7 +2,7 @@ import type { BlobClientInterface } from '@aztec/blob-client/client';
 import type { EpochCache } from '@aztec/epoch-cache';
 import type { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
-import { BlockProposalValidator, type P2PClient } from '@aztec/p2p';
+import type { P2PClient } from '@aztec/p2p';
 import type { L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import type { CheckpointReexecutionTracker } from '@aztec/stdlib/checkpoint';
 import type { ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
@@ -12,7 +12,6 @@ import type { TelemetryClient } from '@aztec/telemetry-client';
 import type { SlashingProtectionDatabase } from '@aztec/validator-ha-signer/types';
 
 import type { FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
-import { DEFAULT_MAX_GOSSIP_CLOCK_DISPARITY_MS } from './config.js';
 import { ValidatorMetrics } from './metrics.js';
 import { ProposalHandler } from './proposal_handler.js';
 import { ValidatorClient } from './validator.js';
@@ -37,23 +36,12 @@ export function createProposalHandler(
     l1Constants: deps.epochCache.getL1Constants(),
     blockDuration: config.blockDurationMs / 1000,
   });
-  const blockProposalValidator = new BlockProposalValidator(deps.epochCache, consensusTimetable, {
-    txsPermitted: !config.disableTransactions,
-    maxTxsPerBlock: config.validateMaxTxsPerBlock ?? config.validateMaxTxsPerCheckpoint,
-    maxBlocksPerCheckpoint: config.maxBlocksPerCheckpoint,
-    signatureContext: {
-      chainId: config.l1ChainId,
-      rollupAddress: config.rollupAddress,
-    },
-    clockDisparityMs: config.maxGossipClockDisparityMs ?? DEFAULT_MAX_GOSSIP_CLOCK_DISPARITY_MS,
-  });
   return new ProposalHandler(
     deps.checkpointsBuilder,
     deps.worldState,
     deps.blockSource,
     deps.l1ToL2MessageSource,
     deps.p2pClient.getTxProvider(),
-    blockProposalValidator,
     deps.epochCache,
     consensusTimetable,
     config,

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -3,13 +3,12 @@ import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
-import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { type FieldsOf, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
-import type { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import { type Checkpoint, CheckpointReexecutionTracker, type ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
@@ -102,7 +101,6 @@ describe('ProposalHandler checkpoint validation', () => {
       blockSource,
       l1ToL2MessageSource,
       mock<ITxProvider>(),
-      mock<BlockProposalValidator>(),
       epochCache,
       consensusTimetable,
       config,
@@ -173,7 +171,6 @@ describe('ProposalHandler checkpoint validation', () => {
         blockSource,
         l1ToL2MessageSource,
         mock<ITxProvider>(),
-        mock<BlockProposalValidator>(),
         epochCache,
         consensusTimetable,
         config,
@@ -727,9 +724,6 @@ describe('ProposalHandler checkpoint validation', () => {
       genesisArchiveRoot: proposal.blockHeader.lastArchive.root,
     } as any);
 
-    const blockProposalValidator = mock<BlockProposalValidator>();
-    blockProposalValidator.validate.mockResolvedValue({ result: 'accept' } as any);
-
     const txProvider = mock<ITxProvider>();
     txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
 
@@ -739,7 +733,6 @@ describe('ProposalHandler checkpoint validation', () => {
       blockSource,
       l1ToL2MessageSource,
       txProvider,
-      blockProposalValidator,
       epochCache,
       consensusTimetable,
       config,
@@ -865,6 +858,54 @@ describe('ProposalHandler checkpoint validation', () => {
         blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
         reason: 'block_number_already_exists',
       });
+    });
+  });
+
+  describe('handleBlockProposal arrival window', () => {
+    // Whether a proposal arrived in time is decided once, at p2p ingress. Re-deciding it here would make
+    // the verdict depend on how long this node took to get around to processing the proposal, turning
+    // local latency into a slashable invalid-proposal verdict against an honest proposer.
+    it('processes a proposal whose receive window closed while it waited to be processed', async () => {
+      const signer = Secp256k1Signer.random();
+      const proposal = await makeBlockProposal({
+        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
+        archiveRoot: Fr.random(),
+        signer,
+      });
+
+      // Parent archive == genesis archive → genesis path → blockNumber = INITIAL_L2_BLOCK_NUM.
+      blockSource.getGenesisValues.mockResolvedValue({
+        genesisArchiveRoot: proposal.blockHeader.lastArchive.root,
+      } as any);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+      // Slot 1's proposal receive window is [-4s, 17s]; 30s is well past its close.
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: EpochNumber(0),
+        slot: SlotNumber(1),
+        ts: 30n,
+        nowMs: 30_000n,
+      });
+
+      const txProvider = mock<ITxProvider>();
+      txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
+
+      const blockHandler = new ProposalHandler(
+        checkpointsBuilder,
+        mock<WorldStateSynchronizer>(),
+        blockSource,
+        l1ToL2MessageSource,
+        txProvider,
+        epochCache,
+        consensusTimetable,
+        config,
+        mock<BlobClientInterface>(),
+        new CheckpointReexecutionTracker(),
+        metrics,
+        dateProvider,
+      );
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: true, blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
     });
   });
 });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -20,7 +20,6 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { isErrorClass } from '@aztec/foundation/types';
 import type { P2P, PeerId } from '@aztec/p2p';
-import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import type { CheckpointReexecutionTracker, ReexecutionOutcome } from '@aztec/stdlib/checkpoint';
 import { getPreviousCheckpointOutHashes, validateCheckpoint } from '@aztec/stdlib/checkpoint';
@@ -248,7 +247,6 @@ export class ProposalHandler {
     private blockSource: L2BlockSource & L2BlockSink,
     private l1ToL2MessageSource: L1ToL2MessageSource,
     private txProvider: ITxProvider,
-    private blockProposalValidator: BlockProposalValidator,
     private epochCache: EpochCache,
     private timetable: ConsensusTimetable,
     private config: ValidatorClientFullConfig,
@@ -472,13 +470,12 @@ export class ProposalHandler {
       txHashes: proposal.txHashes.map(t => t.toString()),
     });
 
-    // Check that the proposal is from the current proposer, or the next proposer
-    // This should have been handled by the p2p layer, but we double check here out of caution
-    const validationResult = await this.blockProposalValidator.validate(proposal);
-    if (validationResult.result !== 'accept') {
-      this.log.warn(`Proposal is not valid, skipping processing`, proposalInfo);
-      return { isValid: false, reason: 'invalid_proposal' };
-    }
+    // Every proposal reaching this handler was already validated on arrival at p2p ingress (signature
+    // context, signature, expected proposer, index within checkpoint, tx fields) — including the
+    // receive-window check that decides whether it arrived in time. That window is deliberately not
+    // re-applied here: its outcome depends on the wall clock at evaluation time, so re-running it turned
+    // node-local processing latency into an invalid-proposal verdict against an honest proposer, which then
+    // fed the invalid-block slashing path. The checks below are all deterministic properties of the payload.
 
     // A tx can only appear once in a block: the second copy would emit nullifiers already emitted by the
     // first. This is not a relaying-peer fault, so it passes gossip validation and is classified here as

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -444,6 +444,13 @@ export class ProposalHandler {
     return this;
   }
 
+  /**
+   * Processes a block proposal: collects its txs and, if requested, re-executes them to check the resulting
+   * block against the proposal. Expects the proposal to have already passed p2p ingress validation (signature
+   * context, signature, expected proposer, index within checkpoint, tx field checks, and the receive-window
+   * timeliness check) — none of those are re-applied here, and only deterministic properties of the payload
+   * are validated before processing.
+   */
   async handleBlockProposal(
     proposal: BlockProposal,
     proposalSender: PeerId,
@@ -470,12 +477,9 @@ export class ProposalHandler {
       txHashes: proposal.txHashes.map(t => t.toString()),
     });
 
-    // Every proposal reaching this handler was already validated on arrival at p2p ingress (signature
-    // context, signature, expected proposer, index within checkpoint, tx fields) — including the
-    // receive-window check that decides whether it arrived in time. That window is deliberately not
-    // re-applied here: its outcome depends on the wall clock at evaluation time, so re-running it turned
-    // node-local processing latency into an invalid-proposal verdict against an honest proposer, which then
-    // fed the invalid-block slashing path. The checks below are all deterministic properties of the payload.
+    // The receive-window check from p2p ingress is deliberately not re-applied here: its outcome depends on
+    // the wall clock at evaluation time, so re-running it turned node-local processing latency into an
+    // invalid-proposal verdict against an honest proposer, which then fed the invalid-block slashing path.
 
     // A tx can only appear once in a block: the second copy would emit nullifiers already emitted by the
     // first. This is not a relaying-peer fault, so it passes gossip validation and is classified here as
@@ -1051,6 +1055,8 @@ export class ProposalHandler {
    * Validates a checkpoint proposal, caches the result, and uploads blobs if configured.
    * Returns a cached result if the same proposal (archive + slot) was already validated.
    * Used by both the all-nodes callback (via register) and the validator client (via delegation).
+   * Expects the proposal to have already passed p2p ingress validation (expected proposer and receive-window
+   * timeliness); only deterministic properties of the signed payload are checked here.
    */
   async handleCheckpointProposal(
     proposal: CheckpointProposalCore,

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -14,7 +14,6 @@ import type { Hex } from '@aztec/foundation/string';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
 import type { P2P, TxProvider } from '@aztec/p2p';
-import { BlockProposalValidator } from '@aztec/p2p';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import { CheckpointReexecutionTracker } from '@aztec/stdlib/checkpoint';
@@ -223,19 +222,12 @@ describe('ValidatorClient HA Integration', () => {
       l1Constants: epochCache.getL1Constants(),
       blockDuration: 3,
     });
-    const blockProposalValidator = new BlockProposalValidator(epochCache, consensusTimetable, {
-      txsPermitted: true,
-      maxTxsPerBlock: undefined,
-      signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
-      clockDisparityMs: 500,
-    });
     const proposalHandler = new ProposalHandler(
       checkpointsBuilder,
       worldState,
       blockSource,
       l1ToL2MessageSource,
       txProvider,
-      blockProposalValidator,
       epochCache,
       consensusTimetable,
       config,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -1449,25 +1449,6 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(true);
     });
 
-    // Whether the signer is the slot's expected proposer is decided once, at p2p ingress (covered by the
-    // p2p proposal validator tests). Re-deriving it during processing only reflects how this node's
-    // committee view looks now, so a disagreement is a local inconsistency and must not be turned into a
-    // proposer offense.
-    it('validates without slashing when the local committee view no longer names the signer as proposer', async () => {
-      epochCache.getProposerAttesterAddressInSlot.mockImplementation(_ => Promise.resolve(EthAddress.random()));
-      epochCache.getTargetAndNextSlot.mockReturnValue({
-        targetSlot: proposal.slotNumber,
-        nextSlot: SlotNumber(proposal.slotNumber + 1),
-      });
-      const emitSpy = jest.spyOn(validatorClient, 'emit');
-
-      const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-
-      expect(isValid).toBe(true);
-      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
-      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
-    });
-
     it('should validate with any validators in the committee', async () => {
       epochCache.filterInCommittee.mockResolvedValueOnce(
         validatorAccounts.map(account => EthAddress.fromString(account.address)),
@@ -1475,34 +1456,6 @@ describe('ValidatorClient', () => {
 
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
       expect(isValid).toBe(true);
-    });
-
-    // Whether a proposal arrived in time is decided once, at p2p ingress (covered by the p2p proposal
-    // validator's receive-window tests). Re-applying that gate here would make the verdict depend on how
-    // long this node took to get around to the proposal, so validation past the window is expected to
-    // succeed and must never be treated as a proposer offense.
-    it('validates a proposal without slashing even once its receive window has closed', async () => {
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
-      const staleSlot = SlotNumber(proposal.slotNumber + 20);
-      epochCache.getTargetAndNextSlot.mockReturnValue({
-        targetSlot: staleSlot,
-        nextSlot: SlotNumber(proposal.slotNumber + 21),
-      });
-      epochCache.getEpochAndSlotNow.mockReturnValue({
-        epoch: EpochNumber(1),
-        slot: staleSlot,
-        ts: 0n,
-        nowMs: BigInt(staleSlot) * 24_000n,
-      });
-      epochCache.getSlotNow.mockReturnValue(staleSlot);
-      epochCache.getTargetSlot.mockReturnValue(staleSlot);
-      const emitSpy = jest.spyOn(validatorClient, 'emit');
-
-      const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-
-      expect(isValid).toBe(true);
-      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
-      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
     });
 
     it('should return false if messages do not match', async () => {

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -1449,16 +1449,23 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(true);
     });
 
-    it('should return false if the proposer is not the current proposer', async () => {
+    // Whether the signer is the slot's expected proposer is decided once, at p2p ingress (covered by the
+    // p2p proposal validator tests). Re-deriving it during processing only reflects how this node's
+    // committee view looks now, so a disagreement is a local inconsistency and must not be turned into a
+    // proposer offense.
+    it('validates without slashing when the local committee view no longer names the signer as proposer', async () => {
       epochCache.getProposerAttesterAddressInSlot.mockImplementation(_ => Promise.resolve(EthAddress.random()));
-
       epochCache.getTargetAndNextSlot.mockReturnValue({
         targetSlot: proposal.slotNumber,
         nextSlot: SlotNumber(proposal.slotNumber + 1),
       });
+      const emitSpy = jest.spyOn(validatorClient, 'emit');
 
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-      expect(isValid).toBe(false);
+
+      expect(isValid).toBe(true);
+      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
+      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
     });
 
     it('should validate with any validators in the committee', async () => {
@@ -1470,37 +1477,32 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(true);
     });
 
-    it('should return false if the proposal is not for the current or next slot', async () => {
+    // Whether a proposal arrived in time is decided once, at p2p ingress (covered by the p2p proposal
+    // validator's receive-window tests). Re-applying that gate here would make the verdict depend on how
+    // long this node took to get around to the proposal, so validation past the window is expected to
+    // succeed and must never be treated as a proposer offense.
+    it('validates a proposal without slashing even once its receive window has closed', async () => {
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
+      const staleSlot = SlotNumber(proposal.slotNumber + 20);
       epochCache.getTargetAndNextSlot.mockReturnValue({
-        targetSlot: SlotNumber(proposal.slotNumber + 20),
+        targetSlot: staleSlot,
         nextSlot: SlotNumber(proposal.slotNumber + 21),
       });
       epochCache.getEpochAndSlotNow.mockReturnValue({
         epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 20),
+        slot: staleSlot,
         ts: 0n,
-        nowMs: 0n,
+        nowMs: BigInt(staleSlot) * 24_000n,
       });
-      // Keep the wall-clock slot consistent with the "now" set above so the always-on pipelining
-      // acceptance window correctly treats the proposal's slot as stale (not the current slot).
-      epochCache.getSlotNow.mockReturnValue(SlotNumber(proposal.slotNumber + 20));
-      epochCache.getEpochAndSlotInNextL1Slot.mockReturnValue({
-        epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 20),
-        ts: 0n,
-        nowSeconds: 0n,
-      });
-      epochCache.getTargetSlot.mockReturnValue(SlotNumber(proposal.slotNumber + 20));
-      epochCache.getTargetEpochAndSlotInNextL1Slot.mockReturnValue({
-        epoch: EpochNumber(1),
-        slot: SlotNumber(proposal.slotNumber + 21),
-        ts: 0n,
-        nowSeconds: 0n,
-      });
+      epochCache.getSlotNow.mockReturnValue(staleSlot);
+      epochCache.getTargetSlot.mockReturnValue(staleSlot);
+      const emitSpy = jest.spyOn(validatorClient, 'emit');
 
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-      expect(isValid).toBe(false);
+
+      expect(isValid).toBe(true);
+      expect(emitSpy).not.toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, expect.anything());
+      expect(validatorClient.hasInvalidProposals(proposal.slotNumber)).toBe(false);
     });
 
     it('should return false if messages do not match', async () => {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -12,7 +12,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
 import type { DuplicateAttestationInfo, DuplicateProposalInfo, OversizedProposalInfo, P2P, PeerId } from '@aztec/p2p';
-import { AuthRequest, AuthResponse, BlockProposalValidator, ReqRespSubProtocol } from '@aztec/p2p';
+import { AuthRequest, AuthResponse, ReqRespSubProtocol } from '@aztec/p2p';
 import {
   OffenseType,
   WANT_TO_CLEAR_SLASH_EVENT,
@@ -58,7 +58,6 @@ import { EventEmitter } from 'events';
 import type { TypedDataDefinition } from 'viem';
 
 import type { FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
-import { DEFAULT_MAX_GOSSIP_CLOCK_DISPARITY_MS } from './config.js';
 import { ValidationService } from './duties/validation_service.js';
 import { HAKeyStore } from './key_store/ha_key_store.js';
 import type { ExtendedValidatorKeyStore } from './key_store/interface.js';
@@ -221,24 +220,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       l1Constants: epochCache.getL1Constants(),
       blockDuration: config.blockDurationMs / 1000,
     });
-    const blockProposalValidator = new BlockProposalValidator(epochCache, consensusTimetable, {
-      txsPermitted: !config.disableTransactions,
-      maxTxsPerBlock: config.validateMaxTxsPerBlock,
-      maxBlocksPerCheckpoint: config.maxBlocksPerCheckpoint,
-      skipSlotValidation: config.skipProposalSlotValidation,
-      signatureContext: {
-        chainId: config.l1ChainId,
-        rollupAddress: config.rollupAddress,
-      },
-      clockDisparityMs: config.maxGossipClockDisparityMs ?? DEFAULT_MAX_GOSSIP_CLOCK_DISPARITY_MS,
-    });
     const proposalHandler = new ProposalHandler(
       checkpointsBuilder,
       worldState,
       blockSource,
       l1ToL2MessageSource,
       txProvider,
-      blockProposalValidator,
       epochCache,
       consensusTimetable,
       config,


### PR DESCRIPTION
Removes the duplicate block-proposal validation that ran again downstream of p2p ingress, whose repeated wall-clock check could turn an honest, on-time proposal into a false slashable offense.

## Context

On mainnet a validator node classified a canonical block proposal as a slashable `invalid_proposal` offense. Block proposals are validated at p2p ingress, where the receive-window check decides whether they arrived in time; `ProposalHandler.handleBlockProposal` then re-ran that same validation "out of caution" before re-execution. When node-local processing stalled (~50s in the incident), the repeated wall-clock check failed an on-time proposal, and `invalid_proposal` is in `SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT` — so local latency was converted into slashing evidence against an honest proposer.

## Approach

Delete the downstream `blockProposalValidator.validate(proposal)` call and, with it, the now-unused `BlockProposalValidator` dependency of `ProposalHandler` (and its construction in `ValidatorClient.new` and `createProposalHandler`).

This is safe because every path into `handleBlockProposal` is post-ingress — gossiped block proposals and checkpoint-embedded blocks both pass ingress validation first, and there is no replay path — so the second pass added no coverage. The checks that remain downstream are deterministic properties of the signed payload rather than of the clock: the signature via `getSender()`, duplicate tx hashes, checkpoint/index consistency, in-hash agreement, embedded-tx integrity via tx collection, and full re-execution. The checkpoint-proposal path already operates without such a re-check. `invalid_proposal` stays in the slashable list, since it is still produced by the structural `computeCheckpointNumber` checks. The p2p package is untouched: ingress keeps its own validator.

Note that dropping the whole call also stops re-deriving the expected proposer downstream; that identity check likewise belongs to ingress, and the two `validator.test.ts` cases that pinned the old repeated-gate behavior were rewritten to assert the new contract (validates, no `WANT_TO_SLASH_EVENT`, slot not marked invalid).

This is the simpler alternative to #25201, which instead splits the validator into `validate()` / `validateStableFields()` and adds a non-slashable reason; the two are open in parallel for comparison.

Fixes A-1703