### PR TITLE
chore(l1-contracts): update gas benchmark

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -12,24 +12,24 @@
 
 ## No Validators
 
-| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
-|----------------------|---------|---------|---------------|--------------|
-| propose              | 195,988 | 222,201 |           932 |       14,912 |
-| submitEpochRootProof | 697,655 | 743,529 |         2,820 |       45,120 |
-| setupEpoch           |  31,998 | 113,793 |             - |            - |
+| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|-----------|-----------|---------------|--------------|
+| propose              |   196,596 |   222,810 |           964 |       15,424 |
+| submitEpochRootProof | 1,000,225 | 1,038,384 |        14,084 |      225,344 |
+| setupEpoch           |    32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,341.5 gas/second
+**Avg Gas Cost per Second**: 3,612.7 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
-| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
-|----------------------|---------|---------|---------------|--------------|
-| propose              | 324,449 | 351,604 |         4,452 |       71,232 |
-| submitEpochRootProof | 896,101 | 941,944 |         5,316 |       85,056 |
-| aggregate3           | 373,118 | 386,457 |             - |            - |
-| setupEpoch           |  46,459 | 547,626 |             - |            - |
+| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|-----------|-----------|---------------|--------------|
+| propose              |   324,981 |   352,180 |         4,484 |       71,744 |
+| submitEpochRootProof | 1,581,276 | 1,678,797 |        16,580 |      265,280 |
+| aggregate3           |   373,892 |   387,303 |             - |            - |
+| setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,304.3 gas/second
+**Avg Gas Cost per Second**: 5,906.4 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,62 +2,62 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 182373,
-      "mean": 195988,
-      "median": 191762,
-      "max": 222201,
-      "calldata_size": 932,
-      "calldata_gas": 14912
+      "min": 182982,
+      "mean": 196596,
+      "median": 192371,
+      "max": 222810,
+      "calldata_size": 964,
+      "calldata_gas": 15424
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29264,
-      "mean": 31998,
-      "median": 29264,
-      "max": 113793
+      "min": 29309,
+      "mean": 32042,
+      "median": 29309,
+      "max": 113837
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 676491,
-      "mean": 697655,
-      "median": 685300,
-      "max": 743529,
-      "calldata_size": 2820,
-      "calldata_gas": 45120
+      "min": 981633,
+      "mean": 1000225,
+      "median": 990442,
+      "max": 1038384,
+      "calldata_size": 14084,
+      "calldata_gas": 225344
     }
   },
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 302105,
-      "mean": 324449,
-      "median": 323910,
-      "max": 351604,
-      "calldata_size": 4452,
-      "calldata_gas": 71232
+      "min": 302633,
+      "mean": 324981,
+      "median": 324474,
+      "max": 352180,
+      "calldata_size": 4484,
+      "calldata_gas": 71744
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29264,
-      "mean": 46459,
-      "median": 29264,
-      "max": 547626
+      "min": 29309,
+      "mean": 46504,
+      "median": 29309,
+      "max": 547670
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 874924,
-      "mean": 896101,
-      "median": 883769,
-      "max": 941944,
-      "calldata_size": 5316,
-      "calldata_gas": 85056
+      "min": 1469608,
+      "mean": 1581276,
+      "median": 1588350,
+      "max": 1678797,
+      "calldata_size": 16580,
+      "calldata_gas": 265280
     },
     "aggregate3": {
       "calls": 55,
-      "min": 362015,
-      "mean": 373118,
-      "median": 372828,
-      "max": 386457
+      "min": 362764,
+      "mean": 373892,
+      "median": 373649,
+      "max": 387303
     }
   }
 }


### PR DESCRIPTION
## Summary

- refresh the checked-in L1 gas benchmark against the current branch state
- record the current epoch-proof header verification and calldata costs
- correct the stale baseline that made downstream gas diffs misleading

## Verification

- `python3 scripts/gas_benchmarks.py`
- repeated the seeded benchmark and confirmed byte-identical JSON and Markdown output