### PR TITLE
fix(pxe): run parallel operations to completion on failure

### DIFF
--- a/yarn-project/foundation/src/promise/utils.test.ts
+++ b/yarn-project/foundation/src/promise/utils.test.ts
@@ -1,0 +1,59 @@
+import { sleep } from '../sleep/index.js';
+import { allToCompletion, promiseWithResolvers } from './utils.js';
+
+describe('allToCompletion', () => {
+  it('resolves with an empty array for no inputs', async () => {
+    await expect(allToCompletion([])).resolves.toEqual([]);
+  });
+
+  it('resolves with the values in input order', async () => {
+    await expect(allToCompletion([Promise.resolve(1), 2, Promise.resolve(3)])).resolves.toEqual([1, 2, 3]);
+  });
+
+  it('rejects with the lone failure when a single promise rejects', async () => {
+    const error = new Error('lone failure');
+    await expect(allToCompletion([Promise.resolve(1), Promise.reject(error)])).rejects.toBe(error);
+  });
+
+  it('rejects with an AggregateError holding every failure when several promises reject', async () => {
+    const first = new Error('first');
+    const second = new Error('second');
+    const promise = allToCompletion([Promise.reject(first), Promise.resolve(1), Promise.reject(second)]);
+    await expect(promise).rejects.toThrow(AggregateError);
+    await expect(promise).rejects.toMatchObject({ errors: [first, second] });
+  });
+
+  it('stringifies non-Error reasons in the AggregateError message', async () => {
+    const promise = allToCompletion([Promise.reject('boom'), Promise.reject(new Error('second'))]);
+    await expect(promise).rejects.toThrow(/boom/);
+  });
+
+  it('does not reject until every promise has settled', async () => {
+    const { promise: slow, resolve: finishSlow } = promiseWithResolvers<void>();
+    let settled = false;
+    const result = allToCompletion([Promise.reject(new Error('fast failure')), slow]);
+    result.finally(() => (settled = true)).catch(() => {});
+
+    await sleep(1);
+    expect(settled).toBe(false);
+
+    finishSlow();
+    await expect(result).rejects.toThrow('fast failure');
+    expect(settled).toBe(true);
+  });
+
+  it('waits for a nested allToCompletion to run its branches to completion before settling', async () => {
+    const { promise: slow, resolve: finishSlow } = promiseWithResolvers<void>();
+    let settled = false;
+    const inner = allToCompletion([Promise.reject(new Error('inner failure')), slow]);
+    const outer = allToCompletion([inner, Promise.resolve()]);
+    outer.finally(() => (settled = true)).catch(() => {});
+
+    await sleep(1);
+    expect(settled).toBe(false);
+
+    finishSlow();
+    await expect(outer).rejects.toThrow('inner failure');
+    expect(settled).toBe(true);
+  });
+});

--- a/yarn-project/foundation/src/promise/utils.ts
+++ b/yarn-project/foundation/src/promise/utils.ts
@@ -1,3 +1,34 @@
+/**
+ * Like `Promise.all`, but runs every promise to completion before resolving or rejecting.
+ *
+ * `Promise.all` rejects as soon as one input rejects, abandoning the still-running siblings. When those siblings have
+ * side effects, the caller observes the rejection and reacts to the failure while the abandoned work is still
+ * producing effects. This helper instead guarantees that by the time it rejects, no input is still running.
+ *
+ * The signature mirrors `Promise.all`'s declaration in TypeScript's standard library, so call sites type exactly as
+ * they did with `Promise.all` (in particular, heterogeneous tuples keep their per-position types).
+ */
+export async function allToCompletion<T extends readonly unknown[] | []>(
+  promises: T,
+): Promise<{ -readonly [P in keyof T]: Awaited<T[P]> }> {
+  const results = await Promise.allSettled<unknown>(promises);
+  const failures = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (failures.length === 1) {
+    // Rethrow a lone failure as-is so error identity is preserved for callers that inspect error types.
+    throw failures[0].reason;
+  } else if (failures.length > 1) {
+    throw new AggregateError(
+      failures.map(failure => failure.reason),
+      `${failures.length} of ${results.length} concurrent operations failed: ${failures
+        .map(failure => (failure.reason instanceof Error ? failure.reason.message : String(failure.reason)))
+        .join(' | ')}`,
+    );
+  }
+  return results.map(result => (result as PromiseFulfilledResult<unknown>).value) as {
+    -readonly [P in keyof T]: Awaited<T[P]>;
+  };
+}
+
 export type PromiseWithResolvers<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;

--- a/yarn-project/pxe/src/contract/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract/contract_sync_service.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Semaphore } from '@aztec/foundation/queue';
 import { isProtocolContract } from '@aztec/protocol-contracts';
 import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
@@ -125,7 +126,9 @@ export class ContractSyncService implements StagedStore {
 
     for (const scope of scopesToSync) {
       const key = toKey(contractAddress, scope);
-      const promise = Promise.all([syncNullifiersPromise, runBounded(syncSlot, () => syncScopeFn(scope))])
+      // This cached promise is what every later request for this scope awaits, and both branches write staged data,
+      // so it must run both to completion even when one fails.
+      const promise = allToCompletion([syncNullifiersPromise, runBounded(syncSlot, () => syncScopeFn(scope))])
         .then(() => {})
         .catch(err => {
           this.syncedContracts.delete(key);
@@ -157,7 +160,7 @@ export class ContractSyncService implements StagedStore {
     const promises = scopes
       .map(scope => this.syncedContracts.get(toKey(contractAddress, scope)))
       .filter(p => p !== undefined);
-    await Promise.all(promises);
+    await allToCompletion(promises);
   }
 }
 

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -26,6 +26,7 @@ import {
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
 import type { KeyStore } from '@aztec/key-store';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -321,7 +322,7 @@ export class ContractFunctionSimulator {
           .map(r => r.inner)
           .concat(r.publicInputs.publicTeardownCallRequest.isEmpty() ? [] : [r.publicInputs.publicTeardownCallRequest]),
       );
-      const publicFunctionsCalldata = await Promise.all(
+      const publicFunctionsCalldata = await allToCompletion(
         publicCallRequests.map(async r => {
           const calldata = await privateExecutionOracle.getHashPreimage(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
@@ -527,7 +528,7 @@ export async function generateSimulatedProvingResult(
     scopedNullifiers.push(...execution.publicInputs.nullifiers.getActiveItems().map(n => n.scope(contractAddress)));
 
     taggedPrivateLogs.push(
-      ...(await Promise.all(
+      ...(await allToCompletion(
         execution.publicInputs.privateLogs.getActiveItems().map(async metadata => {
           metadata.log.fields[0] = await computeSiloedPrivateLogFirstField(contractAddress, metadata.log.fields[0]);
           return new OrderedSideEffect(metadata, metadata.counter);
@@ -606,12 +607,12 @@ export async function generateSimulatedProvingResult(
     scopedNullifiersCLA,
   );
 
-  const siloedNoteHashes = await Promise.all(
+  const siloedNoteHashes = await allToCompletion(
     filteredNoteHashes
       .sort((a, b) => a.counter - b.counter)
       .map(async nh => new OrderedSideEffect(await siloNoteHash(nh.contractAddress, nh.value), nh.counter)),
   );
-  const siloedNullifiers = await Promise.all(
+  const siloedNullifiers = await allToCompletion(
     filteredNullifiers
       .sort((a, b) => a.counter - b.counter)
       .map(async n => new OrderedSideEffect(await siloNullifier(n.contractAddress, n.value), n.counter)),
@@ -648,7 +649,7 @@ export async function generateSimulatedProvingResult(
   if (isPrivateOnlyTx) {
     // We must make the note hashes unique by using the
     // nonce generator and their index in the tx.
-    const uniqueNoteHashes = await Promise.all(
+    const uniqueNoteHashes = await allToCompletion(
       siloedNoteHashes.map(async (orderedSideEffect, i) => {
         const siloedNoteHash = orderedSideEffect.sideEffect;
         const nonce = await computeNoteHashNonce(nonceGenerator, i);
@@ -678,7 +679,7 @@ export async function generateSimulatedProvingResult(
       siloedNoteHashes,
       minRevertibleSideEffectCounter,
     );
-    const nonRevertibleUniqueNoteHashes = await Promise.all(
+    const nonRevertibleUniqueNoteHashes = await allToCompletion(
       nonRevertibleNoteHashes.map(async (noteHash, i) => {
         const nonce = await computeNoteHashNonce(nonceGenerator, i);
         return await computeUniqueNoteHash(nonce, noteHash);
@@ -827,7 +828,7 @@ async function verifyReadRequests(
     }
   }
 
-  const [noteHashResults, nullifierResults] = await Promise.all([
+  const [noteHashResults, nullifierResults] = await allToCompletion([
     settledNoteHashReads.length > 0
       ? node.findLeavesIndexes(
           anchorBlockHash,

--- a/yarn-project/pxe/src/contract_function_simulator/execution_note_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_note_cache.ts
@@ -1,4 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeNoteHashNonce, computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 
@@ -66,7 +67,7 @@ export class ExecutionNoteCache {
     // They cannot be squashed by nullifiers emitted after minRevertibleSideEffectCounter is set.
     // Their indexes in the tx are known at this point and won't change. So we can assign a nonce to each one of them.
     // The nonces will be used to create the "unique" note hashes.
-    const updatedNotes = await Promise.all(
+    const updatedNotes = await allToCompletion(
       this.notes.map(async ({ note, counter }, i) => {
         const noteNonce = await computeNoteHashNonce(nonceGenerator, i);
         const uniqueNoteHash = await computeUniqueNoteHash(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -1,6 +1,7 @@
 import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS, PRIVATE_CONTEXT_INPUTS_LENGTH } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
 import { toACVMWitness } from '@aztec/simulator/client';
 import {
@@ -217,7 +218,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     recipient: AztecAddress,
     deliveryMode: AppTaggingSecretKind,
   ): Promise<ResolvedTaggingStrategy> {
-    const [isUnconstrainedSelfSend, chosenStrategy] = await Promise.all([
+    const [isUnconstrainedSelfSend, chosenStrategy] = await allToCompletion([
       this.#isUnconstrainedSelfSend(recipient, deliveryMode),
       this.#chooseTaggingSecretStrategy(sender, recipient, deliveryMode),
     ]);
@@ -375,7 +376,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       // This is a tagging secret we've not yet used in this tx, so first sync our store to make sure its indices
       // are up to date. We do this here because this store is not synced as part of the global sync because
       // that'd be wasteful as most tagging secrets are not used in each tx.
-      const [{ finalized }, anchor] = await Promise.all([
+      const [{ finalized }, anchor] = await allToCompletion([
         this.l2TipsStore.getL2Tips(),
         logQueryAnchorOf(this.anchorBlockHeader),
       ]);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -5,6 +5,7 @@ import { Aes128 } from '@aztec/foundation/crypto/aes128';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
 import { LogLevels, type Logger, createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import {
@@ -291,7 +292,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   ): Promise<EphemeralArray<boolean>> {
     const hashes = blockHashes.readAll(this.ephemeralArrayService);
     const memberships = await this.#queryWithBlockHashNotAfterAnchor(referenceBlockHash, () =>
-      Promise.all(
+      allToCompletion(
         hashes.map(blockHash =>
           this.aztecNode.getBlockHashMembershipWitness(referenceBlockHash, blockHash).then(Boolean),
         ),
@@ -497,7 +498,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @returns A boolean indicating whether the nullifier exists in the tree or not.
    */
   public async doesNullifierExist(innerNullifier: Fr) {
-    const [nullifier, anchorBlockHash] = await Promise.all([
+    const [nullifier, anchorBlockHash] = await allToCompletion([
       siloNullifier(this.contractAddress, innerNullifier!),
       this.anchorBlockHeader.hash(),
     ]);
@@ -542,7 +543,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       const slots = Array(numberOfElements)
         .fill(0)
         .map((_, i) => new Fr(startStorageSlot.toBigInt() + BigInt(i)));
-      const values = await Promise.all(
+      const values = await allToCompletion(
         slots.map(storageSlot => this.aztecNode.getPublicStorageAt(blockHash, contractAddress, storageSlot)),
       );
 
@@ -657,7 +658,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockHeader, this.jobId);
     const eventService = new EventService(this.anchorBlockHeader, this.aztecNode, this.privateEventStore, this.jobId);
 
-    await Promise.all([
+    await allToCompletion([
       noteService.validateAndStoreNotes(noteValidationRequests, scope, validationTxData),
       eventService.validateAndStoreEvents(eventValidationRequests, scope, validationTxData),
     ]);
@@ -714,7 +715,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     }
 
     const uniqueTxHashes = uniqueBy(hashes, h => h.toString());
-    const options = await Promise.all(uniqueTxHashes.map(txHash => this.#getTxEffectOption(txHash)));
+    const options = await allToCompletion(uniqueTxHashes.map(txHash => this.#getTxEffectOption(txHash)));
     const optionsByHash = new Map(uniqueTxHashes.map((txHash, i) => [txHash.toString(), options[i]]));
 
     return EphemeralArray.fromValues(
@@ -932,7 +933,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const addressSecret = await computeAddressSecret(await recipientCompleteAddress.getPreaddress(), ivskM);
 
     const ephPkPoints = ephPks.readAll(this.ephemeralArrayService);
-    const secrets = await Promise.all(
+    const secrets = await allToCompletion(
       ephPkPoints.map(({ x, y }) => appSiloEcdhSharedSecret(addressSecret, new Point(x, y), this.contractAddress)),
     );
 
@@ -1020,7 +1021,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     if (!targetContractAddress.equals(this.contractAddress)) {
       // Standard handshake registry reads are authorized by default; every other cross-contract call needs the hook.
       if (!(await isStandardHandshakeRegistryUtilityRead(targetContractAddress, functionSelector))) {
-        const [callerClassId, targetClassId] = await Promise.all([
+        const [callerClassId, targetClassId] = await allToCompletion([
           this.anchoredContractData.getCurrentClassId(this.contractAddress),
           this.anchoredContractData.getCurrentClassId(targetContractAddress),
         ]);
@@ -1146,7 +1147,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       }
     }
 
-    const fetched = await Promise.all(misses.map(h => this.#getTxReceiptWithEffect(h)));
+    const fetched = await allToCompletion(misses.map(h => this.#getTxReceiptWithEffect(h)));
     return new Map([
       ...known,
       ...misses
@@ -1220,7 +1221,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       return query();
     }
 
-    const [response] = await Promise.all([
+    const [response] = await allToCompletion([
       query(),
       (async () => {
         const block = await this.aztecNode.getBlock(blockHash);
@@ -1285,7 +1286,7 @@ async function isStandardHandshakeRegistryUtilityRead(
     return false;
   }
 
-  const matches = await Promise.all(
+  const matches = await allToCompletion(
     STANDARD_HANDSHAKE_REGISTRY_DEFAULT_AUTHORIZED_READ_SIGNATURES.map(signature =>
       doesSelectorHaveSignature(functionSelector, signature),
     ),

--- a/yarn-project/pxe/src/error_enriching.ts
+++ b/yarn-project/pxe/src/error_enriching.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { resolveAssertionMessageFromRevertData, resolveOpcodeLocations } from '@aztec/simulator/client';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -35,7 +36,7 @@ export async function enrichSimulationError(
     }
   });
 
-  await Promise.all(
+  await allToCompletion(
     [...mentionedFunctions.entries()].map(async ([contractAddress, fnSelectors]) => {
       const parsedContractAddress = AztecAddress.fromStringUnsafe(contractAddress);
       const classId = await contractClassService.getCurrentClassId(parsedContractAddress, anchorHeader);
@@ -44,7 +45,7 @@ export async function enrichSimulationError(
         err.enrichWithContractName(parsedContractAddress, artifact.name);
         // Map from function selector to function name. It uses a stringified key for the same reason as mentionedFunctions.
         const selectorToNameMap: Map<string, string> = new Map();
-        await Promise.all(
+        await allToCompletion(
           artifact.functions.map(async fn => {
             const selector = await FunctionSelector.fromNameAndParameters(fn);
             selectorToNameMap.set(selector.toString(), fn.name);

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -1,5 +1,6 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { InBlock } from '@aztec/stdlib/block';
 import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
@@ -37,7 +38,7 @@ export class EventService {
 
     const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
 
-    await Promise.all(
+    await allToCompletion(
       requests.map(req => this.#validateAndStoreEvent(req, scope, validationTxData, anchorBlockNumber)),
     );
   }

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -2,6 +2,7 @@ import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2TipsProvider } from '@aztec/stdlib/block';
@@ -73,7 +74,7 @@ export class LogService {
 
     const anchor = await logQueryAnchorOf(this.anchorBlockHeader);
 
-    const [publicLogsPerRequest, privateLogsPerRequest] = await Promise.all([
+    const [publicLogsPerRequest, privateLogsPerRequest] = await allToCompletion([
       this.#fetchPublicLogs(contractAddress, logRetrievalRequests, anchor),
       this.#fetchPrivateLogs(logRetrievalRequests, anchor),
     ]);
@@ -97,7 +98,7 @@ export class LogService {
     const resultsPerRequest: LogResult[][] = requests.map(() => []);
     const groups = LogService.#groupByRange(indices.map(i => ({ index: i, request: requests[i] })));
 
-    await Promise.all(
+    await allToCompletion(
       Array.from(groups.values()).map(async group => {
         const tags = group.entries.map(e => e.request.tag);
         const results = await getAllPublicLogsByTagsFromContract(this.aztecNode, contractAddress, tags, anchor, {
@@ -123,9 +124,9 @@ export class LogService {
     const resultsPerRequest: LogResult[][] = requests.map(() => []);
     const groups = LogService.#groupByRange(indices.map(i => ({ index: i, request: requests[i] })));
 
-    await Promise.all(
+    await allToCompletion(
       Array.from(groups.values()).map(async group => {
-        const siloedTags = await Promise.all(
+        const siloedTags = await allToCompletion(
           group.entries.map(e => SiloedTag.computeFromTagAndApp(e.request.tag, e.request.contractAddress)),
         );
         const results = await getAllPrivateLogsByTags(this.aztecNode, siloedTags, anchor, {
@@ -238,11 +239,11 @@ export class LogService {
     }
     const recipientIvsk = await this.keyStore.getMasterIncomingViewingSecretKey(recipient);
 
-    const [senderPoints, registeredSecrets] = await Promise.all([
+    const [senderPoints, registeredSecrets] = await allToCompletion([
       this.#getSecretsForSenders(recipientCompleteAddress, recipientIvsk),
       this.taggingSecretSourcesStore.getSharedSecretsForRecipient(recipient),
     ]);
-    return Promise.all([
+    return allToCompletion([
       ...senderPoints.map(secret => AppTaggingSecret.computeDirectional(secret, contractAddress, recipient)),
       ...registeredSecrets.flatMap(({ kind, secret }) => {
         switch (kind) {
@@ -268,7 +269,7 @@ export class LogService {
     // (recipient = us, sender = us).
     const allSenders = [...(await this.taggingSecretSourcesStore.getSenders()), ...(await this.keyStore.getAccounts())];
 
-    return Promise.all(
+    return allToCompletion(
       allSenders.map(async sender => {
         const taggingSecretPoint = await computeSharedTaggingSecret(recipientCompleteAddress, recipientIvsk, sender);
 

--- a/yarn-project/pxe/src/messages/tx_resolver_service.ts
+++ b/yarn-project/pxe/src/messages/tx_resolver_service.ts
@@ -1,6 +1,7 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { uniqueBy } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type IndexedTxEffect, TxHash } from '@aztec/stdlib/tx';
@@ -19,7 +20,7 @@ export class TxResolverService {
   async resolveTxs(txHashes: Fr[], anchorBlockNumber: number): Promise<(TxOnchainContext | null)[]> {
     const nonZeroTxHashes = txHashes.filter(h => !h.isZero()).map(h => TxHash.fromField(h));
     const uniqueTxHashes = uniqueBy(nonZeroTxHashes, h => h.toString());
-    const fetched = await Promise.all(
+    const fetched = await allToCompletion(
       uniqueTxHashes.map(h => this.aztecNode.getTxReceipt(h, { includeTxEffect: true })),
     );
     const txEffects = new Map(

--- a/yarn-project/pxe/src/node/caching_aztec_node.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.ts
@@ -1,4 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type BlockParameter, type DataInBlock } from '@aztec/stdlib/block';
 import type { BlockIncludeOptions } from '@aztec/stdlib/interfaces/client';
@@ -325,7 +326,7 @@ function readBatchedPerKey<T>(
   }
 
   // Every position is answered: a cache hit, or the entry its key's request seeded just above.
-  return Promise.all(keys.map((key, index) => cached[index] ?? fetchedByKey.get(key)!));
+  return allToCompletion(keys.map((key, index) => cached[index] ?? fetchedByKey.get(key)!));
 }
 
 /**

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,5 +1,6 @@
 import { chunk } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type DataInBlock, type InBlock } from '@aztec/stdlib/block';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
@@ -135,9 +136,9 @@ export class NoteService {
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.
-    const computed = await Promise.all(
+    const computed = await allToCompletion(
       requests.map(async ({ contractAddress, noteHash, nullifier, noteNonce }) => {
-        const [siloedNoteHash, siloedNullifier] = await Promise.all([
+        const [siloedNoteHash, siloedNullifier] = await allToCompletion([
           siloNoteHash(contractAddress, noteHash),
           siloNullifier(contractAddress, nullifier),
         ]);
@@ -222,7 +223,7 @@ export class NoteService {
   async #findNullifierIndexes(anchorBlockHash: BlockHash, siloedNullifiers: Fr[]) {
     const batches = chunk(siloedNullifiers, MAX_RPC_LEN);
     return (
-      await Promise.all(
+      await allToCompletion(
         batches.map(batch => this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch)),
       )
     ).flat();

--- a/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
@@ -10,6 +10,7 @@ import {
 import { makeTuple } from '@aztec/foundation/array';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import type { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { assertLength } from '@aztec/foundation/serialize';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import { privateKernelResetDimensionsConfig } from '@aztec/noir-protocol-circuits-types/client';
@@ -67,7 +68,7 @@ async function getMasterSecretKeysAndKeyTypeDomainSeparators(
   oracle: PrivateKernelOracle,
 ) {
   const numRequestsToProcess = Math.min(keyValidationRequests.claimedLength, numRequestsToVerify);
-  const keysHints = await Promise.all(
+  const keysHints = await allToCompletion(
     keyValidationRequests.array.slice(0, numRequestsToProcess).map(async ({ request }) => {
       const secretKeys = await oracle.getMasterSecretKey(request.request.pkMHash);
       return new KeyValidationHint(secretKeys);
@@ -168,7 +169,7 @@ export class PrivateKernelResetPrivateInputsBuilder {
 
     // Execute all the expensive node querying operations in parallel.
     const [previousVkMembershipWitness, noteHashReadRequestHints, nullifierReadRequestHints, keyValidationHints] =
-      await Promise.all([
+      await allToCompletion([
         oracle.getVkMembershipWitness(this.previousKernelOutput.verificationKey.keyAsFields),
         buildNoteHashReadRequestHintsFromResetActions<
           typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
@@ -3,6 +3,7 @@ import { uniqueBy } from '@aztec/foundation/collection';
 import { vkAsFieldsMegaHonk } from '@aztec/foundation/crypto/keys';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { pushTestData } from '@aztec/foundation/testing';
 import { Timer } from '@aztec/foundation/timer';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -384,7 +385,7 @@ export class PrivateKernelExecutionProver {
     ]);
     const uniqueAddresses = uniqueBy(allAddresses, a => a.toString());
     return new Map<string, UpdatedClassIdHints>(
-      await Promise.all(
+      await allToCompletion(
         uniqueAddresses.map(
           async addr =>
             [addr.toString(), await this.oracle.getUpdatedClassIdHints(addr)] as [string, UpdatedClassIdHints],

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -3,6 +3,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { Timer } from '@aztec/foundation/timer';
 import { KeyStore } from '@aztec/key-store';
@@ -398,7 +399,7 @@ export class PXE {
 
     pxe.jobQueue.start();
 
-    await Promise.all([pxe.#registerProtocolContracts(), pxe.#registerPreloadedContracts()]);
+    await allToCompletion([pxe.#registerProtocolContracts(), pxe.#registerPreloadedContracts()]);
     log.info(`Started PXE connected to chain ${info.l1ChainId} version ${info.rollupVersion}`);
     return pxe;
   }
@@ -500,7 +501,7 @@ export class PXE {
 
   async #registerProtocolContracts() {
     const registered = Object.fromEntries(
-      await Promise.all(
+      await allToCompletion(
         protocolContractNames.map(async name => {
           const { address, instance, artifact } =
             await this.protocolContractsProvider.getProtocolContractArtifact(name);
@@ -515,7 +516,7 @@ export class PXE {
 
   async #registerPreloadedContracts() {
     const contracts = await this.preloadedContractsProvider.getPreloadedContracts();
-    await Promise.all(
+    await allToCompletion(
       contracts.map(async ({ instance, artifact }) => {
         if (artifact) {
           await this.registerContractClass(artifact);
@@ -858,7 +859,7 @@ export class PXE {
   public async getTaggingSecretSources(filter?: {
     kind?: RegisteredTaggingSecretSource['kind'];
   }): Promise<RegisteredTaggingSecretSource[]> {
-    const [senders, secrets] = await Promise.all([
+    const [senders, secrets] = await allToCompletion([
       this.taggingSecretSourcesStore.getSenders(),
       this.taggingSecretSourcesStore.getAllSharedSecrets(),
     ]);

--- a/yarn-project/pxe/src/storage/address_store/address_store.ts
+++ b/yarn-project/pxe/src/storage/address_store/address_store.ts
@@ -1,4 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAsyncArray, AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { CompleteAddress } from '@aztec/stdlib/contract';
@@ -57,7 +58,7 @@ export class AddressStore {
 
   getCompleteAddresses(): Promise<CompleteAddress[]> {
     return this.#store.transactionAsync(async () => {
-      return await Promise.all(
+      return await allToCompletion(
         (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v)),
       );
     });

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -243,7 +243,7 @@ export class CapsuleStore implements StagedStore {
     jobId: string,
     scope: AztecAddress,
   ): Promise<void> {
-    // We wrap this in a transaction to serialize concurrent calls from Promise.all.
+    // We wrap this in a transaction to serialize concurrent calls from allToCompletion.
     // Without this, concurrent appends to the same array could race: both read length=0,
     // both write at the same slots, one overwrites the other.
     // Equally important: this in practice is expected to perform thousands of DB operations

--- a/yarn-project/pxe/src/storage/contract_store/contract_store.ts
+++ b/yarn-project/pxe/src/storage/contract_store/contract_store.ts
@@ -1,6 +1,7 @@
 import type { FUNCTION_TREE_HEIGHT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { BufferReader, numToUInt8, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
@@ -146,7 +147,7 @@ export class ContractStore {
     const privateFunctions = contract.functions.filter(
       functionArtifact => functionArtifact.functionType === FunctionType.PRIVATE,
     );
-    const privateSelectors = await Promise.all(
+    const privateSelectors = await allToCompletion(
       privateFunctions.map(async fn =>
         (await FunctionSelector.fromNameAndParameters(fn.name, fn.parameters)).toString(),
       ),

--- a/yarn-project/pxe/src/storage/contract_store/private_functions_tree.ts
+++ b/yarn-project/pxe/src/storage/contract_store/private_functions_tree.ts
@@ -1,5 +1,6 @@
 import { FUNCTION_TREE_HEIGHT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { assertLength } from '@aztec/foundation/serialize';
 import { MembershipWitness, type MerkleTree } from '@aztec/foundation/trees';
 import { type ContractArtifact, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
@@ -22,7 +23,7 @@ export class PrivateFunctionsTree {
   private constructor(private readonly privateFunctions: PrivateFunction[]) {}
 
   static async create(artifact: ContractArtifact) {
-    const privateFunctions = await Promise.all(
+    const privateFunctions = await allToCompletion(
       artifact.functions
         .filter(fn => fn.functionType === FunctionType.PRIVATE)
         .map(getContractClassPrivateFunctionFromArtifact),

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.ts
@@ -1,5 +1,6 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 
@@ -217,7 +218,7 @@ export class FactStore implements StagedStore {
     for await (const [, factKey] of this.#factsByBlock.entriesAsync({ start: toBlock + 1 })) {
       factReads.set(factKey, this.#facts.getAsync(factKey));
     }
-    await Promise.all(
+    await allToCompletion(
       Array.from(factReads, async ([factKey, read]) => {
         const buf = await read;
         if (!buf) {
@@ -299,7 +300,7 @@ export class FactStore implements StagedStore {
     reads: Map<FactKeyStr, Promise<FactBuffer | undefined>>,
   ): Promise<CollectionWithFacts> {
     const factKeys = [...reads.keys()];
-    const bufs = await Promise.all(reads.values());
+    const bufs = await allToCompletion([...reads.values()]);
 
     // Await-free tail: deserialize. No DB ops from here on.
     const facts = new Map<FactKeyStr, Fact>();
@@ -427,7 +428,7 @@ export class FactStore implements StagedStore {
     for await (const factKey of this.#factsByCollection.getValuesAsync(collectionKey)) {
       factReads.set(factKey, this.#facts.getAsync(factKey));
     }
-    await Promise.all(
+    await allToCompletion(
       Array.from(factReads, async ([factKey, read]) => {
         const buf = await read;
         if (!buf) {

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Semaphore } from '@aztec/foundation/queue';
 import type { Fr } from '@aztec/foundation/schemas';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
@@ -98,7 +99,7 @@ export class NoteStore implements StagedStore {
   public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: string): Promise<void[]> {
     return this.#withJobLock(jobId, () =>
       this.#store.transactionAsync(() =>
-        Promise.all(
+        allToCompletion(
           notes.map(async note => {
             const noteForJob =
               (await this.#readNote(note.siloedNullifier.toString(), jobId)) ?? new StoredNote(note, new Set());
@@ -190,8 +191,10 @@ export class NoteStore implements StagedStore {
 
       // Await all DB reads together before the await-free tail.
       const entries = [...candidates.entries()];
-      const notes = await Promise.all(entries.map(([, { notePromise }]) => notePromise));
-      const nullifierEmissions = await Promise.all(entries.map(([, { nullificationPromise }]) => nullificationPromise));
+      const notes = await allToCompletion(entries.map(([, { notePromise }]) => notePromise));
+      const nullifierEmissions = await allToCompletion(
+        entries.map(([, { nullificationPromise }]) => nullificationPromise),
+      );
 
       // Await-free tail: filter and sort. No DB ops from here on.
       // Build a lookup: nullifier => emission block number
@@ -278,10 +281,10 @@ export class NoteStore implements StagedStore {
       this.#store.transactionAsync(async () => {
         // Kick off the note read and the existing-emission read together during the synchronous map so all are in
         // flight before the first await, which keeps the IndexedDB transaction alive.
-        const resolved = await Promise.all(
+        const resolved = await allToCompletion(
           siloedNullifiers.map(async nullifier => {
             const key = nullifier.data.toString();
-            const [storedNote, existingEmission] = await Promise.all([
+            const [storedNote, existingEmission] = await allToCompletion([
               this.#readNote(key, jobId),
               this.#readNullifierEmission(key, jobId),
             ]);
@@ -347,7 +350,7 @@ export class NoteStore implements StagedStore {
   /**
    * Functions run withJobLock are forced to wait for each other, i.e. if they share a `jobId`, they run serially
    * instead of concurrently. This is needed because staged data is stored in memory, and concurrent async operations
-   * (e.g., Promise.all in `validateAndStoreNote`) could otherwise interleave and corrupt state.
+   * (e.g., allToCompletion in `validateAndStoreNote`) could otherwise interleave and corrupt state.
    */
   async #withJobLock<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
     let lock = this.#jobLocks.get(jobId);
@@ -415,7 +418,7 @@ export class NoteStore implements StagedStore {
     }
 
     let removedNotes = 0;
-    await Promise.all(
+    await allToCompletion(
       orphanedNotes.map(async ({ block, siloedNullifier }) => {
         const buf = await this.#notes.getAsync(siloedNullifier);
         if (!buf) {
@@ -438,7 +441,7 @@ export class NoteStore implements StagedStore {
       orphanedEmissions.push({ block, siloedNullifier });
     }
 
-    await Promise.all(
+    await allToCompletion(
       orphanedEmissions.map(async ({ block, siloedNullifier }) => {
         await this.#nullifierEmissions.delete(siloedNullifier);
         await this.#nullifierEmissionsByBlockNumber.deleteValue(block, siloedNullifier);

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -1,6 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { EventSelector } from '@aztec/stdlib/abi';
@@ -159,7 +160,7 @@ export class PrivateEventStore implements StagedStore {
       }
 
       const eventIds = [...eventReadPromises.keys()];
-      const eventBuffers = await Promise.all(eventReadPromises.values());
+      const eventBuffers = await allToCompletion([...eventReadPromises.values()]);
 
       const events: Array<{
         l2BlockNumber: number;
@@ -289,7 +290,7 @@ export class PrivateEventStore implements StagedStore {
       const lookupKey = this.#keyFor(entry.contractAddress, entry.eventSelector);
       this.logger.verbose('storing private event log', { eventId, lookupKey });
 
-      await Promise.all([
+      await allToCompletion([
         this.#events.set(eventId, entry.toBuffer()),
         this.#eventsByContractAndEventSelector.set(lookupKey, eventId),
         this.#eventsByBlockNumber.set(entry.l2BlockNumber, eventId),

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -1,3 +1,4 @@
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AppTaggingSecret, SiloedTag, type TaggingIndexRange } from '@aztec/stdlib/logs';
 import { TxEffect, TxHash } from '@aztec/stdlib/tx';
@@ -188,7 +189,7 @@ export class SenderTaggingStore implements StagedStore {
       }));
 
       // Await all reads together
-      const rangeData = await Promise.all(
+      const rangeData = await allToCompletion(
         rangeReadPromises.map(async item => ({
           ...item,
           pendingData: await item.pending,
@@ -293,7 +294,7 @@ export class SenderTaggingStore implements StagedStore {
       const pendingPromise = this.#readPendingIndexes(jobId, secretStr);
       const finalizedPromise = this.#readLastFinalizedIndex(jobId, secretStr);
 
-      const [pendingEntries, lastFinalized] = await Promise.all([pendingPromise, finalizedPromise]);
+      const [pendingEntries, lastFinalized] = await allToCompletion([pendingPromise, finalizedPromise]);
 
       if (pendingEntries.length === 0) {
         return lastFinalized;
@@ -332,7 +333,7 @@ export class SenderTaggingStore implements StagedStore {
 
       // Await all reads together
       const secrets = [...secretReadPromises.keys()];
-      const pendingDataResults = await Promise.all(secretReadPromises.values());
+      const pendingDataResults = await allToCompletion([...secretReadPromises.values()]);
 
       // Process in memory
       for (let i = 0; i < secrets.length; i++) {
@@ -383,7 +384,7 @@ export class SenderTaggingStore implements StagedStore {
 
       // Await all reads together
       const secrets = [...secretDataPromises.keys()];
-      const dataResults = await Promise.all(
+      const dataResults = await allToCompletion(
         secrets.map(async secret => ({
           secret,
           pendingData: await secretDataPromises.get(secret)!.pending,

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -1,4 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { BlockHash } from '@aztec/stdlib/block';
 import { MAX_RPC_LEN } from '@aztec/stdlib/interfaces/api-limit';
@@ -77,7 +78,7 @@ async function getAllPagesInBatches<T extends Tag | SiloedTag, Opts extends LogI
   for (let i = 0; i < tags.length; i += MAX_RPC_LEN) {
     batches.push(tags.slice(i, i + MAX_RPC_LEN));
   }
-  const batchResults = await Promise.all(batches.map(fetchAllPagesForBatch));
+  const batchResults = await allToCompletion(batches.map(fetchAllPagesForBatch));
   return batchResults.flat();
 }
 

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
@@ -1,4 +1,5 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { allToCompletion } from '@aztec/foundation/promise';
 import { isDefined } from '@aztec/foundation/types';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { AppTaggingSecret, LogResult } from '@aztec/stdlib/logs';
@@ -104,7 +105,7 @@ export async function syncTaggedPrivateLogs(
     // Compute tags for all pending secrets and fetch logs in batched RPC calls
     const logsPerSecret = await fetchLogsForSecrets(pending, aztecNode, anchor);
 
-    const nextRound = await Promise.all(
+    const nextRound = await allToCompletion(
       pending.map(async (pendingSecret, i) => {
         const logsFoundWithSecret = logsPerSecret[i];
         if (logsFoundWithSecret.length === 0) {
@@ -148,7 +149,7 @@ function getIndexRangesForSecrets(
   taggingStore: RecipientTaggingStore,
   jobId: string,
 ): Promise<PendingSecret[]> {
-  return Promise.all(
+  return allToCompletion(
     secrets.map(async (secret): Promise<PendingSecret> => {
       const currentHighestFinalizedIndex = await taggingStore.getHighestFinalizedIndex(secret, jobId);
       const boundEnd = unfinalizedTaggingIndexesWindowEnd(currentHighestFinalizedIndex);
@@ -189,9 +190,9 @@ async function fetchLogsForSecrets(
   const indexesPerSecret = pending.map(({ start, end }) => Array.from({ length: end - start }, (_, i) => start + i));
 
   // Compute siloed tags for all indexes
-  const tagsPerSecret = await Promise.all(
+  const tagsPerSecret = await allToCompletion(
     pending.map(({ secret }, i) =>
-      Promise.all(indexesPerSecret[i].map(index => SiloedTag.compute({ extendedSecret: secret, index }))),
+      allToCompletion(indexesPerSecret[i].map(index => SiloedTag.compute({ extendedSecret: secret, index }))),
     ),
   );
 

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/classify_pending_txs.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/classify_pending_txs.ts
@@ -1,4 +1,5 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { TxHash, TxStatus } from '@aztec/stdlib/tx';
 
@@ -53,7 +54,7 @@ export async function classifyPendingTxsFromReceipts(
   pending: TxHash[],
   aztecNode: AztecNode,
 ): Promise<ReceiptClassification> {
-  const receipts = await Promise.all(pending.map(pendingTxHash => aztecNode.getTxReceipt(pendingTxHash)));
+  const receipts = await allToCompletion(pending.map(pendingTxHash => aztecNode.getTxReceipt(pendingTxHash)));
 
   const txHashesFinalized: TxHash[] = [];
   const txHashesDropped: TxHash[] = [];

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -1,4 +1,5 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type AppTaggingSecret, type LogResult, SiloedTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
@@ -31,7 +32,7 @@ export async function loadAndStoreNewTaggingIndexes(
   jobId: string,
 ): Promise<Map<string, TxInLogs>> {
   // We compute the tags for the current window of indexes
-  const siloedTagsForWindow = await Promise.all(
+  const siloedTagsForWindow = await allToCompletion(
     Array.from({ length: end - start }, (_, i) => SiloedTag.compute({ extendedSecret, index: start + i })),
   );
 

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/resolve_pending_txs.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/resolve_pending_txs.ts
@@ -1,4 +1,5 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type MinedTxReceipt, type TxHash, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
@@ -35,7 +36,7 @@ export async function resolvePendingTxs(
 ): Promise<ResolvedPendingTxs> {
   const statusFromLogs = classifyPendingTxsFromLogs(pendingTxs, txsInLogs, finalizedBlockNumber);
 
-  const [statusOfAbsent, receiptsOfRevertedInLogs] = await Promise.all([
+  const [statusOfAbsent, receiptsOfRevertedInLogs] = await allToCompletion([
     classifyPendingTxsFromReceipts(statusFromLogs.txHashesAbsent, aztecNode),
     getReceiptsWithEffect(statusFromLogs.txHashesWithExecutionReverted, aztecNode),
   ]);
@@ -54,7 +55,7 @@ export async function resolvePendingTxs(
 }
 
 function getReceiptsWithEffect(txHashes: TxHash[], aztecNode: AztecNode) {
-  return Promise.all(txHashes.map(txHash => aztecNode.getTxReceipt(txHash, { includeTxEffect: true })));
+  return allToCompletion(txHashes.map(txHash => aztecNode.getTxReceipt(txHash, { includeTxEffect: true })));
 }
 
 function isFinalized(


### PR DESCRIPTION
## Problem

A PXE job that fails aborts and discards its staged writes, but `Promise.all` fan-outs reject while sibling branches are still running. Those late writers recreate the discarded staging entries: they can never be committed, but they wedge reorg handling (every store `rollback()` throws until PXE restarts) and leak memory. The same eager rejection inside `transactionAsync` callbacks can tear commits and rollbacks on backends whose transaction tracking is not context-aware (sqlite-opfs), and even "pure read" fan-outs turn out to write, since per-job store accessors lazily create staging entries.

## Fix

Adds `allToCompletion` to foundation — `Promise.all`, except it only settles once every input has, rethrowing a lone failure as-is and aggregating several into an `AggregateError` — and replaces every `Promise.all` in PXE with it. Classifying individual call sites as safe proved error-prone (a site's safety depends on non-local facts like lazy staging accessors and backend transaction internals), so the rule is now uniform: no PXE code observes a fan-out failure while a sibling branch is still running.