### PR TITLE
fix(wallets): make WalletDB.storeAccount writes atomic

### DIFF
--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -1,4 +1,5 @@
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
@@ -179,6 +180,51 @@ describe('WalletDB', () => {
       expect(senders).toHaveLength(1);
       expect(accounts[0].alias).toEqual('alice');
       expect(senders[0].alias).toEqual('exchange');
+    });
+  });
+
+  describe('atomicity', () => {
+    /** Wraps a store so map writes whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
+    function crashingStore(store: AztecAsyncKVStore, shouldCrash: (key: string) => boolean): AztecAsyncKVStore {
+      const wrapMap = (map: AztecAsyncMap<string, Buffer>): AztecAsyncMap<string, Buffer> =>
+        new Proxy(map, {
+          get(target, prop) {
+            if (prop === 'set') {
+              return (key: string, value: Buffer) =>
+                shouldCrash(key) ? Promise.reject(new Error('simulated write failure')) : target.set(key, value);
+            }
+            const member = Reflect.get(target, prop);
+            return typeof member === 'function' ? member.bind(target) : member;
+          },
+        });
+      return new Proxy(store, {
+        get(target, prop) {
+          if (prop === 'openMap') {
+            return (name: string) => wrapMap(target.openMap(name));
+          }
+          const member = Reflect.get(target, prop);
+          return typeof member === 'function' ? member.bind(target) : member;
+        },
+      });
+    }
+
+    it('persists no partial account data when a write fails midway through storeAccount', async () => {
+      const store = await openTmpStore('wallet-db-atomicity-test');
+      const failingDb = new WalletDB(
+        crashingStore(store, key => key.startsWith('signingKey:')),
+        () => {},
+      );
+      const address = await AztecAddress.random();
+
+      await expect(failingDb.storeAccount(address, makeAccountData('schnorr', 'alice'))).rejects.toThrow(
+        'simulated write failure',
+      );
+
+      // Inspect the same underlying store with a fresh WalletDB: no trace of the account may remain
+      const dbAfterCrash = new WalletDB(store, () => {});
+      await expect(dbAfterCrash.retrieveAccount(address)).rejects.toThrow('does not exist');
+      expect(await dbAfterCrash.listAccounts()).toEqual([]);
+      expect(await store.openMap<string, Buffer>('aliases').getAsync('accounts:alice')).toBeUndefined();
     });
   });
 

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -43,16 +43,18 @@ export class WalletDB {
     },
     log: LogFn = this.userLog,
   ) {
-    if (alias) {
-      await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
-    }
-    await this.accounts.set(accountKey('type', address), Buffer.from(type));
-    await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
-    await this.accounts.set(accountKey('salt', address), salt.toBuffer());
-    await this.accounts.set(
-      accountKey('signingKey', address),
-      'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
-    );
+    await this.store.transactionAsync(async () => {
+      if (alias) {
+        await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
+      }
+      await this.accounts.set(accountKey('type', address), Buffer.from(type));
+      await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
+      await this.accounts.set(accountKey('salt', address), salt.toBuffer());
+      await this.accounts.set(
+        accountKey('signingKey', address),
+        'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
+      );
+    });
     log(`Account stored in database${alias ? ` with alias ${alias}` : ''}`);
   }
 


### PR DESCRIPTION
Fixes [F-548](https://linear.app/aztec-labs/issue/F-548/audit-147-walletdbstoreaccount-writes-non-atomically-partial-data-on)

`WalletDB.storeAccount` wrote each account field (alias, type, sk, salt, signingKey) as a separate awaited `set`, so a failure partway through left a corrupted partial account: `retrieveAccount` would resolve with `signingKey: undefined`, or throw on a missing salt, and `listAccounts` would show a phantom entry.

- Wrap all `storeAccount` writes in `store.transactionAsync()` so they commit atomically. On failure nothing persists; nested calls join the parent transaction.
- Add an atomicity test that injects a write failure on the final field and asserts no trace of the account remains (no secret key, not listed, no alias entry). Red before the fix (retrieveAccount resolved with a corrupt partial account), green after.

`deleteAccount` has the same non-atomicity (parallel deletes plus separate alias cleanup); left as a follow-up since this issue is scoped to account creation.