### PR TITLE
fix: checkpoint block-shape and block-count validation gaps

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -104,19 +104,19 @@ export class ArchiverDataStoreUpdater {
     },
     evictProposedFrom?: CheckpointNumber,
   ): Promise<ReconcileCheckpointsResult> {
-    // Checkpoints here are already accepted by L1, so tolerate up to the physical blob-capacity
-    // ceiling rather than the conservative attestable limit used when building/attesting.
+    // These checkpoints are already on L1, so ingest validates against the physical blob capacity rather than
+    // the conservative build/attest policy, and tolerates an empty non-first block. Both rules are enforced by
+    // proposers and attesters; rejecting an ingest would stall sync rather than undo the checkpoint.
+    const validateOpts = {
+      rollupManaLimit: this.opts?.rollupManaLimit,
+      maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT,
+      allowEmptyNonFirstBlocks: true,
+    };
     for (const checkpoint of checkpoints) {
-      validateCheckpoint(checkpoint.checkpoint, {
-        rollupManaLimit: this.opts?.rollupManaLimit,
-        maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT,
-      });
+      validateCheckpoint(checkpoint.checkpoint, validateOpts);
     }
     if (promoteProposed) {
-      validateCheckpoint(promoteProposed.checkpoint.checkpoint, {
-        rollupManaLimit: this.opts?.rollupManaLimit,
-        maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT,
-      });
+      validateCheckpoint(promoteProposed.checkpoint.checkpoint, validateOpts);
     }
 
     const result = await this.stores.db.transactionAsync(async () => {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -1142,6 +1142,26 @@ describe('CheckpointProposalJob', () => {
       );
     });
 
+    // Only the first block of a checkpoint may be empty (no block-root circuit can prove a zero-tx block at a
+    // later index), so minValidTxsPerBlock: 0 must not reach the builder for anything past index 0.
+    it('floors minValidTxs at 1 past the first block even when configured to 0', async () => {
+      jest
+        .spyOn(job.getTimetable(), 'selectNextSubslot')
+        .mockReturnValueOnce(subslot(10, 0, false))
+        .mockReturnValueOnce(subslot(18, 1, true))
+        .mockReturnValue(noSubslot());
+
+      const { lastBlock } = await setupMultipleBlocks(2, [2, 1]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(lastBlock));
+
+      job.updateConfig({ minValidTxsPerBlock: 0 });
+      await job.executeAndAwait();
+
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(2);
+      expect(checkpointBuilder.buildBlockCalls[0].opts.minValidTxs).toBe(0);
+      expect(checkpointBuilder.buildBlockCalls[1].opts.minValidTxs).toBe(1);
+    });
+
     it('builds multiple blocks with sufficient txs', async () => {
       // Mock timetable to allow 2 blocks
       jest

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1093,7 +1093,11 @@ export class CheckpointProposalJob implements Traceable {
       // Per-block limits are operator overrides (from SEQ_MAX_L2_BLOCK_GAS etc.) further capped
       // by remaining checkpoint-level budgets inside CheckpointBuilder before each block is built.
       // minValidTxs is passed into the builder so it can reject the block *before* updating state.
-      const minValidTxs = forceCreate ? 0 : (this.config.minValidTxsPerBlock ?? minTxs);
+      // Only the first block of a checkpoint may be empty, since this allows a checkpoint to be created
+      // even if there are no transactions. If an empty block appears after the first, it can't be proven
+      // (there is no rollup circuit shaped to allow this), so the floor for minValidTxs is 1.
+      const configuredMinValidTxs = forceCreate ? 0 : (this.config.minValidTxsPerBlock ?? minTxs);
+      const minValidTxs = indexWithinCheckpoint > 0 ? Math.max(configuredMinValidTxs, 1) : configuredMinValidTxs;
       const blockBuilderOptions: BlockBuilderOptions = {
         maxTransactions: this.config.maxTxsPerBlock,
         maxBlockGas:

--- a/yarn-project/stdlib/src/checkpoint/validate.test.ts
+++ b/yarn-project/stdlib/src/checkpoint/validate.test.ts
@@ -116,6 +116,31 @@ describe('validateCheckpointStructure', () => {
     expect(() => validateCheckpointStructure(checkpoint)).toThrow(/indexWithinCheckpoint/);
   });
 
+  it('throws when a block after the first has no txs', async () => {
+    const checkpoint = await makeValidCheckpoint(2);
+    checkpoint.blocks[1].body.txEffects = [];
+    expect(() => validateCheckpointStructure(checkpoint)).toThrow(CheckpointValidationError);
+    expect(() => validateCheckpointStructure(checkpoint)).toThrow(/only the first block of a checkpoint may be empty/);
+  });
+
+  it('accepts an empty block after the first when allowEmptyNonFirstBlocks is set (L1-ingest path)', async () => {
+    const checkpoint = await makeValidCheckpoint(2);
+    checkpoint.blocks[1].body.txEffects = [];
+    expect(() => validateCheckpointStructure(checkpoint, { allowEmptyNonFirstBlocks: true })).not.toThrow();
+  });
+
+  it('passes when only the first block of a checkpoint has no txs', async () => {
+    const checkpoint = await makeValidCheckpoint(2);
+    checkpoint.blocks[0].body.txEffects = [];
+    expect(() => validateCheckpointStructure(checkpoint)).not.toThrow();
+  });
+
+  it('passes on a single-block checkpoint with no txs', async () => {
+    const checkpoint = await makeValidCheckpoint(1);
+    checkpoint.blocks[0].body.txEffects = [];
+    expect(() => validateCheckpointStructure(checkpoint)).not.toThrow();
+  });
+
   it('throws when block numbers are not sequential', async () => {
     const checkpoint = await makeValidCheckpoint(2);
     // Manually set block[1] to a non-sequential number (block[0].number + 2)

--- a/yarn-project/stdlib/src/checkpoint/validate.ts
+++ b/yarn-project/stdlib/src/checkpoint/validate.ts
@@ -38,9 +38,18 @@ export function validateCheckpoint(
      * accepted by L1.
      */
     maxBlocksPerCheckpoint?: number;
+    /**
+     * Whether to tolerate a zero-tx block after the first one. Defaults to false; the L1-sync ingest path
+     * passes true for the same reason it raises `maxBlocksPerCheckpoint` — such a checkpoint is already on
+     * L1, and refusing to ingest it would stall sync rather than undo it.
+     */
+    allowEmptyNonFirstBlocks?: boolean;
   },
 ): void {
-  validateCheckpointStructure(checkpoint, { maxBlocksPerCheckpoint: opts.maxBlocksPerCheckpoint });
+  validateCheckpointStructure(checkpoint, {
+    maxBlocksPerCheckpoint: opts.maxBlocksPerCheckpoint,
+    allowEmptyNonFirstBlocks: opts.allowEmptyNonFirstBlocks,
+  });
   validateCheckpointLimits(checkpoint, opts);
   validateCheckpointBlocksLimits(checkpoint, opts);
 }
@@ -53,15 +62,16 @@ export function validateCheckpoint(
  * - Checkpoint lastArchiveRoot matches the first block's lastArchive root
  * - Sequential block numbers without gaps
  * - Sequential indexWithinCheckpoint starting at 0
+ * - Every block after the first carries at least one tx, unless `allowEmptyNonFirstBlocks` is set
  * - Archive root chaining between consecutive blocks
  * - Consistent slot number across all blocks
  * - Global variables (slot, timestamp, coinbase, feeRecipient, gasFees) match checkpoint header for each block
  */
 export function validateCheckpointStructure(
   checkpoint: Checkpoint,
-  opts: { maxBlocksPerCheckpoint?: number } = {},
+  opts: { maxBlocksPerCheckpoint?: number; allowEmptyNonFirstBlocks?: boolean } = {},
 ): void {
-  const { maxBlocksPerCheckpoint = MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } = opts;
+  const { maxBlocksPerCheckpoint = MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT, allowEmptyNonFirstBlocks = false } = opts;
   const { blocks, number, slot } = checkpoint;
 
   if (blocks.length === 0) {
@@ -114,6 +124,18 @@ export function validateCheckpointStructure(
     }
 
     if (i > 0) {
+      // The only block-root circuit that proves a zero-tx block is `rollup_block_root_first_empty_tx`, which is
+      // pinned to index 0 of a checkpoint: it starts a fresh sponge blob and carries a non-zero in_hash, both of
+      // which the block-merge continuity checks forbid at any later index. An empty block past the first would
+      // therefore have no circuit able to prove it.
+      if (!allowEmptyNonFirstBlocks && block.body.txEffects.length === 0) {
+        throw new CheckpointValidationError(
+          `Block ${block.number} at index ${i} has no txs; only the first block of a checkpoint may be empty`,
+          number,
+          slot,
+        );
+      }
+
       const prev = blocks[i - 1];
       if (block.number !== prev.number + 1) {
         throw new CheckpointValidationError(

--- a/yarn-project/stdlib/src/config/network-consensus-config.test.ts
+++ b/yarn-project/stdlib/src/config/network-consensus-config.test.ts
@@ -1,5 +1,6 @@
 import { l1ContractsConfigMappings } from '@aztec/ethereum/config';
 
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
 import {
   NETWORK_CONSENSUS_ENV_VARS,
   type NetworkConsensusConfig,
@@ -35,6 +36,26 @@ describe('validateNetworkConsensusConfig', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain('11');
     expect(errors[0]).toContain('10');
+  });
+
+  // A long slot with short sub-slots derives more blocks than a node will build or attest to, so the network
+  // would accept a geometry whose later block indices p2p and checkpoint validation both reject.
+  it('errors when the derived count exceeds the attestable ceiling', () => {
+    const errors = validateNetworkConsensusConfig({
+      ...base,
+      aztecSlotDuration: 96,
+      blockDurationMs: 1000,
+      maxBlocksPerCheckpoint: 89,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('89');
+    expect(errors[0]).toContain(String(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT));
+  });
+
+  it('accepts a config sitting exactly on the attestable ceiling', () => {
+    expect(
+      validateNetworkConsensusConfig({ ...base, maxBlocksPerCheckpoint: MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT }),
+    ).not.toContainEqual(expect.stringContaining('exceeds the'));
   });
 
   it('errors when the slot duration is not a multiple of the ethereum slot duration', () => {

--- a/yarn-project/stdlib/src/config/network-consensus-config.ts
+++ b/yarn-project/stdlib/src/config/network-consensus-config.ts
@@ -1,6 +1,7 @@
 import { type L1ContractsConfig, l1ContractsConfigMappings, validateSlotDurations } from '@aztec/ethereum/config';
 import { type EnvVar, pickConfigMappings } from '@aztec/foundation/config';
 
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
 import type { SequencerConfig } from '../interfaces/configs.js';
 import {
   DEFAULT_CHECKPOINT_PROPOSAL_INIT_TIME,
@@ -167,6 +168,13 @@ export function validateNetworkConsensusConfig(config: NetworkConsensusConfig): 
   }
   if (config.maxBlocksPerCheckpoint < 1) {
     errors.push(`maxBlocksPerCheckpoint must be at least 1 (got ${config.maxBlocksPerCheckpoint})`);
+  }
+  if (config.maxBlocksPerCheckpoint > MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT) {
+    errors.push(
+      `maxBlocksPerCheckpoint (${config.maxBlocksPerCheckpoint}) exceeds the ` +
+        `${MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT} blocks nodes will build or attest to, so the network would ` +
+        `reject block indices its own configuration admits`,
+    );
   }
   if (config.checkpointProposalSyncGraceSeconds < 0) {
     errors.push(

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -642,6 +642,59 @@ describe('ProposalHandler checkpoint validation', () => {
       expect(mockDispose).toHaveBeenCalled();
     });
 
+    // A zero-tx block at a non-zero index passes re-execution (nothing failed, 0 effects === 0 hashes, no state
+    // movement), but no block-root circuit can prove it, so the attester has to reject it on structure alone.
+    it('returns checkpoint_validation_failed when a block after the first has no txs', async () => {
+      const lastArchiveRoot = Fr.random();
+      const firstBlockArchiveRoot = Fr.random();
+      const header = makeMatchingHeader({ lastArchiveRoot });
+
+      const makeMinimalBlock = (number: number, index: number, lastArchive: Fr, archive: Fr, numTxs: number) => {
+        const blockHeader = makeBlockHeader(number, {
+          slotNumber: SlotNumber(1),
+          coinbase: header.coinbase,
+          feeRecipient: header.feeRecipient,
+          gasFees: header.gasFees,
+          timestamp: header.timestamp,
+        });
+        unfreeze(blockHeader).lastArchive = new AppendOnlyTreeSnapshot(lastArchive, index);
+        return {
+          archive: new AppendOnlyTreeSnapshot(archive, index + 1),
+          number,
+          checkpointNumber: CheckpointNumber(1),
+          indexWithinCheckpoint: index,
+          slot: SlotNumber(1),
+          header: blockHeader,
+          body: { txEffects: Array.from({ length: numTxs }, () => ({})) },
+          computeDAGasUsed: () => 0,
+          toBlobFields: () => [],
+        } as unknown as L2Block;
+      };
+
+      setupDeepValidationMocks(
+        {
+          header,
+          archive: new AppendOnlyTreeSnapshot(archiveRoot, 1),
+          blocks: [
+            makeMinimalBlock(1, 0, lastArchiveRoot, firstBlockArchiveRoot, 1),
+            makeMinimalBlock(2, 1, firstBlockArchiveRoot, archiveRoot, 0),
+          ],
+          number: CheckpointNumber(1),
+          slot: SlotNumber(1),
+          toBlobFields: () => [],
+        },
+        lastArchiveRoot,
+      );
+
+      const proposal = await makeProposal({ archiveRoot, checkpointHeader: header });
+      const result = await handler.handleCheckpointProposal(proposal, proposalInfo);
+      expect(result).toEqual({
+        isValid: false,
+        reason: 'checkpoint_validation_failed',
+        checkpointNumber: CheckpointNumber(1),
+      });
+    });
+
     it('disposes fork even when validation fails', async () => {
       setupDeepValidationMocks({ header: CheckpointHeader.empty() });
 


### PR DESCRIPTION
Fixes two independent validation gaps around checkpoint shape.

## 1. A zero-tx block after the first in a checkpoint

There is no circuit for proving a non-first block with zero transactions. The zero-tx block-root circuit (`rollup_block_root_first_empty_tx`) exists only so that an epoch can be proven when there are no transactions at all, and it is pinned to index 0: it starts a fresh sponge blob and carries a non-zero `in_hash`, both of which the block-merge continuity checks forbid at any later index.

Validation methods had upper bounds on block contents but no lower bound, so a checkpoint carrying an empty block past the first would pass every node-side check and then be unprovable.

**Fix**: `validateCheckpointStructure` now requires every block after the first to carry at least one tx, and the sequencer floors `minValidTxs` at 1 for any block past index 0 so it never builds one. The archiver passes `allowEmptyNonFirstBlocks` on the L1-ingest path, since such a checkpoint is already final on L1 and refusing to ingest it would only stall sync.

## 2. Block-count ceiling in network config

Network configuration allowed `maxBlocksPerCheckpoint` to be set higher than the attestable limit, which would produce block indices that p2p and checkpoint validation reject. It is now capped at `MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT`.

Fixes A-1614