### PR TITLE
fix(pxe): per-job staging store that rejects dead-job operations

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -251,6 +251,7 @@ describe('BlockSynchronizer', () => {
       const noteAt3 = await noteAt(contract, await blockId(forkBlock));
       const noteAt4 = await noteAt(contract, block4);
       const noteAt5 = await noteAt(contract, block5);
+      noteStore.beginJob('note-job');
       await noteStore.addNotes([noteAt3, noteAt4, noteAt5], scope, 'note-job');
       await noteStore.commit('note-job');
 
@@ -304,6 +305,7 @@ describe('BlockSynchronizer', () => {
       const block9 = makeL2BlockId(BlockNumber(9), Fr.random().toString());
       const note8 = await noteAt(contract, block8);
       const note9 = await noteAt(contract, block9);
+      noteStore.beginJob('note-job');
       await noteStore.addNotes([note8, note9], scope, 'note-job');
       await noteStore.commit('note-job');
 
@@ -499,6 +501,7 @@ describe('BlockSynchronizer', () => {
       const noteAt1 = await noteAt(contract, await blockId(forkBlock));
       const noteAt2 = await noteAt(contract, block2);
       const noteAt3 = await noteAt(contract, block3);
+      noteStore.beginJob('note-job');
       await noteStore.addNotes([noteAt1, noteAt2, noteAt3], scope, 'note-job');
       await noteStore.commit('note-job');
 
@@ -529,6 +532,7 @@ describe('BlockSynchronizer', () => {
 
       // Block 1 note still present and visible via getNotes.
       expect(await noteStore.nullifiersOfNotesAtBlock(1)).toEqual([noteAt1.siloedNullifier.toString()]);
+      noteStore.beginJob('read-job');
       const found = await noteStore.getNotes(
         { contractAddress: contract, scopes: [scope], status: NoteStatus.ACTIVE },
         'read-job',

--- a/yarn-project/pxe/src/job_coordinator/base_staging_store.test.ts
+++ b/yarn-project/pxe/src/job_coordinator/base_staging_store.test.ts
@@ -1,0 +1,234 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+
+import { BaseStagingStore } from './base_staging_store.js';
+import type { JobId } from './job_coordinator.js';
+
+describe('BaseStagingStore', () => {
+  let kv: AztecAsyncKVStore;
+  let store: TestStore;
+
+  beforeEach(async () => {
+    kv = await openTmpStore('base_staging_store_test');
+    store = new TestStore(kv);
+  });
+
+  describe('withStaging', () => {
+    it('accepts operations between beginJob and the end of the job', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await expect(store.readStaged('key', 'job1')).resolves.toBe(1);
+    });
+
+    it('rejects operations for a job that was never begun', async () => {
+      let operationRan = false;
+      await expect(
+        store.op(() => {
+          operationRan = true;
+          return Promise.resolve();
+        }, 'never-begun'),
+      ).rejects.toThrow('Store "test_store": job "never-begun" is not in progress');
+      expect(operationRan).toBe(false);
+    });
+
+    it('rejects operations for a job that was committed', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await store.commit('job1');
+      await expect(store.write('key', 2, 'job1')).rejects.toThrow('Store "test_store": job "job1" is not in progress');
+      await expect(store.readStaged('key', 'job1')).rejects.toThrow(
+        'Store "test_store": job "job1" is not in progress',
+      );
+    });
+
+    it('rejects operations for a job that was discarded', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await store.discardStaged('job1');
+      await expect(store.write('key', 2, 'job1')).rejects.toThrow('Store "test_store": job "job1" is not in progress');
+    });
+
+    it('serializes operations of the same job', async () => {
+      store.beginJob('job1');
+      const gate = promiseWithResolvers<void>();
+      const order: string[] = [];
+
+      const first = store.op(async () => {
+        order.push('first-start');
+        await gate.promise;
+        order.push('first-end');
+      }, 'job1');
+      const second = store.op(() => {
+        order.push('second');
+        return Promise.resolve();
+      }, 'job1');
+
+      await tick();
+      expect(order).toEqual(['first-start']);
+
+      gate.resolve();
+      await first;
+      await second;
+      expect(order).toEqual(['first-start', 'first-end', 'second']);
+    });
+
+    it('releases the lock when the operation throws', async () => {
+      store.beginJob('job1');
+      await expect(store.op(() => Promise.reject(new Error('boom')), 'job1')).rejects.toThrow('boom');
+      await expect(store.op(() => Promise.resolve('ok'), 'job1')).resolves.toBe('ok');
+    });
+
+    it('rejects an operation whose job ended while it waited for the lock', async () => {
+      // An operation can pass the entry liveness check while its job is alive and then lose the job while parked on
+      // the lock: the re-check inside the transaction must reject it instead of running it on the dead job's staging.
+      store.beginJob('job1');
+      const entered = promiseWithResolvers<void>();
+      const gate = promiseWithResolvers<void>();
+
+      const holding = store.op(() => {
+        entered.resolve();
+        return gate.promise;
+      }, 'job1');
+      const queuedWrite = store.write('key', 1, 'job1');
+
+      // Only end the job once the first operation is inside its body, so it is the queued write that finds the job
+      // dead.
+      await entered.promise;
+      await store.discardStaged('job1');
+      gate.resolve();
+
+      await holding;
+      await expect(queuedWrite).rejects.toThrow('Store "test_store": job "job1" is not in progress');
+    });
+
+    it('rejects an operation whose job ended while it waited in the transaction queue', async () => {
+      // The wait point after the lock: an operation can take the lock while its job is alive and then lose the job
+      // while its transaction waited in the kv store's queue. The re-check inside the transaction must reject it
+      // instead of running it on the dead job's staging.
+      store.beginJob('job1');
+      const gate = promiseWithResolvers<void>();
+
+      // Hold the kv store's writer queue so the write's transaction is in flight but not yet executed, then end the
+      // job before releasing.
+      const holdTx = kv.transactionAsync(() => gate.promise);
+      const queuedWrite = store.write('key', 1, 'job1');
+
+      await store.discardStaged('job1');
+      gate.resolve();
+      await holdTx;
+
+      await expect(queuedWrite).rejects.toThrow('Store "test_store": job "job1" is not in progress');
+
+      // The rejected write staged nothing: the rollback guard passes and nothing reaches the db.
+      expect(() => store.rollbackGuard()).not.toThrow();
+      await expect(store.committed('key')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('beginJob', () => {
+    it('rejects beginning a job while another is in progress', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      expect(() => store.beginJob('job2')).toThrow('Store "test_store" has job "job1" in progress');
+      await expect(store.readStaged('key', 'job1')).resolves.toBe(1);
+    });
+
+    it('accepts a new job once the previous one ended', async () => {
+      store.beginJob('job1');
+      await store.commit('job1');
+      expect(() => store.beginJob('job2')).not.toThrow();
+    });
+  });
+
+  describe('commit', () => {
+    it('flushes staged data to the db', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await store.commit('job1');
+      await expect(store.committed('key')).resolves.toBe(1);
+    });
+
+    it('ends the job even when nothing was staged', async () => {
+      store.beginJob('job1');
+      await store.commit('job1');
+      await expect(store.write('key', 1, 'job1')).rejects.toThrow('Store "test_store": job "job1" is not in progress');
+    });
+
+    it('rejects a job that was never begun', async () => {
+      await expect(store.commit('never-begun')).rejects.toThrow(
+        'Store "test_store": job "never-begun" is not in progress',
+      );
+    });
+  });
+
+  describe('assertNoJobInProgress', () => {
+    it('passes when no job is in progress', () => {
+      expect(() => store.rollbackGuard()).not.toThrow();
+    });
+
+    it('throws once a job begins, even before it stages anything', () => {
+      store.beginJob('job1');
+      expect(() => store.rollbackGuard()).toThrow('Store "test_store" has job "job1" in progress');
+    });
+
+    it('passes again once the job is discarded', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await store.discardStaged('job1');
+      expect(() => store.rollbackGuard()).not.toThrow();
+    });
+
+    it('passes again once the job is committed', async () => {
+      store.beginJob('job1');
+      await store.write('key', 1, 'job1');
+      await store.commit('job1');
+      expect(() => store.rollbackGuard()).not.toThrow();
+    });
+  });
+});
+
+type TestDb = { values: AztecAsyncMap<string, number> };
+
+class TestStore extends BaseStagingStore<Map<string, number>, TestDb> {
+  constructor(store: AztecAsyncKVStore) {
+    super({
+      storeName: 'test_store',
+      store,
+      buildStaging: () => new Map(),
+      buildDb: db => ({ values: db.openMap('values') }),
+    });
+  }
+
+  protected async flushStaged(staging: Map<string, number>, db: TestDb): Promise<void> {
+    for (const [key, value] of staging) {
+      await db.values.set(key, value);
+    }
+  }
+
+  write(key: string, value: number, jobId: JobId): Promise<void> {
+    return this.withStaging(jobId, staging => {
+      staging.set(key, value);
+      return Promise.resolve();
+    });
+  }
+
+  // Runs an arbitrary operation body under the job's lock.
+  op<R>(fn: () => Promise<R>, jobId: JobId): Promise<R> {
+    return this.withStaging(jobId, () => fn());
+  }
+
+  readStaged(key: string, jobId: JobId): Promise<number | undefined> {
+    return this.withStaging(jobId, staging => Promise.resolve(staging.get(key)));
+  }
+
+  committed(key: string): Promise<number | undefined> {
+    return this.joblessDb.values.getAsync(key);
+  }
+
+  rollbackGuard(): void {
+    this.assertNoJobInProgress();
+  }
+}
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve));

--- a/yarn-project/pxe/src/job_coordinator/base_staging_store.ts
+++ b/yarn-project/pxe/src/job_coordinator/base_staging_store.ts
@@ -1,0 +1,162 @@
+import { Semaphore } from '@aztec/foundation/queue';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- JobCoordinator is referenced only by {@link} doc tags
+import type { JobCoordinator, JobId, StagedStore } from './job_coordinator.js';
+
+/**
+ * Base class for stores that stage their writes per job, flushing them on commit and dropping them on abort.
+ *
+ * A job's staged data exists only between {@link beginJob} and {@link commit}/{@link discardStaged}. An operation
+ * arriving on behalf of a job that already ended (e.g. one discarded on abort) finds no matching job and throws, so
+ * it cannot stage new data for a dead job.
+ *
+ * The staged data and the store's kv handles live in this base class and are only reachable through
+ * {@link withStaging} (job operations, with the DB read-only), {@link joblessDb} (operations with no job context), and
+ * {@link flushStaged} (the commit-time write-back).
+ */
+export abstract class BaseStagingStore<TStaging, TDb> implements StagedStore {
+  public readonly storeName: string;
+
+  readonly #store: AztecAsyncKVStore;
+  readonly #db: TDb;
+  readonly #buildStaging: () => TStaging;
+  readonly #lock = new Semaphore(1);
+
+  /** {@link JobCoordinator} runs one job at a time, so the store holds a single current-job slot. */
+  #current: CurrentJob<TStaging> | undefined;
+
+  protected constructor({
+    storeName,
+    store,
+    buildStaging,
+    buildDb,
+  }: {
+    /** Unique name identifying this store, used in error messages and for registration with JobCoordinator. */
+    storeName: string;
+    /** The backing kv store; the runners open their transactions on it. */
+    store: AztecAsyncKVStore;
+    /** Creates the empty staged data a job starts with. */
+    buildStaging: () => TStaging;
+    /** Opens the store's kv handles. */
+    buildDb: (store: AztecAsyncKVStore) => TDb;
+  }) {
+    this.storeName = storeName;
+    this.#store = store;
+    this.#buildStaging = buildStaging;
+    this.#db = buildDb(store);
+  }
+
+  /**
+   * Makes the job current, so its operations are accepted until {@link commit} or {@link discardStaged}.
+   *
+   * @throws If a job is already in progress: beginning another would silently discard its staged data.
+   */
+  beginJob(jobId: JobId): void {
+    this.assertNoJobInProgress();
+    this.#current = { jobId, staging: this.#buildStaging() };
+  }
+
+  /**
+   * Commits the job's staged data: flushes it via {@link flushStaged}, then ends the job. Runs inside
+   * {@link JobCoordinator}'s commit transaction.
+   *
+   * Not meant to be overridden: subclasses implement {@link flushStaged}.
+   *
+   * @throws If the job is not in progress.
+   */
+  async commit(jobId: JobId): Promise<void> {
+    const current = this.#currentOrThrow(jobId);
+    await this.flushStaged(current.staging, this.#db);
+    this.#endJob(jobId);
+  }
+
+  /**
+   * Writes the job's staged data to persistent storage. Runs inside {@link JobCoordinator}'s commit transaction: it
+   * must not open a transaction of its own or take the store's lock.
+   */
+  protected abstract flushStaged(staging: TStaging, db: TDb): Promise<void>;
+
+  /** Ends the job, discarding any staged data without committing. A no-op if the job is not in progress. */
+  discardStaged(jobId: JobId): Promise<void> {
+    this.#endJob(jobId);
+    return Promise.resolve();
+  }
+
+  /**
+   * Runs a job operation (read or write). Takes the store's lock, opens a transaction, and calls `fn` with the job's
+   * staged data and a read-only view of the DB (writes are staged in memory until {@link flushStaged} runs on commit).
+   *
+   * The lock serializes the job's operations: staged data lives in JS memory, outside the DB transaction's isolation,
+   * so two operations interleaving across awaits could lose an update. Waiting for the lock inside a transaction would
+   * deadlock, so calls to this method must not nest, and must not happen inside an outer transaction.
+   *
+   * @throws If the job is not in progress.
+   */
+  protected async withStaging<R>(jobId: JobId, fn: (staging: TStaging, db: ReadonlyDb<TDb>) => Promise<R>): Promise<R> {
+    this.#currentOrThrow(jobId);
+    await this.#lock.acquire();
+    try {
+      return await this.#store.transactionAsync(() => {
+        // Re-resolve after the wait: the job may have ended while this operation queued on the lock.
+        const current = this.#currentOrThrow(jobId);
+        return fn(current.staging, this.#db);
+      });
+    } finally {
+      this.#lock.release();
+    }
+  }
+
+  /**
+   * The store's writable kv handles, for operations with no job context. Unlike {@link withStaging} this takes no lock
+   * and opens no transaction.
+   */
+  protected get joblessDb(): TDb {
+    return this.#db;
+  }
+
+  /**
+   * Throws if any job is in progress.
+   */
+  protected assertNoJobInProgress(): void {
+    if (this.#current !== undefined) {
+      throw new Error(`Store "${this.storeName}" has job "${this.#current.jobId}" in progress`);
+    }
+  }
+
+  #currentOrThrow(jobId: JobId): CurrentJob<TStaging> {
+    if (this.#current?.jobId !== jobId) {
+      throw new Error(`Store "${this.storeName}": job "${jobId}" is not in progress`);
+    }
+    return this.#current;
+  }
+
+  #endJob(jobId: JobId): void {
+    if (this.#current?.jobId === jobId) {
+      this.#current = undefined;
+    }
+  }
+}
+
+/**
+ * View of a store's kv handles restricted to the kv interfaces' read methods. Job operations receive this view: during
+ * a job the DB is read-only, since all writes are staged in memory until {@link BaseStagingStore.flushStaged} runs on
+ * commit.
+ */
+export type ReadonlyDb<T> = {
+  readonly [K in keyof T]: Pick<T[K], Extract<keyof T[K], ReadMethod>>;
+};
+
+/** The read surface of the kv interfaces used by staging stores: what {@link ReadonlyDb} exposes during a job. */
+type ReadMethod =
+  | 'getAsync'
+  | 'hasAsync'
+  | 'entriesAsync'
+  | 'valuesAsync'
+  | 'keysAsync'
+  | 'sizeAsync'
+  | 'getValuesAsync'
+  | 'getValueCountAsync';
+
+/** The job in progress: its id and its staged data, created empty when the job begins. */
+type CurrentJob<T> = { jobId: JobId; staging: T };

--- a/yarn-project/pxe/src/job_coordinator/job_coordinator.test.ts
+++ b/yarn-project/pxe/src/job_coordinator/job_coordinator.test.ts
@@ -187,6 +187,27 @@ describe('JobCoordinator', () => {
     });
   });
 
+  describe('beginJob broadcast', () => {
+    it('notifies registered stores with the new job id when a job begins', async () => {
+      const stagedJobIds: string[] = [];
+      const mockStore: StagedStore = {
+        storeName: 'broadcast_store',
+        beginJob: (jobId: string) => stagedJobIds.push(jobId),
+        commit: () => Promise.resolve(),
+        discardStaged: () => Promise.resolve(),
+      };
+      coordinator.registerStore(mockStore);
+
+      const first = coordinator.beginJob();
+      expect(stagedJobIds).toEqual([first]);
+      await coordinator.commitJob(first);
+
+      const second = coordinator.beginJob();
+      expect(stagedJobIds).toEqual([first, second]);
+      await coordinator.abortJob(second);
+    });
+  });
+
   describe('registerStore', () => {
     it('throws on duplicate registration', () => {
       const commitMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);

--- a/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
+++ b/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
@@ -3,6 +3,9 @@ import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundatio
 import { allToCompletion } from '@aztec/foundation/promise';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 
+/** Identifies a job for the duration of its lifecycle, as returned by {@link JobCoordinator.beginJob}. */
+export type JobId = string;
+
 /**
  * Interface that stores must implement to support staged writes.
  */
@@ -11,12 +14,19 @@ export interface StagedStore {
   readonly storeName: string;
 
   /**
+   * Notifies the store that a job has begun.
+   *
+   * Optional only while stores migrate to per-job staging: eventually it becomes required.
+   */
+  beginJob?(jobId: JobId): void;
+
+  /**
    * Commits staged data to main storage.
    * Should be called within a transaction for atomicity.
    *
    * @param jobId - The job identifier
    */
-  commit(jobId: string): Promise<void>;
+  commit(jobId: JobId): Promise<void>;
 
   /**
    * Discards staged data without committing.
@@ -24,7 +34,7 @@ export interface StagedStore {
    *
    * @param jobId - The job identifier
    */
-  discardStaged(jobId: string): Promise<void>;
+  discardStaged(jobId: JobId): Promise<void>;
 
   /**
    * A store may have pending work that must finish before the job's staged writes are committed or discarded, yet
@@ -34,7 +44,7 @@ export interface StagedStore {
    *
    * @param jobId - The job identifier
    */
-  settle?(jobId: string): Promise<void>;
+  settle?(jobId: JobId): Promise<void>;
 }
 
 /**
@@ -56,7 +66,7 @@ export class JobCoordinator {
   /** The underlying KV store */
   kvStore: AztecAsyncKVStore;
 
-  #currentJobId: string | undefined;
+  #currentJobId: JobId | undefined;
   #stores: Map<string, StagedStore> = new Map();
 
   constructor(kvStore: AztecAsyncKVStore, bindings?: LoggerBindings) {
@@ -90,7 +100,7 @@ export class JobCoordinator {
    *
    * @returns Job ID to pass to store operations
    */
-  beginJob(): string {
+  beginJob(): JobId {
     if (this.#currentJobId) {
       throw new Error(
         `Cannot begin job: job ${this.#currentJobId} is already in progress. ` +
@@ -101,6 +111,10 @@ export class JobCoordinator {
     const jobId = randomBytes(8).toString('hex');
     this.#currentJobId = jobId;
 
+    for (const store of this.#stores.values()) {
+      store.beginJob?.(jobId);
+    }
+
     this.log.debug(`Started job ${jobId}`);
     return jobId;
   }
@@ -110,7 +124,7 @@ export class JobCoordinator {
    *
    * @param jobId - The job ID returned from beginJob
    */
-  async commitJob(jobId: string): Promise<void> {
+  async commitJob(jobId: JobId): Promise<void> {
     if (!this.#currentJobId || this.#currentJobId !== jobId) {
       throw new Error(
         `Cannot commit job ${jobId}: no matching job in progress. ` + `Current job: ${this.#currentJobId ?? 'none'}`,
@@ -123,7 +137,6 @@ export class JobCoordinator {
     await allToCompletion([...this.#stores.values()].map(store => store.settle?.(jobId)));
 
     // Commit all stores atomically in a single transaction.
-    // Each store's commit is a no-op if it has no staged data (but that's up to each store to handle).
     await this.kvStore.transactionAsync(async () => {
       for (const store of this.#stores.values()) {
         await store.commit(jobId);
@@ -139,7 +152,7 @@ export class JobCoordinator {
    *
    * @param jobId - The job ID returned from beginJob
    */
-  async abortJob(jobId: string): Promise<void> {
+  async abortJob(jobId: JobId): Promise<void> {
     if (!this.#currentJobId || this.#currentJobId !== jobId) {
       // Job may have already been aborted or never started properly
       this.log.warn(`Abort called for job ${jobId} but current job is ${this.#currentJobId ?? 'none'}`);
@@ -168,7 +181,7 @@ export class JobCoordinator {
    * Settles every store, logging failures instead of propagating them. The abort must run to completion no matter what,
    * so a store that fails to settle cannot stop the others from discarding or mask the error that aborted the job.
    */
-  async #settleStoresLoggingFailures(jobId: string): Promise<void> {
+  async #settleStoresLoggingFailures(jobId: JobId): Promise<void> {
     await allToCompletion(
       [...this.#stores.values()].map(store =>
         store.settle?.(jobId).catch(err => {

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -39,6 +39,7 @@ describe('NoteService', () => {
     const store = await openTmpStore('test');
     keyStore = new KeyStore(store);
     noteStore = new NoteStore(store);
+    noteStore.beginJob('test');
     aztecNode = mock<AztecNode>();
 
     contractAddress = await AztecAddress.random();
@@ -85,6 +86,7 @@ describe('NoteService', () => {
     // Verify that the changes persist after job completion
     {
       await noteStore.commit('test');
+      noteStore.beginJob('fresh-job');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -121,6 +123,7 @@ describe('NoteService', () => {
     // Verify that the changes persist after job completion
     {
       await noteStore.commit('test');
+      noteStore.beginJob('fresh-job');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -167,6 +170,7 @@ describe('NoteService', () => {
     // Verify that the changes persist after job completion
     {
       await noteStore.commit('test');
+      noteStore.beginJob('fresh-job');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -283,6 +287,7 @@ describe('NoteService', () => {
       // Verify note is still stored after committing job
       {
         await noteStore.commit('test');
+        noteStore.beginJob('fresh-job');
 
         const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'fresh-job');
 
@@ -393,6 +398,7 @@ describe('NoteService', () => {
       // Verify store behaves correctly pre and post commit
       await verifyNoteNullifiedInJobContext('test');
       await noteStore.commit('test');
+      noteStore.beginJob('fresh-job');
       await verifyNoteNullifiedInJobContext('fresh-job');
     });
 

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -328,6 +328,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const noteStore = new NoteStore(kvStore);
 
       const jobId = 'fixture-job';
+      noteStore.beginJob(jobId);
 
       // Two contracts so `note_nullifiers_by_contract` exhibits both a multi-value row (contractA → {n1, n2}) and a
       // single-value row (contractB → {n3}).

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -41,6 +41,7 @@ describe('NoteStore', () => {
   async function setupNoteStoreWithNotes(storeName: string) {
     const store = await openTmpStore(storeName);
     const noteStore = new NoteStore(store);
+    noteStore.beginJob('before-each-test-job');
 
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
@@ -62,6 +63,9 @@ describe('NoteStore', () => {
     await noteStore.addNotes([note3], SCOPE_2, 'before-each-test-job');
     await noteStore.commit('before-each-test-job');
 
+    // Leave a live job for the tests to operate under: every store operation requires one.
+    noteStore.beginJob('test');
+
     return { store, noteStore, note1, note2, note3 };
   }
 
@@ -80,15 +84,19 @@ describe('NoteStore', () => {
   }
 
   /**
-   * Runs the same function sequentially in the given list of jobId's.
-   * Handy to assert that state is consistent pre and post commit.
+   * Runs the same function sequentially in the given list of jobId's, committing each job after its run. The first job
+   * must already be live; each subsequent job is begun fresh. Handy to assert that state is consistent pre and post
+   * commit.
    */
   async function verifyAndCommitForEachJob(
     jobIds: string[],
     noteStore: NoteStore,
     fn: (jobId: string) => Promise<void>,
   ) {
-    for (const jobId of jobIds) {
+    for (const [i, jobId] of jobIds.entries()) {
+      if (i > 0) {
+        noteStore.beginJob(jobId);
+      }
       await fn(jobId);
       await noteStore.commit(jobId);
     }
@@ -99,6 +107,7 @@ describe('NoteStore', () => {
     it('creates a NoteStore on an empty store and confirms getNotes returns an empty array', async () => {
       const store = await openTmpStore('note_store_fresh_store');
       const noteStore = new NoteStore(store);
+      noteStore.beginJob('pre-commit');
 
       await verifyAndCommitForEachJob(['pre-commit', 'post-commit'], noteStore, async (jobId: string) => {
         const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: [SCOPE_1, SCOPE_2] }, jobId);
@@ -115,6 +124,7 @@ describe('NoteStore', () => {
       // First note store populates the persistent store; second reopens it to verify persistence
       {
         const noteStore1 = new NoteStore(store);
+        noteStore1.beginJob('first-store');
 
         const noteA = await mkNote({ contractAddress: CONTRACT_A, siloedNullifier: SILOED_NULLIFIER_1 });
         const noteB = await mkNote({ contractAddress: CONTRACT_B, siloedNullifier: SILOED_NULLIFIER_2 });
@@ -123,6 +133,7 @@ describe('NoteStore', () => {
       }
 
       const noteStore2 = new NoteStore(store);
+      noteStore2.beginJob('second-store');
 
       await verifyAndCommitForEachJob(['second-store', 'fresh-job'], noteStore2, async (jobId: string) => {
         const notesA = await noteStore2.getNotes({ contractAddress: CONTRACT_A, scopes: [FAKE_ADDRESS] }, jobId);
@@ -497,6 +508,7 @@ describe('NoteStore', () => {
     it('applying nullifier a second time is a no-op and returns no transitioned notes', async () => {
       await noteStore.applyNullifiers([mkNullifier(note1)], 'test');
       await noteStore.commit('test');
+      noteStore.beginJob('test');
 
       // Second application is idempotent: the emission is already recorded, so no note transitions to nullified. The
       // result is empty (only notes that flip active -> nullified in this call are returned) and visibility is
@@ -524,14 +536,14 @@ describe('NoteStore', () => {
       });
 
       // Add note to stage without committing
-      await noteStore.addNotes([freshNote], SCOPE_1, 'fresh-job');
+      await noteStore.addNotes([freshNote], SCOPE_1, 'test');
 
       // Immediately nullify it in the same job (simulating validateAndStoreNote when nullifier exists on chain)
       const nullifiers = [mkNullifier(freshNote)];
-      await expect(noteStore.applyNullifiers(nullifiers, 'fresh-job')).resolves.toEqual([freshNote]);
+      await expect(noteStore.applyNullifiers(nullifiers, 'test')).resolves.toEqual([freshNote]);
 
       // Verify note is now in nullified state
-      await verifyAndCommitForEachJob(['fresh-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+      await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
         const activeNotes = await noteStore.getNotes(
           { contractAddress: CONTRACT_A, scopes: [SCOPE_1, SCOPE_2] },
           jobId,
@@ -558,6 +570,8 @@ describe('NoteStore', () => {
       );
 
       // Simulate concurrent validateAndStoreNote calls where each note is added and immediately nullified
+      await noteStore.discardStaged('test');
+      noteStore.beginJob('concurrent-job');
       const concurrentStoreNoteCalls = notes.map(async note => {
         await noteStore.addNotes([note], SCOPE_1, 'concurrent-job');
         const nullifiers = [mkNullifier(note)];
@@ -593,6 +607,8 @@ describe('NoteStore', () => {
       // note1 is from setup and committed  (i.e.: it's persisted)
       // We should be able to nullify it in a new job
       const nullifiers = [mkNullifier(note1)];
+      await noteStore.discardStaged('test');
+      noteStore.beginJob('new-job');
       await expect(noteStore.applyNullifiers(nullifiers, 'new-job')).resolves.toEqual([note1]);
 
       // Verify the note is in nullified state
@@ -622,15 +638,15 @@ describe('NoteStore', () => {
       });
 
       // First attempt to store: add and nullify the note
-      await noteStore.addNotes([duplicateNote], SCOPE_1, 'duplicate-job');
-      await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-job');
+      await noteStore.addNotes([duplicateNote], SCOPE_1, 'test');
+      await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'test');
 
       // Second attempt to store (duplicate): try to add the same note again - should not throw
       // This simulates what happens in concurrent validateAndStoreNote calls when the same note is processed twice
-      await noteStore.addNotes([duplicateNote], SCOPE_2, 'duplicate-job');
+      await noteStore.addNotes([duplicateNote], SCOPE_2, 'test');
       const notesAfterSecondAttempt = await noteStore.getNotes(
         { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE, scopes: [SCOPE_1, SCOPE_2] },
-        'duplicate-job',
+        'test',
       );
 
       // Check that the second attempt at calling validateAndStoreNote didn't accidentally overwrite the first one
@@ -639,11 +655,11 @@ describe('NoteStore', () => {
 
       // The second applyNullifiers is a no-op: the emission is already staged, so nothing transitions to nullified and
       // visibility is unchanged.
-      const secondApply = await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-job');
+      const secondApply = await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'test');
       expect(secondApply).toEqual([]);
 
       // Verify the note is nullified and has both scopes
-      await verifyAndCommitForEachJob(['duplicate-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+      await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
         const allNotes = await noteStore.getNotes(
           { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: [SCOPE_1, SCOPE_2] },
           jobId,
@@ -662,6 +678,7 @@ describe('NoteStore', () => {
     beforeEach(async () => {
       store = await openTmpStore('note_store_visibility');
       noteStore = new NoteStore(store);
+      noteStore.beginJob(JOB);
     });
 
     afterEach(async () => {
@@ -672,6 +689,7 @@ describe('NoteStore', () => {
       const note = await mkNote({ l2BlockNumber: BlockNumber(10) });
       await noteStore.addNotes([note], SCOPE_1, JOB);
       await noteStore.commit(JOB);
+      noteStore.beginJob('read-job');
 
       const found = await noteStore.getNotes(activeFilter, 'read-job');
       expect(found).toHaveLength(1);
@@ -687,6 +705,7 @@ describe('NoteStore', () => {
         JOB,
       );
       await noteStore.commit(JOB);
+      noteStore.beginJob('read-job');
 
       expect(await noteStore.getNotes(activeFilter, 'read-job')).toHaveLength(0);
       expect(
@@ -698,6 +717,10 @@ describe('NoteStore', () => {
       const note = await mkNote({ l2BlockNumber: BlockNumber(10) });
       await noteStore.addNotes([note], SCOPE_1, JOB);
       expect(await noteStore.getNotes(activeFilter, JOB)).toHaveLength(1);
+
+      // The staged note was never committed: once the job ends, the next job does not see it.
+      await noteStore.discardStaged(JOB);
+      noteStore.beginJob('other-job');
       expect(await noteStore.getNotes(activeFilter, 'other-job')).toHaveLength(0);
     });
 
@@ -711,6 +734,7 @@ describe('NoteStore', () => {
       );
 
       await noteStore.discardStaged(JOB);
+      noteStore.beginJob('fresh-job');
 
       // A fresh job sees nothing committed — both the note and the nullification were discarded.
       expect(await noteStore.getNotes(activeFilter, 'fresh-job')).toHaveLength(0);
@@ -728,6 +752,7 @@ describe('NoteStore', () => {
     beforeEach(async () => {
       store = await openTmpStore('note_store_block_index');
       noteStore = new NoteStore(store);
+      noteStore.beginJob(JOB);
     });
 
     afterEach(async () => {
@@ -767,6 +792,7 @@ describe('NoteStore.rollback', () => {
   beforeEach(async () => {
     kv = await openTmpStore('note-store-reorg-test');
     store = new NoteStore(kv);
+    store.beginJob(JOB);
   });
 
   it('deletes notes and nullifier emissions above the target block, leaving lower blocks intact', async () => {
@@ -798,6 +824,7 @@ describe('NoteStore.rollback', () => {
     expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
     expect(await store.nullifiersOfNotesAtBlock(11)).toHaveLength(0);
 
+    store.beginJob('read-job');
     const found = await store.getNotes(activeFilter, 'read-job');
     expect(found).toHaveLength(1);
     expect(found[0].siloedNullifier.equals(noteA.siloedNullifier)).toBe(true);
@@ -823,6 +850,7 @@ describe('NoteStore.rollback', () => {
 
     expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
     expect(await store.nullifiersOfNotesAtBlock(50)).toHaveLength(0);
+    store.beginJob('read-job');
     expect(await store.getNotes(activeFilter, 'read-job')).toHaveLength(0);
   });
 
@@ -848,6 +876,7 @@ describe('NoteStore.rollback', () => {
     expect(await store.nullifiersOfNotesAtBlock(10)).toEqual([noteB.siloedNullifier.toString()]);
 
     // The note should read back ACTIVE again (nullification row gone).
+    store.beginJob('read-job');
     const found = await store.getNotes(activeFilter, 'read-job');
     expect(found).toHaveLength(1);
     expect(found[0].siloedNullifier.equals(noteB.siloedNullifier)).toBe(true);
@@ -870,21 +899,14 @@ describe('NoteStore.rollback', () => {
     expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
   });
 
-  it('throws when rollback is called while jobs are running', async () => {
-    // Stage a note under a job but never commit it, so the store still holds in-flight job data. Rolling back now
-    // could later let the job commit notes anchored to blocks the rollback just deleted.
-    const staged = await NoteDao.random({
-      contractAddress: contract,
-      l2BlockNumber: BlockNumber(10),
-      l2BlockHash: FIXED_BLOCK_HASH,
-    });
-    await store.addNotes([staged], scope, 'uncommitted-job');
-
+  it('throws when rollback is called while a job is in progress', async () => {
+    // JOB was begun in beforeEach and has not ended, so it may still stage notes derived from pre-rollback reads
+    // and commit them anchored to blocks the rollback just deleted.
     await expect(kv.transactionAsync(() => store.rollback(0))).rejects.toThrow(
-      'PXE note store rollback is not allowed while jobs are running',
+      `Store "note" has job "${JOB}" in progress`,
     );
 
-    await store.discardStaged('uncommitted-job');
+    await store.discardStaged(JOB);
 
     await expect(kv.transactionAsync(() => store.rollback(0))).resolves.not.toThrow();
   });

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,22 +1,15 @@
 import { createLogger } from '@aztec/foundation/log';
 import { allToCompletion } from '@aztec/foundation/promise';
-import { Semaphore } from '@aztec/foundation/queue';
 import type { Fr } from '@aztec/foundation/schemas';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { DataInBlock } from '@aztec/stdlib/block';
 import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 
-import type { StagedStore } from '../../job_coordinator/job_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../../job_coordinator/base_staging_store.js';
+import type { JobId } from '../../job_coordinator/job_coordinator.js';
 import type { NotesFilter } from '../../notes_filter.js';
 import { StoredNote } from './stored_note.js';
-
-/// Alias types for kv map readability
-type SiloedNullifier = string;
-type JobId = string;
-type AddressStr = string;
-type BlockNum = number;
-type StoredNoteBuffer = Buffer;
 
 /**
  * NoteStore manages the storage and retrieval of notes using an append-only model.
@@ -28,62 +21,22 @@ type StoredNoteBuffer = Buffer;
  * Reorgs are handled by delete-on-prune: the `chain-pruned` event triggers deletion of every note and nullifier
  * originating on a reorg'd block.
  */
-export class NoteStore implements StagedStore {
-  readonly storeName: string = 'note';
-
-  logger = createLogger('note_store');
-
-  #store: AztecAsyncKVStore;
-
-  // Note that we use the siloedNullifier as the note id in this store as it's guaranteed to be unique.
-
-  // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
-  // #nullifiersByContractAddress to find relevant note nullifiers that can be used to read into this map instead.
-  //
-  // nullifier => StoredNote (serialized)
-  #notes: AztecAsyncMap<SiloedNullifier, StoredNoteBuffer>;
-
-  // Indexes which notes (via their nullifiers) belong to a contract. Used in `getNotes` to reduce the amount of notes
-  // checked.
-  //
-  // contract address => nullifier
-  #notesByContractAddress: AztecAsyncMultiMap<AddressStr, SiloedNullifier>;
-
-  // block number => nullifier
-  #notesByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
-
-  // Records, for each nullified note, the block number where its nullifier was emitted.
-  // nullifier => emission block number
-  #nullifierEmissions: AztecAsyncMap<SiloedNullifier, BlockNum>;
-
-  // Index of emitted nullifiers by block height, used for performance reasons upon reorgs.
-  // nullification block number => nullifier
-  #nullifierEmissionsByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
-
-  // In-memory changes performed during a not-yet committed job. When `commit` is called with said job's id, these
-  // changes are persisted in the DB maps specified above and cleared.
-  // jobId => nullifier => StoredNote
-  #notesForJob: Map<JobId, Map<SiloedNullifier, StoredNote>>;
-
-  // Staged nullifier emissions per job.
-  // jobId => nullifier => emission block number
-  #nullifierEmissionsForJob: Map<JobId, Map<SiloedNullifier, BlockNum>>;
-
-  // Per job locks to prevent multiple concurrent writes to affect each other.
-  // jobId => lock
-  #jobLocks: Map<JobId, Semaphore>;
+export class NoteStore extends BaseStagingStore<NoteStoreStaging, NoteStoreDb> {
+  readonly #logger = createLogger('note_store');
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-    this.#notes = store.openMap('notes');
-    this.#notesByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
-    this.#notesByBlockNumber = store.openMultiMap('note_nullifiers_by_block');
-    this.#nullifierEmissions = store.openMap('note_nullifications_by_nullifier');
-    this.#nullifierEmissionsByBlockNumber = store.openMultiMap('note_nullifications_by_block');
-
-    this.#jobLocks = new Map();
-    this.#notesForJob = new Map();
-    this.#nullifierEmissionsForJob = new Map();
+    super({
+      storeName: 'note',
+      store,
+      buildStaging: () => ({ notes: new Map(), nullifierEmissions: new Map() }),
+      buildDb: db => ({
+        notes: db.openMap('notes'),
+        notesByContractAddress: db.openMultiMap('note_nullifiers_by_contract'),
+        notesByBlockNumber: db.openMultiMap('note_nullifiers_by_block'),
+        nullifierEmissions: db.openMap('note_nullifications_by_nullifier'),
+        nullifierEmissionsByBlockNumber: db.openMultiMap('note_nullifications_by_block'),
+      }),
+    });
   }
 
   /**
@@ -96,31 +49,29 @@ export class NoteStore implements StagedStore {
    * @param scope - The scope (user/account) under which to store the notes
    * @param jobId - The job context for staged writes
    */
-  public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: string): Promise<void[]> {
-    return this.#withJobLock(jobId, () =>
-      this.#store.transactionAsync(() =>
-        allToCompletion(
-          notes.map(async note => {
-            const noteForJob =
-              (await this.#readNote(note.siloedNullifier.toString(), jobId)) ?? new StoredNote(note, new Set());
-            noteForJob.addScope(scope.toString());
-            this.#writeNote(noteForJob, jobId);
-          }),
-        ),
+  public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: JobId): Promise<void[]> {
+    return this.withStaging(jobId, (staging, db) =>
+      allToCompletion(
+        notes.map(async note => {
+          const noteForJob =
+            (await this.#readNote(staging, db, note.siloedNullifier.toString())) ?? new StoredNote(note, new Set());
+          noteForJob.addScope(scope.toString());
+          staging.notes.set(note.siloedNullifier.toString(), noteForJob);
+        }),
       ),
     );
   }
 
-  async #readNote(nullifier: string, jobId: string): Promise<StoredNote | undefined> {
+  async #readNote(
+    staging: NoteStoreStaging,
+    db: ReadonlyDb<NoteStoreDb>,
+    nullifier: string,
+  ): Promise<StoredNote | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const noteBuffer = await this.#notes.getAsync(nullifier);
-    const noteForJob = this.#getNotesForJob(jobId).get(nullifier);
+    const noteBuffer = await db.notes.getAsync(nullifier);
+    const noteForJob = staging.notes.get(nullifier);
     return noteForJob ?? (noteBuffer ? StoredNote.fromBuffer(noteBuffer) : undefined);
-  }
-
-  #writeNote(note: StoredNote, jobId: string) {
-    this.#getNotesForJob(jobId).set(note.noteDao.siloedNullifier.toString(), note);
   }
 
   /**
@@ -128,16 +79,15 @@ export class NoteStore implements StagedStore {
    * committed state, the nullifier emission counterpart to {@link #readNote}. Returns the emission block number if the
    * nullifier has been emitted (committed or staged in this job), or `undefined` if it has not.
    */
-  async #readNullifierEmission(nullifier: string, jobId: string): Promise<number | undefined> {
+  async #readNullifierEmission(
+    staging: NoteStoreStaging,
+    db: ReadonlyDb<NoteStoreDb>,
+    nullifier: string,
+  ): Promise<number | undefined> {
     // Always issue the DB read to keep the IndexedDB transaction alive (see #readNote); the staged emission still takes
     // precedence if present.
-    const committed = await this.#nullifierEmissions.getAsync(nullifier);
-    const staged = this.#getNullifierEmissionsForJob(jobId).get(nullifier);
-    return staged ?? committed;
-  }
-
-  #writeNullifierEmission(nullifier: string, blockNumber: BlockNum, jobId: string): void {
-    this.#getNullifierEmissionsForJob(jobId).set(nullifier, blockNumber);
+    const committed = await db.nullifierEmissions.getAsync(nullifier);
+    return staging.nullifierEmissions.get(nullifier) ?? committed;
   }
 
   /**
@@ -152,12 +102,12 @@ export class NoteStore implements StagedStore {
    * @param jobId - the job context to read from.
    * @returns Filtered and deduplicated notes (a note might be present in multiple scopes, but returned at most once)
    */
-  getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
-    if (filter.scopes.length === 0) {
-      return Promise.resolve([]);
-    }
+  getNotes(filter: NotesFilter, jobId: JobId): Promise<NoteDao[]> {
+    return this.withStaging(jobId, async (staging, db) => {
+      if (filter.scopes.length === 0) {
+        return [];
+      }
 
-    return this.#store.transactionAsync(async () => {
       const targetStatus = filter.status ?? NoteStatus.ACTIVE;
 
       // Collect note-read and nullifier-emission-read promises together in one map so all DB reads are in-flight
@@ -169,21 +119,21 @@ export class NoteStore implements StagedStore {
       >();
 
       // Committed notes indexed by contract address
-      for await (const nullifier of this.#notesByContractAddress.getValuesAsync(filter.contractAddress.toString())) {
+      for await (const nullifier of db.notesByContractAddress.getValuesAsync(filter.contractAddress.toString())) {
         candidates.set(nullifier, {
-          notePromise: this.#readNote(nullifier, jobId),
-          nullificationPromise: this.#readNullifierEmission(nullifier, jobId),
+          notePromise: this.#readNote(staging, db, nullifier),
+          nullificationPromise: this.#readNullifierEmission(staging, db, nullifier),
         });
       }
 
       // Staged notes from the current job (not yet committed to the DB index)
-      for (const storedNote of this.#getNotesForJob(jobId).values()) {
+      for (const storedNote of staging.notes.values()) {
         if (storedNote.noteDao.contractAddress.equals(filter.contractAddress)) {
           const nullifier = storedNote.noteDao.siloedNullifier.toString();
           if (!candidates.has(nullifier)) {
             candidates.set(nullifier, {
               notePromise: Promise.resolve(storedNote),
-              nullificationPromise: this.#readNullifierEmission(nullifier, jobId),
+              nullificationPromise: this.#readNullifierEmission(staging, db, nullifier),
             });
           }
         }
@@ -268,126 +218,60 @@ export class NoteStore implements StagedStore {
    *          a repeat application returns an empty array.
    * @throws If any nullifier has no matching note in this store, or was emitted at block 0.
    */
-  applyNullifiers(siloedNullifiers: DataInBlock<Fr>[], jobId: string): Promise<NoteDao[]> {
-    if (siloedNullifiers.length === 0) {
-      return Promise.resolve([]);
-    }
-
+  applyNullifiers(siloedNullifiers: DataInBlock<Fr>[], jobId: JobId): Promise<NoteDao[]> {
     if (siloedNullifiers.some(n => n.l2BlockNumber === 0)) {
       return Promise.reject(new Error('applyNullifiers: nullifiers cannot have been emitted at block 0'));
     }
 
-    return this.#withJobLock(jobId, () =>
-      this.#store.transactionAsync(async () => {
-        // Kick off the note read and the existing-emission read together during the synchronous map so all are in
-        // flight before the first await, which keeps the IndexedDB transaction alive.
-        const resolved = await allToCompletion(
-          siloedNullifiers.map(async nullifier => {
-            const key = nullifier.data.toString();
-            const [storedNote, existingEmission] = await allToCompletion([
-              this.#readNote(key, jobId),
-              this.#readNullifierEmission(key, jobId),
-            ]);
-            if (!storedNote) {
-              throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB: ${key}`);
-            }
-            return { nullifier, storedNote, alreadyEmitted: existingEmission !== undefined };
-          }),
-        );
-
-        // Await-free tail: record an emission only for notes not already nullified, and return exactly those that
-        // transition active -> nullified in this call.
-        const affected: NoteDao[] = [];
-        for (const { nullifier, storedNote, alreadyEmitted } of resolved) {
-          if (alreadyEmitted) {
-            continue;
+    return this.withStaging(jobId, async (staging, db) => {
+      // Kick off the note read and the existing-emission read together during the synchronous map so all are in
+      // flight before the first await, which keeps the IndexedDB transaction alive.
+      const resolved = await allToCompletion(
+        siloedNullifiers.map(async nullifier => {
+          const key = nullifier.data.toString();
+          const [storedNote, existingEmission] = await allToCompletion([
+            this.#readNote(staging, db, key),
+            this.#readNullifierEmission(staging, db, key),
+          ]);
+          if (!storedNote) {
+            throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB: ${key}`);
           }
-          this.#writeNullifierEmission(nullifier.data.toString(), nullifier.l2BlockNumber, jobId);
-          affected.push(storedNote.noteDao);
+          return { nullifier, storedNote, alreadyEmitted: existingEmission !== undefined };
+        }),
+      );
+
+      // Await-free tail: record an emission only for notes not already nullified, and return exactly those that
+      // transition active -> nullified in this call.
+      const affected: NoteDao[] = [];
+      for (const { nullifier, storedNote, alreadyEmitted } of resolved) {
+        if (alreadyEmitted) {
+          continue;
         }
+        staging.nullifierEmissions.set(nullifier.data.toString(), nullifier.l2BlockNumber);
+        affected.push(storedNote.noteDao);
+      }
 
-        return affected;
-      }),
-    );
+      return affected;
+    });
   }
 
-  /**
-   * Commits in-memory job data to persistent storage.
-   *
-   * Called by JobCoordinator when a job completes successfully.
-   *
-   * Note: JobCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync here
-   * (and using one would throw on IndexedDB as it does not support nested txs).
-   *
-   * @param jobId - The jobId identifying which staged data to commit
-   */
-  async commit(jobId: string): Promise<void> {
-    for (const [nullifier, storedNote] of this.#getNotesForJob(jobId)) {
-      await this.#notes.set(nullifier, storedNote.toBuffer());
-      await this.#notesByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
-      await this.#notesByBlockNumber.set(storedNote.noteDao.l2BlockNumber, nullifier);
+  protected async flushStaged(staging: NoteStoreStaging, db: NoteStoreDb): Promise<void> {
+    for (const [nullifier, storedNote] of staging.notes) {
+      await db.notes.set(nullifier, storedNote.toBuffer());
+      await db.notesByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
+      await db.notesByBlockNumber.set(storedNote.noteDao.l2BlockNumber, nullifier);
     }
 
-    for (const [nullifier, blockNumber] of this.#getNullifierEmissionsForJob(jobId)) {
-      await this.#nullifierEmissions.set(nullifier, blockNumber);
-      await this.#nullifierEmissionsByBlockNumber.set(blockNumber, nullifier);
+    for (const [nullifier, blockNumber] of staging.nullifierEmissions) {
+      await db.nullifierEmissions.set(nullifier, blockNumber);
+      await db.nullifierEmissionsByBlockNumber.set(blockNumber, nullifier);
     }
-
-    this.#clearJobData(jobId);
-  }
-
-  discardStaged(jobId: string): Promise<void> {
-    this.#clearJobData(jobId);
-    return Promise.resolve();
-  }
-
-  #clearJobData(jobId: string) {
-    this.#notesForJob.delete(jobId);
-    this.#nullifierEmissionsForJob.delete(jobId);
-    this.#jobLocks.delete(jobId);
-  }
-
-  /**
-   * Functions run withJobLock are forced to wait for each other, i.e. if they share a `jobId`, they run serially
-   * instead of concurrently. This is needed because staged data is stored in memory, and concurrent async operations
-   * (e.g., allToCompletion in `validateAndStoreNote`) could otherwise interleave and corrupt state.
-   */
-  async #withJobLock<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
-    let lock = this.#jobLocks.get(jobId);
-    if (!lock) {
-      lock = new Semaphore(1);
-      this.#jobLocks.set(jobId, lock);
-    }
-    await lock.acquire();
-    try {
-      return await fn();
-    } finally {
-      lock.release();
-    }
-  }
-
-  #getNotesForJob(jobId: string): Map<string, StoredNote> {
-    let notesForJob = this.#notesForJob.get(jobId);
-    if (!notesForJob) {
-      notesForJob = new Map();
-      this.#notesForJob.set(jobId, notesForJob);
-    }
-    return notesForJob;
-  }
-
-  #getNullifierEmissionsForJob(jobId: string): Map<string, BlockNum> {
-    let nullificationsForJob = this.#nullifierEmissionsForJob.get(jobId);
-    if (!nullificationsForJob) {
-      nullificationsForJob = new Map();
-      this.#nullifierEmissionsForJob.set(jobId, nullificationsForJob);
-    }
-    return nullificationsForJob;
   }
 
   /** Returns the nullifiers (note ids) of all notes created at the given block number. Used by delete-on-prune. */
   public async nullifiersOfNotesAtBlock(blockNumber: number): Promise<string[]> {
     const nullifiers: string[] = [];
-    for await (const nullifier of this.#notesByBlockNumber.getValuesAsync(blockNumber)) {
+    for await (const nullifier of this.joblessDb.notesByBlockNumber.getValuesAsync(blockNumber)) {
       nullifiers.push(nullifier);
     }
     return nullifiers;
@@ -400,34 +284,33 @@ export class NoteStore implements StagedStore {
    * Must be called inside a transaction owned by the caller (it issues no `transactionAsync` of its own, because the
    * reorg path wraps it together with other store operations, and IndexedDB has no nested transaction support).
    *
-   * Throws if any job has uncommitted staged writes, since rolling back mid-job could later re-introduce notes or
-   * nullifier emissions anchored to deleted blocks.
+   * Throws if any job is in progress, since rolling back mid-job could later re-introduce notes or nullifier
+   * emissions anchored to deleted blocks.
    */
   public async rollback(toBlock: number): Promise<void> {
-    if (this.#notesForJob.size > 0 || this.#nullifierEmissionsForJob.size > 0) {
-      throw new Error('PXE note store rollback is not allowed while jobs are running');
-    }
+    this.assertNoJobInProgress();
+    const db = this.joblessDb;
     // Snapshot the orphaned (block, nullifier) pairs before mutating so we never delete from the cursor we are
     // iterating. Scanning from `toBlock + 1` upward covers everything above the rollback target without needing to know
     // the chain tip. Each nullifier's rows are independent (nullifiers are globally unique), so the deletes run
     // concurrently. Keeping requests in flight also prevents the IndexedDB transaction from auto-committing mid-way.
     const orphanedNotes: { block: number; siloedNullifier: string }[] = [];
 
-    for await (const [block, siloedNullifier] of this.#notesByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
+    for await (const [block, siloedNullifier] of db.notesByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
       orphanedNotes.push({ block, siloedNullifier });
     }
 
     let removedNotes = 0;
     await allToCompletion(
       orphanedNotes.map(async ({ block, siloedNullifier }) => {
-        const buf = await this.#notes.getAsync(siloedNullifier);
+        const buf = await db.notes.getAsync(siloedNullifier);
         if (!buf) {
           throw new Error(`Note not found for siloedNullifier ${siloedNullifier}`);
         }
         const stored = StoredNote.fromBuffer(buf);
-        await this.#notes.delete(siloedNullifier);
-        await this.#notesByContractAddress.deleteValue(stored.noteDao.contractAddress.toString(), siloedNullifier);
-        await this.#notesByBlockNumber.deleteValue(block, siloedNullifier);
+        await db.notes.delete(siloedNullifier);
+        await db.notesByContractAddress.deleteValue(stored.noteDao.contractAddress.toString(), siloedNullifier);
+        await db.notesByBlockNumber.deleteValue(block, siloedNullifier);
         removedNotes++;
       }),
     );
@@ -435,7 +318,7 @@ export class NoteStore implements StagedStore {
     // Same procedure, with nullifier emissions
     const orphanedEmissions: { block: number; siloedNullifier: string }[] = [];
 
-    for await (const [block, siloedNullifier] of this.#nullifierEmissionsByBlockNumber.entriesAsync({
+    for await (const [block, siloedNullifier] of db.nullifierEmissionsByBlockNumber.entriesAsync({
       start: toBlock + 1,
     })) {
       orphanedEmissions.push({ block, siloedNullifier });
@@ -443,15 +326,53 @@ export class NoteStore implements StagedStore {
 
     await allToCompletion(
       orphanedEmissions.map(async ({ block, siloedNullifier }) => {
-        await this.#nullifierEmissions.delete(siloedNullifier);
-        await this.#nullifierEmissionsByBlockNumber.deleteValue(block, siloedNullifier);
+        await db.nullifierEmissions.delete(siloedNullifier);
+        await db.nullifierEmissionsByBlockNumber.deleteValue(block, siloedNullifier);
       }),
     );
 
-    this.logger.verbose('rolled back notes and nullifier emissions', {
+    this.#logger.verbose('rolled back notes and nullifier emissions', {
       removedNotes,
       removedNullifierEmissions: orphanedEmissions.length,
       toBlock,
     });
   }
 }
+
+/// Alias types for kv map readability
+type SiloedNullifier = string;
+type AddressStr = string;
+type BlockNum = number;
+type StoredNoteBuffer = Buffer;
+
+/** A job's staged data, created and discarded as a unit: notes plus nullifier emissions, both keyed by nullifier. */
+type NoteStoreStaging = {
+  notes: Map<SiloedNullifier, StoredNote>;
+  nullifierEmissions: Map<SiloedNullifier, BlockNum>;
+};
+
+// Note that we use the siloedNullifier as the note id in this store as it's guaranteed to be unique.
+type NoteStoreDb = {
+  // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
+  // notesByContractAddress to find relevant note nullifiers that can be used to read into this map instead.
+  //
+  // nullifier => StoredNote (serialized)
+  notes: AztecAsyncMap<SiloedNullifier, StoredNoteBuffer>;
+
+  // Indexes which notes (via their nullifiers) belong to a contract. Used in `getNotes` to reduce the amount of notes
+  // checked.
+  //
+  // contract address => nullifier
+  notesByContractAddress: AztecAsyncMultiMap<AddressStr, SiloedNullifier>;
+
+  // block number => nullifier
+  notesByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
+
+  // Records, for each nullified note, the block number where its nullifier was emitted.
+  // nullifier => emission block number
+  nullifierEmissions: AztecAsyncMap<SiloedNullifier, BlockNum>;
+
+  // Index of emitted nullifiers by block height, used for performance reasons upon reorgs.
+  // nullification block number => nullifier
+  nullifierEmissionsByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
+};


### PR DESCRIPTION
## Motivation

The PXE staged stores each implemented job staging their own way, and several things were wrong or fragile about that:

- **No uniformity**: some stores serialized their operations with a lock, some read the DB inside transactions, some did neither.
- **Unnecessary generality**: stores keyed staged data by job id to support concurrent jobs, even though the coordinator only ever runs one job at a time.
- **No lifecycle enforcement**: nothing prevented an operation from writing into a store on behalf of a job that had never begun, or that had already ended (committed or discarded). A straggling async write from a dead job could re-create staged state — and since `rollback()` refuses to run while staged data exists, that orphaned entry wedged rollbacks permanently.
- **No control over store discipline**: each store had full discretion, so a store might skip a lock it needed, or write to the DB outside of commit, and nothing would catch it.

## The change

`BaseStagingStore` centralizes the discipline. It owns the staged data, the store's kv handles, and a single current-job slot; subclasses can only reach them through three paths:

- `withStaging` — job operations: takes the store's lock, opens a transaction, re-checks that the job is still current after both waits, and hands `fn` the staged data plus a **read-only** view of the DB.
- `flushStaged` — the commit-time write-back, run inside the coordinator's commit transaction. The only way staged data reaches the DB.
- `joblessDb` — writable handles for operations with no job context (e.g. rollback), named to flag that they run outside job discipline.

Staged data exists only between `beginJob` and `commit`/`discardStaged`; an operation for any other job throws, so a dead job cannot stage new data. `NoteStore` is the first store migrated; the remaining staged stores move in follow-up PRs, after which `beginJob` becomes required on `StagedStore`.