### PR TITLE
chore: drop the arm64 job from the release flow

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -569,6 +569,7 @@ function release {
   # Releases run on a single amd64 job (see ci.sh release); every arm64 artifact is cross-compiled
   # there. Backstop against stray arm64 invocations.
   if [ $(arch) == arm64 ]; then
+    echo "Skipping release on arm64: everything publishes from the amd64 job (arm64 artifacts are cross-compiled there)."
     return
   fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -566,17 +566,18 @@ function release {
     return
   fi
 
+  # Releases run on a single amd64 job (see ci.sh release); every arm64 artifact is cross-compiled
+  # there. Backstop against stray arm64 invocations.
+  if [ $(arch) == arm64 ]; then
+    return
+  fi
+
   # Ensure we have a github release in AztecProtocol/barretenberg for bb artifacts.
   # Users can create aztec-packages releases manually via the GitHub "Create a release" button.
   release_bb_github
 
   # Only the foundation packages are published from here; the labs packages (yarn-project, playground,
   # aztec-up, aztec-nr, the docker release-image) are published from the labs repo.
-  # All foundation artifacts are built or cross-compiled on the amd64 job; nothing publishes from arm64.
-  if [ $(arch) == arm64 ]; then
-    return
-  fi
-
   projects=(
     barretenberg/cpp
     ipc-runtime
@@ -654,7 +655,7 @@ function release_compat_e2e {
     return 0
   fi
 
-  # Compat e2e only runs on amd64 — the arm64 release job publishes nothing.
+  # Compat e2e only runs on amd64.
   if [ "$(arch)" == arm64 ]; then
     echo "Skipping backwards compatibility e2e tests on arm64 (amd64 only)."
     return 0

--- a/ci.sh
+++ b/ci.sh
@@ -425,15 +425,15 @@ case "$cmd" in
   # RELEASES #
   ############
   release)
-    # Spin up ec2 instances (amd64 + arm64) and run the full release flow: backwards-compat e2e
-    # checks, build, and publish. Set DRY_RUN=1 to exercise the whole flow without publishing.
+    # Spin up an ec2 instance and run the full release flow: build and publish. A single amd64 job
+    # suffices: every arm64/darwin/windows artifact is cross-compiled there. Set DRY_RUN=1 to
+    # exercise the whole flow without publishing.
     export CI_DASHBOARD="releases"
-    # Roomier instance lifetime than a standard run: the amd64 job builds, runs the backwards-compat
-    # e2e suite, and then publishes, which together exceed the default 75 min shutdown.
+    # Roomier instance lifetime than a standard run: the build plus publish exceeds the default
+    # 75 min shutdown.
     export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-180}
     multi_job_run \
-      'x-release amd64 ci-release' \
-      'a-release arm64 ci-release'
+      'x-release amd64 ci-release'
     ;;
   ci-private-release)
     # Run the private release flow LOCALLY (no EC2): publish the foundation npm packages to the


### PR DESCRIPTION
FOUNDATION ONLY

Follow-up to #25188, which left this as an open question: with release-image gone (the only arm64-native publisher, now released from the labs repo), the arm64 ci-release job did a full foundation build — including all the cross-compiles via `release-foundation` — and then published nothing.

- `ci.sh release` now spins up only the amd64 instance. Every arm64/darwin/windows artifact is cross-compiled there (bb binaries and static libs in `build_release_dir`, bb.js/wsdb prebuilds, ipc-runtime), so the arm64 box produced nothing a release consumes. It was also a liability: `multi_job_run` halts all jobs on the first failure, so an arm64-only build flake could abort the amd64 job mid-publish.
- `bootstrap.sh release`: the arm64 early-return moves above `release_bb_github`, so a stray arm64 invocation does nothing at all instead of racing the amd64 job on the GitHub release check. The guard stays as a backstop only.
- The stale "arm64 release job" reference in `release_compat_e2e`'s comment is updated.

arm64 build coverage is unaffected for `next` (every merge-queue run includes an `a1-fast arm64 ci-fast` job). Release-branch trees lose their arm64 build canary, but a failure there could only ever block a release whose artifacts don't come from that build.

Validation: `bash -n` on both scripts.
