### PR TITLE
chore: make the AVM circuit-inputs workflow dispatch-only

### DIFF
--- a/.github/workflows/avm-circuit-inputs.yml
+++ b/.github/workflows/avm-circuit-inputs.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - next
-  schedule:
-    # Also run nightly at 3:00 AM UTC as a safety net
-    - cron: "0 3 * * *"
+  # The nightly safety-net run is disabled until this flow is reworked for the repo split
+  # (the labs repo publishes the captured inputs; this repo checks them).
+  # schedule:
+  #   - cron: "0 3 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/avm-circuit-inputs.yml
+++ b/.github/workflows/avm-circuit-inputs.yml
@@ -1,11 +1,11 @@
 name: AVM Circuit Inputs Collection and Check
 
 on:
-  push:
-    branches:
-      - next
-  # The nightly safety-net run is disabled until this flow is reworked for the repo split
+  # The per-push and nightly runs are disabled until this flow is reworked for the repo split
   # (the labs repo publishes the captured inputs; this repo checks them).
+  # push:
+  #   branches:
+  #     - next
   # schedule:
   #   - cron: "0 3 * * *"
   workflow_dispatch:


### PR DESCRIPTION
FOUNDATION SIDE ONLY

Comments out (does not delete) the automatic triggers of `avm-circuit-inputs.yml` — both the per-push-to-next run and the nightly 03:00 UTC safety net of the x-avm-inputs-collection and x-avm-check-circuit jobs — until the flow is reworked for the repo split (the labs repo publishes the captured inputs; this repo checks them).

The workflow is now manual-only (`workflow_dispatch`); the job definitions, tree-hash tarball keying, and failure notification stay intact.

Counterpart of the labs-branch change that made the same workflow dispatch-only there.

Validation: YAML parse.
