### PR TITLE
refactor(p2p): brand ingress-validated proposals with a ValidatedProposal type

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -15,12 +15,13 @@ import {
   BlockProposal,
   CheckpointAttestation,
   CheckpointProposal,
-  type CheckpointProposalCore,
   type Gossipable,
   P2PMessage,
   PeerErrorSeverity,
   PeerErrorSeverityByHarshness,
   TopicType,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
   createTopicString,
   getTopicsForConfig,
   metricsTopicStrToLabels,
@@ -303,13 +304,13 @@ export class LibP2PService extends WithTracer implements P2PService {
     };
 
     this.allNodesCheckpointReceivedCallback = (
-      _checkpoint: CheckpointProposalCore,
+      _checkpoint: ValidatedCheckpointProposalCore,
     ): Promise<CheckpointAttestation[] | undefined> => {
       throw new CheckpointProposalReceivedCallbackNotRegisteredError();
     };
 
     this.validatorCheckpointReceivedCallback = (
-      _checkpoint: CheckpointProposalCore,
+      _checkpoint: ValidatedCheckpointProposalCore,
     ): Promise<CheckpointAttestation[] | undefined> => {
       return Promise.resolve(undefined);
     };
@@ -1321,7 +1322,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       return;
     }
 
-    await this.processValidBlockProposal(block, source);
+    await this.processValidBlockProposal(ValidatedBlockProposal(block), source);
   }
 
   /** Validates a block proposal. Triggers a penalization to the peer that sent it if invalid. Adds to the mempool if valid. */
@@ -1424,7 +1425,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     [Attributes.BLOCK_ARCHIVE]: block.archive.toString(),
     [Attributes.P2P_ID]: await block.p2pMessageLoggingIdentifier().then(i => i.toString()),
   }))
-  protected async processValidBlockProposal(block: BlockProposal, sender: PeerId) {
+  protected async processValidBlockProposal(block: ValidatedBlockProposal, sender: PeerId) {
     const slot = block.slotNumber;
     this.logger.verbose(`Received block proposal for slot ${slot} from external peer ${sender.toString()}.`, {
       p2pMessageIdentifier: await block.p2pMessageLoggingIdentifier(),
@@ -1448,7 +1449,7 @@ export class LibP2PService extends WithTracer implements P2PService {
    * rejected, and letting the error escape would leave the proposal's tx protections in place.
    * Note: Validators do NOT attest to individual blocks, only to checkpoint proposals.
    */
-  private async tryBlockReceivedCallback(block: BlockProposal, sender: PeerId): Promise<boolean> {
+  private async tryBlockReceivedCallback(block: ValidatedBlockProposal, sender: PeerId): Promise<boolean> {
     try {
       const isValid = await this.blockReceivedCallback(block, sender);
       if (!isValid) {
@@ -1484,14 +1485,14 @@ export class LibP2PService extends WithTracer implements P2PService {
     // Process checkpoint proposal if valid and neither equivocated nor oversized.
     const processCheckpointFn = () =>
       result === TopicValidatorResult.Accept && checkpoint && !isEquivocated && !isOversized
-        ? this.processValidCheckpointProposal(checkpoint.toCore(), source)
+        ? this.processValidCheckpointProposal(ValidatedCheckpointProposalCore(checkpoint.toCore()), source)
         : Promise.resolve();
 
     // If the checkpoint contained a valid last block, we process it even if the checkpoint itself is to be rejected
     // TODO(palla/mbps): Is this ok? Should we be considering a block from a checkpoint that was equivocated?
     const processBlockFn = () =>
       processBlock && checkpoint && checkpoint.getBlockProposal()
-        ? this.processValidBlockProposal(checkpoint.getBlockProposal()!, source)
+        ? this.processValidBlockProposal(ValidatedBlockProposal(checkpoint.getBlockProposal()!), source)
         : Promise.resolve();
 
     // A node that skips checkpoint validation attests without re-executing the embedded last block, so run
@@ -1640,7 +1641,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     [Attributes.BLOCK_ARCHIVE]: checkpoint.archive.toString(),
     [Attributes.P2P_ID]: await checkpoint.p2pMessageLoggingIdentifier().then(i => i.toString()),
   }))
-  protected async processValidCheckpointProposal(checkpoint: CheckpointProposalCore, sender: PeerId) {
+  protected async processValidCheckpointProposal(checkpoint: ValidatedCheckpointProposalCore, sender: PeerId) {
     const slot = checkpoint.slotNumber;
     this.logger.verbose(`Received checkpoint proposal for slot ${slot} from external peer ${sender.toString()}.`, {
       p2pMessageIdentifier: await checkpoint.p2pMessageLoggingIdentifier(),

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -2,11 +2,11 @@ import type { SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
 import type {
-  BlockProposal,
   CheckpointAttestation,
-  CheckpointProposalCore,
   Gossipable,
   TopicType,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
 } from '@aztec/stdlib/p2p';
 import type { Tx } from '@aztec/stdlib/tx';
 
@@ -28,18 +28,21 @@ export enum PeerDiscoveryState {
 /**
  * Callback for when a block proposal is received.
  * Validators validate but DO NOT attest to individual blocks - attestations are only for checkpoints.
+ * The proposal is passed as a ValidatedBlockProposal: it has already passed p2p ingress validation, and
+ * consumers are not expected to repeat it.
  * @returns true if the proposal is valid, false otherwise
  */
-export type P2PBlockReceivedCallback = (block: BlockProposal, sender: PeerId) => Promise<boolean>;
+export type P2PBlockReceivedCallback = (block: ValidatedBlockProposal, sender: PeerId) => Promise<boolean>;
 
 /**
  * Callback for when a checkpoint proposal is received.
- * The checkpoint proposal is passed as CheckpointProposalCore (without lastBlock) since
+ * The checkpoint proposal is passed as ValidatedCheckpointProposalCore (without lastBlock) since
  * the lastBlock is extracted and stored separately as a BlockProposal, and the block
- * callback is invoked and awaited before this checkpoint callback.
+ * callback is invoked and awaited before this checkpoint callback. As with block proposals, it has already
+ * passed p2p ingress validation.
  */
 export type P2PCheckpointReceivedCallback = (
-  checkpoint: CheckpointProposalCore,
+  checkpoint: ValidatedCheckpointProposalCore,
   sender: PeerId,
 ) => Promise<CheckpointAttestation[] | undefined>;
 

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -11,6 +11,8 @@ import type {
   CheckpointAttestation,
   CheckpointProposal,
   CheckpointProposalOptions,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { BlockHeader, Tx } from '@aztec/stdlib/tx';
@@ -172,18 +174,18 @@ export interface Validator {
   ): Promise<CheckpointProposal>;
 
   /**
-   * Validate a block proposal from a peer.
+   * Validate a block proposal from a peer that has already passed p2p ingress validation.
    * Note: Validators do NOT attest to individual blocks - attestations are only for checkpoint proposals.
    * @returns true if the proposal is valid, false otherwise
    */
-  validateBlockProposal(proposal: BlockProposal, sender: PeerId): Promise<boolean>;
+  validateBlockProposal(proposal: ValidatedBlockProposal, sender: PeerId): Promise<boolean>;
 
   /**
-   * Validate and attest to a checkpoint proposal from a peer.
+   * Validate and attest to a checkpoint proposal from a peer that has already passed p2p ingress validation.
    * @returns Checkpoint attestations if valid, undefined otherwise
    */
   attestToCheckpointProposal(
-    proposal: CheckpointProposal,
+    proposal: ValidatedCheckpointProposalCore,
     sender: PeerId,
   ): Promise<CheckpointAttestation[] | undefined>;
 

--- a/yarn-project/stdlib/src/p2p/index.ts
+++ b/yarn-project/stdlib/src/p2p/index.ts
@@ -8,6 +8,7 @@ export * from './interface.js';
 export * from './signature_utils.js';
 export * from './signed_txs.js';
 export * from './topic_type.js';
+export * from './validated_proposal.js';
 export * from './message_validator.js';
 export * from './peer_error.js';
 export * from './constants.js';

--- a/yarn-project/stdlib/src/p2p/validated_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/validated_proposal.ts
@@ -1,0 +1,43 @@
+import type { Branded } from '@aztec/foundation/branded-types';
+
+import type { BlockProposal } from './block_proposal.js';
+import type { CheckpointProposalCore } from './checkpoint_proposal.js';
+
+/**
+ * A block proposal that has passed p2p ingress validation.
+ *
+ * Downstream consumers (the validator client's proposal handlers) rely on that validation having already
+ * happened and do not repeat it, so this brand marks the proposals they are allowed to receive. It is a
+ * compile-time marker only: at runtime a `ValidatedBlockProposal` is just a `BlockProposal`.
+ */
+export type ValidatedBlockProposal = Branded<BlockProposal, 'ValidatedBlockProposal'>;
+
+/**
+ * Marks a block proposal as having passed p2p ingress validation.
+ *
+ * May only be called at a point where the gossipsub topic validator has accepted the proposal, which covers
+ * the signature context, the signature itself, the expected proposer for the slot, the index within the
+ * checkpoint, the tx field checks, and the receive-window timeliness check.
+ */
+export function ValidatedBlockProposal(proposal: BlockProposal): ValidatedBlockProposal {
+  return proposal as ValidatedBlockProposal;
+}
+
+/**
+ * A checkpoint proposal (without its last block) that has passed p2p ingress validation.
+ *
+ * Downstream consumers (the validator client's proposal handlers) rely on that validation having already
+ * happened and do not repeat it, so this brand marks the proposals they are allowed to receive. It is a
+ * compile-time marker only: at runtime a `ValidatedCheckpointProposalCore` is just a `CheckpointProposalCore`.
+ */
+export type ValidatedCheckpointProposalCore = Branded<CheckpointProposalCore, 'ValidatedCheckpointProposalCore'>;
+
+/**
+ * Marks a checkpoint proposal as having passed p2p ingress validation.
+ *
+ * May only be called at a point where the gossipsub topic validator has accepted the proposal, which covers
+ * the expected proposer for the slot and the receive-window timeliness check.
+ */
+export function ValidatedCheckpointProposalCore(proposal: CheckpointProposalCore): ValidatedCheckpointProposalCore {
+  return proposal as ValidatedCheckpointProposalCore;
+}

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -16,6 +16,7 @@ import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { accumulateCheckpointOutHashes } from '@aztec/stdlib/messaging';
+import { ValidatedBlockProposal, ValidatedCheckpointProposalCore } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -38,12 +39,14 @@ import { ProposalHandler } from './proposal_handler.js';
 
 /** Creates a checkpoint proposal core with the given overrides. */
 async function makeProposal(overrides: Parameters<typeof makeCheckpointProposal>[0] = {}) {
-  return (
-    await makeCheckpointProposal({
-      checkpointHeader: makeCheckpointHeader(0, { slotNumber: SlotNumber(1) }),
-      ...overrides,
-    })
-  ).toCore();
+  return ValidatedCheckpointProposalCore(
+    (
+      await makeCheckpointProposal({
+        checkpointHeader: makeCheckpointHeader(0, { slotNumber: SlotNumber(1) }),
+        ...overrides,
+      })
+    ).toCore(),
+  );
 }
 
 describe('ProposalHandler checkpoint validation', () => {
@@ -713,11 +716,13 @@ describe('ProposalHandler checkpoint validation', () => {
    * handler wired to accept it up to the block-number guard.
    */
   async function setupGenesisProposal(proposalArchive: Fr, txHashes?: TxHash[]) {
-    const proposal = await makeBlockProposal({
-      blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
-      archiveRoot: proposalArchive,
-      ...(txHashes ? { txHashes } : {}),
-    });
+    const proposal = ValidatedBlockProposal(
+      await makeBlockProposal({
+        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
+        archiveRoot: proposalArchive,
+        ...(txHashes ? { txHashes } : {}),
+      }),
+    );
 
     // Parent archive == genesis archive → genesis path → blockNumber = INITIAL_L2_BLOCK_NUM.
     blockSource.getGenesisValues.mockResolvedValue({
@@ -867,11 +872,13 @@ describe('ProposalHandler checkpoint validation', () => {
     // local latency into a slashable invalid-proposal verdict against an honest proposer.
     it('processes a proposal whose receive window closed while it waited to be processed', async () => {
       const signer = Secp256k1Signer.random();
-      const proposal = await makeBlockProposal({
-        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
-        archiveRoot: Fr.random(),
-        signer,
-      });
+      const proposal = ValidatedBlockProposal(
+        await makeBlockProposal({
+          blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
+          archiveRoot: Fr.random(),
+          signer,
+        }),
+      );
 
       // Parent archive == genesis archive → genesis path → blockNumber = INITIAL_L2_BLOCK_NUM.
       blockSource.getGenesisValues.mockResolvedValue({

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -36,7 +36,13 @@ import {
   accumulateCheckpointOutHashes,
   computeInHashFromL1ToL2Messages,
 } from '@aztec/stdlib/messaging';
-import type { BlockProposal, CheckpointAttestation, CheckpointProposalCore } from '@aztec/stdlib/p2p';
+import type {
+  BlockProposal,
+  CheckpointAttestation,
+  CheckpointProposalCore,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
+} from '@aztec/stdlib/p2p';
 import type { ConsensusTimetable } from '@aztec/stdlib/timetable';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { CheckpointGlobalVariables, FailedTx, Tx, TxHash } from '@aztec/stdlib/tx';
@@ -326,7 +332,7 @@ export class ProposalHandler {
 
     // Non-validator handler that processes or re-executes for monitoring but does not attest.
     // Returns boolean indicating whether the proposal was valid.
-    const blockHandler = async (proposal: BlockProposal, proposalSender: PeerId): Promise<boolean> => {
+    const blockHandler = async (proposal: ValidatedBlockProposal, proposalSender: PeerId): Promise<boolean> => {
       try {
         const { slotNumber, blockNumber } = proposal;
         const result = await this.handleBlockProposal(proposal, proposalSender, shouldReexecute);
@@ -376,7 +382,7 @@ export class ProposalHandler {
     // Runs for all nodes (validators and non-validators). Validators get the cached result in the
     // validator-specific callback (attestToCheckpointProposal) which runs after this one.
     const checkpointHandler = async (
-      proposal: CheckpointProposalCore,
+      proposal: ValidatedCheckpointProposalCore,
       _sender: PeerId,
     ): Promise<CheckpointAttestation[] | undefined> => {
       try {
@@ -452,7 +458,7 @@ export class ProposalHandler {
    * are validated before processing.
    */
   async handleBlockProposal(
-    proposal: BlockProposal,
+    proposal: ValidatedBlockProposal,
     proposalSender: PeerId,
     shouldReexecute: boolean,
   ): Promise<BlockProposalValidationResult> {
@@ -1059,7 +1065,7 @@ export class ProposalHandler {
    * timeliness); only deterministic properties of the signed payload are checked here.
    */
   async handleCheckpointProposal(
-    proposal: CheckpointProposalCore,
+    proposal: ValidatedCheckpointProposalCore,
     proposalInfo: LogData,
   ): Promise<CheckpointProposalValidationResult> {
     const slot = proposal.slotNumber;

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -26,7 +26,12 @@ import { type L1RollupConstants, getTimestampForSlot } from '@aztec/stdlib/epoch
 import { Gas, GasFees } from '@aztec/stdlib/gas';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
-import { type BlockProposal, CheckpointProposal } from '@aztec/stdlib/p2p';
+import {
+  type BlockProposal,
+  CheckpointProposal,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
+} from '@aztec/stdlib/p2p';
 import { mockTx } from '@aztec/stdlib/testing';
 import { BlockHeader, type CheckpointGlobalVariables, Tx } from '@aztec/stdlib/tx';
 import type { GenesisData } from '@aztec/stdlib/world-state';
@@ -355,7 +360,9 @@ describe('ValidatorClient Integration', () => {
   const attestorValidateBlocks = async (blocks: BlockProposalResult[]) => {
     for (const block of blocks) {
       logger.warn(`Validating block proposal ${block.proposal.blockNumber}`);
-      expect(await attestor.validator.validateBlockProposal(block.proposal, mockPeerId)).toBe(true);
+      expect(await attestor.validator.validateBlockProposal(ValidatedBlockProposal(block.proposal), mockPeerId)).toBe(
+        true,
+      );
     }
   };
 
@@ -423,7 +430,10 @@ describe('ValidatorClient Integration', () => {
 
       await attestorValidateBlocks(blocks);
 
-      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      const attestations = await attestor.validator.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(proposal),
+        mockPeerId,
+      );
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
       expect(attestations![0].getSender()).toEqual(validatorSigner.address);
@@ -458,7 +468,10 @@ describe('ValidatorClient Integration', () => {
 
       await attestorValidateBlocks(blocks);
 
-      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      const attestations = await attestor.validator.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(proposal),
+        mockPeerId,
+      );
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
       expect(attestations![0].getSender()).toEqual(validatorSigner.address);
@@ -514,7 +527,10 @@ describe('ValidatorClient Integration', () => {
 
       await attestorValidateBlocks(blocks2);
 
-      const attestations = await attestor.validator.attestToCheckpointProposal(proposal2, mockPeerId);
+      const attestations = await attestor.validator.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(proposal2),
+        mockPeerId,
+      );
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
 
@@ -551,7 +567,10 @@ describe('ValidatorClient Integration', () => {
 
       // Attestation should fail because block 3 wasn't validated
       // The validator will timeout waiting for block with matching archive
-      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      const attestations = await attestor.validator.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(proposal),
+        mockPeerId,
+      );
       expect(attestations).toBeUndefined();
     });
 
@@ -585,7 +604,10 @@ describe('ValidatorClient Integration', () => {
       dateProvider.setTime(Number(getTimestampForSlot(SlotNumber(slotNumber + 1), l1Constants)) * 1000);
 
       // Attestation should fail because archive doesn't match any block
-      const attestations = await attestor.validator.attestToCheckpointProposal(badProposal, mockPeerId);
+      const attestations = await attestor.validator.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(badProposal),
+        mockPeerId,
+      );
       expect(attestations).toBeUndefined();
     });
 
@@ -606,7 +628,10 @@ describe('ValidatorClient Integration', () => {
       epochCache.setCurrentSlot(slot2);
 
       // Block proposal validator should reject the old proposal
-      const isValid = await attestor.validator.validateBlockProposal(blocks[0].proposal, mockPeerId);
+      const isValid = await attestor.validator.validateBlockProposal(
+        ValidatedBlockProposal(blocks[0].proposal),
+        mockPeerId,
+      );
       expect(isValid).toBe(false);
     });
 
@@ -635,7 +660,10 @@ describe('ValidatorClient Integration', () => {
 
       // Block 3 should fail: remaining checkpoint mana is 0, so the processor
       // stops after the first tx's actual gas exceeds the limit.
-      const isValid = await attestor.validator.validateBlockProposal(blocks[2].proposal, mockPeerId);
+      const isValid = await attestor.validator.validateBlockProposal(
+        ValidatedBlockProposal(blocks[2].proposal),
+        mockPeerId,
+      );
       expect(isValid).toBe(false);
     });
 
@@ -662,7 +690,10 @@ describe('ValidatorClient Integration', () => {
       epochCache.setCurrentSlot(slot2);
 
       // Block proposal validator should reject the old proposal
-      const isValid = await attestor.validator.validateBlockProposal(blocks[0].proposal, mockPeerId);
+      const isValid = await attestor.validator.validateBlockProposal(
+        ValidatedBlockProposal(blocks[0].proposal),
+        mockPeerId,
+      );
       expect(isValid).toBe(false);
     });
   });

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -33,7 +33,12 @@ import { type BlockData, BlockHash, L2Block, type L2BlockSink, type L2BlockSourc
 import { type Checkpoint, CheckpointReexecutionTracker } from '@aztec/stdlib/checkpoint';
 import type { SlasherConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { type L1ToL2MessageSource, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
-import type { BlockProposal } from '@aztec/stdlib/p2p';
+import {
+  type BlockProposal,
+  type CheckpointProposalCore,
+  ValidatedBlockProposal,
+  ValidatedCheckpointProposalCore,
+} from '@aztec/stdlib/p2p';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
@@ -344,7 +349,7 @@ describe('ValidatorClient', () => {
   });
 
   describe('validateBlockProposal', () => {
-    let proposal: BlockProposal;
+    let proposal: ValidatedBlockProposal;
     let blockNumber: BlockNumber;
     let sender: PeerId;
     let blockBuildResult: BuildBlockInCheckpointResult;
@@ -423,7 +428,8 @@ describe('ValidatorClient', () => {
         );
 
       expect(checkpointHandler).toBeDefined();
-      return checkpointHandler!;
+      return (checkpoint: CheckpointProposalCore, peer: PeerId) =>
+        checkpointHandler!(ValidatedCheckpointProposalCore(checkpoint), peer);
     };
     const getBroadcastedInvalidCheckpointProposalSlashEvents = (
       emitSpy: jest.SpiedFunction<typeof validatorClient.emit>,
@@ -447,7 +453,7 @@ describe('ValidatorClient', () => {
       const emptyInHash = computeInHashFromL1ToL2Messages([]);
       const blockHeader = makeBlockHeader(1, { blockNumber: BlockNumber(100), slotNumber: SlotNumber(100) });
       blockNumber = BlockNumber(blockHeader.globalVariables.blockNumber);
-      proposal = await makeBlockProposal({ blockHeader, inHash: emptyInHash });
+      proposal = ValidatedBlockProposal(await makeBlockProposal({ blockHeader, inHash: emptyInHash }));
       // The proposal targets slot 100, which under pipelining is built during the previous slot. Set the
       // wall clock to the start of that build slot (target_slot_start - S), matching how a pipelined
       // proposer is positioned when validating an inbound block proposal. With S - 2E = 0 in this config
@@ -582,13 +588,15 @@ describe('ValidatorClient', () => {
         feeRecipient: terminalGlobals.feeRecipient,
         gasFees: terminalGlobals.gasFees,
       });
-      const laterBlock = await makeBlockProposal({
-        signer,
-        blockHeader: laterBlockHeader,
-        indexWithinCheckpoint: IndexWithinCheckpoint(1),
-        inHash: emptyInHash,
-        archiveRoot: Fr.random(),
-      });
+      const laterBlock = ValidatedBlockProposal(
+        await makeBlockProposal({
+          signer,
+          blockHeader: laterBlockHeader,
+          indexWithinCheckpoint: IndexWithinCheckpoint(1),
+          inHash: emptyInHash,
+          archiveRoot: Fr.random(),
+        }),
+      );
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
       p2pClient.getProposalsForSlot.mockResolvedValue({
@@ -671,13 +679,15 @@ describe('ValidatorClient', () => {
       epochCache.filterInCommittee.mockResolvedValue([EthAddress.fromString(validatorAccounts[0].address)]);
 
       const futureSlot = SlotNumber(proposal.slotNumber + 20);
-      const futureProposal = await makeBlockProposal({
-        blockHeader: makeBlockHeader(1, {
-          blockNumber,
-          slotNumber: futureSlot,
+      const futureProposal = ValidatedBlockProposal(
+        await makeBlockProposal({
+          blockHeader: makeBlockHeader(1, {
+            blockNumber,
+            slotNumber: futureSlot,
+          }),
+          inHash: computeInHashFromL1ToL2Messages([]),
         }),
-        inHash: computeInHashFromL1ToL2Messages([]),
-      });
+      );
 
       // Under pipelining, the target slot is the future slot the proposer is building for, built during
       // the previous slot. Position the wall clock at that build slot so the proposal falls within its
@@ -716,13 +726,15 @@ describe('ValidatorClient', () => {
     it('should process block proposal from own validator key (HA peer)', async () => {
       const selfSigner = new Secp256k1Signer(Buffer32.fromString(validatorPrivateKeys[0]));
       const emptyInHash = computeInHashFromL1ToL2Messages([]);
-      const selfProposal = await makeBlockProposal({
-        blockHeader: proposal.blockHeader,
-        inHash: emptyInHash,
-        archiveRoot: proposal.archive,
-        txHashes: proposal.txHashes,
-        signer: selfSigner,
-      });
+      const selfProposal = ValidatedBlockProposal(
+        await makeBlockProposal({
+          blockHeader: proposal.blockHeader,
+          inHash: emptyInHash,
+          archiveRoot: proposal.archive,
+          txHashes: proposal.txHashes,
+          signer: selfSigner,
+        }),
+      );
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(selfSigner.address);
 
@@ -756,7 +768,10 @@ describe('ValidatorClient', () => {
         },
       });
 
-      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+      const attestations = await validatorClient.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(checkpointProposal),
+        sender,
+      );
       expect(attestations).toBeUndefined();
       expect(addCheckpointAttestationsSpy).not.toHaveBeenCalled();
     });
@@ -768,16 +783,18 @@ describe('ValidatorClient', () => {
       expect(didValidate).toBe(true);
 
       const attestationsNegative = await validatorClient.attestToCheckpointProposal(
-        await makeCheckpointProposal({
-          archiveRoot: proposal.archive,
-          checkpointHeader: makeCheckpointHeader(0, { slotNumber: proposal.slotNumber }),
-          lastBlock: {
-            blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(123), slotNumber: proposal.slotNumber }),
-            indexWithinCheckpoint: IndexWithinCheckpoint(0),
-            txHashes: proposal.txHashes,
-          },
-          feeAssetPriceModifier: -MAX_FEE_ASSET_PRICE_MODIFIER_BPS - 1n,
-        }),
+        ValidatedCheckpointProposalCore(
+          await makeCheckpointProposal({
+            archiveRoot: proposal.archive,
+            checkpointHeader: makeCheckpointHeader(0, { slotNumber: proposal.slotNumber }),
+            lastBlock: {
+              blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(123), slotNumber: proposal.slotNumber }),
+              indexWithinCheckpoint: IndexWithinCheckpoint(0),
+              txHashes: proposal.txHashes,
+            },
+            feeAssetPriceModifier: -MAX_FEE_ASSET_PRICE_MODIFIER_BPS - 1n,
+          }),
+        ),
         sender,
       );
 
@@ -785,16 +802,18 @@ describe('ValidatorClient', () => {
       expect(addCheckpointAttestationsSpy).not.toHaveBeenCalled();
 
       const attestationsPositive = await validatorClient.attestToCheckpointProposal(
-        await makeCheckpointProposal({
-          archiveRoot: proposal.archive,
-          checkpointHeader: makeCheckpointHeader(0, { slotNumber: proposal.slotNumber }),
-          lastBlock: {
-            blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(123), slotNumber: proposal.slotNumber }),
-            indexWithinCheckpoint: IndexWithinCheckpoint(0),
-            txHashes: proposal.txHashes,
-          },
-          feeAssetPriceModifier: MAX_FEE_ASSET_PRICE_MODIFIER_BPS + 1n,
-        }),
+        ValidatedCheckpointProposalCore(
+          await makeCheckpointProposal({
+            archiveRoot: proposal.archive,
+            checkpointHeader: makeCheckpointHeader(0, { slotNumber: proposal.slotNumber }),
+            lastBlock: {
+              blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(123), slotNumber: proposal.slotNumber }),
+              indexWithinCheckpoint: IndexWithinCheckpoint(0),
+              txHashes: proposal.txHashes,
+            },
+            feeAssetPriceModifier: MAX_FEE_ASSET_PRICE_MODIFIER_BPS + 1n,
+          }),
+        ),
         sender,
       );
 
@@ -831,7 +850,10 @@ describe('ValidatorClient', () => {
       // Enable blob upload for this attestation
       blobClient.canUpload.mockReturnValue(true);
 
-      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+      const attestations = await validatorClient.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(checkpointProposal),
+        sender,
+      );
 
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
@@ -875,7 +897,10 @@ describe('ValidatorClient', () => {
       blockSource.getBlocksForSlot.mockResolvedValue(blocks);
 
       // Checkpoint validation should fail: proposal points to block 2 but last block in slot is block 3
-      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+      const attestations = await validatorClient.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(checkpointProposal),
+        sender,
+      );
       expect(attestations).toBeUndefined();
       expect(addCheckpointAttestationsSpy).not.toHaveBeenCalled();
     });
@@ -1160,7 +1185,10 @@ describe('ValidatorClient', () => {
       const emitSpy = jest.spyOn(validatorClient, 'emit');
 
       await checkpointHandler(checkpointProposal, sender);
-      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+      const attestations = await validatorClient.attestToCheckpointProposal(
+        ValidatedCheckpointProposalCore(checkpointProposal),
+        sender,
+      );
 
       expect(attestations).toBeUndefined();
       expect(getBroadcastedInvalidCheckpointProposalSlashEvents(emitSpy)).toEqual([
@@ -1405,12 +1433,14 @@ describe('ValidatorClient', () => {
     it('emits an invalid block proposal offense for a proposal with duplicate tx hashes', async () => {
       const signer = Secp256k1Signer.random();
       const txHash = TxHash.random();
-      const duplicateProposal = await makeBlockProposal({
-        blockHeader: proposal.blockHeader,
-        inHash: proposal.inHash,
-        txHashes: [txHash, txHash],
-        signer,
-      });
+      const duplicateProposal = ValidatedBlockProposal(
+        await makeBlockProposal({
+          blockHeader: proposal.blockHeader,
+          inHash: proposal.inHash,
+          txHashes: [txHash, txHash],
+          signer,
+        }),
+      );
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
       const emitSpy = jest.spyOn(validatorClient, 'emit');
 
@@ -1501,11 +1531,13 @@ describe('ValidatorClient', () => {
         // Override the global variables on the block header
         (proposalBlockHeader as any).globalVariables = proposalGlobalVariables;
 
-        const nonFirstBlockProposal = await makeBlockProposal({
-          blockHeader: proposalBlockHeader,
-          indexWithinCheckpoint: IndexWithinCheckpoint(1), // Non-first block in checkpoint
-          inHash: emptyInHash,
-        });
+        const nonFirstBlockProposal = ValidatedBlockProposal(
+          await makeBlockProposal({
+            blockHeader: proposalBlockHeader,
+            indexWithinCheckpoint: IndexWithinCheckpoint(1), // Non-first block in checkpoint
+            inHash: emptyInHash,
+          }),
+        );
 
         // Update epochCache mock for the new proposal
         epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(nonFirstBlockProposal.getSender());

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -40,6 +40,8 @@ import {
   type CheckpointProposalCore,
   type CheckpointProposalOptions,
   type CoordinationSignatureContext,
+  type ValidatedBlockProposal,
+  type ValidatedCheckpointProposalCore,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { ConsensusTimetable } from '@aztec/stdlib/timetable';
@@ -374,7 +376,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       this.log.debug(`Registering validator handlers for p2p client`);
 
       // Block proposal handler - validates but does NOT attest (validators only attest to checkpoints)
-      const blockHandler = (block: BlockProposal, proposalSender: PeerId): Promise<boolean> =>
+      const blockHandler = (block: ValidatedBlockProposal, proposalSender: PeerId): Promise<boolean> =>
         this.validateBlockProposal(block, proposalSender);
       this.p2pClient.registerBlockProposalHandler(blockHandler);
 
@@ -382,7 +384,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       // The checkpoint is received as CheckpointProposalCore since the lastBlock is extracted
       // and processed separately via the block handler above.
       const checkpointHandler = (
-        checkpoint: CheckpointProposalCore,
+        checkpoint: ValidatedCheckpointProposalCore,
         proposalSender: PeerId,
       ): Promise<CheckpointAttestation[] | undefined> => this.attestToCheckpointProposal(checkpoint, proposalSender);
       this.p2pClient.registerValidatorCheckpointProposalHandler(checkpointHandler);
@@ -418,7 +420,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
    * Note: Validators do NOT attest to individual blocks - attestations are only for checkpoint proposals.
    * @returns true if the proposal is valid, false otherwise
    */
-  async validateBlockProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<boolean> {
+  async validateBlockProposal(proposal: ValidatedBlockProposal, proposalSender: PeerId): Promise<boolean> {
     const slotNumber = proposal.slotNumber;
 
     // Note: During escape hatch, we still want to "validate" proposals for observability,
@@ -516,7 +518,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
    * @returns Checkpoint attestations if valid, undefined otherwise
    */
   async attestToCheckpointProposal(
-    proposal: CheckpointProposalCore,
+    proposal: ValidatedCheckpointProposalCore,
     _proposalSender: PeerId,
   ): Promise<CheckpointAttestation[] | undefined> {
     const proposalSlotNumber = proposal.slotNumber;


### PR DESCRIPTION
Follow-up to #25207. That PR removed the duplicate downstream re-validation of inbound block and checkpoint proposals, leaving p2p ingress (gossipsub topic validation) as the single place proposals are validated. The downstream handlers document that precondition in prose; this PR enforces it with the type system.

- Adds branded `ValidatedBlockProposal` and `ValidatedCheckpointProposalCore` types (plus their minting functions) in `stdlib/src/p2p/validated_proposal.ts`, following the existing `Branded<T, Brand>` convention used by `BlockNumber` and friends.
- The p2p received-proposal callbacks (`P2PBlockReceivedCallback`, `P2PCheckpointReceivedCallback`) and the downstream consumers (`ValidatorClient.validateBlockProposal` / `attestToCheckpointProposal`, `ProposalHandler.handleBlockProposal` / `handleCheckpointProposal`, and the `Validator` interface) now take the branded types, so a raw inbound `BlockProposal` / `CheckpointProposalCore` cannot reach them.
- The brands are minted only in `libp2p_service.ts`, at the three points where the topic validator has already returned `Accept`: the block-proposal topic path, the checkpoint-embedded block path (`processBlock` is only set after Accept), and the checkpoint path.
- Purely a compile-time marker: no runtime validation is added and there is no behavior change. The only non-type edits are in tests, which mint validated proposals from constructed ones.

Related to A-1703.
