### PR TITLE
fix(txe): add vector support and fix the AVM vector oracles

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/macros/oracle_testing.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/macros/oracle_testing.nr
@@ -142,6 +142,7 @@ comptime fn synthesizers() -> [TestValueSynthesizer] {
         scalar_synth(),
         option_synth(),
         array_synth(),
+        vector_synth(),
         bounded_vec_synth(),
         tuple_synth(),
         // Matches ANY named data type: must stay last (find-first).
@@ -268,6 +269,31 @@ pub(crate) fn oracle_test_array<T, let N: u32>(build_element: fn(u32) -> T, seed
         array[i] = build_element(seed + i);
     }
     array
+}
+
+comptime fn vector_synth() -> TestValueSynthesizer {
+    TestValueSynthesizer {
+        matches: |t: Type| t.as_vector().is_some(),
+        scenarios: |t: Type, seed: Quoted| @[unnamed(vector_value_expr(t, seed))],
+        // The `+ 1` is the length field that precedes the contents on the wire.
+        width: |t: Type| TEST_COLLECTION_LEN * flat_width(t.as_vector().unwrap()) + 1,
+        // A vector carries no length of its own, so only the element type needs pinning.
+        pinned: |t: Type| {
+            let pinned_element = pinned_type(t.as_vector().unwrap());
+            quote { [$pinned_element] }
+        },
+    }
+}
+
+/// A call to [`oracle_test_array`] converted to a vector, with the element's builder and the pinned element type.
+comptime fn vector_value_expr(typ: Type, seed: Quoted) -> Quoted {
+    let element_type = typ.as_vector().unwrap();
+    let pinned_element = pinned_type(element_type);
+    let build_element = builder_expr(element_type);
+    let len_expr = f"{TEST_COLLECTION_LEN}".quoted_contents();
+    quote {
+        crate::macros::oracle_testing::oracle_test_array::<$pinned_element, $len_expr>($build_element, $seed).as_vector()
+    }
 }
 
 comptime fn bounded_vec_synth() -> TestValueSynthesizer {

--- a/noir-projects/labs/aztec-nr/aztec/src/macros/oracle_testing.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/macros/oracle_testing.nr
@@ -277,7 +277,7 @@ comptime fn vector_synth() -> TestValueSynthesizer {
         scenarios: |t: Type, seed: Quoted| @[unnamed(vector_value_expr(t, seed))],
         // The `+ 1` is the length field that precedes the contents on the wire.
         width: |t: Type| TEST_COLLECTION_LEN * flat_width(t.as_vector().unwrap()) + 1,
-        // A vector carries no length of its own, so only the element type needs pinning.
+        // A vector type does not display a length as it is dynamic
         pinned: |t: Type| {
             let pinned_element = pinned_type(t.as_vector().unwrap());
             quote { [$pinned_element] }

--- a/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
@@ -16,9 +16,6 @@ use crate::macros::oracle_testing::{generate_oracle_tests, generate_oracle_tests
         quote { calldata_copy_opcode },
         quote { return_opcode },
         quote { revert_opcode },
-        // TODO: implement once we support slices
-        quote { emit_public_log_opcode },
-        quote { returndata_copy_opcode },
     ],
 )]
 pub mod avm;

--- a/noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -21,7 +21,7 @@ use crate::protocol::{
 /// [`oracle::version`](crate::oracle::version), which covers oracles used during contract execution by PXE.
 ///
 /// The TypeScript counterparts are in `yarn-project/txe/src/oracle/txe_oracle_version.ts`.
-pub global TXE_ORACLE_VERSION_MAJOR: Field = 7;
+pub global TXE_ORACLE_VERSION_MAJOR: Field = 8;
 pub global TXE_ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the TXE oracle interface version is compatible.

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -46,6 +46,7 @@ export {
   U32,
   U64,
   U128,
+  VECTOR,
   tryFieldWidth,
   isArrayMapping,
   isBoundedVecMapping,
@@ -54,6 +55,7 @@ export {
   isFixedBoundedVecMapping,
   isOptionMapping,
   isStructMapping,
+  isVectorMapping,
   type ArrayMapping,
   type BoundedVecMapping,
   type CompositeMapping,
@@ -68,6 +70,7 @@ export {
   type StructField,
   type StructMapping,
   type TypeMapping,
+  type VectorMapping,
 } from './oracle/oracle_type_mappings.js';
 export { ExecutionNoteCache } from './execution_note_cache.js';
 export { ExecutionTaggingIndexCache } from './execution_tagging_index_cache.js';

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
@@ -28,7 +28,7 @@ import {
   makeEntry,
   slotsOf,
 } from './oracle_registry.js';
-import { FIXED_ARRAY, FIXED_BOUNDED_VEC, LEAF, SCALAR, STRUCT, TX_HASH } from './oracle_type_mappings.js';
+import { FIXED_ARRAY, FIXED_BOUNDED_VEC, LEAF, SCALAR, STRUCT, TX_HASH, VECTOR } from './oracle_type_mappings.js';
 
 /**
  * Tests for the oracle type mappings: how the PXE encodes values to, and decodes them from, the flat field arrays that
@@ -265,6 +265,45 @@ describe('oracle type mappings', () => {
     });
   });
 
+  // A vector carries its element count on the wire, so it takes a length slot ahead of its contents.
+  describe('VECTOR', () => {
+    it('round-trips a mix of Some and None elements', () => {
+      const data = [Option.some(new Fr(7)), Option.none<Fr>(), Option.some(new Fr(9))];
+      const out = roundTrip(VECTOR(OPTION(FIELD)), data);
+      expect(out.map(o => o.isSome())).toEqual([true, false, true]);
+      expect(out[0].value).toEqual(new Fr(7));
+      expect(out[2].value).toEqual(new Fr(9));
+    });
+
+    it('round-trips an empty vector', () => {
+      expect(roundTrip(VECTOR(FIELD), [])).toEqual([]);
+    });
+
+    it('round-trips multi-field elements', () => {
+      const data = [
+        { x: Fr.random(), y: Fr.random() },
+        { x: Fr.random(), y: Fr.random() },
+      ];
+      expect(roundTrip(VECTOR(POINT), data)).toEqual(data);
+    });
+
+    it('serializes the length ahead of the contents', () => {
+      expect(VECTOR(FIELD).serialization!.fn([new Fr(7), new Fr(9)])).toEqual([new Fr(2), [new Fr(7), new Fr(9)]]);
+    });
+
+    it('rejects a length that disagrees with the contents', () => {
+      const length = new FieldReader([new Fr(3)]);
+      const contents = new FieldReader([new Fr(7), new Fr(9)]);
+      expect(() => VECTOR(FIELD).deserialization!.fn([length, contents])).toThrow(
+        'length 3 implies 3 field(s) but the contents slot holds 2',
+      );
+    });
+
+    it('reads two input slots', () => {
+      expect(slotsOf(VECTOR(FIELD))).toBe(2); // length + contents
+    });
+  });
+
   // An EphemeralArray param is a handle to a list of rows, each row being one flat slot of fields.
   describe('EPHEMERAL_ARRAY', () => {
     it('deserializes single-field rows', () => {
@@ -338,6 +377,7 @@ describe('oracle type mappings', () => {
       expect(FIXED_ARRAY(FIELD, 4).label).toBe('array(field,4)');
       expect(FIXED_BOUNDED_VEC(AZTEC_ADDRESS, 8).label).toBe('bounded-vec(aztec-address,8)');
       expect(EPHEMERAL_ARRAY(FIELD).label).toBe('ephemeral-array(field)');
+      expect(VECTOR(FIELD).label).toBe('vector(field)');
     });
 
     it('renders a struct namelessly, splicing nested structs into the parent', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
@@ -287,15 +287,27 @@ describe('oracle type mappings', () => {
       expect(roundTrip(VECTOR(POINT), data)).toEqual(data);
     });
 
+    it('round-trips generic-length array elements', () => {
+      const data = [
+        [new Fr(1), new Fr(2), new Fr(3)],
+        [new Fr(4), new Fr(5), new Fr(6)],
+      ];
+      expect(roundTrip(VECTOR(ARRAY(FIELD)), data)).toEqual(data);
+    });
+
+    it('round-trips an empty vector of array elements', () => {
+      expect(roundTrip(VECTOR(ARRAY(FIELD)), [])).toEqual([]);
+    });
+
     it('serializes the length ahead of the contents', () => {
       expect(VECTOR(FIELD).serialization!.fn([new Fr(7), new Fr(9)])).toEqual([new Fr(2), [new Fr(7), new Fr(9)]]);
     });
 
-    it('rejects a length that disagrees with the contents', () => {
-      const length = new FieldReader([new Fr(3)]);
-      const contents = new FieldReader([new Fr(7), new Fr(9)]);
-      expect(() => VECTOR(FIELD).deserialization!.fn([length, contents])).toThrow(
-        'length 3 implies 3 field(s) but the contents slot holds 2',
+    it('rejects a multi-slot element of unfixed width, such as a nested vector', () => {
+      const length = new FieldReader([new Fr(1)]);
+      const contents = new FieldReader([new Fr(1), new Fr(7)]);
+      expect(() => VECTOR(VECTOR(FIELD)).deserialization!.fn([length, contents])).toThrow(
+        "their width is not fixed by the type, so we can't tell how many fields each of their 2 slots holds",
       );
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -654,6 +654,49 @@ export function ARRAY<T>(inner: TypeMapping<T>): ArrayMapping<T> {
 }
 
 /**
+ * Maps Noir's `[T]` ↔ TS `T[]` over 2 slots:
+ *   slot 0 — length scalar (count of elements)
+ *   slot 1 — the elements' fields, laid end to end
+ *
+ * The contents slot holds exactly `length` elements and is never padded, so deserializing rejects a length that
+ * disagrees with the fields present.
+ *
+ * @example Serializing `[{ x: 1, y: 2 }, { x: 3, y: 4 }]` with `VECTOR(POINT)`:
+ * ```
+ * slot 0: Fr(2)                          // element count, not field count
+ * slot 1: [Fr(1), Fr(2), Fr(3), Fr(4)]   // each element's fields end to end
+ * ```
+ */
+export function VECTOR<T>(inner: TypeMapping<T>): VectorMapping<T> {
+  return {
+    kind: 'vector',
+    label: `vector(${inner.label})`,
+    inner,
+    serialization: inner.serialization
+      ? { fn: values => [new Fr(values.length), packElements(inner, values)] }
+      : undefined,
+    deserialization: inner.deserialization
+      ? {
+          fn: ([lengthReader, contentsReader]) => {
+            const length = lengthReader.readField().toNumber();
+            const elementWidth = fieldWidth(inner.shape);
+            const contentsFields = contentsReader.remainingFields();
+            if (contentsFields !== length * elementWidth) {
+              throw new Error(
+                `Malformed vector: length ${length} implies ${length * elementWidth} field(s) but the contents slot ` +
+                  `holds ${contentsFields}`,
+              );
+            }
+            return unpackElements(inner, contentsReader, length);
+          },
+        }
+      : undefined,
+    // slot 0: the length scalar; slot 1: the contents, sized by that length.
+    shape: ['scalar', { lenFrom: (size: { length: number }) => size.length * fieldWidth(inner.shape) }],
+  };
+}
+
+/**
  * Noir's fixed-length array `[T; length]` in one slot: serializes `values` (each flattened via `element`)
  * zero-padded to exactly `length * elementWidth` fields, and deserializes all `length` elements back. An absent
  * element is the zero encoding, so the padding is derived from the shape.
@@ -889,11 +932,12 @@ export function STRUCT<T>(fields: readonly StructField[]): StructMapping<T> {
 }
 
 /**
- * The composite `TypeMapping`s (`ARRAY`/`BOUNDED_VEC`/`OPTION`/`STRUCT`/`FIXED_ARRAY`/`FIXED_BOUNDED_VEC`/
+ * The composite `TypeMapping`s (`ARRAY`/`VECTOR`/`BOUNDED_VEC`/`OPTION`/`STRUCT`/`FIXED_ARRAY`/`FIXED_BOUNDED_VEC`/
  * `EPHEMERAL_ARRAY`), discriminated by `kind`. The combinators attach `kind` plus the inner mapping(s) at construction;
  * the registry erases params to the base `TypeMapping`, so the guards below recover the structure for recursion.
  */
 export type ArrayMapping<T = any> = TypeMapping<T[]> & { kind: 'array'; inner: TypeMapping<T> };
+export type VectorMapping<T = any> = TypeMapping<T[]> & { kind: 'vector'; inner: TypeMapping<T> };
 export type BoundedVecMapping<T = any> = TypeMapping<BoundedVec<T>> & { kind: 'bounded-vec'; inner: TypeMapping<T> };
 export type OptionMapping<T = any> = TypeMapping<Option<T>> & { kind: 'option'; inner: TypeMapping<T> };
 export type StructMapping<T = any> = TypeMapping<T> & { kind: 'struct'; fields: readonly StructField[] };
@@ -913,6 +957,7 @@ export type EphemeralArrayMapping<T = any> = TypeMapping<EphemeralArray<T>> & {
 };
 export type CompositeMapping =
   | ArrayMapping
+  | VectorMapping
   | BoundedVecMapping
   | OptionMapping
   | StructMapping
@@ -922,6 +967,9 @@ export type CompositeMapping =
 
 export function isArrayMapping(type: TypeMapping<any>): type is ArrayMapping {
   return type.kind === 'array';
+}
+export function isVectorMapping(type: TypeMapping<any>): type is VectorMapping {
+  return type.kind === 'vector';
 }
 export function isBoundedVecMapping(type: TypeMapping<any>): type is BoundedVecMapping {
   return type.kind === 'bounded-vec';

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -654,49 +654,6 @@ export function ARRAY<T>(inner: TypeMapping<T>): ArrayMapping<T> {
 }
 
 /**
- * Maps Noir's `[T]` ↔ TS `T[]` over 2 slots:
- *   slot 0 — length scalar (count of elements)
- *   slot 1 — the elements' fields, laid end to end
- *
- * The contents slot holds exactly `length` elements and is never padded, so deserializing rejects a length that
- * disagrees with the fields present.
- *
- * @example Serializing `[{ x: 1, y: 2 }, { x: 3, y: 4 }]` with `VECTOR(POINT)`:
- * ```
- * slot 0: Fr(2)                          // element count, not field count
- * slot 1: [Fr(1), Fr(2), Fr(3), Fr(4)]   // each element's fields end to end
- * ```
- */
-export function VECTOR<T>(inner: TypeMapping<T>): VectorMapping<T> {
-  return {
-    kind: 'vector',
-    label: `vector(${inner.label})`,
-    inner,
-    serialization: inner.serialization
-      ? { fn: values => [new Fr(values.length), packElements(inner, values)] }
-      : undefined,
-    deserialization: inner.deserialization
-      ? {
-          fn: ([lengthReader, contentsReader]) => {
-            const length = lengthReader.readField().toNumber();
-            const elementWidth = fieldWidth(inner.shape);
-            const contentsFields = contentsReader.remainingFields();
-            if (contentsFields !== length * elementWidth) {
-              throw new Error(
-                `Malformed vector: length ${length} implies ${length * elementWidth} field(s) but the contents slot ` +
-                  `holds ${contentsFields}`,
-              );
-            }
-            return unpackElements(inner, contentsReader, length);
-          },
-        }
-      : undefined,
-    // slot 0: the length scalar; slot 1: the contents, sized by that length.
-    shape: ['scalar', { lenFrom: (size: { length: number }) => size.length * fieldWidth(inner.shape) }],
-  };
-}
-
-/**
  * Noir's fixed-length array `[T; length]` in one slot: serializes `values` (each flattened via `element`)
  * zero-padded to exactly `length * elementWidth` fields, and deserializes all `length` elements back. An absent
  * element is the zero encoding, so the padding is derived from the shape.
@@ -932,6 +889,41 @@ export function STRUCT<T>(fields: readonly StructField[]): StructMapping<T> {
 }
 
 /**
+ * Maps Noir's `[T]` ↔ TS `T[]` over 2 slots:
+ *   slot 0 — length scalar (count of elements)
+ *   slot 1 — the elements' fields, laid end to end
+ *
+ * @example Serializing `[{ x: 1, y: 2 }, { x: 3, y: 4 }]` with `VECTOR(POINT)`:
+ * ```
+ * slot 0: Fr(2)                          // element count, not field count
+ * slot 1: [Fr(1), Fr(2), Fr(3), Fr(4)]   // each element's fields end to end
+ * ```
+ */
+export function VECTOR<T>(inner: TypeMapping<T>): VectorMapping<T> {
+  return {
+    kind: 'vector',
+    label: `vector(${inner.label})`,
+    inner,
+    serialization: inner.serialization
+      ? { fn: values => [new Fr(values.length), packElements(inner, values)] }
+      : undefined,
+    deserialization: inner.deserialization
+      ? {
+          fn: ([lengthReader, contentsReader]) => {
+            const length = lengthReader.readField().toNumber();
+            // If the shape does not fix a width, every element shares one unknown width, so dividing the contents by
+            // the count recovers it.
+            const elementWidth = tryFieldWidth(inner.shape) ?? contentsReader.remainingFields() / length;
+            return unpackElements(inner, contentsReader, length, elementWidth);
+          },
+        }
+      : undefined,
+    // slot 0: the length scalar; slot 1: the contents, sized by that length.
+    shape: ['scalar', { lenFrom: (size: { length: number }) => size.length * fieldWidth(inner.shape) }],
+  };
+}
+
+/**
  * The composite `TypeMapping`s (`ARRAY`/`VECTOR`/`BOUNDED_VEC`/`OPTION`/`STRUCT`/`FIXED_ARRAY`/`FIXED_BOUNDED_VEC`/
  * `EPHEMERAL_ARRAY`), discriminated by `kind`. The combinators attach `kind` plus the inner mapping(s) at construction;
  * the registry erases params to the base `TypeMapping`, so the guards below recover the structure for recursion.
@@ -1087,11 +1079,18 @@ function packElements<T>(element: TypeMapping<T>, values: T[]): Fr[] {
 }
 
 /**
- * Reads `count` fixed-width elements out of a packed run (the inverse of {@link packElements}). Element must be
- * deserializable.
+ * Reads `count` equal-width elements out of a packed run (the inverse of {@link packElements}). Element must be
+ * deserializable. `width` is for an element whose shape fixes no width; such an element must occupy a single slot,
+ * since nothing records how many of a chunk's fields belong to each slot.
  */
-function unpackElements<T>(element: TypeMapping<T>, reader: FieldReader, count: number): T[] {
-  const elementWidth = fieldWidth(element.shape);
+function unpackElements<T>(element: TypeMapping<T>, reader: FieldReader, count: number, width?: number): T[] {
+  if (tryFieldWidth(element.shape) === undefined && element.shape.length !== 1) {
+    throw new Error(
+      `Cannot unpack ${element.label} elements: their width is not fixed by the type, so we can't tell how many ` +
+        `fields each of their ${element.shape.length} slots holds`,
+    );
+  }
+  const elementWidth = width ?? fieldWidth(element.shape);
   return Array.from({ length: count }, () => deserializeElement(element, reader.readFieldArray(elementWidth)));
 }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -644,8 +644,11 @@ export function ARRAY<T>(inner: TypeMapping<T>): ArrayMapping<T> {
     serialization: inner.serialization ? { fn: values => [packElements(inner, values)] } : undefined,
     deserialization: inner.deserialization
       ? {
-          // The whole slot is the array, so read as many elements as its fields hold.
-          fn: ([reader]) => unpackElements(inner, reader, reader.remainingFields() / fieldWidth(inner.shape)),
+          fn: ([reader]) => {
+            // The whole slot is the array, so read as many elements as its fields hold.
+            const elementWidth = fieldWidth(inner.shape);
+            return unpackElements(inner, reader, reader.remainingFields() / elementWidth, elementWidth);
+          },
         }
       : undefined,
     // One slot of variable length (all elements flattened into it).
@@ -669,7 +672,7 @@ export function FIXED_ARRAY<T>(element: TypeMapping<T>, length: number): FixedAr
       ? { fn: values => [padArrayEnd(packElements(element, values), Fr.ZERO, length * elementWidth)] }
       : undefined,
     deserialization: element.deserialization
-      ? { fn: ([reader]) => unpackElements(element, reader, length) }
+      ? { fn: ([reader]) => unpackElements(element, reader, length, elementWidth) }
       : undefined,
     shape: [{ len: length * elementWidth }],
   };
@@ -729,7 +732,7 @@ export function BOUNDED_VEC<T>(inner: TypeMapping<T>): BoundedVecMapping<T> {
                 `Malformed BoundedVec: length ${length} exceeds the ${maxLength} element(s) its storage array holds`,
               );
             }
-            const elements = unpackElements(inner, storageReader, length);
+            const elements = unpackElements(inner, storageReader, length, elementWidth);
             storageReader.skip(storageReader.remainingFields());
             return BoundedVec.from<T>({ data: elements, maxLength });
           },
@@ -1079,18 +1082,17 @@ function packElements<T>(element: TypeMapping<T>, values: T[]): Fr[] {
 }
 
 /**
- * Reads `count` equal-width elements out of a packed run (the inverse of {@link packElements}). Element must be
- * deserializable. `width` is for an element whose shape fixes no width; such an element must occupy a single slot,
- * since nothing records how many of a chunk's fields belong to each slot.
+ * Reads `count` `elementWidth`-field elements out of a packed run (the inverse of {@link packElements}). Element must
+ * be deserializable. When the element's shape fixes no width, `elementWidth` comes from the run's own size, and such an
+ * element must occupy a single slot, since nothing records how many of a chunk's fields belong to each slot.
  */
-function unpackElements<T>(element: TypeMapping<T>, reader: FieldReader, count: number, width?: number): T[] {
+function unpackElements<T>(element: TypeMapping<T>, reader: FieldReader, count: number, elementWidth: number): T[] {
   if (tryFieldWidth(element.shape) === undefined && element.shape.length !== 1) {
     throw new Error(
       `Cannot unpack ${element.label} elements: their width is not fixed by the type, so we can't tell how many ` +
         `fields each of their ${element.shape.length} slots holds`,
     );
   }
-  const elementWidth = width ?? fieldWidth(element.shape);
   return Array.from({ length: count }, () => deserializeElement(element, reader.readFieldArray(elementWidth)));
 }
 

--- a/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
+++ b/yarn-project/txe/src/oracle/test-resolver/default_fixtures.ts
@@ -32,6 +32,7 @@ import {
   isFixedBoundedVecMapping,
   isOptionMapping,
   isStructMapping,
+  isVectorMapping,
   tryFieldWidth,
 } from '@aztec/pxe/simulator';
 import { EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
@@ -99,6 +100,7 @@ const COMPOSITE_IMPLS: CompositeImpl[] = [
     named(Option.none(testValueFor(type.inner, seed)), 'none'),
   ]),
   composite(isArrayMapping, (type, seed) => [unnamed(collectionData(type.inner, seed, DEFAULT_ARRAY_LENGTH))]),
+  composite(isVectorMapping, (type, seed) => [unnamed(collectionData(type.inner, seed, DEFAULT_ARRAY_LENGTH))]),
   composite(isBoundedVecMapping, (type, seed) => [
     unnamed(
       BoundedVec.from({

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -38,6 +38,7 @@ import {
   type TypeMapping,
   U32,
   U64,
+  VECTOR,
   buildACIRCallback,
   makeEntry,
 } from '@aztec/pxe/simulator';
@@ -380,7 +381,7 @@ export const TXE_ORACLE_REGISTRY = {
   }),
 
   aztec_avm_emitPublicLog: makeEntry({
-    params: [{ name: 'message', type: ARRAY(FIELD) }],
+    params: [{ name: 'message', type: VECTOR(FIELD) }],
   }),
 
   aztec_avm_returndataSize: makeEntry({ returnType: U32 }),
@@ -390,7 +391,7 @@ export const TXE_ORACLE_REGISTRY = {
       { name: 'rdOffset', type: U32 },
       { name: 'copySize', type: U32 },
     ],
-    returnType: ARRAY(FIELD),
+    returnType: VECTOR(FIELD),
   }),
 
   aztec_avm_call: makeEntry({

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -5,7 +5,7 @@
  *
  * The Noir counterparts are in `noir-projects/labs/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
-export const TXE_ORACLE_VERSION_MAJOR = 7;
+export const TXE_ORACLE_VERSION_MAJOR = 8;
 export const TXE_ORACLE_VERSION_MINOR = 0;
 
 /**
@@ -14,4 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 0;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-export const TXE_ORACLE_INTERFACE_HASH = 'd062900c87e89ac162a7a1759be638facdd14f4a43c886bd70871240b6b1a1a1';
+export const TXE_ORACLE_INTERFACE_HASH = 'e06f29fc2b03516b7122021f95bdcfa7816680469fc46b21eb36d2368bc4e708';


### PR DESCRIPTION
## Summary

- Continues the oracle type-mapping series (#25200): adds a `VECTOR` combinator for Noir's vector `[T]`, which takes
  two wire slots — the element count, then every element's fields laid end to end.
- `aztec_avm_emitPublicLog` and `aztec_avm_returndataCopy` declared their `[Field]` as a one-slot `ARRAY(FIELD)`, so
  both registry entries disagreed with the wire. Neither surfaced because `emitPublicLog`'s TXE handler is still an
  unimplemented stub (#8811) and `returndataCopy` is never exercised in TXE tests.
- Both now use `VECTOR(FIELD)` and are covered by the generated oracle serialization tests, which go from 104 to 106.
- Naming follows Noir's own rename of slice → vector (noir-lang/noir#10973), so the mapping, the guards and the Noir
  synthesizer all say "vector".

`TXE_ORACLE_VERSION_MAJOR` goes 7 → 8, since the registry labels change.