### PR TITLE
refactor(pxe): match Noir shape for contract class log oracle

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
@@ -104,7 +104,7 @@ pub mod get_membership_witness;
 pub mod keys;
 #[generate_oracle_tests]
 pub mod key_validation_request;
-// TODO: cover with oracle tests once the two sides agree on the param grouping (TS wraps them in a single struct).
+#[generate_oracle_tests]
 pub mod logs;
 // TODO: cover with oracle tests once the test resolver can serve EphemeralArray contents.
 pub mod message_processing;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -14,7 +14,6 @@ import {
   BOOL,
   BOUNDED_VEC,
   CALL_PRIVATE_RESULT,
-  CONTRACT_CLASS_LOG,
   CONTRACT_INSTANCE,
   DELIVERY_MODE,
   EPHEMERAL_ARRAY,
@@ -64,7 +63,6 @@ export {
   BOOL,
   BOUNDED_VEC,
   U8,
-  CONTRACT_CLASS_LOG,
   DELIVERY_MODE,
   RESOLVED_TAGGING_STRATEGY,
   EPHEMERAL_ARRAY,
@@ -528,7 +526,9 @@ export const ORACLE_REGISTRY = {
 
   aztec_prv_notifyCreatedContractClassLog: makeEntry({
     params: [
-      { name: 'log', type: CONTRACT_CLASS_LOG },
+      { name: 'contractAddress', type: AZTEC_ADDRESS },
+      { name: 'message', type: ARRAY(FIELD) },
+      { name: 'length', type: U32 },
       { name: 'counter', type: U32 },
     ],
   }),

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -154,7 +154,7 @@ export interface TypeMapping<T = any> {
    * Examples:
    * - `FIELD` → `['scalar']` // single slot
    * - `OPTION(T)` → `['scalar', ...T.shape]` // [discriminant], [...inner.shape]
-   * - `CONTRACT_CLASS_LOG` → `['scalar', { len: N }, 'scalar']` // [addr], [fields], [len]
+   * - `CONTRACT_CLASS_LOG_ENTRY` → `[{ len: N }, 'scalar', 'scalar']` // [fields], [emittedLength], [address]
    */
   shape: SlotShape[];
 }
@@ -449,12 +449,6 @@ export const PUBLIC_KEYS_AND_PARTIAL_ADDRESS: TypeMapping<{
 }> = STRUCT([
   { name: 'publicKeys', type: PUBLIC_KEYS },
   { name: 'partialAddress', type: FIELD },
-]);
-
-export const CONTRACT_CLASS_LOG: TypeMapping<ContractClassLogData> = STRUCT([
-  { name: 'contractAddress', type: AZTEC_ADDRESS },
-  { name: 'fields', type: FIXED_ARRAY(FIELD, CONTRACT_CLASS_LOG_SIZE_IN_FIELDS) },
-  { name: 'emittedLength', type: U32 },
 ]);
 
 const PUBLIC_DATA_WRITE: TypeMapping<PublicDataWrite> = STRUCT<PublicDataWrite>([

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -44,7 +44,6 @@ import type { ExecutionNoteCache } from '../execution_note_cache.js';
 import { ExecutionTaggingIndexCache } from '../execution_tagging_index_cache.js';
 import type { HashedValuesCache } from '../hashed_values_cache.js';
 import { BoundedVec } from '../noir-structs/bounded_vec.js';
-import type { ContractClassLogData } from '../noir-structs/contract_class_log_data.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import { Option } from '../noir-structs/option.js';
 import type { ResolvedTaggingStrategy } from '../noir-structs/resolved_tagging_strategy.js';
@@ -604,14 +603,16 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * Emit a contract class log.
    * This fn exists because we only carry a poseidon hash through the kernels, and need to
    * keep the preimage in ts for later.
-   * @param logData - The contract class log to be emitted.
+   * @param contractAddress - The address of the contract emitting the log.
+   * @param message - The log fields, zero-padded to `CONTRACT_CLASS_LOG_SIZE_IN_FIELDS`.
+   * @param length - How many of the fields are meaningful, trailing zeros excluded.
    * @param counter - The contract class log's counter.
    */
-  public notifyCreatedContractClassLog(logData: ContractClassLogData, counter: number) {
+  public notifyCreatedContractClassLog(contractAddress: AztecAddress, message: Fr[], length: number, counter: number) {
     const log = ContractClassLog.from({
-      contractAddress: logData.contractAddress,
-      fields: new ContractClassLogFields(logData.fields),
-      emittedLength: logData.emittedLength,
+      contractAddress,
+      fields: new ContractClassLogFields(message),
+      emittedLength: length,
     });
     this.contractClassLogs.push(new CountedContractClassLog(log, counter));
     const text = log.toBuffer().toString('hex');

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 8;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/labs/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'fec4d3a95fc57a62a20bfeb659bb3bfd91b31cd93e07f8cf97b368f9f55cc67b';
+export const ORACLE_INTERFACE_HASH = '16a4ca6f5342a5b7a12fe9ec3aa88be16c40cf685f5a205a58187c2c41bb2661';


### PR DESCRIPTION
## Summary

- The TS registry entry for `aztec_prv_notifyCreatedContractClassLog` wrapped its arguments in a single struct param while the Noir oracle declares four flat ones. The wire layout was identical either way, but the generated oracle roundtrip tests seed values by parameter position, so the two shapes could not be lined up and the oracle was excluded from coverage with a TODO.
- Flattens the TS entry to `contractAddress` / `message` / `length` / `counter` and drops the now-unused `CONTRACT_CLASS_LOG` mapping. `message` maps as a variable `ARRAY(FIELD)`, so the Noir side keeps its generic length and the generated test stays 3 fields wide instead of `CONTRACT_CLASS_LOG_SIZE_IN_FIELDS`.
- Enables `#[generate_oracle_tests]` on the aztec-nr `logs` module. Verified red/green: the new test fails when the TS param width is deliberately drifted, and passes as shipped.
- Updates `ORACLE_INTERFACE_HASH`, which is keyed on parameter names and type labels. The wire layout is unchanged, so compiled contracts are unaffected and neither `ORACLE_VERSION_MAJOR` nor `ORACLE_VERSION_MINOR` needs bumping.