### PR TITLE
fix(wallets): make WalletDB.deleteAccount atomic

### DIFF
--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -184,14 +184,15 @@ describe('WalletDB', () => {
   });
 
   describe('atomicity', () => {
-    /** Wraps a store so map writes whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
+    /** Wraps a store so map writes (set or delete) whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
     function crashingStore(store: AztecAsyncKVStore, shouldCrash: (key: string) => boolean): AztecAsyncKVStore {
       const wrapMap = (map: AztecAsyncMap<string, Buffer>): AztecAsyncMap<string, Buffer> =>
         new Proxy(map, {
           get(target, prop) {
-            if (prop === 'set') {
-              return (key: string, value: Buffer) =>
-                shouldCrash(key) ? Promise.reject(new Error('simulated write failure')) : target.set(key, value);
+            if (prop === 'set' || prop === 'delete') {
+              const write = (target[prop] as (key: string, value?: Buffer) => Promise<void>).bind(target);
+              return (key: string, value?: Buffer) =>
+                shouldCrash(key) ? Promise.reject(new Error('simulated write failure')) : write(key, value);
             }
             const member = Reflect.get(target, prop);
             return typeof member === 'function' ? member.bind(target) : member;
@@ -225,6 +226,34 @@ describe('WalletDB', () => {
       await expect(dbAfterCrash.retrieveAccount(address)).rejects.toThrow('does not exist');
       expect(await dbAfterCrash.listAccounts()).toEqual([]);
       expect(await store.openMap<string, Buffer>('aliases').getAsync('accounts:alice')).toBeUndefined();
+    });
+
+    it('deletes no account data when a write fails midway through deleteAccount', async () => {
+      const store = await openTmpStore('wallet-db-atomicity-test');
+      const db = new WalletDB(store, () => {});
+      const address = await AztecAddress.random();
+      const data = makeAccountData('schnorr', 'alice');
+      await db.storeAccount(address, data);
+
+      // Fail the alias delete, which happens after all the account entry deletes
+      const failingDb = new WalletDB(
+        crashingStore(store, key => key.startsWith('accounts:')),
+        () => {},
+      );
+      await expect(failingDb.deleteAccount(address)).rejects.toThrow('simulated write failure');
+
+      // Inspect the same underlying store with a fresh WalletDB: the account must be fully intact
+      const dbAfterCrash = new WalletDB(store, () => {});
+      const retrieved = await dbAfterCrash.retrieveAccount(address);
+      expect(retrieved.secretKey).toEqual(data.secretKey);
+      expect(retrieved.salt).toEqual(data.salt);
+      expect(retrieved.type).toEqual('schnorr');
+      expect(retrieved.signingKey).toEqual(data.signingKey.toBuffer());
+
+      const accounts = await dbAfterCrash.listAccounts();
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].alias).toEqual('alice');
+      expect(accounts[0].item.toString()).toEqual(address.toString());
     });
   });
 

--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -184,7 +184,7 @@ describe('WalletDB', () => {
   });
 
   describe('atomicity', () => {
-    /** Wraps a store so map writes (set or delete) whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
+    /** Wraps a store so map writes whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
     function crashingStore(store: AztecAsyncKVStore, shouldCrash: (key: string) => boolean): AztecAsyncKVStore {
       const wrapMap = (map: AztecAsyncMap<string, Buffer>): AztecAsyncMap<string, Buffer> =>
         new Proxy(map, {

--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -1,4 +1,5 @@
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
@@ -179,6 +180,51 @@ describe('WalletDB', () => {
       expect(senders).toHaveLength(1);
       expect(accounts[0].alias).toEqual('alice');
       expect(senders[0].alias).toEqual('exchange');
+    });
+  });
+
+  describe('atomicity', () => {
+    /** Wraps a store so map writes whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
+    function crashingStore(store: AztecAsyncKVStore, shouldCrash: (key: string) => boolean): AztecAsyncKVStore {
+      const wrapMap = (map: AztecAsyncMap<string, Buffer>): AztecAsyncMap<string, Buffer> =>
+        new Proxy(map, {
+          get(target, prop) {
+            if (prop === 'set') {
+              return (key: string, value: Buffer) =>
+                shouldCrash(key) ? Promise.reject(new Error('simulated write failure')) : target.set(key, value);
+            }
+            const member = Reflect.get(target, prop);
+            return typeof member === 'function' ? member.bind(target) : member;
+          },
+        });
+      return new Proxy(store, {
+        get(target, prop) {
+          if (prop === 'openMap') {
+            return (name: string) => wrapMap(target.openMap(name));
+          }
+          const member = Reflect.get(target, prop);
+          return typeof member === 'function' ? member.bind(target) : member;
+        },
+      });
+    }
+
+    it('persists no partial account data when a write fails midway through storeAccount', async () => {
+      const store = await openTmpStore('wallet-db-atomicity-test');
+      const failingDb = new WalletDB(
+        crashingStore(store, key => key.startsWith('signingKey:')),
+        () => {},
+      );
+      const address = await AztecAddress.random();
+
+      await expect(failingDb.storeAccount(address, makeAccountData('schnorr', 'alice'))).rejects.toThrow(
+        'simulated write failure',
+      );
+
+      // Inspect the same underlying store with a fresh WalletDB: no trace of the account may remain
+      const dbAfterCrash = new WalletDB(store, () => {});
+      await expect(dbAfterCrash.retrieveAccount(address)).rejects.toThrow('does not exist');
+      expect(await dbAfterCrash.listAccounts()).toEqual([]);
+      expect(await store.openMap<string, Buffer>('aliases').getAsync('accounts:alice')).toBeUndefined();
     });
   });
 

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -122,8 +122,8 @@ export class WalletDB {
   }
 
   /**
-   * Deletes an account's stored data and its alias atomically. Does not deregister the account
-   * from the PXE; callers must do that separately.
+   * Deletes an account's stored data and its alias atomically. Deletion is local to this store;
+   * any state the PXE holds for the account is unaffected.
    */
   async deleteAccount(address: AztecAddress) {
     await this.store.transactionAsync(async () => {

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -121,19 +121,25 @@ export class WalletDB {
     return addresses;
   }
 
+  /**
+   * Deletes an account's stored data and its alias atomically. Does not deregister the account
+   * from the PXE; callers must do that separately.
+   */
   async deleteAccount(address: AztecAddress) {
-    await Promise.all([
-      this.accounts.delete(accountKey('sk', address)),
-      this.accounts.delete(accountKey('salt', address)),
-      this.accounts.delete(accountKey('type', address)),
-      this.accounts.delete(accountKey('signingKey', address)),
-    ]);
-    // Clean up alias if one exists
-    const aliasesByAddress = await this.#readAccountAliases();
-    const alias = aliasesByAddress.get(address.toString());
-    if (alias) {
-      await this.aliases.delete(`accounts:${alias}`);
-    }
+    await this.store.transactionAsync(async () => {
+      await Promise.all([
+        this.accounts.delete(accountKey('sk', address)),
+        this.accounts.delete(accountKey('salt', address)),
+        this.accounts.delete(accountKey('type', address)),
+        this.accounts.delete(accountKey('signingKey', address)),
+      ]);
+      // Clean up alias if one exists
+      const aliasesByAddress = await this.#readAccountAliases();
+      const alias = aliasesByAddress.get(address.toString());
+      if (alias) {
+        await this.aliases.delete(`accounts:${alias}`);
+      }
+    });
   }
 
   async close() {

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -43,16 +43,18 @@ export class WalletDB {
     },
     log: LogFn = this.userLog,
   ) {
-    if (alias) {
-      await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
-    }
-    await this.accounts.set(accountKey('type', address), Buffer.from(type));
-    await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
-    await this.accounts.set(accountKey('salt', address), salt.toBuffer());
-    await this.accounts.set(
-      accountKey('signingKey', address),
-      'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
-    );
+    await this.store.transactionAsync(async () => {
+      if (alias) {
+        await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
+      }
+      await this.accounts.set(accountKey('type', address), Buffer.from(type));
+      await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
+      await this.accounts.set(accountKey('salt', address), salt.toBuffer());
+      await this.accounts.set(
+        accountKey('signingKey', address),
+        'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
+      );
+    });
     log(`Account stored in database${alias ? ` with alias ${alias}` : ''}`);
   }
 


### PR DESCRIPTION
Follow-up to #25216, fixing the same defect in `WalletDB.deleteAccount`: four parallel account entry deletes plus a separate alias scan and delete, with no transaction. A failure partway through could leave any partial mix, e.g. the account entries gone with a stale alias left behind.

The whole body now runs inside `store.transactionAsync()`, so the deletes commit all-or-nothing. 

The red/green test reuses the `crashingStore` helper from #25216, generalized to inject failures on `delete` as well as `set`. It fails the alias delete, which runs after the four account entry deletes, then asserts the account is fully intact. Pre-fix, the account entries were deleted while the stale alias survived (`retrieveAccount` threw "does not exist").

`deleteAccount` now carries a jsdoc note that deletion is local to this store and leaves PXE state unaffected.
