### PR TITLE
refactor(pxe): express sibling paths as plain fixed arrays

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
@@ -71,27 +71,11 @@ pub mod execution;
 pub mod execution_cache;
 #[generate_oracle_tests]
 pub mod get_contract_instance;
-#[generate_oracle_tests_excluding(
-    @[
-        // TODO: cover once the sibling-path mapping is expressible as a plain fixed array
-        quote { get_l1_to_l2_membership_witness_oracle },
-    ],
-)]
+#[generate_oracle_tests]
 pub mod get_l1_to_l2_membership_witness;
-#[generate_oracle_tests_excluding(
-    @[
-        // TODO: cover once the sibling-path mapping is expressible as a plain fixed array
-        quote { get_low_nullifier_membership_witness_oracle },
-        quote { get_nullifier_membership_witness_oracle },
-    ],
-)]
+#[generate_oracle_tests]
 pub mod get_nullifier_membership_witness;
-#[generate_oracle_tests_excluding(
-    @[
-        // TODO: cover once the sibling-path mapping is expressible as a plain fixed array
-        quote { get_public_data_witness_oracle },
-    ],
-)]
+#[generate_oracle_tests]
 pub mod get_public_data_witness;
 #[generate_oracle_tests_excluding(
     @[

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -77,7 +77,6 @@ export type { IMiscOracle, IUtilityExecutionOracle, IPrivateExecutionOracle } fr
 export type { FactCollection } from './noir-structs/fact_collection.js';
 export type { NoteData } from './noir-structs/note_data.js';
 export type { ResolvedTaggingStrategy } from './noir-structs/resolved_tagging_strategy.js';
-export type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
 export { TxResolverService } from '../messages/tx_resolver_service.js';
 export { UtilityExecutionOracle } from './oracle/utility_execution_oracle.js';
 export { PrivateExecutionOracle } from './oracle/private_execution_oracle.js';
@@ -100,4 +99,6 @@ export type { PendingTaggedLog } from './noir-structs/pending_tagged_log.js';
 export type { TxEffectData } from './noir-structs/tx_effect_data.js';
 export type { ProvidedSecret } from './noir-structs/provided_secret.js';
 export type { ResolvedTx } from './noir-structs/resolved_tx.js';
+export type { NullifierMembershipWitnessData } from './noir-structs/nullifier_membership_witness_data.js';
+export type { PublicDataWitnessData } from './noir-structs/public_data_witness_data.js';
 export { TransientArrayService } from './transient_array_service.js';

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_membership_witness_data.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_membership_witness_data.ts
@@ -1,0 +1,11 @@
+import type { NULLIFIER_TREE_HEIGHT } from '@aztec/constants';
+import type { MembershipWitness } from '@aztec/foundation/trees';
+import type { NullifierLeafPreimage } from '@aztec/stdlib/trees';
+
+/**
+ * A nullifier leaf preimage and the witness proving its membership in the nullifier tree.
+ */
+export type NullifierMembershipWitnessData = {
+  leafPreimage: NullifierLeafPreimage;
+  witness: MembershipWitness<typeof NULLIFIER_TREE_HEIGHT>;
+};

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_membership_witness_data.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_membership_witness_data.ts
@@ -1,6 +1,6 @@
 import type { NULLIFIER_TREE_HEIGHT } from '@aztec/constants';
 import type { MembershipWitness } from '@aztec/foundation/trees';
-import type { NullifierLeafPreimage } from '@aztec/stdlib/trees';
+import type { NullifierLeafPreimage, NullifierMembershipWitness } from '@aztec/stdlib/trees';
 
 /**
  * A nullifier leaf preimage and the witness proving its membership in the nullifier tree.
@@ -9,3 +9,7 @@ export type NullifierMembershipWitnessData = {
   leafPreimage: NullifierLeafPreimage;
   witness: MembershipWitness<typeof NULLIFIER_TREE_HEIGHT>;
 };
+
+export function toNullifierMembershipWitnessData(witness: NullifierMembershipWitness): NullifierMembershipWitnessData {
+  return { leafPreimage: witness.leafPreimage, witness: witness.withoutPreimage() };
+}

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/public_data_witness_data.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/public_data_witness_data.ts
@@ -1,0 +1,13 @@
+import type { PUBLIC_DATA_TREE_HEIGHT } from '@aztec/constants';
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { Tuple } from '@aztec/foundation/serialize';
+import type { PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
+
+/**
+ * A public data leaf preimage and the witness proving its membership in the public data tree.
+ */
+export type PublicDataWitnessData = {
+  index: bigint;
+  leafPreimage: PublicDataTreeLeafPreimage;
+  siblingPath: Tuple<Fr, typeof PUBLIC_DATA_TREE_HEIGHT>;
+};

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/message_load_oracle_inputs.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/message_load_oracle_inputs.ts
@@ -1,8 +1,0 @@
-import type { SiblingPath } from '@aztec/foundation/trees';
-
-export type MessageLoadOracleInputs<N extends number> = {
-  /** The index of the message commitment in the merkle tree. */
-  index: bigint;
-  /** The path in the merkle tree to the message. */
-  siblingPath: SiblingPath<N>;
-};

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { ARCHIVE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
+import { ARCHIVE_HEIGHT, L1_TO_L2_MSG_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { FieldReader } from '@aztec/foundation/serialize';
 import { toACVMField } from '@aztec/simulator/client';
@@ -28,7 +28,6 @@ import {
   LOG_RETRIEVAL_REQUEST,
   LOG_RETRIEVAL_RESPONSE,
   MEMBERSHIP_WITNESS,
-  MESSAGE_LOAD_ORACLE_INPUTS,
   type MaybePromise,
   NOTE,
   NOTE_SELECTOR,
@@ -205,7 +204,7 @@ export const ORACLE_REGISTRY = {
         ),
       },
     ],
-    returnType: MESSAGE_LOAD_ORACLE_INPUTS,
+    returnType: MEMBERSHIP_WITNESS(L1_TO_L2_MSG_TREE_HEIGHT),
   }),
 
   aztec_utl_getFromPublicStorage: makeEntry({

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -1,7 +1,6 @@
 import {
   CONTRACT_CLASS_LOG_SIZE_IN_FIELDS,
   FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH,
-  L1_TO_L2_MSG_TREE_HEIGHT,
   MAX_CONTRACT_CLASS_LOGS_PER_TX,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
@@ -18,7 +17,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { FieldReader } from '@aztec/foundation/serialize';
-import { MembershipWitness, type SiblingPath } from '@aztec/foundation/trees';
+import { MembershipWitness } from '@aztec/foundation/trees';
 import type { ACVMField } from '@aztec/simulator/client';
 import { FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
@@ -35,14 +34,12 @@ import {
   Tag,
   appTaggingSecretKindFromDeliveryMode,
 } from '@aztec/stdlib/logs';
-import {
-  type AppendOnlyTreeSnapshot,
-  type NullifierLeaf,
-  type NullifierLeafPreimage,
-  NullifierMembershipWitness,
-  type PublicDataTreeLeaf,
-  type PublicDataTreeLeafPreimage,
-  PublicDataWitness,
+import type {
+  AppendOnlyTreeSnapshot,
+  NullifierLeaf,
+  NullifierLeafPreimage,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
 } from '@aztec/stdlib/trees';
 import {
   BlockHeader,
@@ -69,9 +66,11 @@ import { type LogRetrievalRequest, type LogSource, logSourceFromField } from '..
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
+import type { NullifierMembershipWitnessData } from '../noir-structs/nullifier_membership_witness_data.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
+import type { PublicDataWitnessData } from '../noir-structs/public_data_witness_data.js';
 import {
   type ResolvedTaggingStrategy,
   resolvedTaggingStrategyFromFields,
@@ -80,7 +79,6 @@ import {
 import type { ResolvedTx } from '../noir-structs/resolved_tx.js';
 import type { TxEffectData } from '../noir-structs/tx_effect_data.js';
 import type { UtilityContext } from '../noir-structs/utility_context.js';
-import type { MessageLoadOracleInputs } from './message_load_oracle_inputs.js';
 import { packAsHintedNote } from './note_packing_utils.js';
 
 // `ORACLE_REGISTRY` infers its entry signatures from these mappings, so its emitted declaration (and the oracle
@@ -92,9 +90,7 @@ export type {
   BlockHeader,
   ContractInstancePreimage,
   MembershipWitness,
-  NullifierMembershipWitness,
   PendingTaggedLog,
-  PublicDataWitness,
   TxHash,
 };
 
@@ -400,13 +396,10 @@ const NULLIFIER_LEAF_PREIMAGE: TypeMapping<NullifierLeafPreimage> = STRUCT<Nulli
   { name: 'nextIndex', type: BIGINT },
 ]);
 
-export const NULLIFIER_MEMBERSHIP_WITNESS: TypeMapping<NullifierMembershipWitness> = STRUCT<NullifierMembershipWitness>(
-  [
-    { name: 'leafPreimage', type: NULLIFIER_LEAF_PREIMAGE },
-    { name: 'index', type: BIGINT },
-    { name: 'siblingPath', type: SIBLING_PATH(NULLIFIER_TREE_HEIGHT) },
-  ],
-);
+export const NULLIFIER_MEMBERSHIP_WITNESS: TypeMapping<NullifierMembershipWitnessData> = STRUCT([
+  { name: 'leafPreimage', type: NULLIFIER_LEAF_PREIMAGE },
+  { name: 'witness', type: MEMBERSHIP_WITNESS(NULLIFIER_TREE_HEIGHT) },
+]);
 
 const PUBLIC_DATA_LEAF: TypeMapping<PublicDataTreeLeaf> = STRUCT<PublicDataTreeLeaf>([
   { name: 'slot', type: FIELD },
@@ -419,17 +412,10 @@ const PUBLIC_DATA_LEAF_PREIMAGE: TypeMapping<PublicDataTreeLeafPreimage> = STRUC
   { name: 'nextIndex', type: BIGINT },
 ]);
 
-export const PUBLIC_DATA_WITNESS: TypeMapping<PublicDataWitness> = STRUCT<PublicDataWitness>([
+export const PUBLIC_DATA_WITNESS: TypeMapping<PublicDataWitnessData> = STRUCT([
   { name: 'index', type: BIGINT },
   { name: 'leafPreimage', type: PUBLIC_DATA_LEAF_PREIMAGE },
-  { name: 'siblingPath', type: SIBLING_PATH(PUBLIC_DATA_TREE_HEIGHT) },
-]);
-
-export const MESSAGE_LOAD_ORACLE_INPUTS: TypeMapping<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>> = STRUCT<
-  MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>
->([
-  { name: 'index', type: BIGINT },
-  { name: 'siblingPath', type: SIBLING_PATH(L1_TO_L2_MSG_TREE_HEIGHT) },
+  { name: 'siblingPath', type: FIXED_ARRAY(FIELD, PUBLIC_DATA_TREE_HEIGHT) },
 ]);
 
 export const UTILITY_CONTEXT: TypeMapping<UtilityContext> = STRUCT<UtilityContext>([
@@ -618,15 +604,6 @@ export function ALIAS<B, T>(
       base.deserialization && wrap ? { fn: readers => wrap(base.deserialization!.fn(readers)) } : undefined,
     shape: base.shape,
   };
-}
-
-function SIBLING_PATH<N extends number>(height: N): TypeMapping<SiblingPath<N>> {
-  return LEAF({
-    // On the wire (and in Noir) a sibling path is a plain `[Field; height]`, so it shares the fixed-array kind.
-    kind: `array(field,${height})`,
-    serialization: { fn: sp => [sp.toFields()] },
-    shape: [{ len: height }],
-  });
 }
 
 export function MEMBERSHIP_WITNESS<N extends number>(height: N): TypeMapping<MembershipWitness<N>> {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -34,7 +34,7 @@ import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/k
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
 import { type UnsiloedMessageNullifier, getL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
-import { MerkleTreeId, type NullifierMembershipWitness } from '@aztec/stdlib/trees';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   type BlockHeader,
   CallContext,
@@ -74,7 +74,10 @@ import type { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import type { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
-import type { NullifierMembershipWitnessData } from '../noir-structs/nullifier_membership_witness_data.js';
+import {
+  type NullifierMembershipWitnessData,
+  toNullifierMembershipWitnessData,
+} from '../noir-structs/nullifier_membership_witness_data.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
@@ -1325,10 +1328,6 @@ function toLogRetrievalResponse(retrievedLog: RetrievedTaggedLog): LogRetrievalR
     blockTimestamp,
     blockHash,
   };
-}
-
-function toNullifierMembershipWitnessData(witness: NullifierMembershipWitness): NullifierMembershipWitnessData {
-  return { leafPreimage: witness.leafPreimage, witness: witness.withoutPreimage() };
 }
 
 function toValidationTxData(tx: TxOnchainContext): ValidationTxData {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -1,4 +1,9 @@
-import { ARCHIVE_HEIGHT, type NOTE_HASH_TREE_HEIGHT, PRIVATE_LOG_CIPHERTEXT_LEN } from '@aztec/constants';
+import {
+  ARCHIVE_HEIGHT,
+  L1_TO_L2_MSG_TREE_HEIGHT,
+  type NOTE_HASH_TREE_HEIGHT,
+  PRIVATE_LOG_CIPHERTEXT_LEN,
+} from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { uniqueBy } from '@aztec/foundation/collection';
 import { Aes128 } from '@aztec/foundation/crypto/aes128';
@@ -29,7 +34,7 @@ import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/k
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
 import { type UnsiloedMessageNullifier, getL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
-import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
+import { MerkleTreeId, type NullifierMembershipWitness, type PublicDataWitness } from '@aztec/stdlib/trees';
 import {
   type BlockHeader,
   CallContext,
@@ -69,9 +74,11 @@ import type { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import type { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
+import type { NullifierMembershipWitnessData } from '../noir-structs/nullifier_membership_witness_data.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
+import type { PublicDataWitnessData } from '../noir-structs/public_data_witness_data.js';
 import type { ResolvedTx } from '../noir-structs/resolved_tx.js';
 import type { TxEffectData } from '../noir-structs/tx_effect_data.js';
 import type { UtilityContext } from '../noir-structs/utility_context.js';
@@ -304,14 +311,17 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param nullifier - Nullifier we try to find witness for.
    * @returns The nullifier membership witness (if found).
    */
-  public async getNullifierMembershipWitness(blockHash: BlockHash, nullifier: Fr): Promise<NullifierMembershipWitness> {
+  public async getNullifierMembershipWitness(
+    blockHash: BlockHash,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitnessData> {
     const witness = await this.#queryWithBlockHashNotAfterAnchor(blockHash, () =>
       this.aztecNode.getNullifierMembershipWitness(blockHash, nullifier),
     );
     if (!witness) {
       throw new Error(`Nullifier membership witness not found at block ${blockHash.toString()}.`);
     }
-    return witness;
+    return toNullifierMembershipWitnessData(witness);
   }
 
   /**
@@ -326,7 +336,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   public async getLowNullifierMembershipWitness(
     blockHash: BlockHash,
     nullifier: Fr,
-  ): Promise<NullifierMembershipWitness> {
+  ): Promise<NullifierMembershipWitnessData> {
     const witness = await this.#queryWithBlockHashNotAfterAnchor(blockHash, () =>
       this.aztecNode.getLowNullifierMembershipWitness(blockHash, nullifier),
     );
@@ -335,7 +345,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
         `Low nullifier witness not found for nullifier ${nullifier} at block hash ${blockHash.toString()}.`,
       );
     }
-    return witness;
+    return toNullifierMembershipWitnessData(witness);
   }
 
   /**
@@ -344,14 +354,14 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param leafSlot - The slot of the public data tree to get the witness for.
    * @returns - The witness
    */
-  public async getPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness> {
+  public async getPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitnessData> {
     const witness = await this.#queryWithBlockHashNotAfterAnchor(blockHash, () =>
       this.aztecNode.getPublicDataWitness(blockHash, leafSlot),
     );
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${leafSlot} at block hash ${blockHash.toString()}.`);
     }
-    return witness;
+    return toPublicDataWitnessData(witness);
   }
 
   /**
@@ -520,7 +530,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       await this.anchorBlockHeader.hash(),
     );
 
-    return { index: messageIndex, siblingPath };
+    return new MembershipWitness(L1_TO_L2_MSG_TREE_HEIGHT, messageIndex, siblingPath.toTuple());
   }
 
   /**
@@ -1310,6 +1320,18 @@ function toLogRetrievalResponse(retrievedLog: RetrievedTaggedLog): LogRetrievalR
     blockNumber,
     blockTimestamp,
     blockHash,
+  };
+}
+
+function toNullifierMembershipWitnessData(witness: NullifierMembershipWitness): NullifierMembershipWitnessData {
+  return { leafPreimage: witness.leafPreimage, witness: witness.withoutPreimage() };
+}
+
+function toPublicDataWitnessData(witness: PublicDataWitness): PublicDataWitnessData {
+  return {
+    index: witness.index,
+    leafPreimage: witness.leafPreimage,
+    siblingPath: witness.siblingPath.toTuple(),
   };
 }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -34,7 +34,7 @@ import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/k
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
 import { type UnsiloedMessageNullifier, getL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
-import { MerkleTreeId, type NullifierMembershipWitness, type PublicDataWitness } from '@aztec/stdlib/trees';
+import { MerkleTreeId, type NullifierMembershipWitness } from '@aztec/stdlib/trees';
 import {
   type BlockHeader,
   CallContext,
@@ -361,7 +361,11 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${leafSlot} at block hash ${blockHash.toString()}.`);
     }
-    return toPublicDataWitnessData(witness);
+    return {
+      index: witness.index,
+      leafPreimage: witness.leafPreimage,
+      siblingPath: witness.siblingPath.toTuple(),
+    };
   }
 
   /**
@@ -1325,14 +1329,6 @@ function toLogRetrievalResponse(retrievedLog: RetrievedTaggedLog): LogRetrievalR
 
 function toNullifierMembershipWitnessData(witness: NullifierMembershipWitness): NullifierMembershipWitnessData {
   return { leafPreimage: witness.leafPreimage, witness: witness.withoutPreimage() };
-}
-
-function toPublicDataWitnessData(witness: PublicDataWitness): PublicDataWitnessData {
-  return {
-    index: witness.index,
-    leafPreimage: witness.leafPreimage,
-    siblingPath: witness.siblingPath.toTuple(),
-  };
 }
 
 function toValidationTxData(tx: TxOnchainContext): ValidationTxData {

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -59,10 +59,15 @@ import type { TxEffectsData } from './noir-structs/tx_effects_data.js';
 // Spreading `ORACLE_REGISTRY` re-materializes its entries into `TXE_ORACLE_REGISTRY`'s inferred type, which names the
 // protocol types below. Re-exporting them gives tsc a portable path to each instead of falling back to a deep
 // node_modules path that breaks .d.ts portability (TS2742).
-export type { ContractClassLogData, EmbeddedCurvePoint, TxEffectData } from '@aztec/pxe/simulator';
+export type {
+  ContractClassLogData,
+  EmbeddedCurvePoint,
+  NullifierMembershipWitnessData,
+  PublicDataWitnessData,
+  TxEffectData,
+} from '@aztec/pxe/simulator';
 export type { BlockHash } from '@aztec/stdlib/block';
 export type { MembershipWitness } from '@aztec/foundation/trees';
-export type { NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 
 const GAS: TypeMapping<GasData> = STRUCT([
   { name: 'daGas', type: U32 },


### PR DESCRIPTION
## Summary

- The four witness oracles (`getNullifierMembershipWitness`, `getLowNullifierMembershipWitness`, `getPublicDataWitness`, `getL1ToL2MembershipWitnessV2`) were excluded from the generated oracle serialization tests because their TS mappings routed the sibling path through a hand-rolled, serialize-only `SIBLING_PATH` leaf that no test-value synthesizer could build. On the Noir side these are already plain `[Field; N]`, so the gap was entirely TS-side.
- `SIBLING_PATH` is gone. The path is now `FIXED_ARRAY(FIELD, height)`, matching `MEMBERSHIP_WITNESS(height)` — the sibling that was already covered by the tests for exactly this reason: foundation's `MembershipWitness` stores its path as a plain `Tuple<Fr, N>`, while stdlib's witness types wrap it in the `SiblingPath` class. Converting from the node's types now happens in the oracle handlers, where the type-mapping layer already says it belongs.
- `MessageLoadOracleInputs` is deleted outright: its wire shape is identical to `MEMBERSHIP_WITNESS(L1_TO_L2_MSG_TREE_HEIGHT)`, so the registry uses that combinator directly, as the note-hash and archive witness oracles already do.
- The four oracles are un-excluded in `oracle/mod.nr`, taking the generated suite from 104 to 109 tests.

No wire format changes: the oracle interface hash is unchanged in both PXE and TXE, so no version bump.
