### PR TITLE
test(aztec-nr): cover get_tx_effect with a generated oracle test

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/oracle/mod.nr
@@ -87,7 +87,15 @@ pub mod keys;
 pub mod key_validation_request;
 #[generate_oracle_tests]
 pub mod logs;
-// TODO: cover with oracle tests once the test resolver can serve EphemeralArray contents.
+#[generate_oracle_tests_excluding(
+    @[
+        // TODO: cover with oracle tests once the test resolver can serve EphemeralArray contents.
+        quote { get_pending_tagged_logs_oracle },
+        quote { validate_and_store_enqueued_notes_and_events_oracle },
+        quote { get_logs_by_tag_oracle },
+        quote { get_tx_effects_oracle },
+    ],
+)]
 pub mod message_processing;
 #[generate_oracle_tests_excluding(
     @[


### PR DESCRIPTION
## Summary

Same shape as #25236: `message_processing` was unannotated behind a single `EphemeralArray` TODO, so none of its oracles had generated serialization tests. It now uses `#[generate_oracle_tests_excluding]`, listing the four oracles that really do take or return an `EphemeralArray`.

That covers `get_tx_effect` — singular, `Field -> Option<TxEffect>`. Not `get_tx_effects` — plural, the `EphemeralArray` one — which stays excluded. Two tests are generated, one per `Option` scenario. No wire change, so no oracle version bump.