### PR TITLE
feat: introduce a protocol fee margin (AZIP-23)

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -612,8 +612,12 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     return StakingLib.LEGACY_SLASHER_DRAIN_WINDOW;
   }
 
-  function getBurnAddress() external pure override(IRollup) returns (address) {
-    return address(bytes20("CUAUHXICALLI"));
+  function getProtocolFeeRecipient() external view override(IRollup) returns (address) {
+    return RewardExtLib.getProtocolFeeRecipient();
+  }
+
+  function getProtocolFeeMargin() external view override(IRollup) returns (uint16) {
+    return RewardExtLib.getProtocolFeeMargin();
   }
 
   /**

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -326,6 +326,30 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
   }
 
   /**
+   * @notice Updates the protocol fee margin applied on top of operator cost in the mana base fee
+   * @dev Only callable by owner. Increases are rate-limited (30-day cooldown, x3/2 step on the fee
+   *      multiplier); decreases are immediate. Setting the current value is a no-op and emits no
+   *      event.
+   * @param _protocolFeeMarginBps The new margin in basis points
+   */
+  function setProtocolFeeMargin(uint16 _protocolFeeMarginBps) external override(IRollupCore) onlyOwner {
+    (bool changed, uint16 oldBps) = RewardExtLib.updateProtocolFeeMargin(_protocolFeeMarginBps);
+    if (changed) {
+      emit IRollupCore.ProtocolFeeMarginUpdated(oldBps, _protocolFeeMarginBps);
+    }
+  }
+
+  /**
+   * @notice Updates the recipient of the protocol fee tranche of the reward waterfall
+   * @dev Only callable by owner. Rejects the zero address.
+   * @param _recipient The new protocol fee recipient
+   */
+  function setProtocolFeeRecipient(address _recipient) external override(IRollupCore) onlyOwner {
+    address oldRecipient = RewardExtLib.updateProtocolFeeRecipient(_recipient);
+    emit IRollupCore.ProtocolFeeRecipientUpdated(oldRecipient, _recipient);
+  }
+
+  /**
    * @notice Updates the configuration for the staking entry queue
    * @dev Only callable by owner. Controls how validators enter the active set.
    * @param _config New configuration including queue size limits and timing parameters

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -118,6 +118,8 @@ interface IRollupCore {
   event RewardConfigUpdated(MutableRewardConfig rewardConfig);
   event ManaTargetUpdated(uint256 indexed manaTarget);
   event PrunedPending(uint256 provenCheckpointNumber, uint256 pendingCheckpointNumber);
+  event ProtocolFeeMarginUpdated(uint16 oldBps, uint16 newBps);
+  event ProtocolFeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
 
   function claimSequencerRewards(address _recipient) external returns (uint256);
   function claimProverRewards(address _recipient, Epoch[] memory _epochs) external returns (uint256);
@@ -126,6 +128,9 @@ interface IRollupCore {
   function updateL1GasFeeOracle() external;
 
   function setProvingCostPerMana(EthValue _provingCostPerMana) external;
+
+  function setProtocolFeeMargin(uint16 _protocolFeeMarginBps) external;
+  function setProtocolFeeRecipient(address _recipient) external;
 
   function propose(
     ProposeArgs calldata _args,
@@ -231,7 +236,8 @@ interface IRollup is IRollupCore, IHaveVersion {
   function getFeeAsset() external view returns (IERC20);
   function getFeeAssetPortal() external view returns (IFeeJuicePortal);
   function getRewardDistributor() external view returns (IRewardDistributor);
-  function getBurnAddress() external view returns (address);
+  function getProtocolFeeRecipient() external view returns (address);
+  function getProtocolFeeMargin() external view returns (uint16);
 
   function getInbox() external view returns (IInbox);
   function getOutbox() external view returns (IOutbox);

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -119,7 +119,7 @@ interface IRollupCore {
   event ManaTargetUpdated(uint256 indexed manaTarget);
   event PrunedPending(uint256 provenCheckpointNumber, uint256 pendingCheckpointNumber);
   event ProtocolFeeMarginUpdated(uint16 oldBps, uint16 newBps);
-  event ProtocolFeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+  event ProtocolFeeRecipientUpdated(address oldRecipient, address newRecipient);
 
   function claimSequencerRewards(address _recipient) external returns (uint256);
   function claimProverRewards(address _recipient, Epoch[] memory _epochs) external returns (uint256);

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -206,6 +206,8 @@ library Errors {
   error FeeLib__ProvingCostAboveCeiling(uint256 provided, uint256 maximum);
   error FeeLib__ProvingCostCooldown(uint256 nextAllowed);
   error FeeLib__ProvingCostStepExceeded(uint256 current, uint256 requested);
+  error FeeLib__ProtocolFeeMarginCooldown(uint256 nextAllowed);
+  error FeeLib__ProtocolFeeMarginStepExceeded(uint256 current, uint256 requested);
 
   // SignatureLib (duplicated)
   error SignatureLib__InvalidSignature(address, address); // 0xd9cbae6c
@@ -223,6 +225,7 @@ library Errors {
 
   error RewardLib__InvalidSequencerBps();
   error RewardLib__ZeroShares(address prover);
+  error RewardLib__InvalidProtocolFeeRecipient();
 
   // SlashingProposer
   error SlashingProposer__InvalidSignature();

--- a/l1-contracts/src/core/libraries/compressed-data/fees/FeeConfig.sol
+++ b/l1-contracts/src/core/libraries/compressed-data/fees/FeeConfig.sol
@@ -38,13 +38,14 @@ function subEthValue(EthValue _a, EthValue _b) pure returns (EthValue) {
 
 using {addEthValue as +, subEthValue as -} for EthValue global;
 
-// 32 bit manaTarget, 128 bit congestionUpdateFraction, 64 bit provingCostPerMana
+// 16 bit protocolFeeMarginBps, 32 bit manaTarget, 128 bit congestionUpdateFraction, 64 bit provingCostPerMana
 type CompressedFeeConfig is uint256;
 
 struct FeeConfig {
   uint256 manaTarget;
   uint256 congestionUpdateFraction;
   EthValue provingCostPerMana;
+  uint256 protocolFeeMarginBps;
 }
 
 /// @notice Library for converting between ETH and fee asset values using the price oracle.
@@ -89,6 +90,7 @@ library PriceLib {
 library FeeConfigLib {
   using SafeCast for uint256;
 
+  uint256 private constant MASK_16_BITS = 0xFFFF;
   uint256 private constant MASK_32_BITS = 0xFFFFFFFF;
   uint256 private constant MASK_64_BITS = 0xFFFFFFFFFFFFFFFF;
   uint256 private constant MASK_128_BITS = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
@@ -105,11 +107,16 @@ library FeeConfigLib {
     return EthValue.wrap(CompressedFeeConfig.unwrap(_compressedFeeConfig) & MASK_64_BITS);
   }
 
+  function getProtocolFeeMarginBps(CompressedFeeConfig _compressedFeeConfig) internal pure returns (uint256) {
+    return (CompressedFeeConfig.unwrap(_compressedFeeConfig) >> 224) & MASK_16_BITS;
+  }
+
   function compress(FeeConfig memory _config) internal pure returns (CompressedFeeConfig) {
     uint256 value = 0;
     value |= uint256(EthValue.unwrap(_config.provingCostPerMana).toUint64());
     value |= uint256(_config.congestionUpdateFraction.toUint128()) << 64;
     value |= uint256(_config.manaTarget.toUint32()) << 192;
+    value |= uint256(_config.protocolFeeMarginBps.toUint16()) << 224;
 
     return CompressedFeeConfig.wrap(value);
   }
@@ -118,7 +125,8 @@ library FeeConfigLib {
     return FeeConfig({
       provingCostPerMana: getProvingCostPerMana(_compressedFeeConfig),
       congestionUpdateFraction: getCongestionUpdateFraction(_compressedFeeConfig),
-      manaTarget: getManaTarget(_compressedFeeConfig)
+      manaTarget: getManaTarget(_compressedFeeConfig),
+      protocolFeeMarginBps: getProtocolFeeMarginBps(_compressedFeeConfig)
     });
   }
 }

--- a/l1-contracts/src/core/libraries/compressed-data/fees/FeeStructs.sol
+++ b/l1-contracts/src/core/libraries/compressed-data/fees/FeeStructs.sol
@@ -11,7 +11,7 @@ import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 /*struct CompressedFeeHeader {
   uint1 preHeat;
   uint63 proverCost; Max value: 9.2233720369E18
-  uint64 congestionCost;
+  uint64 protocolFee;
   uint48 ethPerFeeAsset;
   uint48 excessMana;
   uint32 manaUsed;
@@ -22,7 +22,7 @@ struct FeeHeader {
   uint256 excessMana;
   uint256 manaUsed;
   uint256 ethPerFeeAsset;
-  uint256 congestionCost;
+  uint256 protocolFee;
   uint256 proverCost;
 }
 
@@ -91,7 +91,7 @@ library FeeHeaderLib {
     return (CompressedFeeHeader.unwrap(_compressedFeeHeader) >> 80) & MASK_48_BITS;
   }
 
-  function getCongestionCost(CompressedFeeHeader _compressedFeeHeader) internal pure returns (uint256) {
+  function getProtocolFee(CompressedFeeHeader _compressedFeeHeader) internal pure returns (uint256) {
     return (CompressedFeeHeader.unwrap(_compressedFeeHeader) >> 128) & MASK_64_BITS;
   }
 
@@ -106,9 +106,9 @@ library FeeHeaderLib {
     // Cap excessMana to uint48 max to prevent overflow during compression.
     value |= Math.min(_feeHeader.excessMana, MASK_48_BITS) << 32;
     value |= uint256(_feeHeader.ethPerFeeAsset.toUint48()) << 80;
-    // Cap congestionCost to uint64 max to prevent overflow during compression.
+    // Cap protocolFee to uint64 max to prevent overflow during compression.
     // The uncapped value is still used for fee validation; this only affects storage.
-    value |= Math.min(_feeHeader.congestionCost, MASK_64_BITS) << 128;
+    value |= Math.min(_feeHeader.protocolFee, MASK_64_BITS) << 128;
     // Cap proverCost to uint63 max to prevent overflow during compression.
     value |= Math.min(_feeHeader.proverCost, MASK_63_BITS) << 192;
 
@@ -127,7 +127,7 @@ library FeeHeaderLib {
     value >>= 48;
     uint256 ethPerFeeAsset = value & MASK_48_BITS;
     value >>= 48;
-    uint256 congestionCost = value & MASK_64_BITS;
+    uint256 protocolFee = value & MASK_64_BITS;
     value >>= 64;
     uint256 proverCost = value & MASK_63_BITS;
 
@@ -135,7 +135,7 @@ library FeeHeaderLib {
       manaUsed: uint256(manaUsed),
       excessMana: uint256(excessMana),
       ethPerFeeAsset: uint256(ethPerFeeAsset),
-      congestionCost: uint256(congestionCost),
+      protocolFee: uint256(protocolFee),
       proverCost: uint256(proverCost)
     });
   }

--- a/l1-contracts/src/core/libraries/rollup/FeeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/FeeLib.sol
@@ -60,6 +60,9 @@ uint256 constant MAX_FEE_ASSET_PRICE_MODIFIER_BPS = 100;
 uint256 constant L1_GAS_PER_CHECKPOINT_PROPOSED = 300_000;
 uint256 constant L1_GAS_PER_EPOCH_VERIFIED = 3_600_000;
 
+// The uncongested baseline of the congestion multiplier is (1 + mu) * 1e9, where mu is the
+// protocol fee margin: congestionMultiplier scales this minimum by (10_000 + marginBps) / 10_000.
+// At a margin of 0 the baseline is exactly 1e9.
 uint256 constant MINIMUM_CONGESTION_MULTIPLIER = 1e9;
 
 // The magic values are used to have the fakeExponential case where
@@ -94,12 +97,26 @@ uint256 constant MIN_PROVING_COST_PER_MANA = 2;
 // that proving costs will go down.
 uint256 constant MAX_INITIAL_PROVING_COST_PER_MANA = 2e8;
 
+/*
+ * Protocol-fee-margin rate limit
+ *
+ * `setProtocolFeeMargin` multiplies the fee users pay, so increases are constrained to a bounded
+ * multiplicative step per cooldown, mirroring the proving-cost limiter above. The bounded quantity
+ * is the fee multiplier (10_000 + marginBps), not the margin itself, so each step raises the
+ * pinned fee by at most x3/2. Decreases are immediate and unrestricted (floor 0 is structural via
+ * uint16). `protocolMarginLastUpdate == 0` after `initialize`, so the first post-init update is
+ * not gated by the cooldown; the 30-day cadence engages after that (decreases stamp it too).
+ */
+uint256 constant PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL = 30 days;
+uint256 constant PROTOCOL_FEE_MARGIN_STEP_NUM = 3;
+uint256 constant PROTOCOL_FEE_MARGIN_STEP_DEN = 2;
+
 struct OracleInput {
   int256 feeAssetPriceModifier;
 }
 
 struct ManaMinFeeComponents {
-  uint256 congestionCost;
+  uint256 protocolFee;
   uint256 congestionMultiplier;
   uint256 sequencerCost;
   uint256 proverCost;
@@ -109,6 +126,7 @@ struct FeeStore {
   CompressedFeeConfig config;
   L1GasOracleValues l1GasOracleValues;
   uint64 provingCostLastUpdate;
+  uint64 protocolMarginLastUpdate;
 }
 
 library FeeLib {
@@ -168,7 +186,8 @@ library FeeLib {
     feeStore.config = FeeConfig({
         manaTarget: _manaTarget,
         congestionUpdateFraction: _manaTarget * MAGIC_CONGESTION_VALUE_MULTIPLIER / MAGIC_CONGESTION_VALUE_DIVISOR,
-        provingCostPerMana: _provingCostPerMana
+        provingCostPerMana: _provingCostPerMana,
+        protocolFeeMarginBps: 0
       }).compress();
 
     feeStore.l1GasOracleValues = L1GasOracleValues({
@@ -220,6 +239,49 @@ library FeeLib {
     feeStore.provingCostLastUpdate = uint64(block.timestamp);
   }
 
+  /**
+   * @notice Updates the protocol fee margin (in basis points) applied on top of operator cost.
+   * @dev Idempotent: setting the current value is a no-op (no state change, no cooldown stamp).
+   *      Increases are gated by the 30-day cooldown (first-ever update exempt) and the x3/2 step
+   *      on the fee multiplier `(10_000 + bps)`. Decreases are immediate and unrestricted but
+   *      still stamp the cooldown. The uint16 parameter makes values above 65535 unrepresentable
+   *      at the ABI boundary, so the reverting `toUint16` inside `compress` can never fire from
+   *      this path and later `compress` round-trips (updateManaTarget, updateProvingCostPerMana)
+   *      never see an out-of-range margin.
+   * @param _bps The new protocol fee margin in basis points
+   * @return changed Whether state was mutated (false for the idempotent no-op)
+   * @return oldBps The margin in effect before this call
+   */
+  function updateProtocolFeeMargin(uint16 _bps) internal returns (bool changed, uint16 oldBps) {
+    FeeStore storage feeStore = getStorage();
+    FeeConfig memory config = feeStore.config.decompress();
+
+    oldBps = uint16(config.protocolFeeMarginBps);
+
+    if (_bps == oldBps) {
+      return (false, oldBps);
+    }
+
+    if (_bps > oldBps) {
+      uint256 nextAllowed = uint256(feeStore.protocolMarginLastUpdate) + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+      require(
+        feeStore.protocolMarginLastUpdate == 0 || block.timestamp >= nextAllowed,
+        Errors.FeeLib__ProtocolFeeMarginCooldown(nextAllowed)
+      );
+      require(
+        (10_000 + uint256(_bps)) * PROTOCOL_FEE_MARGIN_STEP_DEN
+          <= (10_000 + uint256(oldBps)) * PROTOCOL_FEE_MARGIN_STEP_NUM,
+        Errors.FeeLib__ProtocolFeeMarginStepExceeded(oldBps, _bps)
+      );
+    }
+
+    config.protocolFeeMarginBps = _bps;
+    feeStore.config = config.compress();
+    feeStore.protocolMarginLastUpdate = uint64(block.timestamp);
+
+    return (true, oldBps);
+  }
+
   function updateL1GasFeeOracle() internal {
     Slot slot = Timestamp.wrap(block.timestamp).slotFromTimestamp();
     // The slot where we find a new queued value acceptable
@@ -242,7 +304,7 @@ library FeeLib {
     uint256 _checkpointNumber,
     int256 _feeAssetPriceModifierBps,
     uint256 _manaUsed,
-    uint256 _congestionCost,
+    uint256 _protocolFee,
     uint256 _proverCost
   ) internal view returns (FeeHeader memory) {
     require(
@@ -254,7 +316,7 @@ library FeeLib {
       excessMana: FeeLib.computeExcessMana(parentFeeHeader),
       ethPerFeeAsset: FeeLib.computeNewEthPerFeeAsset(parentFeeHeader.getEthPerFeeAsset(), _feeAssetPriceModifierBps),
       manaUsed: _manaUsed,
-      congestionCost: _congestionCost,
+      protocolFee: _protocolFee,
       proverCost: _proverCost
     });
   }
@@ -312,7 +374,7 @@ library FeeLib {
       FeeLib.clampedAdd(parentFeeHeader.getExcessMana() + parentFeeHeader.getManaUsed(), -int256(manaTarget));
     uint256 congestionMultiplier_ = congestionMultiplier(excessMana);
 
-    EthValue congestionCost =
+    EthValue protocolFee =
     EthValue.wrap(
         Math.mulDiv(EthValue.unwrap(total), congestionMultiplier_, MINIMUM_CONGESTION_MULTIPLIER, Math.Rounding.Floor)
       ) - total;
@@ -324,7 +386,7 @@ library FeeLib {
     return ManaMinFeeComponents({
       sequencerCost: FeeAssetValue.unwrap(sequencerCostPerMana.toFeeAsset(ethPerFeeAsset)),
       proverCost: FeeAssetValue.unwrap(proverCostPerMana.toFeeAsset(ethPerFeeAsset)),
-      congestionCost: FeeAssetValue.unwrap(congestionCost.toFeeAsset(ethPerFeeAsset)),
+      protocolFee: FeeAssetValue.unwrap(protocolFee.toFeeAsset(ethPerFeeAsset)),
       congestionMultiplier: congestionMultiplier_
     });
   }
@@ -342,6 +404,10 @@ library FeeLib {
     return getStorage().config.getProvingCostPerMana();
   }
 
+  function getProtocolFeeMarginBps() internal view returns (uint16) {
+    return uint16(getStorage().config.getProtocolFeeMarginBps());
+  }
+
   function getEthPerFeeAssetAtCheckpoint(uint256 _checkpointNumber) internal view returns (EthPerFeeAssetE12) {
     return EthPerFeeAssetE12.wrap(STFLib.getFeeHeader(_checkpointNumber).getEthPerFeeAsset());
   }
@@ -357,7 +423,11 @@ library FeeLib {
     // Cap the exponent to prevent overflow in the Taylor series.
     // At e^100, the multiplier is ~2.69e43 * MINIMUM_CONGESTION_MULTIPLIER, more than enough
     uint256 cappedNumerator = Math.min(_numerator, denominator * 100);
-    return fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, cappedNumerator, denominator);
+    // The protocol fee margin scales only this factor: (10_000 + bps) * 1e5 == (1 + mu) * 1e9,
+    // exactly 1e9 (== MINIMUM_CONGESTION_MULTIPLIER) at mu = 0. The mulDiv divisor in
+    // getManaMinFeeComponentsAt MUST stay MINIMUM_CONGESTION_MULTIPLIER — scaling both sites
+    // cancels the margin.
+    return fakeExponential((10_000 + feeStore.config.getProtocolFeeMarginBps()) * 1e5, cappedNumerator, denominator);
   }
 
   function computeManaLimit(uint256 _manaTarget) internal pure returns (uint256) {
@@ -394,7 +464,24 @@ library FeeLib {
     // Cap at uint128 max to ensure the fee can always be represented in the proposal header's
     // feePerL2Gas field (uint128). Without this cap, extreme congestion or parameter combinations
     // could produce fees that no valid header can represent, causing a liveness failure.
-    return Math.min(_components.sequencerCost + _components.proverCost + _components.congestionCost, type(uint128).max);
+    return Math.min(_components.sequencerCost + _components.proverCost + _components.protocolFee, type(uint128).max);
+  }
+
+  /**
+   * @notice The per-mana protocol fee written to the fee header: the pinned fee minus the two
+   *         converted operator costs, as one subtraction.
+   * @dev The single subtraction guarantees `fee - protocolFee == cost * manaUsed` holds exactly
+   *      in the reward waterfall; converting the margin and congestion tranches separately could
+   *      drift by a wei because the Ceil conversion is not additive. The subtraction can go
+   *      negative only when the uint128 cap in {summedMinFee} binds, in which case the protocol
+   *      fee is clamped to 0 and operators stay whole.
+   * @param _components The mana min fee components (in fee asset)
+   * @return The per-mana protocol fee
+   */
+  function protocolFeePerMana(ManaMinFeeComponents memory _components) internal pure returns (uint256) {
+    uint256 manaMinFee = summedMinFee(_components);
+    uint256 operatorCost = _components.sequencerCost + _components.proverCost;
+    return manaMinFee > operatorCost ? manaMinFee - operatorCost : 0;
   }
 
   function getStorage() internal pure returns (FeeStore storage storageStruct) {

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -290,7 +290,7 @@ library ProposeLib {
       checkpointNumber,
       _args.oracleInput.feeAssetPriceModifier,
       v.header.totalManaUsed,
-      components.congestionCost,
+      FeeLib.protocolFeePerMana(components),
       components.proverCost
     );
 

--- a/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
@@ -30,6 +30,14 @@ library RewardExtLib {
     RewardLib.updateConfig(_config);
   }
 
+  function updateProtocolFeeMargin(uint16 _bps) external returns (bool changed, uint16 oldBps) {
+    return FeeLib.updateProtocolFeeMargin(_bps);
+  }
+
+  function updateProtocolFeeRecipient(address _recipient) external returns (address oldRecipient) {
+    return RewardLib.updateProtocolFeeRecipient(_recipient);
+  }
+
   function claimSequencerRewards(address _sequencer) external returns (uint256) {
     return RewardLib.claimSequencerRewards(_sequencer);
   }
@@ -79,6 +87,14 @@ library RewardExtLib {
 
   function getRewardDistributor() external view returns (IRewardDistributor) {
     return RewardLib.getStorage().config.rewardDistributor;
+  }
+
+  function getProtocolFeeRecipient() external view returns (address) {
+    return RewardLib.getProtocolFeeRecipient();
+  }
+
+  function getProtocolFeeMargin() external view returns (uint16) {
+    return FeeLib.getProtocolFeeMarginBps();
   }
 
   // FeeLib/STFLib/ProposeLib view wrappers - overflow from RollupOperationsExtLib

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -80,13 +80,6 @@ library RewardLib {
 
   bytes32 private constant REWARD_STORAGE_POSITION = keccak256("aztec.reward.storage");
 
-  // A Cuauhxicalli [kʷaːʍʃiˈkalːi] ("eagle gourd bowl") is a ceremonial Aztec vessel or altar used to hold
-  // offerings,
-  // such as sacrificial hearts, during rituals performed within temples.
-  // Deploy-time default for `protocolFeeRecipient`: the protocol fee is burned until governance
-  // redirects it via {updateProtocolFeeRecipient}.
-  address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
-
   /// @notice One-shot writer used during rollup construction. Writes every field of
   ///         {RewardConfig}, including the immutable `rewardDistributor` and `booster`.
   /// @dev Must only be reachable from the constructor path. Post-deployment updates go through
@@ -95,7 +88,8 @@ library RewardLib {
     require(Bps.unwrap(_config.sequencerBps) <= 10_000, Errors.RewardLib__InvalidSequencerBps());
     RewardStorage storage rewardStorage = getStorage();
     rewardStorage.config = _config;
-    rewardStorage.protocolFeeRecipient = BURN_ADDRESS;
+    // A Cuauhxicalli ("eagle gourd bowl") is a ceremonial Aztec vessel used to hold offerings.
+    rewardStorage.protocolFeeRecipient = address(bytes20("CUAUHXICALLI"));
   }
 
   /// @notice Owner-gated post-deployment writer for the protocol fee recipient.

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -54,6 +54,7 @@ struct RewardStorage {
   mapping(Epoch => EpochRewards) epochRewards;
   mapping(address prover => BitMaps.BitMap claimed) proverClaimed;
   RewardConfig config;
+  address protocolFeeRecipient;
 }
 
 struct Values {
@@ -66,7 +67,7 @@ struct Values {
 
 struct Totals {
   uint256 feesToClaim;
-  uint256 totalBurn;
+  uint256 totalProtocolFee;
 }
 
 library RewardLib {
@@ -82,6 +83,8 @@ library RewardLib {
   // A Cuauhxicalli [kʷaːʍʃiˈkalːi] ("eagle gourd bowl") is a ceremonial Aztec vessel or altar used to hold
   // offerings,
   // such as sacrificial hearts, during rituals performed within temples.
+  // Deploy-time default for `protocolFeeRecipient`: the protocol fee is burned until governance
+  // redirects it via {updateProtocolFeeRecipient}.
   address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
 
   /// @notice One-shot writer used during rollup construction. Writes every field of
@@ -92,6 +95,17 @@ library RewardLib {
     require(Bps.unwrap(_config.sequencerBps) <= 10_000, Errors.RewardLib__InvalidSequencerBps());
     RewardStorage storage rewardStorage = getStorage();
     rewardStorage.config = _config;
+    rewardStorage.protocolFeeRecipient = BURN_ADDRESS;
+  }
+
+  /// @notice Owner-gated post-deployment writer for the protocol fee recipient.
+  /// @param _recipient The new recipient of the protocol fee tranche
+  /// @return oldRecipient The recipient in effect before this call
+  function updateProtocolFeeRecipient(address _recipient) internal returns (address oldRecipient) {
+    require(_recipient != address(0), Errors.RewardLib__InvalidProtocolFeeRecipient());
+    RewardStorage storage rewardStorage = getStorage();
+    oldRecipient = rewardStorage.protocolFeeRecipient;
+    rewardStorage.protocolFeeRecipient = _recipient;
   }
 
   /// @notice Owner-gated post-deployment writer. Only updates the mutable subset
@@ -216,18 +230,18 @@ library RewardLib {
         v.manaUsed = feeHeader.getManaUsed();
 
         uint256 fee = _args.headers[i].accumulatedFees;
-        uint256 burn = feeHeader.getCongestionCost() * v.manaUsed;
+        uint256 protocolFee = feeHeader.getProtocolFee() * v.manaUsed;
 
         t.feesToClaim += fee;
-        t.totalBurn += burn;
+        t.totalProtocolFee += protocolFee;
 
         // Compute the proving fee in the fee asset
-        v.proverFee = Math.min(v.manaUsed * feeHeader.getProverCost(), fee - burn);
+        v.proverFee = Math.min(v.manaUsed * feeHeader.getProverCost(), fee - protocolFee);
         if (v.proverFee > 0) {
           $er.rewards += v.proverFee.toUint128();
         }
 
-        v.sequencerFee = fee - burn - v.proverFee;
+        v.sequencerFee = fee - protocolFee - v.proverFee;
 
         {
           v.sequencer = _args.headers[i].coinbase;
@@ -244,8 +258,8 @@ library RewardLib {
         rollupStore.config.feeAssetPortal.distributeFees(address(this), t.feesToClaim);
       }
 
-      if (t.totalBurn > 0) {
-        rollupStore.config.feeAsset.safeTransfer(BURN_ADDRESS, t.totalBurn);
+      if (t.totalProtocolFee > 0) {
+        rollupStore.config.feeAsset.safeTransfer(rewardStorage.protocolFeeRecipient, t.totalProtocolFee);
       }
     }
   }
@@ -272,6 +286,10 @@ library RewardLib {
 
   function getCheckpointReward() internal view returns (uint256) {
     return getStorage().config.checkpointReward;
+  }
+
+  function getProtocolFeeRecipient() internal view returns (address) {
+    return getStorage().protocolFeeRecipient;
   }
 
   function getSpecificProverRewardsForEpoch(Epoch _epoch, address _prover) internal view returns (uint256) {

--- a/l1-contracts/src/core/libraries/rollup/STFLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/STFLib.sol
@@ -131,7 +131,7 @@ library STFLib {
         payloadDigest: bytes32(0),
         slotNumber: Slot.wrap(0),
         feeHeader: FeeHeader({
-          excessMana: 0, manaUsed: 0, ethPerFeeAsset: _initialEthPerFeeAsset, congestionCost: 0, proverCost: 0
+          excessMana: 0, manaUsed: 0, ethPerFeeAsset: _initialEthPerFeeAsset, protocolFee: 0, proverCost: 0
         }),
         // Genesis Inbox consumption base case, matching the Inbox's genesis bucket-0 sentinel {0, 0, 0}, so
         // checkpoint 1 validates its consumption against it.

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -200,7 +200,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     vm.label(coinbase, "coinbase");
     vm.label(address(rollup), "ROLLUP");
     vm.label(address(asset), "ASSET");
-    vm.label(rollup.getBurnAddress(), "BURN_ADDRESS");
+    vm.label(rollup.getProtocolFeeRecipient(), "BURN_ADDRESS");
 
     _;
   }

--- a/l1-contracts/test/compression/FeeConfig.t.sol
+++ b/l1-contracts/test/compression/FeeConfig.t.sol
@@ -17,12 +17,14 @@ contract FeeConfigTest is Test {
   function test_compressAndDecompress(
     uint32 _manaTarget,
     uint128 _congestionUpdateFraction,
-    uint64 _provingCostPerMana
+    uint64 _provingCostPerMana,
+    uint16 _protocolFeeMarginBps
   ) public pure {
     FeeConfig memory a = FeeConfig({
       manaTarget: _manaTarget,
       congestionUpdateFraction: _congestionUpdateFraction,
-      provingCostPerMana: EthValue.wrap(_provingCostPerMana)
+      provingCostPerMana: EthValue.wrap(_provingCostPerMana),
+      protocolFeeMarginBps: _protocolFeeMarginBps
     });
     CompressedFeeConfig b = a.compress();
     FeeConfig memory c = b.decompress();
@@ -30,9 +32,11 @@ contract FeeConfigTest is Test {
     assertEq(c.manaTarget, a.manaTarget, "Mana target");
     assertEq(c.congestionUpdateFraction, a.congestionUpdateFraction, "Congestion update fraction");
     assertEq(EthValue.unwrap(c.provingCostPerMana), EthValue.unwrap(a.provingCostPerMana), "Proving cost per mana");
+    assertEq(c.protocolFeeMarginBps, a.protocolFeeMarginBps, "Protocol fee margin bps");
 
     assertEq(b.getManaTarget(), a.manaTarget, "Mana target");
     assertEq(b.getCongestionUpdateFraction(), a.congestionUpdateFraction, "Congestion update fraction");
     assertEq(EthValue.unwrap(b.getProvingCostPerMana()), EthValue.unwrap(a.provingCostPerMana), "Proving cost per mana");
+    assertEq(b.getProtocolFeeMarginBps(), a.protocolFeeMarginBps, "Protocol fee margin bps");
   }
 }

--- a/l1-contracts/test/compression/FeeStructs.t.sol
+++ b/l1-contracts/test/compression/FeeStructs.t.sol
@@ -11,7 +11,7 @@ contract FeeStructsTest is Test {
 
   function test_compressAndDecompress(
     uint64 _proverCost,
-    uint64 _congestionCost,
+    uint64 _protocolFee,
     uint48 _ethPerFeeAsset,
     uint48 _excessMana,
     uint32 _manaUsed
@@ -20,7 +20,7 @@ contract FeeStructsTest is Test {
       excessMana: _excessMana,
       manaUsed: _manaUsed,
       ethPerFeeAsset: _ethPerFeeAsset,
-      congestionCost: _congestionCost,
+      protocolFee: _protocolFee,
       proverCost: bound(_proverCost, 0, 2 ** 63 - 1)
     });
 
@@ -32,14 +32,14 @@ contract FeeStructsTest is Test {
     assertEq(compressedFeeHeader.getManaUsed(), feeHeader.manaUsed, "Getter Mana used");
     assertEq(compressedFeeHeader.getExcessMana(), feeHeader.excessMana, "Getter Excess mana");
     assertEq(compressedFeeHeader.getEthPerFeeAsset(), feeHeader.ethPerFeeAsset, "Getter Eth per fee asset");
-    assertEq(compressedFeeHeader.getCongestionCost(), feeHeader.congestionCost, "Getter Congestion cost");
+    assertEq(compressedFeeHeader.getProtocolFee(), feeHeader.protocolFee, "Getter Protocol fee");
     assertEq(compressedFeeHeader.getProverCost(), feeHeader.proverCost, "Getter Prover cost");
 
     // Check the decompressed value
     assertEq(decompressedFeeHeader.manaUsed, feeHeader.manaUsed, "Decompressed Mana used");
     assertEq(decompressedFeeHeader.excessMana, feeHeader.excessMana, "Decompressed Excess mana");
     assertEq(decompressedFeeHeader.ethPerFeeAsset, feeHeader.ethPerFeeAsset, "Decompressed Eth per fee asset");
-    assertEq(decompressedFeeHeader.congestionCost, feeHeader.congestionCost, "Decompressed Congestion cost");
+    assertEq(decompressedFeeHeader.protocolFee, feeHeader.protocolFee, "Decompressed Protocol fee");
     assertEq(decompressedFeeHeader.proverCost, feeHeader.proverCost, "Decompressed Prover cost");
   }
 }

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -173,7 +173,7 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
     vm.label(coinbase, "coinbase");
     vm.label(address(rollup), "ROLLUP");
     vm.label(address(asset), "ASSET");
-    vm.label(rollup.getBurnAddress(), "BURN_ADDRESS");
+    vm.label(rollup.getProtocolFeeRecipient(), "BURN_ADDRESS");
 
     _;
   }

--- a/l1-contracts/test/fees/FeeHeaderOverflow.t.sol
+++ b/l1-contracts/test/fees/FeeHeaderOverflow.t.sol
@@ -28,7 +28,7 @@ import {console} from "forge-std/console.sol";
  *      the FeeConfig allows provingCostPerMana up to uint64. Governance can set a
  *      valid config value that always reverts during compression.
  *
- *   2. FeeHeader compression - congestionCost (uint64): with a cheap fee asset (low
+ *   2. FeeHeader compression - protocolFee (uint64): with a cheap fee asset (low
  *      ethPerFeeAsset) and moderate congestion, the fee-asset conversion amplifies
  *      the congestion cost beyond 64 bits.
  *
@@ -44,7 +44,7 @@ import {console} from "forge-std/console.sol";
  *      proposer can work around the revert - permanent liveness failure.
  *
  *   Additionally, even after fixing (1)-(4), the summed mana min fee (sequencerCost +
- *   proverCost + congestionCost) can exceed the uint128 capacity of the proposal header's
+ *   proverCost + protocolFee) can exceed the uint128 capacity of the proposal header's
  *   feePerL2Gas field. Without capping summedMinFee at type(uint128).max, the proposer
  *   cannot construct a valid header, causing the same liveness failure.
  */
@@ -60,7 +60,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
 
   address internal coinbase = address(bytes20("MONEY MAKER"));
   uint256 internal constant MAX_PROVER_COST = (1 << 63) - 1;
-  uint256 internal constant MAX_CONGESTION_COST = type(uint64).max;
+  uint256 internal constant MAX_PROTOCOL_FEE = type(uint64).max;
 
   function setUp() public {
     // Warp to a timestamp large enough so that setupEpoch's
@@ -189,11 +189,11 @@ contract FeeHeaderOverflowTest is DecoderBase {
     // Verify the stored fee header has capped proverCost
     FeeHeader memory storedFeeHeader = rollup.getFeeHeader(1);
     assertEq(storedFeeHeader.proverCost, MAX_PROVER_COST, "stored proverCost should be capped at 63-bit max");
-    assertEq(storedFeeHeader.congestionCost, 0, "congestionCost should be zero (no congestion)");
+    assertEq(storedFeeHeader.protocolFee, 0, "protocolFee should be zero (no congestion)");
   }
 
   // -----------------------------------------------------------------------
-  //  2. Compression overflow - congestionCost exceeds 64 bits
+  //  2. Compression overflow - protocolFee exceeds 64 bits
   // -----------------------------------------------------------------------
 
   /**
@@ -208,7 +208,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
    *         Note: proverCost stays within 63 bits here because provingCostPerMana is
    *         at the default (100 wei), so this specifically tests the congestion path.
    */
-  function test_propose_compressOverflow_congestionCost() public {
+  function test_propose_compressOverflow_protocolFee() public {
     // excessMana = 1e10 (~100x target): high enough for large congestion multiplier,
     // but well below the ~975x threshold that would overflow fakeExponential
     uint256 excessMana = 10_000_000_000;
@@ -237,11 +237,11 @@ contract FeeHeaderOverflowTest is DecoderBase {
     // Warp to slot 1
     vm.warp(block.timestamp + SLOT_DURATION);
 
-    // Fee computation succeeds (uint256 intermediates), but congestionCost exceeds uint64
+    // Fee computation succeeds (uint256 intermediates), but protocolFee exceeds uint64
     ManaMinFeeComponents memory components = rollup.getManaMinFeeComponentsAt(Timestamp.wrap(block.timestamp), true);
     uint256 manaMinFee = rollup.getManaMinFeeAt(Timestamp.wrap(block.timestamp), true);
 
-    assertTrue(components.congestionCost > MAX_CONGESTION_COST, "congestionCost should exceed 64-bit limit");
+    assertTrue(components.protocolFee > MAX_PROTOCOL_FEE, "protocolFee should exceed 64-bit limit");
     assertTrue(components.proverCost <= MAX_PROVER_COST, "proverCost should still fit in 63 bits");
 
     (ProposeArgs memory proposeArgs, CommitteeAttestations memory attestations, address[] memory signers) =
@@ -249,14 +249,12 @@ contract FeeHeaderOverflowTest is DecoderBase {
 
     skipBlobCheck(address(rollup));
 
-    // propose succeeds because compress() caps congestionCost at 64-bit max instead of reverting.
+    // propose succeeds because compress() caps protocolFee at 64-bit max instead of reverting.
     rollup.propose(proposeArgs, attestations, signers, Signature({v: 0, r: 0, s: 0}), full.checkpoint.blobCommitments);
 
-    // Verify the stored fee header has capped congestionCost
+    // Verify the stored fee header has capped protocolFee
     FeeHeader memory storedFeeHeader = rollup.getFeeHeader(1);
-    assertEq(
-      storedFeeHeader.congestionCost, MAX_CONGESTION_COST, "stored congestionCost should be capped at 64-bit max"
-    );
+    assertEq(storedFeeHeader.protocolFee, MAX_PROTOCOL_FEE, "stored protocolFee should be capped at 64-bit max");
     assertLe(storedFeeHeader.proverCost, MAX_PROVER_COST, "proverCost should still fit in 63 bits");
   }
 
@@ -291,7 +289,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
 
     // Construct the modified CompressedFeeHeader with high excessMana.
     // Bit layout: manaUsed(32) | excessMana(48) | ethPerFeeAsset(48) |
-    //             congestionCost(64) | proverCost(63) | preHeat(1)
+    //             protocolFee(64) | proverCost(63) | preHeat(1)
     uint256 compressedValue = 0;
     compressedValue |= excessMana << 32;
     compressedValue |= ethPerFeeAsset << 80;
@@ -317,7 +315,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
     // The congestion multiplier is capped (excessMana > denominator * 100 threshold)
     assertTrue(components.congestionMultiplier > 0, "congestionMultiplier should be non-zero");
     // Individual components exceed their compressed field widths
-    assertTrue(components.congestionCost > MAX_CONGESTION_COST, "congestionCost exceeds 64-bit limit");
+    assertTrue(components.protocolFee > MAX_PROTOCOL_FEE, "protocolFee exceeds 64-bit limit");
 
     // summedMinFee caps the total at uint128 max, ensuring the header can represent it
     assertEq(manaMinFee, type(uint128).max, "mana min fee should be capped at uint128 max");
@@ -334,9 +332,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
 
     // Verify the stored fee header has capped values
     FeeHeader memory storedFeeHeader = rollup.getFeeHeader(1);
-    assertEq(
-      storedFeeHeader.congestionCost, MAX_CONGESTION_COST, "stored congestionCost should be capped at 64-bit max"
-    );
+    assertEq(storedFeeHeader.protocolFee, MAX_PROTOCOL_FEE, "stored protocolFee should be capped at 64-bit max");
     assertLe(storedFeeHeader.proverCost, MAX_PROVER_COST, "proverCost should fit in 63 bits");
   }
 
@@ -356,7 +352,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
    *         the result exceeds uint48.
    *
    *         After fix: compress() caps excessMana at uint48 max (via Math.min) instead
-   *         of reverting, consistent with the congestionCost and proverCost caps.
+   *         of reverting, consistent with the protocolFee and proverCost caps.
    *         At uint48 max, the congestion multiplier is already pinned at the e^100 cap,
    *         so capping excessMana doesn't change observable fee behavior. The system
    *         naturally recovers as manaUsed drops to 0 under extreme fees.
@@ -382,7 +378,7 @@ contract FeeHeaderOverflowTest is DecoderBase {
     uint256 ethPerFeeAsset = genesisFeeHeader.ethPerFeeAsset;
 
     // Construct parent header with near-max excessMana and manaUsed > manaTarget.
-    // Bit layout: preHeat(1) | proverCost(63) | congestionCost(64) |
+    // Bit layout: preHeat(1) | proverCost(63) | protocolFee(64) |
     //             ethPerFeeAsset(48) | excessMana(48) | manaUsed(32)
     uint256 compressedValue = 0;
     compressedValue |= parentManaUsed; // bits 0-31

--- a/l1-contracts/test/fees/FeeModelTestPoints.t.sol
+++ b/l1-contracts/test/fees/FeeModelTestPoints.t.sol
@@ -46,8 +46,8 @@ struct L1GasOracleValuesModel {
 }
 
 struct ManaMinFeeComponentsModel {
-  uint256 congestion_cost;
   uint256 congestion_multiplier;
+  uint256 protocol_fee;
   uint256 prover_cost;
   uint256 sequencer_cost;
 }
@@ -137,10 +137,10 @@ contract FeeModelTestPoints is TestBase {
     internal
     pure
   {
-    assertEq(a.congestion_cost, b.congestion_cost, string.concat(_message, " congestion_cost mismatch"));
     assertEq(
       a.congestion_multiplier, b.congestion_multiplier, string.concat(_message, " congestion_multiplier mismatch")
     );
+    assertEq(a.protocol_fee, b.protocol_fee, string.concat(_message, " protocol_fee mismatch"));
     assertEq(a.prover_cost, b.prover_cost, string.concat(_message, " prover_cost mismatch"));
     assertEq(a.sequencer_cost, b.sequencer_cost, string.concat(_message, " sequencer_cost mismatch"));
   }

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -119,7 +119,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     vm.label(address(rewardDistributor), "REWARD DISTRIBUTOR");
     vm.label(address(rollup.getFeeAssetPortal()), "FEE ASSET PORTAL");
     vm.label(address(asset), "ASSET");
-    vm.label(rollup.getBurnAddress(), "BURN_ADDRESS");
+    vm.label(rollup.getProtocolFeeRecipient(), "BURN_ADDRESS");
   }
 
   function _loadL1Metadata(uint256 index) internal {
@@ -153,7 +153,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     uint128 manaMinFee = SafeCast.toUint128(
       point.outputs.mana_min_fee_components_in_fee_asset.sequencer_cost
         + point.outputs.mana_min_fee_components_in_fee_asset.prover_cost
-        + point.outputs.mana_min_fee_components_in_fee_asset.congestion_cost
+        + point.outputs.mana_min_fee_components_in_fee_asset.protocol_fee
     );
 
     assertEq(rollup.getManaMinFeeAt(Timestamp.wrap(block.timestamp), true), manaMinFee, "mana min fee mismatch");
@@ -209,11 +209,11 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     uint256 minFee =
       point.outputs.mana_min_fee_components_in_fee_asset.sequencer_cost
       + point.outputs.mana_min_fee_components_in_fee_asset.prover_cost
-      + point.outputs.mana_min_fee_components_in_fee_asset.congestion_cost;
+      + point.outputs.mana_min_fee_components_in_fee_asset.protocol_fee;
     uint256 manaUsed = rollup.getFeeHeader(_checkpointNumber).manaUsed;
 
     fee = manaUsed * minFee;
-    burn = manaUsed * point.outputs.mana_min_fee_components_in_fee_asset.congestion_cost;
+    burn = manaUsed * point.outputs.mana_min_fee_components_in_fee_asset.protocol_fee;
     proverFee = Math.min(manaUsed * point.outputs.mana_min_fee_components_in_fee_asset.prover_cost, fee - burn);
   }
 
@@ -337,6 +337,51 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     );
   }
 
+  function test_protocolFeePaidToUpdatedRecipient() public {
+    // Propose through the first epoch and into the next, mirroring test_FeeModelEquivalence.
+    Slot nextSlot = Slot.wrap(1);
+    for (uint256 i = 0; i < SLOT_DURATION / 12 * (EPOCH_DURATION + 1); i++) {
+      _loadL1Metadata(i);
+
+      if (rollup.getCurrentSlot() == nextSlot) {
+        TestPoint memory point = points[Slot.unwrap(nextSlot) - 1];
+        Checkpoint memory b = getCheckpoint();
+        skipBlobCheck(address(rollup));
+        checkpointHeaders[rollup.getPendingCheckpointNumber() + 1] = b.header;
+        rollup.propose(
+          ProposeArgs({
+            header: b.header,
+            archive: b.archive,
+            oracleInput: OracleInput({feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier})
+          }),
+          AttestationLibHelper.packAttestations(b.attestations),
+          b.signers,
+          b.attestationsAndSignersSignature,
+          b.blobInputs
+        );
+        nextSlot = nextSlot + Slot.wrap(1);
+      }
+    }
+
+    address burnAddress = rollup.getProtocolFeeRecipient();
+    address newRecipient = makeAddr("newProtocolFeeRecipient");
+
+    vm.prank(rollup.owner());
+    rollup.setProtocolFeeRecipient(newRecipient);
+    assertEq(rollup.getProtocolFeeRecipient(), newRecipient, "recipient not updated");
+
+    uint256 start = rollup.getProvenCheckpointNumber() + 1;
+    uint256 used = _getUsedCheckpointsInEpoch(start, rollup.getPendingCheckpointNumber());
+    (uint256 protocolFeeSum,,) = _buildEpochFees(start, used);
+    assertGt(protocolFeeSum, 0, "trace should accrue a protocol fee");
+
+    uint256 burnBalanceBefore = asset.balanceOf(burnAddress);
+    _submitEpochProof(start, used);
+
+    assertEq(asset.balanceOf(newRecipient), protocolFeeSum, "protocol fee should be paid to the new recipient");
+    assertEq(asset.balanceOf(burnAddress), burnBalanceBefore, "old recipient should receive nothing");
+  }
+
   function test_FeeModelEquivalence() public {
     Slot nextSlot = Slot.wrap(1);
     Epoch nextEpoch = Epoch.wrap(1);
@@ -387,7 +432,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
 
         assertEq(minFeePrediction, componentsFeeAsset.summedMinFee(), "mana min fee mismatch");
 
-        assertEq(componentsFeeAsset.congestionCost, feeHeader.congestionCost, "congestion cost mismatch");
+        assertEq(componentsFeeAsset.protocolFee, feeHeader.protocolFee, "protocol fee mismatch");
         // Want to check the fee header to see if they are as we want them.
 
         assertEq(point.checkpoint_header.checkpoint_number, nextSlot, "invalid checkpoint number");
@@ -418,11 +463,11 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
         uint256 usedCheckpointsInEpoch = _getUsedCheckpointsInEpoch(start, pendingCheckpointNumber);
         (uint256 burnSum, uint256 proverFees, uint256 sequencerFees) = _buildEpochFees(start, usedCheckpointsInEpoch);
 
-        uint256 burnAddressBalanceBefore = asset.balanceOf(rollup.getBurnAddress());
+        uint256 burnAddressBalanceBefore = asset.balanceOf(rollup.getProtocolFeeRecipient());
         uint256 sequencerRewardsBefore = rollup.getSequencerRewards(coinbase);
         _submitEpochProof(start, usedCheckpointsInEpoch);
 
-        uint256 burned = asset.balanceOf(rollup.getBurnAddress()) - burnAddressBalanceBefore;
+        uint256 burned = asset.balanceOf(rollup.getProtocolFeeRecipient()) - burnAddressBalanceBefore;
         assertEq(burnSum, burned, "Sum of burned does not match");
 
         // The reward is not yet distributed, but only accumulated.
@@ -452,8 +497,8 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     pure
   {
     ManaMinFeeComponentsModel memory bModel = ManaMinFeeComponentsModel({
-      congestion_cost: b.congestionCost,
       congestion_multiplier: b.congestionMultiplier,
+      protocol_fee: b.protocolFee,
       prover_cost: b.proverCost,
       sequencer_cost: b.sequencerCost
     });

--- a/l1-contracts/test/fees/MinimalFeeModel.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.sol
@@ -94,8 +94,8 @@ contract MinimalFeeModel {
       FeeLib.getManaMinFeeComponentsAt(populatedThrough, Timestamp.wrap(block.timestamp), _inFeeAsset);
 
     return ManaMinFeeComponentsModel({
-      congestion_cost: components.congestionCost,
       congestion_multiplier: components.congestionMultiplier,
+      protocol_fee: components.protocolFee,
       prover_cost: components.proverCost,
       sequencer_cost: components.sequencerCost
     });

--- a/l1-contracts/test/fees/ProtocolFeeMarginRateLimit.t.sol
+++ b/l1-contracts/test/fees/ProtocolFeeMarginRateLimit.t.sol
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {RollupBuilder} from "../builder/RollupBuilder.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {IRollupCore} from "@aztec/core/interfaces/IRollup.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {
+  FeeLib,
+  FeeStore,
+  ManaMinFeeComponents,
+  PROTOCOL_FEE_MARGIN_STEP_DEN,
+  PROTOCOL_FEE_MARGIN_STEP_NUM,
+  PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL,
+  MINIMUM_CONGESTION_MULTIPLIER,
+  EthValue
+} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+import {
+  FeeConfig,
+  FeeConfigLib,
+  CompressedFeeConfig,
+  EthPerFeeAssetE12
+} from "@aztec/core/libraries/compressed-data/fees/FeeConfig.sol";
+import {TestConstants} from "../harnesses/TestConstants.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+/**
+ * @notice Harness exposing FeeLib's margin updater on its own storage, so states that the
+ *         hardcoded mu=0 deployment cannot produce (a nonzero margin with no cooldown stamp,
+ *         i.e. a deployment starting at mu > 0) can still be exercised.
+ */
+contract FeeLibMarginHarness {
+  using FeeConfigLib for FeeConfig;
+  using FeeConfigLib for CompressedFeeConfig;
+
+  constructor() {
+    TimeLib.initialize(
+      block.timestamp,
+      TestConstants.AZTEC_SLOT_DURATION,
+      TestConstants.AZTEC_EPOCH_DURATION,
+      TestConstants.AZTEC_PROOF_SUBMISSION_EPOCHS
+    );
+    FeeLib.initialize(
+      TestConstants.AZTEC_MANA_TARGET, EthValue.wrap(100), TestConstants.AZTEC_INITIAL_ETH_PER_FEE_ASSET
+    );
+  }
+
+  /// @notice Writes the margin directly into config without stamping the cooldown, emulating a
+  ///         deployment that starts at a nonzero margin.
+  function seedMargin(uint16 _bps) external {
+    FeeStore storage feeStore = FeeLib.getStorage();
+    FeeConfig memory config = feeStore.config.decompress();
+    config.protocolFeeMarginBps = _bps;
+    feeStore.config = config.compress();
+  }
+
+  function update(uint16 _bps) external returns (bool, uint16) {
+    return FeeLib.updateProtocolFeeMargin(_bps);
+  }
+
+  function getMargin() external view returns (uint16) {
+    return FeeLib.getProtocolFeeMarginBps();
+  }
+
+  function getLastUpdate() external view returns (uint64) {
+    return FeeLib.getStorage().protocolMarginLastUpdate;
+  }
+
+  function congestionMultiplierAt(uint256 _excessMana) external view returns (uint256) {
+    return FeeLib.congestionMultiplier(_excessMana);
+  }
+
+  /// @notice The components at checkpoint 0 (zero excess mana), in wei.
+  function components() external view returns (ManaMinFeeComponents memory) {
+    return FeeLib.getManaMinFeeComponentsAt(0, Timestamp.wrap(block.timestamp), false);
+  }
+}
+
+/**
+ * @title ProtocolFeeMarginRateLimitTest
+ * @notice Exercises the rate limiter on setProtocolFeeMargin:
+ *
+ *           - multiplicative step cap (3/2) on the fee multiplier (10_000 + bps)
+ *           - cooldown (30 days) between updates, with the first post-init update exempt
+ *           - immediate, unrestricted decreases that still stamp the cooldown
+ *           - idempotent no-op when setting the current value
+ *
+ *         Tests go through the real Rollup surface so the whole path is validated; the
+ *         first-ever-update-is-a-decrease case uses the FeeLib harness because the deployed
+ *         margin is hardcoded to 0.
+ */
+contract ProtocolFeeMarginRateLimitTest is Test {
+  // From 0, the step cap permits (10_000 + new) * 2 <= (10_000 + 0) * 3, i.e. new <= 5000.
+  uint16 internal constant MAX_FIRST_STEP = 5000;
+
+  Rollup internal rollup;
+
+  function setUp() public {
+    RollupBuilder builder = new RollupBuilder(address(this)).setMakeGovernance(false).setTargetCommitteeSize(0);
+    builder.deploy();
+    rollup = builder.getConfig().rollup;
+  }
+
+  function test_initialMarginIsZero() public view {
+    assertEq(rollup.getProtocolFeeMargin(), 0);
+  }
+
+  function test_revertsWhen_notOwner(address _caller) public {
+    vm.assume(_caller != address(this));
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    rollup.setProtocolFeeMargin(1);
+
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    rollup.setProtocolFeeRecipient(address(0xbeef));
+  }
+
+  // ---------------------------------------------------------------------
+  // Step cap
+  // ---------------------------------------------------------------------
+
+  function test_firstUpdate_bypassesCooldown_atStepCap() public {
+    vm.expectEmit(true, true, true, true, address(rollup));
+    emit IRollupCore.ProtocolFeeMarginUpdated(0, MAX_FIRST_STEP);
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP);
+    assertEq(rollup.getProtocolFeeMargin(), MAX_FIRST_STEP);
+  }
+
+  function test_revertsWhen_aboveStepCap() public {
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginStepExceeded.selector, 0, MAX_FIRST_STEP + 1)
+    );
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP + 1);
+  }
+
+  function test_stepCapBoundsTheFeeMultiplier() public {
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP);
+
+    // From 5000, the cap permits (10_000 + new) * 2 <= 15_000 * 3, i.e. new <= 12_500.
+    uint16 nextMax =
+      uint16((10_000 + uint256(MAX_FIRST_STEP)) * PROTOCOL_FEE_MARGIN_STEP_NUM / PROTOCOL_FEE_MARGIN_STEP_DEN - 10_000);
+    assertEq(nextMax, 12_500);
+
+    vm.warp(block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginStepExceeded.selector, MAX_FIRST_STEP, nextMax + 1)
+    );
+    rollup.setProtocolFeeMargin(nextMax + 1);
+
+    rollup.setProtocolFeeMargin(nextMax);
+    assertEq(rollup.getProtocolFeeMargin(), nextMax);
+  }
+
+  // ---------------------------------------------------------------------
+  // Cooldown
+  // ---------------------------------------------------------------------
+
+  function test_revertsWhen_withinCooldown() public {
+    rollup.setProtocolFeeMargin(1000);
+
+    uint256 nextAllowed = block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginCooldown.selector, nextAllowed));
+    rollup.setProtocolFeeMargin(1100);
+  }
+
+  function test_succeedsAt_cooldownBoundary() public {
+    rollup.setProtocolFeeMargin(1000);
+
+    vm.warp(block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL);
+    rollup.setProtocolFeeMargin(1100);
+    assertEq(rollup.getProtocolFeeMargin(), 1100);
+  }
+
+  function test_revertsWhen_oneSecondShortOfCooldown() public {
+    rollup.setProtocolFeeMargin(1000);
+
+    uint256 nextAllowed = block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+    vm.warp(nextAllowed - 1);
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginCooldown.selector, nextAllowed));
+    rollup.setProtocolFeeMargin(1100);
+  }
+
+  // ---------------------------------------------------------------------
+  // Decreases
+  // ---------------------------------------------------------------------
+
+  function test_decreaseIsImmediate_butStampsCooldown() public {
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP);
+
+    // A decrease is not gated by the cooldown that is still running from the increase.
+    vm.expectEmit(true, true, true, true, address(rollup));
+    emit IRollupCore.ProtocolFeeMarginUpdated(MAX_FIRST_STEP, 1000);
+    rollup.setProtocolFeeMargin(1000);
+    assertEq(rollup.getProtocolFeeMargin(), 1000);
+
+    // But it stamps the cooldown: the next increase reverts until 30 days after the DECREASE.
+    uint256 nextAllowed = block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginCooldown.selector, nextAllowed));
+    rollup.setProtocolFeeMargin(1100);
+
+    vm.warp(nextAllowed - 1);
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginCooldown.selector, nextAllowed));
+    rollup.setProtocolFeeMargin(1100);
+
+    vm.warp(nextAllowed);
+    rollup.setProtocolFeeMargin(1100);
+    assertEq(rollup.getProtocolFeeMargin(), 1100);
+  }
+
+  function test_decreaseToZeroIsAlwaysAllowed() public {
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP);
+    rollup.setProtocolFeeMargin(0);
+    assertEq(rollup.getProtocolFeeMargin(), 0);
+  }
+
+  /// @notice A decrease as the first-ever update (only reachable on a deployment starting at
+  ///         mu > 0) succeeds unrestricted but consumes the lastUpdate == 0 cooldown bypass.
+  function test_decreaseAsFirstUpdate_consumesBypass() public {
+    FeeLibMarginHarness harness = new FeeLibMarginHarness();
+    harness.seedMargin(1000);
+    assertEq(harness.getLastUpdate(), 0, "seeding must not stamp the cooldown");
+
+    (bool changed, uint16 oldBps) = harness.update(500);
+    assertTrue(changed);
+    assertEq(oldBps, 1000);
+    assertEq(harness.getMargin(), 500);
+    assertEq(harness.getLastUpdate(), uint64(block.timestamp), "decrease must stamp the cooldown");
+
+    uint256 nextAllowed = block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__ProtocolFeeMarginCooldown.selector, nextAllowed));
+    harness.update(600);
+
+    vm.warp(nextAllowed);
+    harness.update(600);
+    assertEq(harness.getMargin(), 600);
+  }
+
+  // ---------------------------------------------------------------------
+  // Idempotency
+  // ---------------------------------------------------------------------
+
+  function test_idempotentAtZero_noEventNoStamp() public {
+    vm.recordLogs();
+    rollup.setProtocolFeeMargin(0);
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertEq(logs.length, 0, "no-op must emit no events");
+
+    // The first-update bypass is still available, proving the no-op did not stamp lastUpdate.
+    rollup.setProtocolFeeMargin(MAX_FIRST_STEP);
+    assertEq(rollup.getProtocolFeeMargin(), MAX_FIRST_STEP);
+  }
+
+  function test_idempotentAtNonZero_noRevertNoEventNoStamp() public {
+    rollup.setProtocolFeeMargin(1000);
+    uint256 nextAllowed = block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL;
+
+    // Same-value call inside the cooldown window must not revert, emit, or change state.
+    vm.warp(block.timestamp + PROTOCOL_FEE_MARGIN_UPDATE_INTERVAL / 2);
+    vm.recordLogs();
+    rollup.setProtocolFeeMargin(1000);
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    assertEq(logs.length, 0, "no-op must emit no events");
+    assertEq(rollup.getProtocolFeeMargin(), 1000);
+
+    // The original cooldown boundary is unchanged: an increase succeeds at the boundary set by
+    // the FIRST update. Had the no-op stamped lastUpdate, this would still be cooling down.
+    vm.warp(nextAllowed);
+    rollup.setProtocolFeeMargin(1100);
+    assertEq(rollup.getProtocolFeeMargin(), 1100);
+  }
+
+  // ---------------------------------------------------------------------
+  // Multiplier scaling
+  // ---------------------------------------------------------------------
+
+  /// @notice At zero excess mana the congestion multiplier equals the scaled factor exactly:
+  ///         (10_000 + bps) * 1e5, which is (1 + mu) * MINIMUM_CONGESTION_MULTIPLIER.
+  function test_multiplierAtZeroExcessEqualsScaledFactor(uint16 _bps) public {
+    FeeLibMarginHarness harness = new FeeLibMarginHarness();
+    assertEq(harness.congestionMultiplierAt(0), MINIMUM_CONGESTION_MULTIPLIER, "mu=0 baseline must be 1e9");
+
+    harness.seedMargin(_bps);
+    assertEq(harness.congestionMultiplierAt(0), (10_000 + uint256(_bps)) * 1e5, "baseline must scale with (1+mu)");
+  }
+
+  /// @notice At mu = 5000 the fee components carry a nonzero margin tranche while operator costs
+  ///         stay untouched. This is the L1-side guard against the silent cancellation where both
+  ///         the fakeExponential factor AND the mulDiv divisor get scaled and mu vanishes.
+  function test_componentsScaleWithMargin() public {
+    FeeLibMarginHarness harness = new FeeLibMarginHarness();
+
+    ManaMinFeeComponents memory base = harness.components();
+    assertEq(base.protocolFee, 0, "mu=0 at zero excess must have no protocol fee");
+
+    harness.seedMargin(5000);
+    ManaMinFeeComponents memory scaled = harness.components();
+
+    assertEq(scaled.sequencerCost, base.sequencerCost, "sequencer cost must not scale with mu");
+    assertEq(scaled.proverCost, base.proverCost, "prover cost must not scale with mu");
+
+    // At zero excess mana the entire protocol fee is the margin: floor(cost * 3 / 2) - cost.
+    uint256 cost = base.sequencerCost + base.proverCost;
+    assertEq(scaled.protocolFee, cost * 15_000 / 10_000 - cost, "protocol fee must be exactly mu * cost");
+    assertGt(scaled.protocolFee, 0, "mu=5000 must produce a nonzero protocol fee");
+  }
+}

--- a/l1-contracts/test/fees/ProtocolFeeNearCap.t.sol
+++ b/l1-contracts/test/fees/ProtocolFeeNearCap.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {FeeLib, ManaMinFeeComponents} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {Test} from "forge-std/Test.sol";
+
+/**
+ * @title ProtocolFeeNearCapTest
+ * @notice The fee header's per-mana protocol fee moved from the separately-converted congestion
+ *         component to the single subtraction `summedMinFee - sequencerCost - proverCost`. The
+ *         two are identical whenever the uint128 cap in summedMinFee does not bind, which is the
+ *         only place mu = 0 behavior genuinely changes. These fuzzes pin that equivalence and the
+ *         cap-binding/clamp behavior.
+ */
+contract ProtocolFeeNearCapTest is Test {
+  uint256 internal constant CAP = type(uint128).max;
+
+  function _components(uint256 _sequencerCost, uint256 _proverCost, uint256 _protocolFee)
+    internal
+    pure
+    returns (ManaMinFeeComponents memory)
+  {
+    return ManaMinFeeComponents({
+      sequencerCost: _sequencerCost, proverCost: _proverCost, protocolFee: _protocolFee, congestionMultiplier: 0
+    });
+  }
+
+  /// @notice When the cap does not bind, the header value equals the old behavior (the
+  ///         separately-converted congestion component) exactly.
+  function test_headerValueUnchangedWhenCapDoesNotBind(
+    uint128 _sequencerCost,
+    uint128 _proverCost,
+    uint128 _protocolFee
+  ) public pure {
+    // Bound the sum inside the cap; the components stay near it.
+    uint256 s = uint256(_sequencerCost);
+    uint256 p = uint256(_proverCost);
+    uint256 c = uint256(_protocolFee);
+    vm.assume(s + p + c <= CAP);
+
+    ManaMinFeeComponents memory components = _components(s, p, c);
+    assertEq(FeeLib.summedMinFee(components), s + p + c, "cap must not bind");
+    assertEq(FeeLib.protocolFeePerMana(components), c, "header value must equal the old congestion component");
+  }
+
+  /// @notice When the cap binds but still covers operator cost, the header value is exactly
+  ///         `cap - sequencerCost - proverCost`: the shortfall reduces only the protocol tranche
+  ///         and operators stay whole.
+  function test_operatorsWholeWhenCapBinds(uint128 _sequencerCost, uint128 _proverCost, uint256 _protocolFee)
+    public
+    pure
+  {
+    uint256 s = uint256(_sequencerCost);
+    uint256 p = uint256(_proverCost);
+    vm.assume(s + p <= CAP);
+    // Force the cap to bind: the raw sum must exceed the cap.
+    uint256 c = bound(_protocolFee, CAP + 1 - s - p, type(uint256).max - s - p);
+
+    ManaMinFeeComponents memory components = _components(s, p, c);
+    uint256 headerValue = FeeLib.protocolFeePerMana(components);
+
+    assertEq(FeeLib.summedMinFee(components), CAP, "cap must bind");
+    assertEq(headerValue, CAP - s - p, "shortfall must reduce only the protocol tranche");
+    assertEq(FeeLib.summedMinFee(components) - headerValue, s + p, "operators must stay whole");
+    assertLt(headerValue, c, "protocol tranche must absorb the shortfall");
+  }
+
+  /// @notice When the capped fee cannot even cover operator cost, the header value clamps to 0
+  ///         instead of underflowing.
+  function test_negativeClampWhenOperatorCostExceedsCap(
+    uint256 _sequencerCost,
+    uint256 _proverCost,
+    uint256 _protocolFee
+  ) public pure {
+    uint256 s = bound(_sequencerCost, 1, CAP);
+    uint256 p = bound(_proverCost, CAP + 1 - s, CAP);
+    uint256 c = bound(_protocolFee, 0, CAP);
+    // Operator cost alone exceeds the cap, so the subtraction would go negative.
+    assertGt(s + p, CAP, "setup: operator cost must exceed the cap");
+
+    ManaMinFeeComponents memory components = _components(s, p, c);
+    assertEq(FeeLib.summedMinFee(components), CAP, "cap must bind");
+    assertEq(FeeLib.protocolFeePerMana(components), 0, "header value must clamp to zero");
+  }
+
+  /// @notice Boundary: operator cost equal to the capped fee leaves exactly zero for the protocol.
+  function test_zeroAtExactBoundary() public pure {
+    ManaMinFeeComponents memory components = _components(CAP - 1, 1, 5);
+    assertEq(FeeLib.summedMinFee(components), CAP, "cap must bind");
+    assertEq(FeeLib.protocolFeePerMana(components), 0, "capped fee == operator cost must give zero");
+  }
+}

--- a/l1-contracts/test/fees/ProtocolFeeRecipient.t.sol
+++ b/l1-contracts/test/fees/ProtocolFeeRecipient.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {RollupBuilder} from "../builder/RollupBuilder.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {IRollupCore} from "@aztec/core/interfaces/IRollup.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {Test} from "forge-std/Test.sol";
+
+/**
+ * @title ProtocolFeeRecipientTest
+ * @notice Exercises the protocol fee recipient setter semantics: burn-address default,
+ *         owner gating, zero-address rejection, and event emission. The end-to-end
+ *         "epoch proof pays the new recipient" flow lives in FeeRollup.t.sol, which owns
+ *         the proven-epoch machinery.
+ */
+contract ProtocolFeeRecipientTest is Test {
+  address internal constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
+
+  Rollup internal rollup;
+
+  function setUp() public {
+    RollupBuilder builder = new RollupBuilder(address(this)).setMakeGovernance(false).setTargetCommitteeSize(0);
+    builder.deploy();
+    rollup = builder.getConfig().rollup;
+  }
+
+  function test_defaultIsBurnAddress() public view {
+    assertEq(rollup.getProtocolFeeRecipient(), BURN_ADDRESS);
+  }
+
+  function test_revertsWhen_notOwner(address _caller) public {
+    vm.assume(_caller != address(this));
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    rollup.setProtocolFeeRecipient(address(0xbeef));
+  }
+
+  function test_revertsWhen_zeroAddress() public {
+    vm.expectRevert(abi.encodeWithSelector(Errors.RewardLib__InvalidProtocolFeeRecipient.selector));
+    rollup.setProtocolFeeRecipient(address(0));
+  }
+
+  function test_setEmitsEventAndUpdates(address _recipient) public {
+    vm.assume(_recipient != address(0));
+
+    vm.expectEmit(true, true, true, true, address(rollup));
+    emit IRollupCore.ProtocolFeeRecipientUpdated(BURN_ADDRESS, _recipient);
+    rollup.setProtocolFeeRecipient(_recipient);
+    assertEq(rollup.getProtocolFeeRecipient(), _recipient);
+
+    // Setting again (even to the same value) always sets and emits; idempotency is a
+    // margin-setter property only.
+    vm.expectEmit(true, true, true, true, address(rollup));
+    emit IRollupCore.ProtocolFeeRecipientUpdated(_recipient, _recipient);
+    rollup.setProtocolFeeRecipient(_recipient);
+    assertEq(rollup.getProtocolFeeRecipient(), _recipient);
+  }
+}

--- a/l1-contracts/test/fixtures/fee_data_points.json
+++ b/l1-contracts/test/fixtures/fee_data_points.json
@@ -12044,13 +12044,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 0,
+          "protocol_fee": 0,
           "congestion_multiplier": 1000000000,
           "prover_cost": 18201193100000,
           "sequencer_cost": 400000100000
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 0,
+          "protocol_fee": 0,
           "congestion_multiplier": 1000000000,
           "prover_cost": 182011931,
           "sequencer_cost": 4000001
@@ -12098,13 +12098,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 2324332829961,
+          "protocol_fee": 2324332829961,
           "congestion_multiplier": 1124118914,
           "prover_cost": 18323963656499,
           "sequencer_cost": 402698177792
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 23087598,
+          "protocol_fee": 23087598,
           "congestion_multiplier": 1124118914,
           "prover_cost": 182011931,
           "sequencer_cost": 4000001
@@ -12152,13 +12152,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 4971774534903,
+          "protocol_fee": 4971774534903,
           "congestion_multiplier": 1263633325,
           "prover_cost": 18453135605739,
           "sequencer_cost": 405536936346
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 49038944,
+          "protocol_fee": 49038944,
           "congestion_multiplier": 1263633325,
           "prover_cost": 182011931,
           "sequencer_cost": 4000001
@@ -12206,13 +12206,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 7902350145560,
+          "protocol_fee": 7902350145560,
           "congestion_multiplier": 1420454705,
           "prover_cost": 18390609016628,
           "sequencer_cost": 404162815333
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 78209591,
+          "protocol_fee": 78209591,
           "congestion_multiplier": 1420454705,
           "prover_cost": 182011931,
           "sequencer_cost": 4000001
@@ -12260,13 +12260,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 15590305224342,
+          "protocol_fee": 15590305224342,
           "congestion_multiplier": 1596746902,
           "prover_cost": 20330472542484,
           "sequencer_cost": 5795017472143
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 154991643,
+          "protocol_fee": 154991643,
           "congestion_multiplier": 1596746902,
           "prover_cost": 202116206,
           "sequencer_cost": 57611398
@@ -12314,13 +12314,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 20661586825218,
+          "protocol_fee": 20661586825218,
           "congestion_multiplier": 1794892619,
           "prover_cost": 20227314973689,
           "sequencer_cost": 5765613339391
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 206455555,
+          "protocol_fee": 206455555,
           "congestion_multiplier": 1794892619,
           "prover_cost": 202116206,
           "sequencer_cost": 57611398
@@ -12368,13 +12368,13 @@
           "slot_of_change": 5
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 26459033982856,
+          "protocol_fee": 26459033982856,
           "congestion_multiplier": 2017626606,
           "prover_cost": 20233385652947,
           "sequencer_cost": 5767343731653
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 264305720,
+          "protocol_fee": 264305720,
           "congestion_multiplier": 2017626606,
           "prover_cost": 202116206,
           "sequencer_cost": 57611398
@@ -12422,13 +12422,13 @@
           "slot_of_change": 10
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 32943403545421,
+          "protocol_fee": 32943403545421,
           "congestion_multiplier": 2268032006,
           "prover_cost": 20217212681028,
           "sequencer_cost": 5762733772162
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 329342914,
+          "protocol_fee": 329342914,
           "congestion_multiplier": 2268032006,
           "prover_cost": 202116206,
           "sequencer_cost": 57611398
@@ -12476,13 +12476,13 @@
           "slot_of_change": 10
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 40204640253022,
+          "protocol_fee": 40204640253022,
           "congestion_multiplier": 2549537632,
           "prover_cost": 20190965242557,
           "sequencer_cost": 5755252177023
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 402457696,
+          "protocol_fee": 402457696,
           "congestion_multiplier": 2549537632,
           "prover_cost": 202116206,
           "sequencer_cost": 57611398
@@ -12530,13 +12530,13 @@
           "slot_of_change": 10
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 45811394730939,
+          "protocol_fee": 45811394730939,
           "congestion_multiplier": 2775565163,
           "prover_cost": 20125189800853,
           "sequencer_cost": 5675831609382
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 459499742,
+          "protocol_fee": 459499742,
           "congestion_multiplier": 2775565163,
           "prover_cost": 201860685,
           "sequencer_cost": 56930010
@@ -12584,13 +12584,13 @@
           "slot_of_change": 10
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 55002024544558,
+          "protocol_fee": 55002024544558,
           "congestion_multiplier": 3120052117,
           "prover_cost": 20236491766535,
           "sequencer_cost": 5707221684271
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 548649760,
+          "protocol_fee": 548649760,
           "congestion_multiplier": 3120052117,
           "prover_cost": 201860685,
           "sequencer_cost": 56930010
@@ -12638,13 +12638,13 @@
           "slot_of_change": 10
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 51852768777659,
+          "protocol_fee": 51852768777659,
           "congestion_multiplier": 2998064412,
           "prover_cost": 20242565500312,
           "sequencer_cost": 5708934636571
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 517080477,
+          "protocol_fee": 517080477,
           "congestion_multiplier": 2998064412,
           "prover_cost": 201860685,
           "sequencer_cost": 56930010
@@ -12692,13 +12692,13 @@
           "slot_of_change": 15
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 61019783490946,
+          "protocol_fee": 61019783490946,
           "congestion_multiplier": 3370111057,
           "prover_cost": 20081911657000,
           "sequencer_cost": 5663626037196
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 613362687,
+          "protocol_fee": 613362687,
           "congestion_multiplier": 3370111057,
           "prover_cost": 201860685,
           "sequencer_cost": 56930010
@@ -12746,13 +12746,13 @@
           "slot_of_change": 15
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 71430632366953,
+          "protocol_fee": 71430632366953,
           "congestion_multiplier": 3788358280,
           "prover_cost": 19982002301496,
           "sequencer_cost": 5635448977320
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 721601177,
+          "protocol_fee": 721601177,
           "congestion_multiplier": 3788358280,
           "prover_cost": 201860685,
           "sequencer_cost": 56930010
@@ -12800,13 +12800,13 @@
           "slot_of_change": 15
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86339730542451,
+          "protocol_fee": 86339730542451,
           "congestion_multiplier": 4258548217,
           "prover_cost": 20283076926138,
           "sequencer_cost": 6213302707356
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 868115340,
+          "protocol_fee": 868115340,
           "congestion_multiplier": 4258548217,
           "prover_cost": 203939138,
           "sequencer_cost": 62472553
@@ -12854,13 +12854,13 @@
           "slot_of_change": 15
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100300348873300,
+          "protocol_fee": 100300348873300,
           "congestion_multiplier": 4786949836,
           "prover_cost": 20274968668808,
           "sequencer_cost": 6210818909784
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1008887709,
+          "protocol_fee": 1008887709,
           "congestion_multiplier": 4786949836,
           "prover_cost": 203939138,
           "sequencer_cost": 62472553
@@ -12908,13 +12908,13 @@
           "slot_of_change": 15
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104459385614940,
+          "protocol_fee": 104459385614940,
           "congestion_multiplier": 4946739595,
           "prover_cost": 20260786251776,
           "sequencer_cost": 6206474418539
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1051457569,
+          "protocol_fee": 1051457569,
           "congestion_multiplier": 4946739595,
           "prover_cost": 203939138,
           "sequencer_cost": 62472553
@@ -12962,13 +12962,13 @@
           "slot_of_change": 20
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105687201225103,
+          "protocol_fee": 105687201225103,
           "congestion_multiplier": 4969969063,
           "prover_cost": 20378986192614,
           "sequencer_cost": 6242682535044
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1057646171,
+          "protocol_fee": 1057646171,
           "congestion_multiplier": 4969969063,
           "prover_cost": 203939138,
           "sequencer_cost": 62472553
@@ -13016,13 +13016,13 @@
           "slot_of_change": 20
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 103489070990129,
+          "protocol_fee": 103489070990129,
           "congestion_multiplier": 4903726632,
           "prover_cost": 20293753977246,
           "sequencer_cost": 6216573401975
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1039998413,
+          "protocol_fee": 1039998413,
           "congestion_multiplier": 4903726632,
           "prover_cost": 203939138,
           "sequencer_cost": 62472553
@@ -13070,13 +13070,13 @@
           "slot_of_change": 20
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109806009745847,
+          "protocol_fee": 109806009745847,
           "congestion_multiplier": 4875108282,
           "prover_cost": 20820534970420,
           "sequencer_cost": 7515708001978
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1101051872,
+          "protocol_fee": 1101051872,
           "congestion_multiplier": 4875108282,
           "prover_cost": 208772626,
           "sequencer_cost": 75361853
@@ -13124,13 +13124,13 @@
           "slot_of_change": 20
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112592774387203,
+          "protocol_fee": 112592774387203,
           "congestion_multiplier": 4964712959,
           "prover_cost": 20866441263561,
           "sequencer_cost": 7532279060080
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1126511650,
+          "protocol_fee": 1126511650,
           "congestion_multiplier": 4964712959,
           "prover_cost": 208772626,
           "sequencer_cost": 75361853
@@ -13178,13 +13178,13 @@
           "slot_of_change": 20
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112941322429969,
+          "protocol_fee": 112941322429969,
           "congestion_multiplier": 4964657304,
           "prover_cost": 20931330319348,
           "sequencer_cost": 7555702434960
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1126495837,
+          "protocol_fee": 1126495837,
           "congestion_multiplier": 4964657304,
           "prover_cost": 208772626,
           "sequencer_cost": 75361853
@@ -13232,13 +13232,13 @@
           "slot_of_change": 25
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 111348587401187,
+          "protocol_fee": 111348587401187,
           "congestion_multiplier": 4930635271,
           "prover_cost": 20814768339538,
           "sequencer_cost": 7513626388133
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1116829004,
+          "protocol_fee": 1116829004,
           "congestion_multiplier": 4930635271,
           "prover_cost": 208772626,
           "sequencer_cost": 75361853
@@ -13286,13 +13286,13 @@
           "slot_of_change": 25
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109292781895253,
+          "protocol_fee": 109292781895253,
           "congestion_multiplier": 4864237667,
           "prover_cost": 20781517990316,
           "sequencer_cost": 7501623818743
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1097963156,
+          "protocol_fee": 1097963156,
           "congestion_multiplier": 4864237667,
           "prover_cost": 208772626,
           "sequencer_cost": 75361853
@@ -13340,13 +13340,13 @@
           "slot_of_change": 25
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112206317006340,
+          "protocol_fee": 112206317006340,
           "congestion_multiplier": 4897128589,
           "prover_cost": 21005808869294,
           "sequencer_cost": 7786240082431
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1119905667,
+          "protocol_fee": 1119905667,
           "congestion_multiplier": 4897128589,
           "prover_cost": 209654189,
           "sequencer_cost": 77712687
@@ -13394,13 +13394,13 @@
           "slot_of_change": 25
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112373187111775,
+          "protocol_fee": 112373187111775,
           "congestion_multiplier": 4897850096,
           "prover_cost": 21033154069365,
           "sequencer_cost": 7796376149753
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1120113005,
+          "protocol_fee": 1120113005,
           "congestion_multiplier": 4897850096,
           "prover_cost": 209654189,
           "sequencer_cost": 77712687
@@ -13448,13 +13448,13 @@
           "slot_of_change": 25
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 111933984719410,
+          "protocol_fee": 111933984719410,
           "congestion_multiplier": 4909793723,
           "prover_cost": 20886946641469,
           "sequencer_cost": 7742181324763
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1123545207,
+          "protocol_fee": 1123545207,
           "congestion_multiplier": 4909793723,
           "prover_cost": 209654189,
           "sequencer_cost": 77712687
@@ -13502,13 +13502,13 @@
           "slot_of_change": 30
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 111992305615124,
+          "protocol_fee": 111992305615124,
           "congestion_multiplier": 4939995825,
           "prover_cost": 20737636698504,
           "sequencer_cost": 7686836488016
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1132224291,
+          "protocol_fee": 1132224291,
           "congestion_multiplier": 4939995825,
           "prover_cost": 209654189,
           "sequencer_cost": 77712687
@@ -13556,13 +13556,13 @@
           "slot_of_change": 30
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112654997800540,
+          "protocol_fee": 112654997800540,
           "congestion_multiplier": 4939926067,
           "prover_cost": 20860716875929,
           "sequencer_cost": 7732458716457
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1132204245,
+          "protocol_fee": 1132204245,
           "congestion_multiplier": 4939926067,
           "prover_cost": 209654189,
           "sequencer_cost": 77712687
@@ -13610,13 +13610,13 @@
           "slot_of_change": 30
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 108794925270861,
+          "protocol_fee": 108794925270861,
           "congestion_multiplier": 4848820952,
           "prover_cost": 20735308951453,
           "sequencer_cost": 7531769893250
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1096471268,
+          "protocol_fee": 1096471268,
           "congestion_multiplier": 4848820952,
           "prover_cost": 208977307,
           "sequencer_cost": 75907670
@@ -13664,13 +13664,13 @@
           "slot_of_change": 30
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110435262774799,
+          "protocol_fee": 110435262774799,
           "congestion_multiplier": 4933026498,
           "prover_cost": 20597308654619,
           "sequencer_cost": 7481643488893
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1120460163,
+          "protocol_fee": 1120460163,
           "congestion_multiplier": 4933026498,
           "prover_cost": 208977307,
           "sequencer_cost": 75907670
@@ -13718,13 +13718,13 @@
           "slot_of_change": 30
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 111009253702983,
+          "protocol_fee": 111009253702983,
           "congestion_multiplier": 4957817178,
           "prover_cost": 20574677402761,
           "sequencer_cost": 7473423048012
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1127522655,
+          "protocol_fee": 1127522655,
           "congestion_multiplier": 4957817178,
           "prover_cost": 208977307,
           "sequencer_cost": 75907670
@@ -13772,13 +13772,13 @@
           "slot_of_change": 35
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112348711722159,
+          "protocol_fee": 112348711722159,
           "congestion_multiplier": 5009978774,
           "prover_cost": 20552071573822,
           "sequencer_cost": 7465211841600
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1142382710,
+          "protocol_fee": 1142382710,
           "congestion_multiplier": 5009978774,
           "prover_cost": 208977307,
           "sequencer_cost": 75907670
@@ -13826,13 +13826,13 @@
           "slot_of_change": 35
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 111661120539909,
+          "protocol_fee": 111661120539909,
           "congestion_multiplier": 5010545122,
           "prover_cost": 20423405281695,
           "sequencer_cost": 7418475865417
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1142544054,
+          "protocol_fee": 1142544054,
           "congestion_multiplier": 5010545122,
           "prover_cost": 208977307,
           "sequencer_cost": 75907670
@@ -13880,13 +13880,13 @@
           "slot_of_change": 35
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 113845851463423,
+          "protocol_fee": 113845851463423,
           "congestion_multiplier": 4969411185,
           "prover_cost": 20578213013282,
           "sequencer_cost": 8102577705901
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1171655168,
+          "protocol_fee": 1171655168,
           "congestion_multiplier": 4969411185,
           "prover_cost": 211782593,
           "sequencer_cost": 83388432
@@ -13934,13 +13934,13 @@
           "slot_of_change": 35
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 115884788598170,
+          "protocol_fee": 115884788598170,
           "congestion_multiplier": 5015854701,
           "prover_cost": 20704511099723,
           "sequencer_cost": 8152307002552
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1185363948,
+          "protocol_fee": 1185363948,
           "congestion_multiplier": 5015854701,
           "prover_cost": 211782593,
           "sequencer_cost": 83388432
@@ -13988,13 +13988,13 @@
           "slot_of_change": 35
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 115998726647802,
+          "protocol_fee": 115998726647802,
           "congestion_multiplier": 5022616891,
           "prover_cost": 20690028423285,
           "sequencer_cost": 8146604514627
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1187359950,
+          "protocol_fee": 1187359950,
           "congestion_multiplier": 5022616891,
           "prover_cost": 211782593,
           "sequencer_cost": 83388432
@@ -14042,13 +14042,13 @@
           "slot_of_change": 40
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 114124767142106,
+          "protocol_fee": 114124767142106,
           "congestion_multiplier": 4979794073,
           "prover_cost": 20574810398420,
           "sequencer_cost": 8101237941787
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1174719895,
+          "protocol_fee": 1174719895,
           "congestion_multiplier": 4979794073,
           "prover_cost": 211782593,
           "sequencer_cost": 83388432
@@ -14096,13 +14096,13 @@
           "slot_of_change": 40
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107874083274598,
+          "protocol_fee": 107874083274598,
           "congestion_multiplier": 4761818296,
           "prover_cost": 20574810398420,
           "sequencer_cost": 8101237941787
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1110379762,
+          "protocol_fee": 1110379762,
           "congestion_multiplier": 4761818296,
           "prover_cost": 211782593,
           "sequencer_cost": 83388432
@@ -14150,13 +14150,13 @@
           "slot_of_change": 40
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105703105410698,
+          "protocol_fee": 105703105410698,
           "congestion_multiplier": 4902630819,
           "prover_cost": 20066105403455,
           "sequencer_cost": 7018984211454
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1094452596,
+          "protocol_fee": 1094452596,
           "congestion_multiplier": 4902630819,
           "prover_cost": 207764957,
           "sequencer_cost": 72674738
@@ -14204,13 +14204,13 @@
           "slot_of_change": 40
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106040097441787,
+          "protocol_fee": 106040097441787,
           "congestion_multiplier": 4917421682,
           "prover_cost": 20054073762985,
           "sequencer_cost": 7014775627238
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1098600541,
+          "protocol_fee": 1098600541,
           "congestion_multiplier": 4917421682,
           "prover_cost": 207764957,
           "sequencer_cost": 72674738
@@ -14258,13 +14258,13 @@
           "slot_of_change": 40
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107752104958614,
+          "protocol_fee": 107752104958614,
           "congestion_multiplier": 4965541513,
           "prover_cost": 20130570122591,
           "sequencer_cost": 7041533522181
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1112095252,
+          "protocol_fee": 1112095252,
           "congestion_multiplier": 4965541513,
           "prover_cost": 207764957,
           "sequencer_cost": 72674738
@@ -14312,13 +14312,13 @@
           "slot_of_change": 45
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106772490242308,
+          "protocol_fee": 106772490242308,
           "congestion_multiplier": 4927524331,
           "prover_cost": 20140641547885,
           "sequencer_cost": 7045056436753
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1101433725,
+          "protocol_fee": 1101433725,
           "congestion_multiplier": 4927524331,
           "prover_cost": 207764957,
           "sequencer_cost": 72674738
@@ -14366,13 +14366,13 @@
           "slot_of_change": 45
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106147346874311,
+          "protocol_fee": 106147346874311,
           "congestion_multiplier": 4930298667,
           "prover_cost": 20008586171331,
           "sequencer_cost": 6998864383814
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1102211759,
+          "protocol_fee": 1102211759,
           "congestion_multiplier": 4930298667,
           "prover_cost": 207764957,
           "sequencer_cost": 72674738
@@ -14420,13 +14420,13 @@
           "slot_of_change": 45
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107061611308926,
+          "protocol_fee": 107061611308926,
           "congestion_multiplier": 4937900423,
           "prover_cost": 20011080375468,
           "sequencer_cost": 7176405292160
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1115818596,
+          "protocol_fee": 1115818596,
           "congestion_multiplier": 4937900423,
           "prover_cost": 208559682,
           "sequencer_cost": 74794003
@@ -14474,13 +14474,13 @@
           "slot_of_change": 45
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107044379348274,
+          "protocol_fee": 107044379348274,
           "congestion_multiplier": 4921911123,
           "prover_cost": 20089429886425,
           "sequencer_cost": 7204503117691
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1111287968,
+          "protocol_fee": 1111287968,
           "congestion_multiplier": 4921911123,
           "prover_cost": 208559682,
           "sequencer_cost": 74794003
@@ -14528,13 +14528,13 @@
           "slot_of_change": 45
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105386016851230,
+          "protocol_fee": 105386016851230,
           "congestion_multiplier": 4867329395,
           "prover_cost": 20057339111400,
           "sequencer_cost": 7192994673199
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1095822035,
+          "protocol_fee": 1095822035,
           "congestion_multiplier": 4867329395,
           "prover_cost": 208559682,
           "sequencer_cost": 74794003
@@ -14582,13 +14582,13 @@
           "slot_of_change": 50
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107931324980889,
+          "protocol_fee": 107931324980889,
           "congestion_multiplier": 4957169149,
           "prover_cost": 20075408222729,
           "sequencer_cost": 7199474646481
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1121278460,
+          "protocol_fee": 1121278460,
           "congestion_multiplier": 4957169149,
           "prover_cost": 208559682,
           "sequencer_cost": 74794003
@@ -14636,13 +14636,13 @@
           "slot_of_change": 50
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107970062437352,
+          "protocol_fee": 107970062437352,
           "congestion_multiplier": 4943942480,
           "prover_cost": 20149963841890,
           "sequencer_cost": 7226211900536
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1117530635,
+          "protocol_fee": 1117530635,
           "congestion_multiplier": 4943942480,
           "prover_cost": 208559682,
           "sequencer_cost": 74794003
@@ -14690,13 +14690,13 @@
           "slot_of_change": 50
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107717059429051,
+          "protocol_fee": 107717059429051,
           "congestion_multiplier": 4937451012,
           "prover_cost": 20077880539125,
           "sequencer_cost": 7279173331184
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1120820886,
+          "protocol_fee": 1120820886,
           "congestion_multiplier": 4937451012,
           "prover_cost": 208914985,
           "sequencer_cost": 75741480
@@ -14744,13 +14744,13 @@
           "slot_of_change": 50
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104578057164120,
+          "protocol_fee": 104578057164120,
           "congestion_multiplier": 4838764066,
           "prover_cost": 19993907989831,
           "sequencer_cost": 7248729343822
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1092729008,
+          "protocol_fee": 1092729008,
           "congestion_multiplier": 4838764066,
           "prover_cost": 208914985,
           "sequencer_cost": 75741480
@@ -14798,13 +14798,13 @@
           "slot_of_change": 50
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105900675055837,
+          "protocol_fee": 105900675055837,
           "congestion_multiplier": 4900919120,
           "prover_cost": 19924173880834,
           "sequencer_cost": 7223447458840
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1110421846,
+          "protocol_fee": 1110421846,
           "congestion_multiplier": 4900919120,
           "prover_cost": 208914985,
           "sequencer_cost": 75741480
@@ -14852,13 +14852,13 @@
           "slot_of_change": 55
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107095771802944,
+          "protocol_fee": 107095771802944,
           "congestion_multiplier": 4932317314,
           "prover_cost": 19988136662359,
           "sequencer_cost": 7246636966943
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1119359545,
+          "protocol_fee": 1119359545,
           "congestion_multiplier": 4932317314,
           "prover_cost": 208914985,
           "sequencer_cost": 75741480
@@ -14906,13 +14906,13 @@
           "slot_of_change": 55
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109229424674767,
+          "protocol_fee": 109229424674767,
           "congestion_multiplier": 5010660275,
           "prover_cost": 19988136662359,
           "sequencer_cost": 7246636966943
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1141660376,
+          "protocol_fee": 1141660376,
           "congestion_multiplier": 5010660275,
           "prover_cost": 208914985,
           "sequencer_cost": 75741480
@@ -14960,13 +14960,13 @@
           "slot_of_change": 55
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110164640387027,
+          "protocol_fee": 110164640387027,
           "congestion_multiplier": 4979230751,
           "prover_cost": 20062105970517,
           "sequencer_cost": 7622802819977
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1155925734,
+          "protocol_fee": 1155925734,
           "congestion_multiplier": 4979230751,
           "prover_cost": 210505880,
           "sequencer_cost": 79983867
@@ -15014,13 +15014,13 @@
           "slot_of_change": 55
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109699664341596,
+          "protocol_fee": 109699664341596,
           "congestion_multiplier": 4941434317,
           "prover_cost": 20169002900136,
           "sequencer_cost": 7663419404186
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1144946257,
+          "protocol_fee": 1144946257,
           "congestion_multiplier": 4941434317,
           "prover_cost": 210505880,
           "sequencer_cost": 79983867
@@ -15068,13 +15068,13 @@
           "slot_of_change": 55
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105265547655218,
+          "protocol_fee": 105265547655218,
           "congestion_multiplier": 4772285814,
           "prover_cost": 20221580059563,
           "sequencer_cost": 7683396634878
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1095810351,
+          "protocol_fee": 1095810351,
           "congestion_multiplier": 4772285814,
           "prover_cost": 210505880,
           "sequencer_cost": 79983867
@@ -15122,13 +15122,13 @@
           "slot_of_change": 60
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110630517517754,
+          "protocol_fee": 110630517517754,
           "congestion_multiplier": 4989520684,
           "prover_cost": 20094983134051,
           "sequencer_cost": 7635294835285
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1158914854,
+          "protocol_fee": 1158914854,
           "congestion_multiplier": 4989520684,
           "prover_cost": 210505880,
           "sequencer_cost": 79983867
@@ -15176,13 +15176,13 @@
           "slot_of_change": 60
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110778183261345,
+          "protocol_fee": 110778183261345,
           "congestion_multiplier": 4999240050,
           "prover_cost": 20072903129159,
           "sequencer_cost": 7626905311085
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1161738230,
+          "protocol_fee": 1161738230,
           "congestion_multiplier": 4999240050,
           "prover_cost": 210505880,
           "sequencer_cost": 79983867
@@ -15230,13 +15230,13 @@
           "slot_of_change": 60
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110796244647894,
+          "protocol_fee": 110796244647894,
           "congestion_multiplier": 5027946596,
           "prover_cost": 20044117204498,
           "sequencer_cost": 7462763041026
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1159719915,
+          "protocol_fee": 1159719915,
           "congestion_multiplier": 5027946596,
           "prover_cost": 209804601,
           "sequencer_cost": 78113793
@@ -15284,13 +15284,13 @@
           "slot_of_change": 60
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109785506496636,
+          "protocol_fee": 109785506496636,
           "congestion_multiplier": 4987609377,
           "prover_cost": 20062174259782,
           "sequencer_cost": 7469485987386
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1148106087,
+          "protocol_fee": 1148106087,
           "congestion_multiplier": 4987609377,
           "prover_cost": 209804601,
           "sequencer_cost": 78113793
@@ -15338,13 +15338,13 @@
           "slot_of_change": 60
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109358684956312,
+          "protocol_fee": 109358684956312,
           "congestion_multiplier": 4950259652,
           "prover_cost": 20173127502716,
           "sequencer_cost": 7510795751852
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1137352414,
+          "protocol_fee": 1137352414,
           "congestion_multiplier": 4950259652,
           "prover_cost": 209804601,
           "sequencer_cost": 78113793
@@ -15392,13 +15392,13 @@
           "slot_of_change": 65
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107855949130628,
+          "protocol_fee": 107855949130628,
           "congestion_multiplier": 4923639033,
           "prover_cost": 20030908885901,
           "sequencer_cost": 7457845361147
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1129687849,
+          "protocol_fee": 1129687849,
           "congestion_multiplier": 4923639033,
           "prover_cost": 209804601,
           "sequencer_cost": 78113793
@@ -15446,13 +15446,13 @@
           "slot_of_change": 65
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 108119484606984,
+          "protocol_fee": 108119484606984,
           "congestion_multiplier": 4952105396,
           "prover_cost": 19935220600518,
           "sequencer_cost": 7422218997944
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1137883838,
+          "protocol_fee": 1137883838,
           "congestion_multiplier": 4952105396,
           "prover_cost": 209804601,
           "sequencer_cost": 78113793
@@ -15500,13 +15500,13 @@
           "slot_of_change": 65
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105172305520660,
+          "protocol_fee": 105172305520660,
           "congestion_multiplier": 4892716509,
           "prover_cost": 19901474416873,
           "sequencer_cost": 7116240676600
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1101664440,
+          "protocol_fee": 1101664440,
           "congestion_multiplier": 4892716509,
           "prover_cost": 208465019,
           "sequencer_cost": 74541575
@@ -15554,13 +15554,13 @@
           "slot_of_change": 65
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 108747830909328,
+          "protocol_fee": 108747830909328,
           "congestion_multiplier": 5022238774,
           "prover_cost": 19915416354591,
           "sequencer_cost": 7121225944637
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1138320095,
+          "protocol_fee": 1138320095,
           "congestion_multiplier": 5022238774,
           "prover_cost": 208465019,
           "sequencer_cost": 74541575
@@ -15608,13 +15608,13 @@
           "slot_of_change": 65
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106865944519867,
+          "protocol_fee": 106865944519867,
           "congestion_multiplier": 4955795841,
           "prover_cost": 19899496787578,
           "sequencer_cost": 7115533528690
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1119516307,
+          "protocol_fee": 1119516307,
           "congestion_multiplier": 4955795841,
           "prover_cost": 208465019,
           "sequencer_cost": 74541575
@@ -15662,13 +15662,13 @@
           "slot_of_change": 70
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106649436103309,
+          "protocol_fee": 106649436103309,
           "congestion_multiplier": 4925278966,
           "prover_cost": 20013574936918,
           "sequencer_cost": 7156324856491
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1110879830,
+          "protocol_fee": 1110879830,
           "congestion_multiplier": 4925278966,
           "prover_cost": 208465019,
           "sequencer_cost": 74541575
@@ -15716,13 +15716,13 @@
           "slot_of_change": 70
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 108494006113292,
+          "protocol_fee": 108494006113292,
           "congestion_multiplier": 4987578597,
           "prover_cost": 20041633891255,
           "sequencer_cost": 7166357996147
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1128511037,
+          "protocol_fee": 1128511037,
           "congestion_multiplier": 4987578597,
           "prover_cost": 208465019,
           "sequencer_cost": 74541575
@@ -15770,13 +15770,13 @@
           "slot_of_change": 70
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110693247558599,
+          "protocol_fee": 110693247558599,
           "congestion_multiplier": 4945529361,
           "prover_cost": 20336157664217,
           "sequencer_cost": 7719202596432
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1145629728,
+          "protocol_fee": 1145629728,
           "congestion_multiplier": 4945529361,
           "prover_cost": 210470894,
           "sequencer_cost": 79890582
@@ -15824,13 +15824,13 @@
           "slot_of_change": 70
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109907165725267,
+          "protocol_fee": 109907165725267,
           "congestion_multiplier": 4929262647,
           "prover_cost": 20275333173164,
           "sequencer_cost": 7696114824542
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1140906501,
+          "protocol_fee": 1140906501,
           "congestion_multiplier": 4929262647,
           "prover_cost": 210470894,
           "sequencer_cost": 79890582
@@ -15878,13 +15878,13 @@
           "slot_of_change": 70
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100286340685931,
+          "protocol_fee": 100286340685931,
           "congestion_multiplier": 4578140149,
           "prover_cost": 20315966523152,
           "sequencer_cost": 7711538439264
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1038954054,
+          "protocol_fee": 1038954054,
           "congestion_multiplier": 4578140149,
           "prover_cost": 210470894,
           "sequencer_cost": 79890582
@@ -15932,13 +15932,13 @@
           "slot_of_change": 75
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109529916167436,
+          "protocol_fee": 109529916167436,
           "congestion_multiplier": 4868864341,
           "prover_cost": 20521178786416,
           "sequencer_cost": 7789432949208
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1123369160,
+          "protocol_fee": 1123369160,
           "congestion_multiplier": 4868864341,
           "prover_cost": 210470894,
           "sequencer_cost": 79890582
@@ -15986,13 +15986,13 @@
           "slot_of_change": 75
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112351725772498,
+          "protocol_fee": 112351725772498,
           "congestion_multiplier": 4960600304,
           "prover_cost": 20562304289158,
           "sequencer_cost": 7805043375366
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1150005750,
+          "protocol_fee": 1150005750,
           "congestion_multiplier": 4960600304,
           "prover_cost": 210470894,
           "sequencer_cost": 79890582
@@ -16040,13 +16040,13 @@
           "slot_of_change": 75
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109393253958720,
+          "protocol_fee": 109393253958720,
           "congestion_multiplier": 4983666767,
           "prover_cost": 20260052625656,
           "sequencer_cost": 7200390339207
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1124538256,
+          "protocol_fee": 1124538256,
           "congestion_multiplier": 4983666767,
           "prover_cost": 208268823,
           "sequencer_cost": 74018407
@@ -16094,13 +16094,13 @@
           "slot_of_change": 75
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 108966696569108,
+          "protocol_fee": 108966696569108,
           "congestion_multiplier": 4976862941,
           "prover_cost": 20215579352834,
           "sequencer_cost": 7184584609089
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1122617623,
+          "protocol_fee": 1122617623,
           "congestion_multiplier": 4976862941,
           "prover_cost": 208268823,
           "sequencer_cost": 74018407
@@ -16148,13 +16148,13 @@
           "slot_of_change": 75
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106760731767737,
+          "protocol_fee": 106760731767737,
           "congestion_multiplier": 4888560968,
           "prover_cost": 20256091961447,
           "sequencer_cost": 7198982725474
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1097691104,
+          "protocol_fee": 1097691104,
           "congestion_multiplier": 4888560968,
           "prover_cost": 208268823,
           "sequencer_cost": 74018407
@@ -16202,13 +16202,13 @@
           "slot_of_change": 80
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109102158508278,
+          "protocol_fee": 109102158508278,
           "congestion_multiplier": 4963113636,
           "prover_cost": 20310931823267,
           "sequencer_cost": 7218472724762
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1118736370,
+          "protocol_fee": 1118736370,
           "congestion_multiplier": 4963113636,
           "prover_cost": 208268823,
           "sequencer_cost": 74018407
@@ -16256,13 +16256,13 @@
           "slot_of_change": 80
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107943936327459,
+          "protocol_fee": 107943936327459,
           "congestion_multiplier": 4932020265,
           "prover_cost": 20254220544589,
           "sequencer_cost": 7198317626912
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1109959108,
+          "protocol_fee": 1109959108,
           "congestion_multiplier": 4932020265,
           "prover_cost": 208268823,
           "sequencer_cost": 74018407
@@ -16310,13 +16310,13 @@
           "slot_of_change": 80
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 113777067283010,
+          "protocol_fee": 113777067283010,
           "congestion_multiplier": 4985527409,
           "prover_cost": 20426454451583,
           "sequencer_cost": 8121101656107
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1181639014,
+          "protocol_fee": 1181639014,
           "congestion_multiplier": 4985527409,
           "prover_cost": 212140250,
           "sequencer_cost": 84342221
@@ -16364,13 +16364,13 @@
           "slot_of_change": 80
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 116403138405721,
+          "protocol_fee": 116403138405721,
           "congestion_multiplier": 5057536639,
           "prover_cost": 20527038395213,
           "sequencer_cost": 8161091583538
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1202988488,
+          "protocol_fee": 1202988488,
           "congestion_multiplier": 5057536639,
           "prover_cost": 212140250,
           "sequencer_cost": 84342221
@@ -16418,13 +16418,13 @@
           "slot_of_change": 80
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 113561398685529,
+          "protocol_fee": 113561398685529,
           "congestion_multiplier": 4987377208,
           "prover_cost": 20378277208604,
           "sequencer_cost": 8101947461302
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1182187447,
+          "protocol_fee": 1182187447,
           "congestion_multiplier": 4987377208,
           "prover_cost": 212140250,
           "sequencer_cost": 84342221
@@ -16472,13 +16472,13 @@
           "slot_of_change": 85
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 115693733111709,
+          "protocol_fee": 115693733111709,
           "congestion_multiplier": 5048029812,
           "prover_cost": 20449852853583,
           "sequencer_cost": 8130404337670
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1200169881,
+          "protocol_fee": 1200169881,
           "congestion_multiplier": 5048029812,
           "prover_cost": 212140250,
           "sequencer_cost": 84342221
@@ -16526,13 +16526,13 @@
           "slot_of_change": 85
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112573247850473,
+          "protocol_fee": 112573247850473,
           "congestion_multiplier": 4919545852,
           "prover_cost": 20550552468607,
           "sequencer_cost": 8170440253462
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1162076639,
+          "protocol_fee": 1162076639,
           "congestion_multiplier": 4919545852,
           "prover_cost": 212140250,
           "sequencer_cost": 84342221
@@ -16580,13 +16580,13 @@
           "slot_of_change": 85
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106388227024957,
+          "protocol_fee": 106388227024957,
           "congestion_multiplier": 4890229573,
           "prover_cost": 20256604354827,
           "sequencer_cost": 7090940322087
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1091310751,
+          "protocol_fee": 1091310751,
           "congestion_multiplier": 4890229573,
           "prover_cost": 207788500,
           "sequencer_cost": 72737554
@@ -16634,13 +16634,13 @@
           "slot_of_change": 85
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106597419808303,
+          "protocol_fee": 106597419808303,
           "congestion_multiplier": 4936857723,
           "prover_cost": 20056044206046,
           "sequencer_cost": 7020733093813
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1104391162,
+          "protocol_fee": 1104391162,
           "congestion_multiplier": 4936857723,
           "prover_cost": 207788500,
           "sequencer_cost": 72737554
@@ -16688,13 +16688,13 @@
           "slot_of_change": 85
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105687062838554,
+          "protocol_fee": 105687062838554,
           "congestion_multiplier": 4918068519,
           "prover_cost": 19980120698916,
           "sequencer_cost": 6994155635485
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1099120300,
+          "protocol_fee": 1099120300,
           "congestion_multiplier": 4918068519,
           "prover_cost": 207788500,
           "sequencer_cost": 72737554
@@ -16742,13 +16742,13 @@
           "slot_of_change": 90
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107408155630093,
+          "protocol_fee": 107408155630093,
           "congestion_multiplier": 5018904606,
           "prover_cost": 19796019217492,
           "sequencer_cost": 6929709857944
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1127407450,
+          "protocol_fee": 1127407450,
           "congestion_multiplier": 5018904606,
           "prover_cost": 207788500,
           "sequencer_cost": 72737554
@@ -16796,13 +16796,13 @@
           "slot_of_change": 90
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105774674004023,
+          "protocol_fee": 105774674004023,
           "congestion_multiplier": 4975989920,
           "prover_cost": 19705375996159,
           "sequencer_cost": 6897979679390
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1115368763,
+          "protocol_fee": 1115368763,
           "congestion_multiplier": 4975989920,
           "prover_cost": 207788500,
           "sequencer_cost": 72737554
@@ -16850,13 +16850,13 @@
           "slot_of_change": 90
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101292726852671,
+          "protocol_fee": 101292726852671,
           "congestion_multiplier": 4972594849,
           "prover_cost": 19420088285569,
           "sequencer_cost": 6077786713257
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1066719075,
+          "protocol_fee": 1066719075,
           "congestion_multiplier": 4972594849,
           "prover_cost": 204513979,
           "sequencer_cost": 64005494
@@ -16904,13 +16904,13 @@
           "slot_of_change": 90
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99619290760287,
+          "protocol_fee": 99619290760287,
           "congestion_multiplier": 4917122269,
           "prover_cost": 19369728348895,
           "sequencer_cost": 6062025870696
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1051823607,
+          "protocol_fee": 1051823607,
           "congestion_multiplier": 4917122269,
           "prover_cost": 204513979,
           "sequencer_cost": 64005494
@@ -16958,13 +16958,13 @@
           "slot_of_change": 90
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101444477897997,
+          "protocol_fee": 101444477897997,
           "congestion_multiplier": 4987693464,
           "prover_cost": 19375541874127,
           "sequencer_cost": 6063845294268
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1070773347,
+          "protocol_fee": 1070773347,
           "congestion_multiplier": 4987693464,
           "prover_cost": 204513979,
           "sequencer_cost": 64005494
@@ -17012,13 +17012,13 @@
           "slot_of_change": 95
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100405125739807,
+          "protocol_fee": 100405125739807,
           "congestion_multiplier": 4956704476,
           "prover_cost": 19327224111394,
           "sequencer_cost": 6048723578443
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1062452200,
+          "protocol_fee": 1062452200,
           "congestion_multiplier": 4956704476,
           "prover_cost": 204513979,
           "sequencer_cost": 64005494
@@ -17066,13 +17066,13 @@
           "slot_of_change": 95
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99404601211757,
+          "protocol_fee": 99404601211757,
           "congestion_multiplier": 4912575672,
           "prover_cost": 19350444674994,
           "sequencer_cost": 6055990776761
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1050602757,
+          "protocol_fee": 1050602757,
           "congestion_multiplier": 4912575672,
           "prover_cost": 204513979,
           "sequencer_cost": 64005494
@@ -17120,13 +17120,13 @@
           "slot_of_change": 95
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98081182463811,
+          "protocol_fee": 98081182463811,
           "congestion_multiplier": 4980830753,
           "prover_cost": 19111232056423,
           "sequencer_cost": 5527138315626
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1039103433,
+          "protocol_fee": 1039103433,
           "congestion_multiplier": 4980830753,
           "prover_cost": 202470508,
           "sequencer_cost": 58556272
@@ -17174,13 +17174,13 @@
           "slot_of_change": 95
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97556063827448,
+          "protocol_fee": 97556063827448,
           "congestion_multiplier": 4959913503,
           "prover_cost": 19109321903445,
           "sequencer_cost": 5526585882393
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1033643470,
+          "protocol_fee": 1033643470,
           "congestion_multiplier": 4959913503,
           "prover_cost": 202470508,
           "sequencer_cost": 58556272
@@ -17228,13 +17228,13 @@
           "slot_of_change": 95
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98616443088859,
+          "protocol_fee": 98616443088859,
           "congestion_multiplier": 5000153367,
           "prover_cost": 19122708222792,
           "sequencer_cost": 5530457325027
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1044147152,
+          "protocol_fee": 1044147152,
           "congestion_multiplier": 5000153367,
           "prover_cost": 202470508,
           "sequencer_cost": 58556272
@@ -17282,13 +17282,13 @@
           "slot_of_change": 100
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99047245341349,
+          "protocol_fee": 99047245341349,
           "congestion_multiplier": 5037715720,
           "prover_cost": 19027571819342,
           "sequencer_cost": 5502943030859
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1053951932,
+          "protocol_fee": 1053951932,
           "congestion_multiplier": 5037715720,
           "prover_cost": 202470508,
           "sequencer_cost": 58556272
@@ -17336,13 +17336,13 @@
           "slot_of_change": 100
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97349418949539,
+          "protocol_fee": 97349418949539,
           "congestion_multiplier": 5001044467,
           "prover_cost": 18872815421402,
           "sequencer_cost": 5458186103931
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1044379753,
+          "protocol_fee": 1044379753,
           "congestion_multiplier": 5001044467,
           "prover_cost": 202470508,
           "sequencer_cost": 58556272
@@ -17390,13 +17390,13 @@
           "slot_of_change": 100
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99331336083013,
+          "protocol_fee": 99331336083013,
           "congestion_multiplier": 4995846347,
           "prover_cost": 19000832053168,
           "sequencer_cost": 5857815537406
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1067027344,
+          "protocol_fee": 1067027344,
           "congestion_multiplier": 4995846347,
           "prover_cost": 204108876,
           "sequencer_cost": 62925252
@@ -17444,13 +17444,13 @@
           "slot_of_change": 100
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101818747421236,
+          "protocol_fee": 101818747421236,
           "congestion_multiplier": 5093860245,
           "prover_cost": 19010338902068,
           "sequencer_cost": 5860746428382
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1093200400,
+          "protocol_fee": 1093200400,
           "congestion_multiplier": 5093860245,
           "prover_cost": 204108876,
           "sequencer_cost": 62925252
@@ -17498,13 +17498,13 @@
           "slot_of_change": 100
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100122430646174,
+          "protocol_fee": 100122430646174,
           "congestion_multiplier": 5039342770,
           "prover_cost": 18945924315763,
           "sequencer_cost": 5840887889375
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1078642374,
+          "protocol_fee": 1078642374,
           "congestion_multiplier": 5039342770,
           "prover_cost": 204108876,
           "sequencer_cost": 62925252
@@ -17552,13 +17552,13 @@
           "slot_of_change": 105
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96889782205908,
+          "protocol_fee": 96889782205908,
           "congestion_multiplier": 4899933960,
           "prover_cost": 18989601389223,
           "sequencer_cost": 5854353207043
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1041415464,
+          "protocol_fee": 1041415464,
           "congestion_multiplier": 4899933960,
           "prover_cost": 204108876,
           "sequencer_cost": 62925252
@@ -17606,13 +17606,13 @@
           "slot_of_change": 105
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91880305306439,
+          "protocol_fee": 91880305306439,
           "congestion_multiplier": 4706802227,
           "prover_cost": 18946026315731,
           "sequencer_cost": 5840919335209
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 989842700,
+          "protocol_fee": 989842700,
           "congestion_multiplier": 4706802227,
           "prover_cost": 204108876,
           "sequencer_cost": 62925252
@@ -17660,13 +17660,13 @@
           "slot_of_change": 105
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92197483344037,
+          "protocol_fee": 92197483344037,
           "congestion_multiplier": 4925017743,
           "prover_cost": 18578842647204,
           "sequencer_cost": 4910855847729
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 994352255,
+          "protocol_fee": 994352255,
           "congestion_multiplier": 4925017743,
           "prover_cost": 200373301,
           "sequencer_cost": 52963708
@@ -17714,13 +17714,13 @@
           "slot_of_change": 105
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92280096548742,
+          "protocol_fee": 92280096548742,
           "congestion_multiplier": 4926570298,
           "prover_cost": 18588137555333,
           "sequencer_cost": 4913312725953
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 994745574,
+          "protocol_fee": 994745574,
           "congestion_multiplier": 4926570298,
           "prover_cost": 200373301,
           "sequencer_cost": 52963708
@@ -17768,13 +17768,13 @@
           "slot_of_change": 105
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91564053790830,
+          "protocol_fee": 91564053790830,
           "congestion_multiplier": 4930387694,
           "prover_cost": 18425990158806,
           "sequencer_cost": 4870453086871
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 995712662,
+          "protocol_fee": 995712662,
           "congestion_multiplier": 4930387694,
           "prover_cost": 200373301,
           "sequencer_cost": 52963708
@@ -17822,13 +17822,13 @@
           "slot_of_change": 110
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91490184501098,
+          "protocol_fee": 91490184501098,
           "congestion_multiplier": 4923682015,
           "prover_cost": 18442590111743,
           "sequencer_cost": 4874840872348
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 994013865,
+          "protocol_fee": 994013865,
           "congestion_multiplier": 4923682015,
           "prover_cost": 200373301,
           "sequencer_cost": 52963708
@@ -17876,13 +17876,13 @@
           "slot_of_change": 110
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89583482098358,
+          "protocol_fee": 89583482098358,
           "congestion_multiplier": 4838452475,
           "prover_cost": 18459204696559,
           "sequencer_cost": 4879232525400
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 972422069,
+          "protocol_fee": 972422069,
           "congestion_multiplier": 4838452475,
           "prover_cost": 200373301,
           "sequencer_cost": 52963708
@@ -17930,13 +17930,13 @@
           "slot_of_change": 110
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89897597391954,
+          "protocol_fee": 89897597391954,
           "congestion_multiplier": 4841333296,
           "prover_cost": 18451388668638,
           "sequencer_cost": 4951318295441
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 977880983,
+          "protocol_fee": 977880983,
           "congestion_multiplier": 4841333296,
           "prover_cost": 200709058,
           "sequencer_cost": 53859059
@@ -17984,13 +17984,13 @@
           "slot_of_change": 110
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93416832522638,
+          "protocol_fee": 93416832522638,
           "congestion_multiplier": 4980533633,
           "prover_cost": 18503198272228,
           "sequencer_cost": 4965221088491
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013316951,
+          "protocol_fee": 1013316951,
           "congestion_multiplier": 4980533633,
           "prover_cost": 200709058,
           "sequencer_cost": 53859059
@@ -18038,13 +18038,13 @@
           "slot_of_change": 110
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91738188120314,
+          "protocol_fee": 91738188120314,
           "congestion_multiplier": 4919559927,
           "prover_cost": 18453375197099,
           "sequencer_cost": 4951851368311
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 997794990,
+          "protocol_fee": 997794990,
           "congestion_multiplier": 4919559927,
           "prover_cost": 200709058,
           "sequencer_cost": 53859059
@@ -18092,13 +18092,13 @@
           "slot_of_change": 115
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91255602388312,
+          "protocol_fee": 91255602388312,
           "congestion_multiplier": 4896211803,
           "prover_cost": 18466302313309,
           "sequencer_cost": 4955320281581
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 991851302,
+          "protocol_fee": 991851302,
           "congestion_multiplier": 4896211803,
           "prover_cost": 200709058,
           "sequencer_cost": 53859059
@@ -18146,13 +18146,13 @@
           "slot_of_change": 115
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90729806410156,
+          "protocol_fee": 90729806410156,
           "congestion_multiplier": 4878023477,
           "prover_cost": 18446013106832,
           "sequencer_cost": 4949875796018
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 987221134,
+          "protocol_fee": 987221134,
           "congestion_multiplier": 4878023477,
           "prover_cost": 200709058,
           "sequencer_cost": 53859059
@@ -18200,13 +18200,13 @@
           "slot_of_change": 115
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98756255156898,
+          "protocol_fee": 98756255156898,
           "congestion_multiplier": 5027710752,
           "prover_cost": 18718683019904,
           "sequencer_cost": 5800519403774
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1077564756,
+          "protocol_fee": 1077564756,
           "congestion_multiplier": 5027710752,
           "prover_cost": 204246233,
           "sequencer_cost": 63291538
@@ -18254,13 +18254,13 @@
           "slot_of_change": 115
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97075123301999,
+          "protocol_fee": 97075123301999,
           "congestion_multiplier": 4948061177,
           "prover_cost": 18771242844625,
           "sequencer_cost": 5816806569000
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1056255487,
+          "protocol_fee": 1056255487,
           "congestion_multiplier": 4948061177,
           "prover_cost": 204246233,
           "sequencer_cost": 63291538
@@ -18308,13 +18308,13 @@
           "slot_of_change": 115
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96901023468708,
+          "protocol_fee": 96901023468708,
           "congestion_multiplier": 4936251321,
           "prover_cost": 18793795457900,
           "sequencer_cost": 5823795141367
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1053095904,
+          "protocol_fee": 1053095904,
           "congestion_multiplier": 4936251321,
           "prover_cost": 204246233,
           "sequencer_cost": 63291538
@@ -18362,13 +18362,13 @@
           "slot_of_change": 120
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95237329357143,
+          "protocol_fee": 95237329357143,
           "congestion_multiplier": 4876406969,
           "prover_cost": 18756283746437,
           "sequencer_cost": 5812171064504
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1037085279,
+          "protocol_fee": 1037085279,
           "congestion_multiplier": 4876406969,
           "prover_cost": 204246233,
           "sequencer_cost": 63291538
@@ -18416,13 +18416,13 @@
           "slot_of_change": 120
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96531117467576,
+          "protocol_fee": 96531117467576,
           "congestion_multiplier": 4948319770,
           "prover_cost": 18664826894588,
           "sequencer_cost": 5783830542727
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1056324670,
+          "protocol_fee": 1056324670,
           "congestion_multiplier": 4948319770,
           "prover_cost": 204246233,
           "sequencer_cost": 63291538
@@ -18470,13 +18470,13 @@
           "slot_of_change": 120
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96469358939101,
+          "protocol_fee": 96469358939101,
           "congestion_multiplier": 4948569861,
           "prover_cost": 18570831404369,
           "sequencer_cost": 5860636801455
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1063566193,
+          "protocol_fee": 1063566193,
           "congestion_multiplier": 4948569861,
           "prover_cost": 204741782,
           "sequencer_cost": 64613005
@@ -18524,13 +18524,13 @@
           "slot_of_change": 120
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98037722355072,
+          "protocol_fee": 98037722355072,
           "congestion_multiplier": 4978254210,
           "prover_cost": 18731927264690,
           "sequencer_cost": 5911475899986
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1071561815,
+          "protocol_fee": 1071561815,
           "congestion_multiplier": 4978254210,
           "prover_cost": 204741782,
           "sequencer_cost": 64613005
@@ -18578,13 +18578,13 @@
           "slot_of_change": 120
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95851553377548,
+          "protocol_fee": 95851553377548,
           "congestion_multiplier": 4892653677,
           "prover_cost": 18716953834506,
           "sequencer_cost": 5906750541488
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1048504902,
+          "protocol_fee": 1048504902,
           "congestion_multiplier": 4892653677,
           "prover_cost": 204741782,
           "sequencer_cost": 64613005
@@ -18632,13 +18632,13 @@
           "slot_of_change": 125
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97621190862815,
+          "protocol_fee": 97621190862815,
           "congestion_multiplier": 4949852080,
           "prover_cost": 18786464247351,
           "sequencer_cost": 5928686839047
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1063911565,
+          "protocol_fee": 1063911565,
           "congestion_multiplier": 4949852080,
           "prover_cost": 204741782,
           "sequencer_cost": 64613005
@@ -18686,13 +18686,13 @@
           "slot_of_change": 125
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96757166748113,
+          "protocol_fee": 96757166748113,
           "congestion_multiplier": 4948169337,
           "prover_cost": 18628125385827,
           "sequencer_cost": 5878717802188
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1063458310,
+          "protocol_fee": 1063458310,
           "congestion_multiplier": 4948169337,
           "prover_cost": 204741782,
           "sequencer_cost": 64613005
@@ -18740,13 +18740,13 @@
           "slot_of_change": 125
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94712022195763,
+          "protocol_fee": 94712022195763,
           "congestion_multiplier": 4930446757,
           "prover_cost": 18497273764810,
           "sequencer_cost": 5599738131721
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1042645631,
+          "protocol_fee": 1042645631,
           "congestion_multiplier": 4930446757,
           "prover_cost": 203628866,
           "sequencer_cost": 61645210
@@ -18794,13 +18794,13 @@
           "slot_of_change": 125
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95717188564080,
+          "protocol_fee": 95717188564080,
           "congestion_multiplier": 4932438433,
           "prover_cost": 18684115119675,
           "sequencer_cost": 5656301205432
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1043173971,
+          "protocol_fee": 1043173971,
           "congestion_multiplier": 4932438433,
           "prover_cost": 203628866,
           "sequencer_cost": 61645210
@@ -18848,13 +18848,13 @@
           "slot_of_change": 125
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95771815069211,
+          "protocol_fee": 95771815069211,
           "congestion_multiplier": 4914222070,
           "prover_cost": 18781781745498,
           "sequencer_cost": 5685868131660
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1038341642,
+          "protocol_fee": 1038341642,
           "congestion_multiplier": 4914222070,
           "prover_cost": 203628866,
           "sequencer_cost": 61645210
@@ -18902,13 +18902,13 @@
           "slot_of_change": 130
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96377328347938,
+          "protocol_fee": 96377328347938,
           "congestion_multiplier": 4938181549,
           "prover_cost": 18785539952361,
           "sequencer_cost": 5687005865498
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1044697471,
+          "protocol_fee": 1044697471,
           "congestion_multiplier": 4938181549,
           "prover_cost": 203628866,
           "sequencer_cost": 61645210
@@ -18956,13 +18956,13 @@
           "slot_of_change": 130
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96463801684782,
+          "protocol_fee": 96463801684782,
           "congestion_multiplier": 4946839060,
           "prover_cost": 18761151421293,
           "sequencer_cost": 5679622648429
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1046994084,
+          "protocol_fee": 1046994084,
           "congestion_multiplier": 4946839060,
           "prover_cost": 203628866,
           "sequencer_cost": 61645210
@@ -19010,13 +19010,13 @@
           "slot_of_change": 130
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104987616828960,
+          "protocol_fee": 104987616828960,
           "congestion_multiplier": 4879769969,
           "prover_cost": 19488880224900,
           "sequencer_cost": 7571388211804
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1138255899,
+          "protocol_fee": 1138255899,
           "congestion_multiplier": 4879769969,
           "prover_cost": 211294756,
           "sequencer_cost": 82087560
@@ -19064,13 +19064,13 @@
           "slot_of_change": 130
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105033773211812,
+          "protocol_fee": 105033773211812,
           "congestion_multiplier": 4877206034,
           "prover_cost": 19510341614893,
           "sequencer_cost": 7579725915834
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1137503685,
+          "protocol_fee": 1137503685,
           "congestion_multiplier": 4877206034,
           "prover_cost": 211294756,
           "sequencer_cost": 82087560
@@ -19118,13 +19118,13 @@
           "slot_of_change": 130
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110152653733333,
+          "protocol_fee": 110152653733333,
           "congestion_multiplier": 5075922388,
           "prover_cost": 19463630203588,
           "sequencer_cost": 7561578632623
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1195803550,
+          "protocol_fee": 1195803550,
           "congestion_multiplier": 5075922388,
           "prover_cost": 211294756,
           "sequencer_cost": 82087560
@@ -19172,13 +19172,13 @@
           "slot_of_change": 135
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106287728303911,
+          "protocol_fee": 106287728303911,
           "congestion_multiplier": 4939989559,
           "prover_cost": 19428659648514,
           "sequencer_cost": 7547992646902
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1155923261,
+          "protocol_fee": 1155923261,
           "congestion_multiplier": 4939989559,
           "prover_cost": 211294756,
           "sequencer_cost": 82087560
@@ -19226,13 +19226,13 @@
           "slot_of_change": 135
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105823118225263,
+          "protocol_fee": 105823118225263,
           "congestion_multiplier": 4920805397,
           "prover_cost": 19438379360106,
           "sequencer_cost": 7551768734031
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1150294967,
+          "protocol_fee": 1150294967,
           "congestion_multiplier": 4920805397,
           "prover_cost": 211294756,
           "sequencer_cost": 82087560
@@ -19280,13 +19280,13 @@
           "slot_of_change": 135
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101416302977149,
+          "protocol_fee": 101416302977149,
           "congestion_multiplier": 4992769828,
           "prover_cost": 18992634121223,
           "sequencer_cost": 6407353214323
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1103495276,
+          "protocol_fee": 1103495276,
           "congestion_multiplier": 4992769828,
           "prover_cost": 206655946,
           "sequencer_cost": 69717430
@@ -19334,13 +19334,13 @@
           "slot_of_change": 135
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101422118089354,
+          "protocol_fee": 101422118089354,
           "congestion_multiplier": 4999387434,
           "prover_cost": 18962295068129,
           "sequencer_cost": 6397118034299
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1105324207,
+          "protocol_fee": 1105324207,
           "congestion_multiplier": 4999387434,
           "prover_cost": 206655946,
           "sequencer_cost": 69717430
@@ -19388,13 +19388,13 @@
           "slot_of_change": 135
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102049959468407,
+          "protocol_fee": 102049959468407,
           "congestion_multiplier": 5001609665,
           "prover_cost": 19069083275470,
           "sequencer_cost": 6433144093622
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1105938372,
+          "protocol_fee": 1105938372,
           "congestion_multiplier": 5001609665,
           "prover_cost": 206655946,
           "sequencer_cost": 69717430
@@ -19442,13 +19442,13 @@
           "slot_of_change": 140
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102244929146199,
+          "protocol_fee": 102244929146199,
           "congestion_multiplier": 4986001154,
           "prover_cost": 19180329353859,
           "sequencer_cost": 6470674059892
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1101624595,
+          "protocol_fee": 1101624595,
           "congestion_multiplier": 4986001154,
           "prover_cost": 206655946,
           "sequencer_cost": 69717430
@@ -19496,13 +19496,13 @@
           "slot_of_change": 140
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102995415615382,
+          "protocol_fee": 102995415615382,
           "congestion_multiplier": 5007629489,
           "prover_cost": 19216842601338,
           "sequencer_cost": 6482992165538
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1107602091,
+          "protocol_fee": 1107602091,
           "congestion_multiplier": 5007629489,
           "prover_cost": 206655946,
           "sequencer_cost": 69717430
@@ -19550,13 +19550,13 @@
           "slot_of_change": 140
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101079330330887,
+          "protocol_fee": 101079330330887,
           "congestion_multiplier": 5012296477,
           "prover_cost": 19016504142342,
           "sequencer_cost": 6175884036818
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1092540302,
+          "protocol_fee": 1092540302,
           "congestion_multiplier": 5012296477,
           "prover_cost": 205544468,
           "sequencer_cost": 66753531
@@ -19604,13 +19604,13 @@
           "slot_of_change": 140
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 103224365696090,
+          "protocol_fee": 103224365696090,
           "congestion_multiplier": 5076135739,
           "prover_cost": 19115907830108,
           "sequencer_cost": 6208166818337
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1109923605,
+          "protocol_fee": 1109923605,
           "congestion_multiplier": 5076135739,
           "prover_cost": 205544468,
           "sequencer_cost": 66753531
@@ -19658,13 +19658,13 @@
           "slot_of_change": 140
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99453725842325,
+          "protocol_fee": 99453725842325,
           "congestion_multiplier": 4927240276,
           "prover_cost": 19115907830108,
           "sequencer_cost": 6208166818337
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1069379668,
+          "protocol_fee": 1069379668,
           "congestion_multiplier": 4927240276,
           "prover_cost": 205544468,
           "sequencer_cost": 66753531
@@ -19712,13 +19712,13 @@
           "slot_of_change": 145
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98465704473351,
+          "protocol_fee": 98465704473351,
           "congestion_multiplier": 4862562789,
           "prover_cost": 19242911527596,
           "sequencer_cost": 6249413101148
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1051768118,
+          "protocol_fee": 1051768118,
           "congestion_multiplier": 4862562789,
           "prover_cost": 205544468,
           "sequencer_cost": 66753531
@@ -19766,13 +19766,13 @@
           "slot_of_change": 145
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 101639708477190,
+          "protocol_fee": 101639708477190,
           "congestion_multiplier": 4961154747,
           "prover_cost": 19368810259423,
           "sequencer_cost": 6290300530421
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1078614511,
+          "protocol_fee": 1078614511,
           "congestion_multiplier": 4961154747,
           "prover_cost": 205544468,
           "sequencer_cost": 66753531
@@ -19820,13 +19820,13 @@
           "slot_of_change": 145
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97155354948773,
+          "protocol_fee": 97155354948773,
           "congestion_multiplier": 4901814536,
           "prover_cost": 19161791918066,
           "sequencer_cost": 5738252436809
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1031025937,
+          "protocol_fee": 1031025937,
           "congestion_multiplier": 4901814536,
           "prover_cost": 203347561,
           "sequencer_cost": 60895121
@@ -19874,13 +19874,13 @@
           "slot_of_change": 145
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95246490352619,
+          "protocol_fee": 95246490352619,
           "congestion_multiplier": 4811765218,
           "prover_cost": 19229094692631,
           "sequencer_cost": 5758407144250
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1007231064,
+          "protocol_fee": 1007231064,
           "congestion_multiplier": 4811765218,
           "prover_cost": 203347561,
           "sequencer_cost": 60895121
@@ -19928,13 +19928,13 @@
           "slot_of_change": 145
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98439193601961,
+          "protocol_fee": 98439193601961,
           "congestion_multiplier": 4948991749,
           "prover_cost": 19183057143367,
           "sequencer_cost": 5744620590238
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1043492170,
+          "protocol_fee": 1043492170,
           "congestion_multiplier": 4948991749,
           "prover_cost": 203347561,
           "sequencer_cost": 60895121
@@ -19982,13 +19982,13 @@
           "slot_of_change": 150
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96033363755052,
+          "protocol_fee": 96033363755052,
           "congestion_multiplier": 4845930006,
           "prover_cost": 19215724538364,
           "sequencer_cost": 5754403274433
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1016258859,
+          "protocol_fee": 1016258859,
           "congestion_multiplier": 4845930006,
           "prover_cost": 203347561,
           "sequencer_cost": 60895121
@@ -20036,13 +20036,13 @@
           "slot_of_change": 150
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96588696709809,
+          "protocol_fee": 96588696709809,
           "congestion_multiplier": 4880161119,
           "prover_cost": 19156340410227,
           "sequencer_cost": 5736619910568
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1025304180,
+          "protocol_fee": 1025304180,
           "congestion_multiplier": 4880161119,
           "prover_cost": 203347561,
           "sequencer_cost": 60895121
@@ -20090,13 +20090,13 @@
           "slot_of_change": 150
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94854320481570,
+          "protocol_fee": 94854320481570,
           "congestion_multiplier": 4913235385,
           "prover_cost": 18903102919698,
           "sequencer_cost": 5336256891328
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013035511,
+          "protocol_fee": 1013035511,
           "congestion_multiplier": 4913235385,
           "prover_cost": 201883419,
           "sequencer_cost": 56990738
@@ -20144,13 +20144,13 @@
           "slot_of_change": 150
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95451908817724,
+          "protocol_fee": 95451908817724,
           "congestion_multiplier": 4929225590,
           "prover_cost": 18944781794775,
           "sequencer_cost": 5348022641390
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1017174962,
+          "protocol_fee": 1017174962,
           "congestion_multiplier": 4929225590,
           "prover_cost": 201883419,
           "sequencer_cost": 56990738
@@ -20198,13 +20198,13 @@
           "slot_of_change": 150
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95280306974734,
+          "protocol_fee": 95280306974734,
           "congestion_multiplier": 4908433923,
           "prover_cost": 19011322412461,
           "sequencer_cost": 5366806744254
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1011792537,
+          "protocol_fee": 1011792537,
           "congestion_multiplier": 4908433923,
           "prover_cost": 201883419,
           "sequencer_cost": 56990738
@@ -20252,13 +20252,13 @@
           "slot_of_change": 155
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94413171907759,
+          "protocol_fee": 94413171907759,
           "congestion_multiplier": 4891065871,
           "prover_cost": 18922388683351,
           "sequencer_cost": 5341701171542
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1007296397,
+          "protocol_fee": 1007296397,
           "congestion_multiplier": 4891065871,
           "prover_cost": 201883419,
           "sequencer_cost": 56990738
@@ -20306,13 +20306,13 @@
           "slot_of_change": 155
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95341079355925,
+          "protocol_fee": 95341079355925,
           "congestion_multiplier": 4913197713,
           "prover_cost": 19000289874687,
           "sequencer_cost": 5363692310820
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013025759,
+          "protocol_fee": 1013025759,
           "congestion_multiplier": 4913197713,
           "prover_cost": 201883419,
           "sequencer_cost": 56990738
@@ -20360,13 +20360,13 @@
           "slot_of_change": 155
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95503274553431,
+          "protocol_fee": 95503274553431,
           "congestion_multiplier": 4997387122,
           "prover_cost": 18928508876931,
           "sequencer_cost": 4962916129150
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1010081215,
+          "protocol_fee": 1010081215,
           "congestion_multiplier": 4997387122,
           "prover_cost": 200195557,
           "sequencer_cost": 52489806
@@ -20414,13 +20414,13 @@
           "slot_of_change": 155
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95604433437412,
+          "protocol_fee": 95604433437412,
           "congestion_multiplier": 4998819898,
           "prover_cost": 18941769041537,
           "sequencer_cost": 4966392847006
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1010443257,
+          "protocol_fee": 1010443257,
           "congestion_multiplier": 4998819898,
           "prover_cost": 200195557,
           "sequencer_cost": 52489806
@@ -20468,13 +20468,13 @@
           "slot_of_change": 155
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91838771448520,
+          "protocol_fee": 91838771448520,
           "congestion_multiplier": 4831326971,
           "prover_cost": 18991147102126,
           "sequencer_cost": 4979339412154
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 968120246,
+          "protocol_fee": 968120246,
           "congestion_multiplier": 4831326971,
           "prover_cost": 200195557,
           "sequencer_cost": 52489806
@@ -20522,13 +20522,13 @@
           "slot_of_change": 160
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93959933920668,
+          "protocol_fee": 93959933920668,
           "congestion_multiplier": 4915897563,
           "prover_cost": 19010158125865,
           "sequencer_cost": 4984323963074
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 989489997,
+          "protocol_fee": 989489997,
           "congestion_multiplier": 4915897563,
           "prover_cost": 200195557,
           "sequencer_cost": 52489806
@@ -20576,13 +20576,13 @@
           "slot_of_change": 160
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93559129327744,
+          "protocol_fee": 93559129327744,
           "congestion_multiplier": 4938185177,
           "prover_cost": 18821940118766,
           "sequencer_cost": 4934974582766
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 995121751,
+          "protocol_fee": 995121751,
           "congestion_multiplier": 4938185177,
           "prover_cost": 200195557,
           "sequencer_cost": 52489806
@@ -20630,13 +20630,13 @@
           "slot_of_change": 160
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92659399017826,
+          "protocol_fee": 92659399017826,
           "congestion_multiplier": 4933971098,
           "prover_cost": 18768974866748,
           "sequencer_cost": 4784680387044
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 985354782,
+          "protocol_fee": 985354782,
           "congestion_multiplier": 4933971098,
           "prover_cost": 199592263,
           "sequencer_cost": 50881052
@@ -20684,13 +20684,13 @@
           "slot_of_change": 160
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93374418994582,
+          "protocol_fee": 93374418994582,
           "congestion_multiplier": 4957588468,
           "prover_cost": 18800938105214,
           "sequencer_cost": 4792828614706
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 991270302,
+          "protocol_fee": 991270302,
           "congestion_multiplier": 4957588468,
           "prover_cost": 199592263,
           "sequencer_cost": 50881052
@@ -20738,13 +20738,13 @@
           "slot_of_change": 160
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93569763055805,
+          "protocol_fee": 93569763055805,
           "congestion_multiplier": 4971419967,
           "prover_cost": 18774654494400,
           "sequencer_cost": 4786128265962
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 994734724,
+          "protocol_fee": 994734724,
           "congestion_multiplier": 4971419967,
           "prover_cost": 199592263,
           "sequencer_cost": 50881052
@@ -20792,13 +20792,13 @@
           "slot_of_change": 165
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91320467376138,
+          "protocol_fee": 91320467376138,
           "congestion_multiplier": 4879440232,
           "prover_cost": 18757773993707,
           "sequencer_cost": 4781825004801
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 971696255,
+          "protocol_fee": 971696255,
           "congestion_multiplier": 4879440232,
           "prover_cost": 199592263,
           "sequencer_cost": 50881052
@@ -20846,13 +20846,13 @@
           "slot_of_change": 165
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91554264913527,
+          "protocol_fee": 91554264913527,
           "congestion_multiplier": 4858257010,
           "prover_cost": 18909048027055,
           "sequencer_cost": 4820388533473
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 966390423,
+          "protocol_fee": 966390423,
           "congestion_multiplier": 4858257010,
           "prover_cost": 199592263,
           "sequencer_cost": 50881052
@@ -20900,13 +20900,13 @@
           "slot_of_change": 165
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95663047949164,
+          "protocol_fee": 95663047949164,
           "congestion_multiplier": 4984125865,
           "prover_cost": 18944945315563,
           "sequencer_cost": 5066105356114
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013092341,
+          "protocol_fee": 1013092341,
           "congestion_multiplier": 4984125865,
           "prover_cost": 200631063,
           "sequencer_cost": 53651150
@@ -20954,13 +20954,13 @@
           "slot_of_change": 165
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95159938625410,
+          "protocol_fee": 95159938625410,
           "congestion_multiplier": 4984573693,
           "prover_cost": 18843192372826,
           "sequencer_cost": 5038895400128
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013206216,
+          "protocol_fee": 1013206216,
           "congestion_multiplier": 4984573693,
           "prover_cost": 200631063,
           "sequencer_cost": 53651150
@@ -21008,13 +21008,13 @@
           "slot_of_change": 165
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94201381223924,
+          "protocol_fee": 94201381223924,
           "congestion_multiplier": 4946408566,
           "prover_cost": 18833776725319,
           "sequencer_cost": 5036377543176
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1003501503,
+          "protocol_fee": 1003501503,
           "congestion_multiplier": 4946408566,
           "prover_cost": 200631063,
           "sequencer_cost": 53651150
@@ -21062,13 +21062,13 @@
           "slot_of_change": 170
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92926657438812,
+          "protocol_fee": 92926657438812,
           "congestion_multiplier": 4889502248,
           "prover_cost": 18850743361592,
           "sequencer_cost": 5040914624992
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 989031239,
+          "protocol_fee": 989031239,
           "congestion_multiplier": 4889502248,
           "prover_cost": 200631063,
           "sequencer_cost": 53651150
@@ -21116,13 +21116,13 @@
           "slot_of_change": 170
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92409153599506,
+          "protocol_fee": 92409153599506,
           "congestion_multiplier": 4878671480,
           "prover_cost": 18798110042427,
           "sequencer_cost": 5026839844849
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 986277167,
+          "protocol_fee": 986277167,
           "congestion_multiplier": 4878671480,
           "prover_cost": 200631063,
           "sequencer_cost": 53651150
@@ -21170,13 +21170,13 @@
           "slot_of_change": 170
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92963155816234,
+          "protocol_fee": 92963155816234,
           "congestion_multiplier": 4856467458,
           "prover_cost": 18915424710021,
           "sequencer_cost": 5190355223776
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 988915743,
+          "protocol_fee": 988915743,
           "congestion_multiplier": 4856467458,
           "prover_cost": 201216935,
           "sequencer_cost": 55213530
@@ -21224,13 +21224,13 @@
           "slot_of_change": 170
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95569931469952,
+          "protocol_fee": 95569931469952,
           "congestion_multiplier": 4961434496,
           "prover_cost": 18930570637168,
           "sequencer_cost": 5194511236305
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1015832489,
+          "protocol_fee": 1015832489,
           "congestion_multiplier": 4961434496,
           "prover_cost": 201216935,
           "sequencer_cost": 55213530
@@ -21278,13 +21278,13 @@
           "slot_of_change": 170
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94825279166379,
+          "protocol_fee": 94825279166379,
           "congestion_multiplier": 4950613729,
           "prover_cost": 18834516288520,
           "sequencer_cost": 5168154112534
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1013057715,
+          "protocol_fee": 1013057715,
           "congestion_multiplier": 4950613729,
           "prover_cost": 201216935,
           "sequencer_cost": 55213530
@@ -21332,13 +21332,13 @@
           "slot_of_change": 175
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93932380819343,
+          "protocol_fee": 93932380819343,
           "congestion_multiplier": 4899325222,
           "prover_cost": 18902566784466,
           "sequencer_cost": 5186827034371
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 999905779,
+          "protocol_fee": 999905779,
           "congestion_multiplier": 4899325222,
           "prover_cost": 201216935,
           "sequencer_cost": 55213530
@@ -21386,13 +21386,13 @@
           "slot_of_change": 175
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96354577494146,
+          "protocol_fee": 96354577494146,
           "congestion_multiplier": 4975076221,
           "prover_cost": 19020494370238,
           "sequencer_cost": 5219186131257
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1019330643,
+          "protocol_fee": 1019330643,
           "congestion_multiplier": 4975076221,
           "prover_cost": 201216935,
           "sequencer_cost": 55213530
@@ -21440,13 +21440,13 @@
           "slot_of_change": 175
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99376841470692,
+          "protocol_fee": 99376841470692,
           "congestion_multiplier": 5032674318,
           "prover_cost": 19125505223617,
           "sequencer_cost": 5517407566815
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1051723498,
+          "protocol_fee": 1051723498,
           "congestion_multiplier": 5032674318,
           "prover_cost": 202408760,
           "sequencer_cost": 58391745
@@ -21494,13 +21494,13 @@
           "slot_of_change": 175
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96917149552111,
+          "protocol_fee": 96917149552111,
           "congestion_multiplier": 4960784044,
           "prover_cost": 18990672549393,
           "sequencer_cost": 5478510460134
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1032974478,
+          "protocol_fee": 1032974478,
           "congestion_multiplier": 4960784044,
           "prover_cost": 202408760,
           "sequencer_cost": 58391745
@@ -21548,13 +21548,13 @@
           "slot_of_change": 175
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96342859710875,
+          "protocol_fee": 96342859710875,
           "congestion_multiplier": 4953850482,
           "prover_cost": 18911247024107,
           "sequencer_cost": 5455597444813
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1031166202,
+          "protocol_fee": 1031166202,
           "congestion_multiplier": 4953850482,
           "prover_cost": 202408760,
           "sequencer_cost": 58391745
@@ -21602,13 +21602,13 @@
           "slot_of_change": 180
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97903356936636,
+          "protocol_fee": 97903356936636,
           "congestion_multiplier": 5000213429,
           "prover_cost": 18994824978804,
           "sequencer_cost": 5479708370735
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1043257682,
+          "protocol_fee": 1043257682,
           "congestion_multiplier": 5000213429,
           "prover_cost": 202408760,
           "sequencer_cost": 58391745
@@ -21656,13 +21656,13 @@
           "slot_of_change": 180
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 98516236972338,
+          "protocol_fee": 98516236972338,
           "congestion_multiplier": 5028474874,
           "prover_cost": 18979642682432,
           "sequencer_cost": 5475328516927
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1050628281,
+          "protocol_fee": 1050628281,
           "congestion_multiplier": 5028474874,
           "prover_cost": 202408760,
           "sequencer_cost": 58391745
@@ -21710,13 +21710,13 @@
           "slot_of_change": 180
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100404138030454,
+          "protocol_fee": 100404138030454,
           "congestion_multiplier": 4902995999,
           "prover_cost": 19450329057757,
           "sequencer_cost": 6274559752708
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1060054138,
+          "protocol_fee": 1060054138,
           "congestion_multiplier": 4902995999,
           "prover_cost": 205354104,
           "sequencer_cost": 66246005
@@ -21764,13 +21764,13 @@
           "slot_of_change": 180
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102038233088501,
+          "protocol_fee": 102038233088501,
           "congestion_multiplier": 4997853363,
           "prover_cost": 19297876195345,
           "sequencer_cost": 6225379371655
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1085817409,
+          "protocol_fee": 1085817409,
           "congestion_multiplier": 4997853363,
           "prover_cost": 205354104,
           "sequencer_cost": 66246005
@@ -21818,13 +21818,13 @@
           "slot_of_change": 180
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100607952554659,
+          "protocol_fee": 100607952554659,
           "congestion_multiplier": 4963495005,
           "prover_cost": 19192318515652,
           "sequencer_cost": 6191327095900
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1076485675,
+          "protocol_fee": 1076485675,
           "congestion_multiplier": 4963495005,
           "prover_cost": 205354104,
           "sequencer_cost": 66246005
@@ -21872,13 +21872,13 @@
           "slot_of_change": 185
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93673889852703,
+          "protocol_fee": 93673889852703,
           "congestion_multiplier": 4692169373,
           "prover_cost": 19182728771071,
           "sequencer_cost": 6188233501689
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1002793604,
+          "protocol_fee": 1002793604,
           "congestion_multiplier": 4692169373,
           "prover_cost": 205354104,
           "sequencer_cost": 66246005
@@ -21926,13 +21926,13 @@
           "slot_of_change": 185
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 99874036673263,
+          "protocol_fee": 99874036673263,
           "congestion_multiplier": 4959380675,
           "prover_cost": 19072112132677,
           "sequencer_cost": 6152549236133
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1075368222,
+          "protocol_fee": 1075368222,
           "congestion_multiplier": 4959380675,
           "prover_cost": 205354104,
           "sequencer_cost": 66246005
@@ -21980,13 +21980,13 @@
           "slot_of_change": 185
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90615313608431,
+          "protocol_fee": 90615313608431,
           "congestion_multiplier": 4957139198,
           "prover_cost": 18409917930944,
           "sequencer_cost": 4489279984849
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 977921280,
+          "protocol_fee": 977921280,
           "congestion_multiplier": 4957139198,
           "prover_cost": 198680000,
           "sequencer_cost": 48448350
@@ -22034,13 +22034,13 @@
           "slot_of_change": 185
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90592785282146,
+          "protocol_fee": 90592785282146,
           "congestion_multiplier": 4958924552,
           "prover_cost": 18397040695073,
           "sequencer_cost": 4486139855845
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 978362492,
+          "protocol_fee": 978362492,
           "congestion_multiplier": 4958924552,
           "prover_cost": 198680000,
           "sequencer_cost": 48448350
@@ -22088,13 +22088,13 @@
           "slot_of_change": 185
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90724047393429,
+          "protocol_fee": 90724047393429,
           "congestion_multiplier": 4953163123,
           "prover_cost": 18450547740189,
           "sequencer_cost": 4499187611277
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 976938679,
+          "protocol_fee": 976938679,
           "congestion_multiplier": 4953163123,
           "prover_cost": 198680000,
           "sequencer_cost": 48448350
@@ -22142,13 +22142,13 @@
           "slot_of_change": 190
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92686044901513,
+          "protocol_fee": 92686044901513,
           "congestion_multiplier": 5005941012,
           "prover_cost": 18601217992176,
           "sequencer_cost": 4535928728162
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 989981592,
+          "protocol_fee": 989981592,
           "congestion_multiplier": 5005941012,
           "prover_cost": 198680000,
           "sequencer_cost": 48448350
@@ -22196,13 +22196,13 @@
           "slot_of_change": 190
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92105829147911,
+          "protocol_fee": 92105829147911,
           "congestion_multiplier": 4999971585,
           "prover_cost": 18512360224366,
           "sequencer_cost": 4514260657722
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 988506377,
+          "protocol_fee": 988506377,
           "congestion_multiplier": 4999971585,
           "prover_cost": 198680000,
           "sequencer_cost": 48448350
@@ -22250,13 +22250,13 @@
           "slot_of_change": 190
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88991912113750,
+          "protocol_fee": 88991912113750,
           "congestion_multiplier": 4901164896,
           "prover_cost": 18532518843071,
           "sequencer_cost": 4279106534547
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 948974332,
+          "protocol_fee": 948974332,
           "congestion_multiplier": 4901164896,
           "prover_cost": 197623405,
           "sequencer_cost": 45630689
@@ -22304,13 +22304,13 @@
           "slot_of_change": 190
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91534687437091,
+          "protocol_fee": 91534687437091,
           "congestion_multiplier": 5031893827,
           "prover_cost": 18443988200606,
           "sequencer_cost": 4258665057925
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 980774679,
+          "protocol_fee": 980774679,
           "congestion_multiplier": 5031893827,
           "prover_cost": 197623405,
           "sequencer_cost": 45630689
@@ -22358,13 +22358,13 @@
           "slot_of_change": 190
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90576717772700,
+          "protocol_fee": 90576717772700,
           "congestion_multiplier": 5023210832,
           "prover_cost": 18290349623607,
           "sequencer_cost": 4223190342137
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 978662505,
+          "protocol_fee": 978662505,
           "congestion_multiplier": 5023210832,
           "prover_cost": 197623405,
           "sequencer_cost": 45630689
@@ -22412,13 +22412,13 @@
           "slot_of_change": 195
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89062243125178,
+          "protocol_fee": 89062243125178,
           "congestion_multiplier": 4967017811,
           "prover_cost": 18239280338871,
           "sequencer_cost": 4211398587768
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 964993323,
+          "protocol_fee": 964993323,
           "congestion_multiplier": 4967017811,
           "prover_cost": 197623405,
           "sequencer_cost": 45630689
@@ -22466,13 +22466,13 @@
           "slot_of_change": 195
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88986761038162,
+          "protocol_fee": 88986761038162,
           "congestion_multiplier": 4973168415,
           "prover_cost": 18195611049689,
           "sequencer_cost": 4201315471583
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 966489483,
+          "protocol_fee": 966489483,
           "congestion_multiplier": 4973168415,
           "prover_cost": 197623405,
           "sequencer_cost": 45630689
@@ -22520,13 +22520,13 @@
           "slot_of_change": 195
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90594399115344,
+          "protocol_fee": 90594399115344,
           "congestion_multiplier": 5018998240,
           "prover_cost": 18201300505406,
           "sequencer_cost": 4340236908594
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 986705093,
+          "protocol_fee": 986705093,
           "congestion_multiplier": 5018998240,
           "prover_cost": 198238700,
           "sequencer_cost": 47271508
@@ -22574,13 +22574,13 @@
           "slot_of_change": 195
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89565537566784,
+          "protocol_fee": 89565537566784,
           "congestion_multiplier": 4952296438,
           "prover_cost": 18298281857233,
           "sequencer_cost": 4363362840861
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 970329120,
+          "protocol_fee": 970329120,
           "congestion_multiplier": 4952296438,
           "prover_cost": 198238700,
           "sequencer_cost": 47271508
@@ -22628,13 +22628,13 @@
           "slot_of_change": 195
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89552961105776,
+          "protocol_fee": 89552961105776,
           "congestion_multiplier": 4935539079,
           "prover_cost": 18373614856330,
           "sequencer_cost": 4381326560707
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 966215017,
+          "protocol_fee": 966215017,
           "congestion_multiplier": 4935539079,
           "prover_cost": 198238700,
           "sequencer_cost": 47271508
@@ -22682,13 +22682,13 @@
           "slot_of_change": 200
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90744853867745,
+          "protocol_fee": 90744853867745,
           "congestion_multiplier": 4948039086,
           "prover_cost": 18559208419855,
           "sequencer_cost": 4425582740872
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 969283897,
+          "protocol_fee": 969283897,
           "congestion_multiplier": 4948039086,
           "prover_cost": 198238700,
           "sequencer_cost": 47271508
@@ -22736,13 +22736,13 @@
           "slot_of_change": 200
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91457991668100,
+          "protocol_fee": 91457991668100,
           "congestion_multiplier": 5000950154,
           "prover_cost": 18457692510741,
           "sequencer_cost": 4401375509338
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 982274104,
+          "protocol_fee": 982274104,
           "congestion_multiplier": 5000950154,
           "prover_cost": 198238700,
           "sequencer_cost": 47271508
@@ -22790,13 +22790,13 @@
           "slot_of_change": 200
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89613561484121,
+          "protocol_fee": 89613561484121,
           "congestion_multiplier": 4991925205,
           "prover_cost": 18317725928667,
           "sequencer_cost": 4130981621793
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 964678250,
+          "protocol_fee": 964678250,
           "congestion_multiplier": 4991925205,
           "prover_cost": 197187920,
           "sequencer_cost": 44469476
@@ -22844,13 +22844,13 @@
           "slot_of_change": 200
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89645150528733,
+          "protocol_fee": 89645150528733,
           "congestion_multiplier": 4984147411,
           "prover_cost": 18359955192262,
           "sequencer_cost": 4140505091709
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 962798688,
+          "protocol_fee": 962798688,
           "congestion_multiplier": 4984147411,
           "prover_cost": 197187920,
           "sequencer_cost": 44469476
@@ -22898,13 +22898,13 @@
           "slot_of_change": 200
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87425271226608,
+          "protocol_fee": 87425271226608,
           "congestion_multiplier": 4888985031,
           "prover_cost": 18343446258178,
           "sequencer_cost": 4136782025671
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939801995,
+          "protocol_fee": 939801995,
           "congestion_multiplier": 4888985031,
           "prover_cost": 197187920,
           "sequencer_cost": 44469476
@@ -22952,13 +22952,13 @@
           "slot_of_change": 205
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89930357307331,
+          "protocol_fee": 89930357307331,
           "congestion_multiplier": 5004020192,
           "prover_cost": 18326953359787,
           "sequencer_cost": 4133062575974
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 967601093,
+          "protocol_fee": 967601093,
           "congestion_multiplier": 5004020192,
           "prover_cost": 197187920,
           "sequencer_cost": 44469476
@@ -23006,13 +23006,13 @@
           "slot_of_change": 205
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85930566286063,
+          "protocol_fee": 85930566286063,
           "congestion_multiplier": 4834352011,
           "prover_cost": 18286723906136,
           "sequencer_cost": 4123990099711
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926599522,
+          "protocol_fee": 926599522,
           "congestion_multiplier": 4834352011,
           "prover_cost": 197187920,
           "sequencer_cost": 44469476
@@ -23060,13 +23060,13 @@
           "slot_of_change": 205
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86431854923491,
+          "protocol_fee": 86431854923491,
           "congestion_multiplier": 4896164432,
           "prover_cost": 18161867799913,
           "sequencer_cost": 4021963631788
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936851384,
+          "protocol_fee": 936851384,
           "congestion_multiplier": 4896164432,
           "prover_cost": 196859954,
           "sequencer_cost": 43594832
@@ -23114,13 +23114,13 @@
           "slot_of_change": 205
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87839761527144,
+          "protocol_fee": 87839761527144,
           "congestion_multiplier": 4952502368,
           "prover_cost": 18194618879672,
           "sequencer_cost": 4029216390873
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 950398111,
+          "protocol_fee": 950398111,
           "congestion_multiplier": 4952502368,
           "prover_cost": 196859954,
           "sequencer_cost": 43594832
@@ -23168,13 +23168,13 @@
           "slot_of_change": 205
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88346450571111,
+          "protocol_fee": 88346450571111,
           "congestion_multiplier": 4960195495,
           "prover_cost": 18264022529901,
           "sequencer_cost": 4044585898031
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952247960,
+          "protocol_fee": 952247960,
           "congestion_multiplier": 4960195495,
           "prover_cost": 196859954,
           "sequencer_cost": 43594832
@@ -23222,13 +23222,13 @@
           "slot_of_change": 210
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90195382245227,
+          "protocol_fee": 90195382245227,
           "congestion_multiplier": 5053182768,
           "prover_cost": 18218477034543,
           "sequencer_cost": 4034499802925
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 974607195,
+          "protocol_fee": 974607195,
           "congestion_multiplier": 5053182768,
           "prover_cost": 196859954,
           "sequencer_cost": 43594832
@@ -23276,13 +23276,13 @@
           "slot_of_change": 210
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88374436159691,
+          "protocol_fee": 88374436159691,
           "congestion_multiplier": 4986047310,
           "prover_cost": 18151317814934,
           "sequencer_cost": 4019627327154
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 958464152,
+          "protocol_fee": 958464152,
           "congestion_multiplier": 4986047310,
           "prover_cost": 196859954,
           "sequencer_cost": 43594832
@@ -23330,13 +23330,13 @@
           "slot_of_change": 210
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84922359652697,
+          "protocol_fee": 84922359652697,
           "congestion_multiplier": 4921056316,
           "prover_cost": 17968013145993,
           "sequencer_cost": 3690017964940
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924340311,
+          "protocol_fee": 924340311,
           "congestion_multiplier": 4921056316,
           "prover_cost": 195573450,
           "sequencer_cost": 40164126
@@ -23384,13 +23384,13 @@
           "slot_of_change": 210
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85496649107014,
+          "protocol_fee": 85496649107014,
           "congestion_multiplier": 4955862266,
           "prover_cost": 17930360248386,
           "sequencer_cost": 3682285342114
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932545381,
+          "protocol_fee": 932545381,
           "congestion_multiplier": 4955862266,
           "prover_cost": 195573450,
           "sequencer_cost": 40164126
@@ -23438,13 +23438,13 @@
           "slot_of_change": 210
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84261270768150,
+          "protocol_fee": 84261270768150,
           "congestion_multiplier": 4924043839,
           "prover_cost": 17814565639510,
           "sequencer_cost": 3658505073059
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 925044582,
+          "protocol_fee": 925044582,
           "congestion_multiplier": 4924043839,
           "prover_cost": 195573450,
           "sequencer_cost": 40164126
@@ -23492,13 +23492,13 @@
           "slot_of_change": 215
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85242195937819,
+          "protocol_fee": 85242195937819,
           "congestion_multiplier": 4969725480,
           "prover_cost": 17814565639510,
           "sequencer_cost": 3658505073059
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935813462,
+          "protocol_fee": 935813462,
           "congestion_multiplier": 4969725480,
           "prover_cost": 195573450,
           "sequencer_cost": 40164126
@@ -23546,13 +23546,13 @@
           "slot_of_change": 215
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83861641890437,
+          "protocol_fee": 83861641890437,
           "congestion_multiplier": 4935504678,
           "prover_cost": 17678442957723,
           "sequencer_cost": 3630550110140
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927746333,
+          "protocol_fee": 927746333,
           "congestion_multiplier": 4935504678,
           "prover_cost": 195573450,
           "sequencer_cost": 40164126
@@ -23600,13 +23600,13 @@
           "slot_of_change": 215
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84996326584126,
+          "protocol_fee": 84996326584126,
           "congestion_multiplier": 4933441465,
           "prover_cost": 17674165633860,
           "sequencer_cost": 3934475898632
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947163280,
+          "protocol_fee": 947163280,
           "congestion_multiplier": 4933441465,
           "prover_cost": 196953461,
           "sequencer_cost": 43844143
@@ -23654,13 +23654,13 @@
           "slot_of_change": 215
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86082771828446,
+          "protocol_fee": 86082771828446,
           "congestion_multiplier": 4979735872,
           "prover_cost": 17691858160412,
           "sequencer_cost": 3938414461886
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 958310862,
+          "protocol_fee": 958310862,
           "congestion_multiplier": 4979735872,
           "prover_cost": 196953461,
           "sequencer_cost": 43844143
@@ -23708,13 +23708,13 @@
           "slot_of_change": 215
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85854742534062,
+          "protocol_fee": 85854742534062,
           "congestion_multiplier": 4947759784,
           "prover_cost": 17787914257167,
           "sequencer_cost": 3959797672015
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 950611097,
+          "protocol_fee": 950611097,
           "congestion_multiplier": 4947759784,
           "prover_cost": 196953461,
           "sequencer_cost": 43844143
@@ -23762,13 +23762,13 @@
           "slot_of_change": 220
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86599018888331,
+          "protocol_fee": 86599018888331,
           "congestion_multiplier": 4975611712,
           "prover_cost": 17816420996756,
           "sequencer_cost": 3966143605519
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 957317774,
+          "protocol_fee": 957317774,
           "congestion_multiplier": 4975611712,
           "prover_cost": 196953461,
           "sequencer_cost": 43844143
@@ -23816,13 +23816,13 @@
           "slot_of_change": 220
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86717592388230,
+          "protocol_fee": 86717592388230,
           "congestion_multiplier": 4973092820,
           "prover_cost": 17852126532054,
           "sequencer_cost": 3974092075110
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 956711231,
+          "protocol_fee": 956711231,
           "congestion_multiplier": 4973092820,
           "prover_cost": 196953461,
           "sequencer_cost": 43844143
@@ -23870,13 +23870,13 @@
           "slot_of_change": 220
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85272294052133,
+          "protocol_fee": 85272294052133,
           "congestion_multiplier": 4923708845,
           "prover_cost": 17792178887282,
           "sequencer_cost": 3940395429088
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 943494189,
+          "protocol_fee": 943494189,
           "congestion_multiplier": 4923708845,
           "prover_cost": 196861332,
           "sequencer_cost": 43598454
@@ -23924,13 +23924,13 @@
           "slot_of_change": 220
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87725761767300,
+          "protocol_fee": 87725761767300,
           "congestion_multiplier": 5003502194,
           "prover_cost": 17939281329150,
           "sequencer_cost": 3972973889164
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 962681280,
+          "protocol_fee": 962681280,
           "congestion_multiplier": 5003502194,
           "prover_cost": 196861332,
           "sequencer_cost": 43598454
@@ -23978,13 +23978,13 @@
           "slot_of_change": 220
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83744914733713,
+          "protocol_fee": 83744914733713,
           "congestion_multiplier": 4840938892,
           "prover_cost": 17850032451912,
           "sequencer_cost": 3953208133090
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 923591344,
+          "protocol_fee": 923591344,
           "congestion_multiplier": 4840938892,
           "prover_cost": 196861332,
           "sequencer_cost": 43598454
@@ -24032,13 +24032,13 @@
           "slot_of_change": 225
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85557137216376,
+          "protocol_fee": 85557137216376,
           "congestion_multiplier": 4925233019,
           "prover_cost": 17844679998993,
           "sequencer_cost": 3952022736902
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 943860691,
+          "protocol_fee": 943860691,
           "congestion_multiplier": 4925233019,
           "prover_cost": 196861332,
           "sequencer_cost": 43598454
@@ -24086,13 +24086,13 @@
           "slot_of_change": 225
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86982189454164,
+          "protocol_fee": 86982189454164,
           "congestion_multiplier": 5007372804,
           "prover_cost": 17770046003582,
           "sequencer_cost": 3935493707140
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 963612006,
+          "protocol_fee": 963612006,
           "congestion_multiplier": 5007372804,
           "prover_cost": 196861332,
           "sequencer_cost": 43598454
@@ -24140,13 +24140,13 @@
           "slot_of_change": 225
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84911691144719,
+          "protocol_fee": 84911691144719,
           "congestion_multiplier": 4905988981,
           "prover_cost": 17729566996105,
           "sequencer_cost": 4009278552165
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944625242,
+          "protocol_fee": 944625242,
           "congestion_multiplier": 4905988981,
           "prover_cost": 197237816,
           "sequencer_cost": 44602406
@@ -24194,13 +24194,13 @@
           "slot_of_change": 225
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87557240292672,
+          "protocol_fee": 87557240292672,
           "congestion_multiplier": 5025269183,
           "prover_cost": 17740211318082,
           "sequencer_cost": 4011685607667
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 973471992,
+          "protocol_fee": 973471992,
           "congestion_multiplier": 5025269183,
           "prover_cost": 197237816,
           "sequencer_cost": 44602406
@@ -24248,13 +24248,13 @@
           "slot_of_change": 225
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85717594189374,
+          "protocol_fee": 85717594189374,
           "congestion_multiplier": 4914292262,
           "prover_cost": 17859873416610,
           "sequencer_cost": 4038745416023
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946633309,
+          "protocol_fee": 946633309,
           "congestion_multiplier": 4914292262,
           "prover_cost": 197237816,
           "sequencer_cost": 44602406
@@ -24302,13 +24302,13 @@
           "slot_of_change": 230
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84225799201524,
+          "protocol_fee": 84225799201524,
           "congestion_multiplier": 4864630942,
           "prover_cost": 17774556221443,
           "sequencer_cost": 4019452198045
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934623204,
+          "protocol_fee": 934623204,
           "congestion_multiplier": 4864630942,
           "prover_cost": 197237816,
           "sequencer_cost": 44602406
@@ -24356,13 +24356,13 @@
           "slot_of_change": 230
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84179830684240,
+          "protocol_fee": 84179830684240,
           "congestion_multiplier": 4874495329,
           "prover_cost": 17719626302563,
           "sequencer_cost": 4007030611793
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937008810,
+          "protocol_fee": 937008810,
           "congestion_multiplier": 4874495329,
           "prover_cost": 197237816,
           "sequencer_cost": 44602406
@@ -24410,13 +24410,13 @@
           "slot_of_change": 230
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86240631536065,
+          "protocol_fee": 86240631536065,
           "congestion_multiplier": 4922559097,
           "prover_cost": 17786767215334,
           "sequencer_cost": 4199040880244
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 960235618,
+          "protocol_fee": 960235618,
           "congestion_multiplier": 4922559097,
           "prover_cost": 198044554,
           "sequencer_cost": 46753700
@@ -24464,13 +24464,13 @@
           "slot_of_change": 230
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85429879618901,
+          "protocol_fee": 85429879618901,
           "congestion_multiplier": 4903168281,
           "prover_cost": 17707086426906,
           "sequencer_cost": 4180230104574
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 955488780,
+          "protocol_fee": 955488780,
           "congestion_multiplier": 4903168281,
           "prover_cost": 198044554,
           "sequencer_cost": 46753700
@@ -24518,13 +24518,13 @@
           "slot_of_change": 230
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86286413964083,
+          "protocol_fee": 86286413964083,
           "congestion_multiplier": 4929292429,
           "prover_cost": 17765713624969,
           "sequencer_cost": 4194070618613
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 961883926,
+          "protocol_fee": 961883926,
           "congestion_multiplier": 4929292429,
           "prover_cost": 198044554,
           "sequencer_cost": 46753700
@@ -24572,13 +24572,13 @@
           "slot_of_change": 235
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85183780718587,
+          "protocol_fee": 85183780718587,
           "congestion_multiplier": 4886839064,
           "prover_cost": 17730253344132,
           "sequencer_cost": 4185699273385
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 951491416,
+          "protocol_fee": 951491416,
           "congestion_multiplier": 4886839064,
           "prover_cost": 198044554,
           "sequencer_cost": 46753700
@@ -24626,13 +24626,13 @@
           "slot_of_change": 235
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85634776030469,
+          "protocol_fee": 85634776030469,
           "congestion_multiplier": 4919921003,
           "prover_cost": 17673698413001,
           "sequencer_cost": 4172347973234
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 959589817,
+          "protocol_fee": 959589817,
           "congestion_multiplier": 4919921003,
           "prover_cost": 198044554,
           "sequencer_cost": 46753700
@@ -24680,13 +24680,13 @@
           "slot_of_change": 235
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82685897147148,
+          "protocol_fee": 82685897147148,
           "congestion_multiplier": 4931934878,
           "prover_cost": 17468553911054,
           "sequencer_cost": 3560761118262
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 925155966,
+          "protocol_fee": 925155966,
           "congestion_multiplier": 4931934878,
           "prover_cost": 195452156,
           "sequencer_cost": 39840644
@@ -24734,13 +24734,13 @@
           "slot_of_change": 235
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82746527748475,
+          "protocol_fee": 82746527748475,
           "congestion_multiplier": 4917111200,
           "prover_cost": 17547518371049,
           "sequencer_cost": 3576857103098
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921668062,
+          "protocol_fee": 921668062,
           "congestion_multiplier": 4917111200,
           "prover_cost": 195452156,
           "sequencer_cost": 39840644
@@ -24788,13 +24788,13 @@
           "slot_of_change": 235
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82008774345666,
+          "protocol_fee": 82008774345666,
           "congestion_multiplier": 4905479808,
           "prover_cost": 17442862293491,
           "sequencer_cost": 3555524181458
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 918931279,
+          "protocol_fee": 918931279,
           "congestion_multiplier": 4905479808,
           "prover_cost": 195452156,
           "sequencer_cost": 39840644
@@ -24842,13 +24842,13 @@
           "slot_of_change": 240
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81908219267262,
+          "protocol_fee": 81908219267262,
           "congestion_multiplier": 4924875133,
           "prover_cost": 17335384051020,
           "sequencer_cost": 3533615994392
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 923494859,
+          "protocol_fee": 923494859,
           "congestion_multiplier": 4924875133,
           "prover_cost": 195452156,
           "sequencer_cost": 39840644
@@ -24896,13 +24896,13 @@
           "slot_of_change": 240
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81745775806767,
+          "protocol_fee": 81745775806767,
           "congestion_multiplier": 4940985085,
           "prover_cost": 17230280846513,
           "sequencer_cost": 3512191931134
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927285415,
+          "protocol_fee": 927285415,
           "congestion_multiplier": 4940985085,
           "prover_cost": 195452156,
           "sequencer_cost": 39840644
@@ -24950,13 +24950,13 @@
           "slot_of_change": 240
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81323024174438,
+          "protocol_fee": 81323024174438,
           "congestion_multiplier": 4952910729,
           "prover_cost": 17193313007105,
           "sequencer_cost": 3379634321977
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921751914,
+          "protocol_fee": 921751914,
           "congestion_multiplier": 4952910729,
           "prover_cost": 194876781,
           "sequencer_cost": 38306303
@@ -25004,13 +25004,13 @@
           "slot_of_change": 240
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81554116543805,
+          "protocol_fee": 81554116543805,
           "congestion_multiplier": 4963746947,
           "prover_cost": 17195033352104,
           "sequencer_cost": 3379972484669
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924278737,
+          "protocol_fee": 924278737,
           "congestion_multiplier": 4963746947,
           "prover_cost": 194876781,
           "sequencer_cost": 38306303
@@ -25058,13 +25058,13 @@
           "slot_of_change": 240
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83738872178665,
+          "protocol_fee": 83738872178665,
           "congestion_multiplier": 5051209929,
           "prover_cost": 17274497162710,
           "sequencer_cost": 3395592430724
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944673625,
+          "protocol_fee": 944673625,
           "congestion_multiplier": 5051209929,
           "prover_cost": 194876781,
           "sequencer_cost": 38306303
@@ -25112,13 +25112,13 @@
           "slot_of_change": 245
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80990507685859,
+          "protocol_fee": 80990507685859,
           "congestion_multiplier": 4944498502,
           "prover_cost": 17159529732362,
           "sequencer_cost": 3372993652155
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 919790325,
+          "protocol_fee": 919790325,
           "congestion_multiplier": 4944498502,
           "prover_cost": 194876781,
           "sequencer_cost": 38306303
@@ -25166,13 +25166,13 @@
           "slot_of_change": 245
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81804938004084,
+          "protocol_fee": 81804938004084,
           "congestion_multiplier": 4976195391,
           "prover_cost": 17193918274425,
           "sequencer_cost": 3379753297431
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927181503,
+          "protocol_fee": 927181503,
           "congestion_multiplier": 4976195391,
           "prover_cost": 194876781,
           "sequencer_cost": 38306303
@@ -25220,13 +25220,13 @@
           "slot_of_change": 245
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83620563824147,
+          "protocol_fee": 83620563824147,
           "congestion_multiplier": 4993741955,
           "prover_cost": 17302527464717,
           "sequencer_cost": 3635371084377
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947001631,
+          "protocol_fee": 947001631,
           "congestion_multiplier": 4993741955,
           "prover_cost": 195950864,
           "sequencer_cost": 41170523
@@ -25274,13 +25274,13 @@
           "slot_of_change": 245
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82070336022870,
+          "protocol_fee": 82070336022870,
           "congestion_multiplier": 4931461408,
           "prover_cost": 17250776589651,
           "sequencer_cost": 3624497896331
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932233582,
+          "protocol_fee": 932233582,
           "congestion_multiplier": 4931461408,
           "prover_cost": 195950864,
           "sequencer_cost": 41170523
@@ -25328,13 +25328,13 @@
           "slot_of_change": 245
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82078714029488,
+          "protocol_fee": 82078714029488,
           "congestion_multiplier": 4918101004,
           "prover_cost": 17311367356109,
           "sequencer_cost": 3637228401791
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929065544,
+          "protocol_fee": 929065544,
           "congestion_multiplier": 4918101004,
           "prover_cost": 195950864,
           "sequencer_cost": 41170523
@@ -25382,13 +25382,13 @@
           "slot_of_change": 250
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82957939097442,
+          "protocol_fee": 82957939097442,
           "congestion_multiplier": 4949775388,
           "prover_cost": 17356494356131,
           "sequencer_cost": 3646709871555
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936576218,
+          "protocol_fee": 936576218,
           "congestion_multiplier": 4949775388,
           "prover_cost": 195950864,
           "sequencer_cost": 41170523
@@ -25436,13 +25436,13 @@
           "slot_of_change": 250
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80447663396570,
+          "protocol_fee": 80447663396570,
           "congestion_multiplier": 4835618817,
           "prover_cost": 17332230278915,
           "sequencer_cost": 3641611834584
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909507253,
+          "protocol_fee": 909507253,
           "congestion_multiplier": 4835618817,
           "prover_cost": 195950864,
           "sequencer_cost": 41170523
@@ -25490,13 +25490,13 @@
           "slot_of_change": 250
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79652878801026,
+          "protocol_fee": 79652878801026,
           "congestion_multiplier": 4844399909,
           "prover_cost": 17226895980328,
           "sequencer_cost": 3492300952752
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903313349,
+          "protocol_fee": 903313349,
           "congestion_multiplier": 4844399909,
           "prover_cost": 195363750,
           "sequencer_cost": 39604872
@@ -25544,13 +25544,13 @@
           "slot_of_change": 250
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82926948323732,
+          "protocol_fee": 82926948323732,
           "congestion_multiplier": 5011626387,
           "prover_cost": 17187365698791,
           "sequencer_cost": 3484287225843
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 942606324,
+          "protocol_fee": 942606324,
           "congestion_multiplier": 5011626387,
           "prover_cost": 195363750,
           "sequencer_cost": 39604872
@@ -25598,13 +25598,13 @@
           "slot_of_change": 250
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82191641289473,
+          "protocol_fee": 82191641289473,
           "congestion_multiplier": 4972079438,
           "prover_cost": 17204570712987,
           "sequencer_cost": 3487775090839
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933314032,
+          "protocol_fee": 933314032,
           "congestion_multiplier": 4972079438,
           "prover_cost": 195363750,
           "sequencer_cost": 39604872
@@ -25652,13 +25652,13 @@
           "slot_of_change": 255
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81192889453792,
+          "protocol_fee": 81192889453792,
           "congestion_multiplier": 4920281215,
           "prover_cost": 17220069069345,
           "sequencer_cost": 3490916975757
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921143074,
+          "protocol_fee": 921143074,
           "congestion_multiplier": 4920281215,
           "prover_cost": 195363750,
           "sequencer_cost": 39604872
@@ -25706,13 +25706,13 @@
           "slot_of_change": 255
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82327221117698,
+          "protocol_fee": 82327221117698,
           "congestion_multiplier": 4994130820,
           "prover_cost": 17137808458841,
           "sequencer_cost": 3474240796325
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 938495414,
+          "protocol_fee": 938495414,
           "congestion_multiplier": 4994130820,
           "prover_cost": 195363750,
           "sequencer_cost": 39604872
@@ -25760,13 +25760,13 @@
           "slot_of_change": 255
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82271887496938,
+          "protocol_fee": 82271887496938,
           "congestion_multiplier": 4979975346,
           "prover_cost": 17039987767479,
           "sequencer_cost": 3631468811892
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947243218,
+          "protocol_fee": 947243218,
           "congestion_multiplier": 4979975346,
           "prover_cost": 196191109,
           "sequencer_cost": 41811174
@@ -25814,13 +25814,13 @@
           "slot_of_change": 255
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81248578355190,
+          "protocol_fee": 81248578355190,
           "congestion_multiplier": 4927720360,
           "prover_cost": 17051924855837,
           "sequencer_cost": 3634012778746
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934806412,
+          "protocol_fee": 934806412,
           "congestion_multiplier": 4927720360,
           "prover_cost": 196191109,
           "sequencer_cost": 41811174
@@ -25868,13 +25868,13 @@
           "slot_of_change": 255
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81661042085240,
+          "protocol_fee": 81661042085240,
           "congestion_multiplier": 4940948450,
           "prover_cost": 17080963430891,
           "sequencer_cost": 3640201320727
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937954728,
+          "protocol_fee": 937954728,
           "congestion_multiplier": 4940948450,
           "prover_cost": 196191109,
           "sequencer_cost": 41811174
@@ -25922,13 +25922,13 @@
           "slot_of_change": 260
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82116969590840,
+          "protocol_fee": 82116969590840,
           "congestion_multiplier": 4979991925,
           "prover_cost": 17007830631781,
           "sequencer_cost": 3624615659357
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947247164,
+          "protocol_fee": 947247164,
           "congestion_multiplier": 4979991925,
           "prover_cost": 196191109,
           "sequencer_cost": 41811174
@@ -25976,13 +25976,13 @@
           "slot_of_change": 260
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80404500887344,
+          "protocol_fee": 80404500887344,
           "congestion_multiplier": 4900110606,
           "prover_cost": 16994235643985,
           "sequencer_cost": 3621718370060
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928235228,
+          "protocol_fee": 928235228,
           "congestion_multiplier": 4900110606,
           "prover_cost": 196191109,
           "sequencer_cost": 41811174
@@ -26030,13 +26030,13 @@
           "slot_of_change": 260
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80329917047102,
+          "protocol_fee": 80329917047102,
           "congestion_multiplier": 4989369458,
           "prover_cost": 16886127370117,
           "sequencer_cost": 3249866032813
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 925519372,
+          "protocol_fee": 925519372,
           "congestion_multiplier": 4989369458,
           "prover_cost": 194553145,
           "sequencer_cost": 37443260
@@ -26084,13 +26084,13 @@
           "slot_of_change": 260
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79206346700592,
+          "protocol_fee": 79206346700592,
           "congestion_multiplier": 4972905793,
           "prover_cost": 16718939110875,
           "sequencer_cost": 3217689357079
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921699861,
+          "protocol_fee": 921699861,
           "congestion_multiplier": 4972905793,
           "prover_cost": 194553145,
           "sequencer_cost": 37443260
@@ -26138,13 +26138,13 @@
           "slot_of_change": 260
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78475736106097,
+          "protocol_fee": 78475736106097,
           "congestion_multiplier": 4941376047,
           "prover_cost": 16697233710891,
           "sequencer_cost": 3213511984696
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914385073,
+          "protocol_fee": 914385073,
           "congestion_multiplier": 4941376047,
           "prover_cost": 194553145,
           "sequencer_cost": 37443260
@@ -26192,13 +26192,13 @@
           "slot_of_change": 265
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78165187338511,
+          "protocol_fee": 78165187338511,
           "congestion_multiplier": 4947370786,
           "prover_cost": 16605901260373,
           "sequencer_cost": 3195934347021
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915775831,
+          "protocol_fee": 915775831,
           "congestion_multiplier": 4947370786,
           "prover_cost": 194553145,
           "sequencer_cost": 37443260
@@ -26246,13 +26246,13 @@
           "slot_of_change": 265
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78001374542984,
+          "protocol_fee": 78001374542984,
           "congestion_multiplier": 4946188345,
           "prover_cost": 16576065230342,
           "sequencer_cost": 3190192171896
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915501509,
+          "protocol_fee": 915501509,
           "congestion_multiplier": 4946188345,
           "prover_cost": 194553145,
           "sequencer_cost": 37443260
@@ -26300,13 +26300,13 @@
           "slot_of_change": 265
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79806177937705,
+          "protocol_fee": 79806177937705,
           "congestion_multiplier": 5010108084,
           "prover_cost": 16617358305880,
           "sequencer_cost": 3283895302003
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936309782,
+          "protocol_fee": 936309782,
           "congestion_multiplier": 5010108084,
           "prover_cost": 194959783,
           "sequencer_cost": 38527635
@@ -26354,13 +26354,13 @@
           "slot_of_change": 265
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80608601273039,
+          "protocol_fee": 80608601273039,
           "congestion_multiplier": 5054478649,
           "prover_cost": 16600757968156,
           "sequencer_cost": 3280614770281
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946669751,
+          "protocol_fee": 946669751,
           "congestion_multiplier": 5054478649,
           "prover_cost": 194959783,
           "sequencer_cost": 38527635
@@ -26408,13 +26408,13 @@
           "slot_of_change": 265
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78808981562897,
+          "protocol_fee": 78808981562897,
           "congestion_multiplier": 4960393079,
           "prover_cost": 16615712638533,
           "sequencer_cost": 3283570087900
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924701954,
+          "protocol_fee": 924701954,
           "congestion_multiplier": 4960393079,
           "prover_cost": 194959783,
           "sequencer_cost": 38527635
@@ -26462,13 +26462,13 @@
           "slot_of_change": 270
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78727006250162,
+          "protocol_fee": 78727006250162,
           "congestion_multiplier": 4931348975,
           "prover_cost": 16721055585565,
           "sequencer_cost": 3304387789637
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917920521,
+          "protocol_fee": 917920521,
           "congestion_multiplier": 4931348975,
           "prover_cost": 194959783,
           "sequencer_cost": 38527635
@@ -26516,13 +26516,13 @@
           "slot_of_change": 270
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79036604731690,
+          "protocol_fee": 79036604731690,
           "congestion_multiplier": 4939704693,
           "prover_cost": 16751208956443,
           "sequencer_cost": 3310346649712
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 919871476,
+          "protocol_fee": 919871476,
           "congestion_multiplier": 4939704693,
           "prover_cost": 194959783,
           "sequencer_cost": 38527635
@@ -26570,13 +26570,13 @@
           "slot_of_change": 270
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76635012860518,
+          "protocol_fee": 76635012860518,
           "congestion_multiplier": 4957033000,
           "prover_cost": 16465546991343,
           "sequencer_cost": 2901239419453
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 899590904,
+          "protocol_fee": 899590904,
           "congestion_multiplier": 4957033000,
           "prover_cost": 193283145,
           "sequencer_cost": 34056608
@@ -26624,13 +26624,13 @@
           "slot_of_change": 270
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76740762009573,
+          "protocol_fee": 76740762009573,
           "congestion_multiplier": 4979532003,
           "prover_cost": 16395048501088,
           "sequencer_cost": 2888817542485
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904705822,
+          "protocol_fee": 904705822,
           "congestion_multiplier": 4979532003,
           "prover_cost": 193283145,
           "sequencer_cost": 34056608
@@ -26678,13 +26678,13 @@
           "slot_of_change": 270
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75607226476864,
+          "protocol_fee": 75607226476864,
           "congestion_multiplier": 4931336274,
           "prover_cost": 16350901920126,
           "sequencer_cost": 2881038888002
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 893749017,
+          "protocol_fee": 893749017,
           "congestion_multiplier": 4931336274,
           "prover_cost": 193283145,
           "sequencer_cost": 34056608
@@ -26732,13 +26732,13 @@
           "slot_of_change": 275
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74631554231520,
+          "protocol_fee": 74631554231520,
           "congestion_multiplier": 4897290985,
           "prover_cost": 16280894174478,
           "sequencer_cost": 2868703480533
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 886009169,
+          "protocol_fee": 886009169,
           "congestion_multiplier": 4897290985,
           "prover_cost": 193283145,
           "sequencer_cost": 34056608
@@ -26786,13 +26786,13 @@
           "slot_of_change": 275
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74927299849340,
+          "protocol_fee": 74927299849340,
           "congestion_multiplier": 4916647422,
           "prover_cost": 16264630608379,
           "sequencer_cost": 2865837830269
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890409657,
+          "protocol_fee": 890409657,
           "congestion_multiplier": 4916647422,
           "prover_cost": 193283145,
           "sequencer_cost": 34056608
@@ -26840,13 +26840,13 @@
           "slot_of_change": 275
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78535642108372,
+          "protocol_fee": 78535642108372,
           "congestion_multiplier": 4963015408,
           "prover_cost": 16480703127967,
           "sequencer_cost": 3336439644809
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 930863332,
+          "protocol_fee": 930863332,
           "congestion_multiplier": 4963015408,
           "prover_cost": 195341654,
           "sequencer_cost": 39545985
@@ -26894,13 +26894,13 @@
           "slot_of_change": 275
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78228115760633,
+          "protocol_fee": 78228115760633,
           "congestion_multiplier": 4919469822,
           "prover_cost": 16598553523170,
           "sequencer_cost": 3360297894524
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920635012,
+          "protocol_fee": 920635012,
           "congestion_multiplier": 4919469822,
           "prover_cost": 195341654,
           "sequencer_cost": 39545985
@@ -26948,13 +26948,13 @@
           "slot_of_change": 275
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78027856175491,
+          "protocol_fee": 78027856175491,
           "congestion_multiplier": 4932892628,
           "prover_cost": 16499556980426,
           "sequencer_cost": 3340256517203
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 923787863,
+          "protocol_fee": 923787863,
           "congestion_multiplier": 4932892628,
           "prover_cost": 195341654,
           "sequencer_cost": 39545985
@@ -27002,13 +27002,13 @@
           "slot_of_change": 280
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78169827661478,
+          "protocol_fee": 78169827661478,
           "congestion_multiplier": 4948716539,
           "prover_cost": 16463337988945,
           "sequencer_cost": 3332924155341
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927504704,
+          "protocol_fee": 927504704,
           "congestion_multiplier": 4948716539,
           "prover_cost": 195341654,
           "sequencer_cost": 39545985
@@ -27056,13 +27056,13 @@
           "slot_of_change": 280
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78786540093894,
+          "protocol_fee": 78786540093894,
           "congestion_multiplier": 5006534575,
           "prover_cost": 16353768002995,
           "sequencer_cost": 3310742234936
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 941085446,
+          "protocol_fee": 941085446,
           "congestion_multiplier": 5006534575,
           "prover_cost": 195341654,
           "sequencer_cost": 39545985
@@ -27110,13 +27110,13 @@
           "slot_of_change": 280
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77065109301125,
+          "protocol_fee": 77065109301125,
           "congestion_multiplier": 4864882002,
           "prover_cost": 16427757858882,
           "sequencer_cost": 3512077112707
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920615403,
+          "protocol_fee": 920615403,
           "congestion_multiplier": 4864882002,
           "prover_cost": 196245059,
           "sequencer_cost": 41955073
@@ -27164,13 +27164,13 @@
           "slot_of_change": 280
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77209285663491,
+          "protocol_fee": 77209285663491,
           "congestion_multiplier": 4887988117,
           "prover_cost": 16360679574297,
           "sequencer_cost": 3497736500308
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926119282,
+          "protocol_fee": 926119282,
           "congestion_multiplier": 4887988117,
           "prover_cost": 196245059,
           "sequencer_cost": 41955073
@@ -27218,13 +27218,13 @@
           "slot_of_change": 280
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77194787385996,
+          "protocol_fee": 77194787385996,
           "congestion_multiplier": 4911747757,
           "prover_cost": 16258252586122,
           "sequencer_cost": 3475838717057
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931778832,
+          "protocol_fee": 931778832,
           "congestion_multiplier": 4911747757,
           "prover_cost": 196245059,
           "sequencer_cost": 41955073
@@ -27272,13 +27272,13 @@
           "slot_of_change": 285
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77983370194635,
+          "protocol_fee": 77983370194635,
           "congestion_multiplier": 4946966007,
           "prover_cost": 16277786487132,
           "sequencer_cost": 3480014854010
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940167823,
+          "protocol_fee": 940167823,
           "congestion_multiplier": 4946966007,
           "prover_cost": 196245059,
           "sequencer_cost": 41955073
@@ -27326,13 +27326,13 @@
           "slot_of_change": 285
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78297230388699,
+          "protocol_fee": 78297230388699,
           "congestion_multiplier": 4964436394,
           "prover_cost": 16271278517740,
           "sequencer_cost": 3478623520479
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944329272,
+          "protocol_fee": 944329272,
           "congestion_multiplier": 4964436394,
           "prover_cost": 196245059,
           "sequencer_cost": 41955073
@@ -27380,13 +27380,13 @@
           "slot_of_change": 285
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76939942510197,
+          "protocol_fee": 76939942510197,
           "congestion_multiplier": 5022241156,
           "prover_cost": 16061713107591,
           "sequencer_cost": 3066911839964
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931392704,
+          "protocol_fee": 931392704,
           "congestion_multiplier": 5022241156,
           "prover_cost": 194434281,
           "sequencer_cost": 37126351
@@ -27434,13 +27434,13 @@
           "slot_of_change": 285
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75715637848623,
+          "protocol_fee": 75715637848623,
           "congestion_multiplier": 4980403315,
           "prover_cost": 15972269094155,
           "sequencer_cost": 3049832908098
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921704707,
+          "protocol_fee": 921704707,
           "congestion_multiplier": 4980403315,
           "prover_cost": 194434281,
           "sequencer_cost": 37126351
@@ -27488,13 +27488,13 @@
           "slot_of_change": 285
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76586510048831,
+          "protocol_fee": 76586510048831,
           "congestion_multiplier": 5022159002,
           "prover_cost": 15988258349371,
           "sequencer_cost": 3052885984429
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931373680,
+          "protocol_fee": 931373680,
           "congestion_multiplier": 5022159002,
           "prover_cost": 194434281,
           "sequencer_cost": 37126351
@@ -27542,13 +27542,13 @@
           "slot_of_change": 290
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76413587978156,
+          "protocol_fee": 76413587978156,
           "congestion_multiplier": 4999834191,
           "prover_cost": 16041194924319,
           "sequencer_cost": 3062993985200
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926204133,
+          "protocol_fee": 926204133,
           "congestion_multiplier": 4999834191,
           "prover_cost": 194434281,
           "sequencer_cost": 37126351
@@ -27596,13 +27596,13 @@
           "slot_of_change": 290
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75565002391935,
+          "protocol_fee": 75565002391935,
           "congestion_multiplier": 4945526614,
           "prover_cost": 16081399301542,
           "sequencer_cost": 3070670830111
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913628636,
+          "protocol_fee": 913628636,
           "congestion_multiplier": 4945526614,
           "prover_cost": 194434281,
           "sequencer_cost": 37126351
@@ -27650,13 +27650,13 @@
           "slot_of_change": 290
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76664571948923,
+          "protocol_fee": 76664571948923,
           "congestion_multiplier": 4950720098,
           "prover_cost": 16160218713136,
           "sequencer_cost": 3244996047104
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926088863,
+          "protocol_fee": 926088863,
           "congestion_multiplier": 4950720098,
           "prover_cost": 195211402,
           "sequencer_cost": 39198741
@@ -27704,13 +27704,13 @@
           "slot_of_change": 290
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76545894283311,
+          "protocol_fee": 76545894283311,
           "congestion_multiplier": 4924881233,
           "prover_cost": 16241426180166,
           "sequencer_cost": 3261302627738
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920031971,
+          "protocol_fee": 920031971,
           "congestion_multiplier": 4924881233,
           "prover_cost": 195211402,
           "sequencer_cost": 39198741
@@ -27758,13 +27758,13 @@
           "slot_of_change": 290
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75694576985701,
+          "protocol_fee": 75694576985701,
           "congestion_multiplier": 4891709288,
           "prover_cost": 16197692743568,
           "sequencer_cost": 3252520888369
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912256130,
+          "protocol_fee": 912256130,
           "congestion_multiplier": 4891709288,
           "prover_cost": 195211402,
           "sequencer_cost": 39198741
@@ -27812,13 +27812,13 @@
           "slot_of_change": 295
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75850154765131,
+          "protocol_fee": 75850154765131,
           "congestion_multiplier": 4914136761,
           "prover_cost": 16137983104717,
           "sequencer_cost": 3240531103733
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917513357,
+          "protocol_fee": 917513357,
           "congestion_multiplier": 4914136761,
           "prover_cost": 195211402,
           "sequencer_cost": 39198741
@@ -27866,13 +27866,13 @@
           "slot_of_change": 295
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75748148201784,
+          "protocol_fee": 75748148201784,
           "congestion_multiplier": 4882683358,
           "prover_cost": 16246837128646,
           "sequencer_cost": 3262389154272
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 910140361,
+          "protocol_fee": 910140361,
           "congestion_multiplier": 4882683358,
           "prover_cost": 195211402,
           "sequencer_cost": 39198741
@@ -27920,13 +27920,13 @@
           "slot_of_change": 295
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75342344953365,
+          "protocol_fee": 75342344953365,
           "congestion_multiplier": 4924696227,
           "prover_cost": 16112729057253,
           "sequencer_cost": 3084258585150
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909338179,
+          "protocol_fee": 909338179,
           "congestion_multiplier": 4924696227,
           "prover_cost": 194471246,
           "sequencer_cost": 37225203
@@ -27974,13 +27974,13 @@
           "slot_of_change": 295
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76289001345942,
+          "protocol_fee": 76289001345942,
           "congestion_multiplier": 4958907680,
           "prover_cost": 16174191272747,
           "sequencer_cost": 3096023529817
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917264851,
+          "protocol_fee": 917264851,
           "congestion_multiplier": 4958907680,
           "prover_cost": 194471246,
           "sequencer_cost": 37225203
@@ -28028,13 +28028,13 @@
           "slot_of_change": 295
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77467419635888,
+          "protocol_fee": 77467419635888,
           "congestion_multiplier": 5057848428,
           "prover_cost": 16023570243135,
           "sequencer_cost": 3067192026350
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940189071,
+          "protocol_fee": 940189071,
           "congestion_multiplier": 5057848428,
           "prover_cost": 194471246,
           "sequencer_cost": 37225203
@@ -28082,13 +28082,13 @@
           "slot_of_change": 300
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75306747054594,
+          "protocol_fee": 75306747054594,
           "congestion_multiplier": 4966365100,
           "prover_cost": 15935922873480,
           "sequencer_cost": 3050414784496
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 918992709,
+          "protocol_fee": 918992709,
           "congestion_multiplier": 4966365100,
           "prover_cost": 194471246,
           "sequencer_cost": 37225203
@@ -28136,13 +28136,13 @@
           "slot_of_change": 300
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74063924467713,
+          "protocol_fee": 74063924467713,
           "congestion_multiplier": 4898565771,
           "prover_cost": 15945490174117,
           "sequencer_cost": 3052246133426
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903283845,
+          "protocol_fee": 903283845,
           "congestion_multiplier": 4898565771,
           "prover_cost": 194471246,
           "sequencer_cost": 37225203
@@ -28190,13 +28190,13 @@
           "slot_of_change": 300
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75857344616178,
+          "protocol_fee": 75857344616178,
           "congestion_multiplier": 4959426763,
           "prover_cost": 16084951307331,
           "sequencer_cost": 3073717159147
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917015013,
+          "protocol_fee": 917015013,
           "congestion_multiplier": 4959426763,
           "prover_cost": 194445797,
           "sequencer_cost": 37157177
@@ -28244,13 +28244,13 @@
           "slot_of_change": 300
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77623914637250,
+          "protocol_fee": 77623914637250,
           "congestion_multiplier": 5028944824,
           "prover_cost": 16175534841957,
           "sequencer_cost": 3091027013520
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933115603,
+          "protocol_fee": 933115603,
           "congestion_multiplier": 5028944824,
           "prover_cost": 194445797,
           "sequencer_cost": 37157177
@@ -28298,13 +28298,13 @@
           "slot_of_change": 300
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77227463137585,
+          "protocol_fee": 77227463137585,
           "congestion_multiplier": 4983515461,
           "prover_cost": 16276450075127,
           "sequencer_cost": 3110311180309
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922594027,
+          "protocol_fee": 922594027,
           "congestion_multiplier": 4983515461,
           "prover_cost": 194445797,
           "sequencer_cost": 37157177
@@ -28352,13 +28352,13 @@
           "slot_of_change": 305
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75925235505525,
+          "protocol_fee": 75925235505525,
           "congestion_multiplier": 4922218782,
           "prover_cost": 16252072884078,
           "sequencer_cost": 3105652876471
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908397534,
+          "protocol_fee": 908397534,
           "congestion_multiplier": 4922218782,
           "prover_cost": 194445797,
           "sequencer_cost": 37157177
@@ -28406,13 +28406,13 @@
           "slot_of_change": 305
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74971835989475,
+          "protocol_fee": 74971835989475,
           "congestion_multiplier": 4882649272,
           "prover_cost": 16211545270875,
           "sequencer_cost": 3097908344470
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 899233118,
+          "protocol_fee": 899233118,
           "congestion_multiplier": 4882649272,
           "prover_cost": 194445797,
           "sequencer_cost": 37157177
@@ -28460,13 +28460,13 @@
           "slot_of_change": 305
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75434508110886,
+          "protocol_fee": 75434508110886,
           "congestion_multiplier": 4958918356,
           "prover_cost": 16131031586572,
           "sequencer_cost": 2923291182868
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 905687298,
+          "protocol_fee": 905687298,
           "congestion_multiplier": 4958918356,
           "prover_cost": 193673569,
           "sequencer_cost": 35097832
@@ -28514,13 +28514,13 @@
           "slot_of_change": 305
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75558011099867,
+          "protocol_fee": 75558011099867,
           "congestion_multiplier": 4966589311,
           "prover_cost": 16126194912620,
           "sequencer_cost": 2922414673127
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907442193,
+          "protocol_fee": 907442193,
           "congestion_multiplier": 4966589311,
           "prover_cost": 193673569,
           "sequencer_cost": 35097832
@@ -28568,13 +28568,13 @@
           "slot_of_change": 305
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77060035946587,
+          "protocol_fee": 77060035946587,
           "congestion_multiplier": 5005391559,
           "prover_cost": 16287440913177,
           "sequencer_cost": 2951635929633
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916319038,
+          "protocol_fee": 916319038,
           "congestion_multiplier": 5005391559,
           "prover_cost": 193673569,
           "sequencer_cost": 35097832
@@ -28622,13 +28622,13 @@
           "slot_of_change": 310
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75253266483982,
+          "protocol_fee": 75253266483982,
           "congestion_multiplier": 4919694210,
           "prover_cost": 16253309032006,
           "sequencer_cost": 2945450495878
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896713935,
+          "protocol_fee": 896713935,
           "congestion_multiplier": 4919694210,
           "prover_cost": 193673569,
           "sequencer_cost": 35097832
@@ -28676,13 +28676,13 @@
           "slot_of_change": 310
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75930030462389,
+          "protocol_fee": 75930030462389,
           "congestion_multiplier": 4949407465,
           "prover_cost": 16276096487985,
           "sequencer_cost": 2949580074869
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903511478,
+          "protocol_fee": 903511478,
           "congestion_multiplier": 4949407465,
           "prover_cost": 193673569,
           "sequencer_cost": 35097832
@@ -28730,13 +28730,13 @@
           "slot_of_change": 310
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74224979558971,
+          "protocol_fee": 74224979558971,
           "congestion_multiplier": 4907337732,
           "prover_cost": 16119470183844,
           "sequencer_cost": 2876834891224
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890818292,
+          "protocol_fee": 890818292,
           "congestion_multiplier": 4907337732,
           "prover_cost": 193459385,
           "sequencer_cost": 34526613
@@ -28784,13 +28784,13 @@
           "slot_of_change": 310
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74961781307870,
+          "protocol_fee": 74961781307870,
           "congestion_multiplier": 4920079742,
           "prover_cost": 16226566142046,
           "sequencer_cost": 2895948260693
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 893723292,
+          "protocol_fee": 893723292,
           "congestion_multiplier": 4920079742,
           "prover_cost": 193459385,
           "sequencer_cost": 34526613
@@ -28838,13 +28838,13 @@
           "slot_of_change": 310
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 73614424073899,
+          "protocol_fee": 73614424073899,
           "congestion_multiplier": 4871178291,
           "prover_cost": 16136203889667,
           "sequencer_cost": 2879821348485
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 882574446,
+          "protocol_fee": 882574446,
           "congestion_multiplier": 4871178291,
           "prover_cost": 193459385,
           "sequencer_cost": 34526613
@@ -28892,13 +28892,13 @@
           "slot_of_change": 315
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 73889261584763,
+          "protocol_fee": 73889261584763,
           "congestion_multiplier": 4889905407,
           "prover_cost": 16118473657510,
           "sequencer_cost": 2876657041599
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 886843966,
+          "protocol_fee": 886843966,
           "congestion_multiplier": 4889905407,
           "prover_cost": 193459385,
           "sequencer_cost": 34526613
@@ -28946,13 +28946,13 @@
           "slot_of_change": 315
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74285680914822,
+          "protocol_fee": 74285680914822,
           "congestion_multiplier": 4930719581,
           "prover_cost": 16036687790908,
           "sequencer_cost": 2862060753261
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896149026,
+          "protocol_fee": 896149026,
           "congestion_multiplier": 4930719581,
           "prover_cost": 193459385,
           "sequencer_cost": 34526613
@@ -29000,13 +29000,13 @@
           "slot_of_change": 315
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75299238248388,
+          "protocol_fee": 75299238248388,
           "congestion_multiplier": 4954198695,
           "prover_cost": 16129577744498,
           "sequencer_cost": 2913278739080
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903925037,
+          "protocol_fee": 903925037,
           "congestion_multiplier": 4954198695,
           "prover_cost": 193626516,
           "sequencer_cost": 34972274
@@ -29054,13 +29054,13 @@
           "slot_of_change": 315
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76127529043808,
+          "protocol_fee": 76127529043808,
           "congestion_multiplier": 4974108170,
           "prover_cost": 16225308165316,
           "sequencer_cost": 2930569297089
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908476318,
+          "protocol_fee": 908476318,
           "congestion_multiplier": 4974108170,
           "prover_cost": 193626516,
           "sequencer_cost": 34972274
@@ -29108,13 +29108,13 @@
           "slot_of_change": 315
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75359779186063,
+          "protocol_fee": 75359779186063,
           "congestion_multiplier": 4917505897,
           "prover_cost": 16293743024461,
           "sequencer_cost": 2942929807905
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 895537107,
+          "protocol_fee": 895537107,
           "congestion_multiplier": 4917505897,
           "prover_cost": 193626516,
           "sequencer_cost": 34972274
@@ -29162,13 +29162,13 @@
           "slot_of_change": 320
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 74730932637138,
+          "protocol_fee": 74730932637138,
           "congestion_multiplier": 4878600069,
           "prover_cost": 16319855366546,
           "sequencer_cost": 2947646145321
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 886643282,
+          "protocol_fee": 886643282,
           "congestion_multiplier": 4878600069,
           "prover_cost": 193626516,
           "sequencer_cost": 34972274
@@ -29216,13 +29216,13 @@
           "slot_of_change": 320
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76239815187638,
+          "protocol_fee": 76239815187638,
           "congestion_multiplier": 4925257014,
           "prover_cost": 16451467382933,
           "sequencer_cost": 2971417535696
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 897309003,
+          "protocol_fee": 897309003,
           "congestion_multiplier": 4925257014,
           "prover_cost": 193626516,
           "sequencer_cost": 34972274
@@ -29270,13 +29270,13 @@
           "slot_of_change": 320
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77534861244612,
+          "protocol_fee": 77534861244612,
           "congestion_multiplier": 4915064403,
           "prover_cost": 16572229997795,
           "sequencer_cost": 3232006490183
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911182246,
+          "protocol_fee": 911182246,
           "congestion_multiplier": 4915064403,
           "prover_cost": 194755256,
           "sequencer_cost": 37982230
@@ -29324,13 +29324,13 @@
           "slot_of_change": 320
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 75726794813671,
+          "protocol_fee": 75726794813671,
           "congestion_multiplier": 4812296052,
           "prover_cost": 16622096695233,
           "sequencer_cost": 3241731764922
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 887264199,
+          "protocol_fee": 887264199,
           "congestion_multiplier": 4812296052,
           "prover_cost": 194755256,
           "sequencer_cost": 37982230
@@ -29378,13 +29378,13 @@
           "slot_of_change": 320
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78404027308484,
+          "protocol_fee": 78404027308484,
           "congestion_multiplier": 4933260324,
           "prover_cost": 16680479415303,
           "sequencer_cost": 3253117880743
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915417119,
+          "protocol_fee": 915417119,
           "congestion_multiplier": 4933260324,
           "prover_cost": 194755256,
           "sequencer_cost": 37982230
@@ -29432,13 +29432,13 @@
           "slot_of_change": 325
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76987291405304,
+          "protocol_fee": 76987291405304,
           "congestion_multiplier": 4852531791,
           "prover_cost": 16722286423957,
           "sequencer_cost": 3261271311110
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896628563,
+          "protocol_fee": 896628563,
           "congestion_multiplier": 4852531791,
           "prover_cost": 194755256,
           "sequencer_cost": 37982230
@@ -29486,13 +29486,13 @@
           "slot_of_change": 325
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78220810005436,
+          "protocol_fee": 78220810005436,
           "congestion_multiplier": 4915823973,
           "prover_cost": 16715601015423,
           "sequencer_cost": 3259967486352
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911359027,
+          "protocol_fee": 911359027,
           "congestion_multiplier": 4915823973,
           "prover_cost": 194755256,
           "sequencer_cost": 37982230
@@ -29540,13 +29540,13 @@
           "slot_of_change": 325
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80029360729414,
+          "protocol_fee": 80029360729414,
           "congestion_multiplier": 4903702451,
           "prover_cost": 16858869805247,
           "sequencer_cost": 3642016677042
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932430645,
+          "protocol_fee": 932430645,
           "congestion_multiplier": 4903702451,
           "prover_cost": 196424496,
           "sequencer_cost": 42433526
@@ -29594,13 +29594,13 @@
           "slot_of_change": 325
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79667212448680,
+          "protocol_fee": 79667212448680,
           "congestion_multiplier": 4906633152,
           "prover_cost": 16769990105745,
           "sequencer_cost": 3622816021745
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933130667,
+          "protocol_fee": 933130667,
           "congestion_multiplier": 4906633152,
           "prover_cost": 196424496,
           "sequencer_cost": 42433526
@@ -29648,13 +29648,13 @@
           "slot_of_change": 325
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78171924616343,
+          "protocol_fee": 78171924616343,
           "congestion_multiplier": 4846341888,
           "prover_cost": 16713166358652,
           "sequencer_cost": 3610540404402
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 918729615,
+          "protocol_fee": 918729615,
           "congestion_multiplier": 4846341888,
           "prover_cost": 196424496,
           "sequencer_cost": 42433526
@@ -29702,13 +29702,13 @@
           "slot_of_change": 330
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79909960703329,
+          "protocol_fee": 79909960703329,
           "congestion_multiplier": 4916525125,
           "prover_cost": 16778603695411,
           "sequencer_cost": 3624676812983
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935493444,
+          "protocol_fee": 935493444,
           "congestion_multiplier": 4916525125,
           "prover_cost": 196424496,
           "sequencer_cost": 42433526
@@ -29756,13 +29756,13 @@
           "slot_of_change": 330
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80623528718388,
+          "protocol_fee": 80623528718388,
           "congestion_multiplier": 4934506692,
           "prover_cost": 16851064092631,
           "sequencer_cost": 3640330411246
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939788485,
+          "protocol_fee": 939788485,
           "congestion_multiplier": 4934506692,
           "prover_cost": 196424496,
           "sequencer_cost": 42433526
@@ -29810,13 +29810,13 @@
           "slot_of_change": 330
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78155087772898,
+          "protocol_fee": 78155087772898,
           "congestion_multiplier": 4855599748,
           "prover_cost": 16820190127520,
           "sequencer_cost": 3450349585510
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908646447,
+          "protocol_fee": 908646447,
           "congestion_multiplier": 4855599748,
           "prover_cost": 195554844,
           "sequencer_cost": 40114444
@@ -29864,13 +29864,13 @@
           "slot_of_change": 330
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77060431563986,
+          "protocol_fee": 77060431563986,
           "congestion_multiplier": 4813002026,
           "prover_cost": 16769881335984,
           "sequencer_cost": 3440029671364
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 898607472,
+          "protocol_fee": 898607472,
           "congestion_multiplier": 4813002026,
           "prover_cost": 195554844,
           "sequencer_cost": 40114444
@@ -29918,13 +29918,13 @@
           "slot_of_change": 330
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79705832336608,
+          "protocol_fee": 79705832336608,
           "congestion_multiplier": 4904459171,
           "prover_cost": 16939274443578,
           "sequencer_cost": 3474777521070
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920161112,
+          "protocol_fee": 920161112,
           "congestion_multiplier": 4904459171,
           "prover_cost": 195554844,
           "sequencer_cost": 40114444
@@ -29972,13 +29972,13 @@
           "slot_of_change": 335
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81041870414426,
+          "protocol_fee": 81041870414426,
           "congestion_multiplier": 4954026475,
           "prover_cost": 17007303871204,
           "sequencer_cost": 3488732494565
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931842604,
+          "protocol_fee": 931842604,
           "congestion_multiplier": 4954026475,
           "prover_cost": 195554844,
           "sequencer_cost": 40114444
@@ -30026,13 +30026,13 @@
           "slot_of_change": 335
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80760788785345,
+          "protocol_fee": 80760788785345,
           "congestion_multiplier": 4941494452,
           "prover_cost": 17002203928364,
           "sequencer_cost": 3487686336019
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928889191,
+          "protocol_fee": 928889191,
           "congestion_multiplier": 4941494452,
           "prover_cost": 195554844,
           "sequencer_cost": 40114444
@@ -30080,13 +30080,13 @@
           "slot_of_change": 335
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78613247758240,
+          "protocol_fee": 78613247758240,
           "congestion_multiplier": 4924048878,
           "prover_cost": 16964043796354,
           "sequencer_cost": 3069663792235
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 897407250,
+          "protocol_fee": 897407250,
           "congestion_multiplier": 4924048878,
           "prover_cost": 193652550,
           "sequencer_cost": 35041658
@@ -30134,13 +30134,13 @@
           "slot_of_change": 335
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77621098857874,
+          "protocol_fee": 77621098857874,
           "congestion_multiplier": 4903583827,
           "prover_cost": 16837760639495,
           "sequencer_cost": 3046812705617
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 892727011,
+          "protocol_fee": 892727011,
           "congestion_multiplier": 4903583827,
           "prover_cost": 193652550,
           "sequencer_cost": 35041658
@@ -30188,13 +30188,13 @@
           "slot_of_change": 335
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 76343013863570,
+          "protocol_fee": 76343013863570,
           "congestion_multiplier": 4819344101,
           "prover_cost": 16925775181993,
           "sequencer_cost": 3062739041197
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 873461874,
+          "protocol_fee": 873461874,
           "congestion_multiplier": 4819344101,
           "prover_cost": 193652550,
           "sequencer_cost": 35041658
@@ -30242,13 +30242,13 @@
           "slot_of_change": 340
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77712230052699,
+          "protocol_fee": 77712230052699,
           "congestion_multiplier": 4896397229,
           "prover_cost": 16888621422619,
           "sequencer_cost": 3056016024488
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 891083478,
+          "protocol_fee": 891083478,
           "congestion_multiplier": 4896397229,
           "prover_cost": 193652550,
           "sequencer_cost": 35041658
@@ -30296,13 +30296,13 @@
           "slot_of_change": 340
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78807524889478,
+          "protocol_fee": 78807524889478,
           "congestion_multiplier": 4951708896,
           "prover_cost": 16886933679306,
           "sequencer_cost": 3055710625339
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903732936,
+          "protocol_fee": 903732936,
           "congestion_multiplier": 4951708896,
           "prover_cost": 193652550,
           "sequencer_cost": 35041658
@@ -30350,13 +30350,13 @@
           "slot_of_change": 340
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79806369435308,
+          "protocol_fee": 79806369435308,
           "congestion_multiplier": 4932733376,
           "prover_cost": 16985880600369,
           "sequencer_cost": 3306969653938
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914912669,
+          "protocol_fee": 914912669,
           "congestion_multiplier": 4932733376,
           "prover_cost": 194728785,
           "sequencer_cost": 37911616
@@ -30404,13 +30404,13 @@
           "slot_of_change": 340
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79143815651921,
+          "protocol_fee": 79143815651921,
           "congestion_multiplier": 4918413972,
           "prover_cost": 16906421207017,
           "sequencer_cost": 3291499758162
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911581397,
+          "protocol_fee": 911581397,
           "congestion_multiplier": 4918413972,
           "prover_cost": 194728785,
           "sequencer_cost": 37911616
@@ -30458,13 +30458,13 @@
           "slot_of_change": 340
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78802577633810,
+          "protocol_fee": 78802577633810,
           "congestion_multiplier": 4887473767,
           "prover_cost": 16967504320977,
           "sequencer_cost": 3303391988479
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904383456,
+          "protocol_fee": 904383456,
           "congestion_multiplier": 4887473767,
           "prover_cost": 194728785,
           "sequencer_cost": 37911616
@@ -30512,13 +30512,13 @@
           "slot_of_change": 345
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79927778239912,
+          "protocol_fee": 79927778239912,
           "congestion_multiplier": 4940221727,
           "prover_cost": 16979390485518,
           "sequencer_cost": 3305706097848
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916654762,
+          "protocol_fee": 916654762,
           "congestion_multiplier": 4940221727,
           "prover_cost": 194728785,
           "sequencer_cost": 37911616
@@ -30566,13 +30566,13 @@
           "slot_of_change": 345
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80640798240120,
+          "protocol_fee": 80640798240120,
           "congestion_multiplier": 4965433013,
           "prover_cost": 17021946323498,
           "sequencer_cost": 3313991265283
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922519926,
+          "protocol_fee": 922519926,
           "congestion_multiplier": 4965433013,
           "prover_cost": 194728785,
           "sequencer_cost": 37911616
@@ -30620,13 +30620,13 @@
           "slot_of_change": 345
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79950275678268,
+          "protocol_fee": 79950275678268,
           "congestion_multiplier": 4884763345,
           "prover_cost": 17173028685087,
           "sequencer_cost": 3407446527293
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907943633,
+          "protocol_fee": 907943633,
           "congestion_multiplier": 4884763345,
           "prover_cost": 195022993,
           "sequencer_cost": 38696169
@@ -30674,13 +30674,13 @@
           "slot_of_change": 345
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 68561877347763,
+          "protocol_fee": 68561877347763,
           "congestion_multiplier": 4347394589,
           "prover_cost": 17090992671546,
           "sequencer_cost": 3391169064850
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 782350258,
+          "protocol_fee": 782350258,
           "congestion_multiplier": 4347394589,
           "prover_cost": 195022993,
           "sequencer_cost": 38696169
@@ -30728,13 +30728,13 @@
           "slot_of_change": 345
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79682180211033,
+          "protocol_fee": 79682180211033,
           "congestion_multiplier": 4861921242,
           "prover_cost": 17216675447608,
           "sequencer_cost": 3416106852277
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 902604996,
+          "protocol_fee": 902604996,
           "congestion_multiplier": 4861921242,
           "prover_cost": 195022993,
           "sequencer_cost": 38696169
@@ -30782,13 +30782,13 @@
           "slot_of_change": 350
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80825806239327,
+          "protocol_fee": 80825806239327,
           "congestion_multiplier": 4878175248,
           "prover_cost": 17390581818481,
           "sequencer_cost": 3450613092869
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 906403869,
+          "protocol_fee": 906403869,
           "congestion_multiplier": 4878175248,
           "prover_cost": 195022993,
           "sequencer_cost": 38696169
@@ -30836,13 +30836,13 @@
           "slot_of_change": 350
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79830710382707,
+          "protocol_fee": 79830710382707,
           "congestion_multiplier": 4868732654,
           "prover_cost": 17218399177853,
           "sequencer_cost": 3416448872240
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904196953,
+          "protocol_fee": 904196953,
           "congestion_multiplier": 4868732654,
           "prover_cost": 195022993,
           "sequencer_cost": 38696169
@@ -30890,13 +30890,13 @@
           "slot_of_change": 350
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81820973539040,
+          "protocol_fee": 81820973539040,
           "congestion_multiplier": 4930835515,
           "prover_cost": 17259468158673,
           "sequencer_cost": 3555692700019
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927388206,
+          "protocol_fee": 927388206,
           "congestion_multiplier": 4930835515,
           "prover_cost": 195624991,
           "sequencer_cost": 40301494
@@ -30944,13 +30944,13 @@
           "slot_of_change": 350
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80617092710654,
+          "protocol_fee": 80617092710654,
           "congestion_multiplier": 4888877784,
           "prover_cost": 17188994596879,
           "sequencer_cost": 3541174157100
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917489266,
+          "protocol_fee": 917489266,
           "congestion_multiplier": 4888877784,
           "prover_cost": 195624991,
           "sequencer_cost": 40301494
@@ -30998,13 +30998,13 @@
           "slot_of_change": 350
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82191751191532,
+          "protocol_fee": 82191751191532,
           "congestion_multiplier": 4927964443,
           "prover_cost": 17350353339685,
           "sequencer_cost": 3574416323001
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926710844,
+          "protocol_fee": 926710844,
           "congestion_multiplier": 4927964443,
           "prover_cost": 195624991,
           "sequencer_cost": 40301494
@@ -31052,13 +31052,13 @@
           "slot_of_change": 355
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81754868389611,
+          "protocol_fee": 81754868389611,
           "congestion_multiplier": 4916853257,
           "prover_cost": 17307086337616,
           "sequencer_cost": 3565502713265
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924089421,
+          "protocol_fee": 924089421,
           "congestion_multiplier": 4916853257,
           "prover_cost": 195624991,
           "sequencer_cost": 40301494
@@ -31106,13 +31106,13 @@
           "slot_of_change": 355
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79733392925979,
+          "protocol_fee": 79733392925979,
           "congestion_multiplier": 4790972590,
           "prover_cost": 17439628882898,
           "sequencer_cost": 3592808338002
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 894390837,
+          "protocol_fee": 894390837,
           "congestion_multiplier": 4790972590,
           "prover_cost": 195624991,
           "sequencer_cost": 40301494
@@ -31160,13 +31160,13 @@
           "slot_of_change": 355
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79253371509240,
+          "protocol_fee": 79253371509240,
           "congestion_multiplier": 4825095514,
           "prover_cost": 17294847849249,
           "sequencer_cost": 3424470458761
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 893540235,
+          "protocol_fee": 893540235,
           "congestion_multiplier": 4825095514,
           "prover_cost": 194990347,
           "sequencer_cost": 38609110
@@ -31214,13 +31214,13 @@
           "slot_of_change": 355
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80236971871555,
+          "protocol_fee": 80236971871555,
           "congestion_multiplier": 4893479947,
           "prover_cost": 17201957538527,
           "sequencer_cost": 3406077690710
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909514801,
+          "protocol_fee": 909514801,
           "congestion_multiplier": 4893479947,
           "prover_cost": 194990347,
           "sequencer_cost": 38609110
@@ -31268,13 +31268,13 @@
           "slot_of_change": 355
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80951962136814,
+          "protocol_fee": 80951962136814,
           "congestion_multiplier": 4926996090,
           "prover_cost": 17207120270577,
           "sequencer_cost": 3407099938696
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917344154,
+          "protocol_fee": 917344154,
           "congestion_multiplier": 4926996090,
           "prover_cost": 194990347,
           "sequencer_cost": 38609110
@@ -31322,13 +31322,13 @@
           "slot_of_change": 360
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80648294635138,
+          "protocol_fee": 80648294635138,
           "congestion_multiplier": 4913829753,
           "prover_cost": 17200241362207,
           "sequencer_cost": 3405737878809
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914268505,
+          "protocol_fee": 914268505,
           "congestion_multiplier": 4913829753,
           "prover_cost": 194990347,
           "sequencer_cost": 38609110
@@ -31376,13 +31376,13 @@
           "slot_of_change": 360
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80259466167895,
+          "protocol_fee": 80259466167895,
           "congestion_multiplier": 4902360374,
           "prover_cost": 17167623376171,
           "sequencer_cost": 3399279346732
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911589264,
+          "protocol_fee": 911589264,
           "congestion_multiplier": 4902360374,
           "prover_cost": 194990347,
           "sequencer_cost": 38609110
@@ -31430,13 +31430,13 @@
           "slot_of_change": 360
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78713301788223,
+          "protocol_fee": 78713301788223,
           "congestion_multiplier": 4881000568,
           "prover_cost": 17030049340949,
           "sequencer_cost": 3251653902322
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 898676772,
+          "protocol_fee": 898676772,
           "congestion_multiplier": 4881000568,
           "prover_cost": 194433589,
           "sequencer_cost": 37124422
@@ -31484,13 +31484,13 @@
           "slot_of_change": 360
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79849368932209,
+          "protocol_fee": 79849368932209,
           "congestion_multiplier": 4939770533,
           "prover_cost": 17018138078684,
           "sequencer_cost": 3249379610471
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912285428,
+          "protocol_fee": 912285428,
           "congestion_multiplier": 4939770533,
           "prover_cost": 194433589,
           "sequencer_cost": 37124422
@@ -31538,13 +31538,13 @@
           "slot_of_change": 360
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81290996807197,
+          "protocol_fee": 81290996807197,
           "congestion_multiplier": 4990444876,
           "prover_cost": 17105375632148,
           "sequencer_cost": 3266036422526
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924019478,
+          "protocol_fee": 924019478,
           "congestion_multiplier": 4990444876,
           "prover_cost": 194433589,
           "sequencer_cost": 37124422
@@ -31592,13 +31592,13 @@
           "slot_of_change": 365
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78634138093875,
+          "protocol_fee": 78634138093875,
           "congestion_multiplier": 4872375743,
           "prover_cost": 17050814224272,
           "sequencer_cost": 3255618671451
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896679624,
+          "protocol_fee": 896679624,
           "congestion_multiplier": 4872375743,
           "prover_cost": 194433589,
           "sequencer_cost": 37124422
@@ -31646,13 +31646,13 @@
           "slot_of_change": 365
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 73810372446654,
+          "protocol_fee": 73810372446654,
           "congestion_multiplier": 4607202158,
           "prover_cost": 17181394015122,
           "sequencer_cost": 3280551088144
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 835276556,
+          "protocol_fee": 835276556,
           "congestion_multiplier": 4607202158,
           "prover_cost": 194433589,
           "sequencer_cost": 37124422
@@ -31700,13 +31700,13 @@
           "slot_of_change": 365
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79406511824924,
+          "protocol_fee": 79406511824924,
           "congestion_multiplier": 4913488294,
           "prover_cost": 17023180664941,
           "sequencer_cost": 3267288069881
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907321832,
+          "protocol_fee": 907321832,
           "congestion_multiplier": 4913488294,
           "prover_cost": 194511799,
           "sequencer_cost": 37332981
@@ -31754,13 +31754,13 @@
           "slot_of_change": 365
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78922739133386,
+          "protocol_fee": 78922739133386,
           "congestion_multiplier": 4892368549,
           "prover_cost": 17011273373559,
           "sequencer_cost": 3265002683158
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 902425329,
+          "protocol_fee": 902425329,
           "congestion_multiplier": 4892368549,
           "prover_cost": 194511799,
           "sequencer_cost": 37332981
@@ -31808,13 +31808,13 @@
           "slot_of_change": 365
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 73382174393033,
+          "protocol_fee": 73382174393033,
           "congestion_multiplier": 4621648362,
           "prover_cost": 16999373814268,
           "sequencer_cost": 3262718780469
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 839660267,
+          "protocol_fee": 839660267,
           "congestion_multiplier": 4621648362,
           "prover_cost": 194511799,
           "sequencer_cost": 37332981
@@ -31862,13 +31862,13 @@
           "slot_of_change": 370
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79332072922004,
+          "protocol_fee": 79332072922004,
           "congestion_multiplier": 4894935591,
           "prover_cost": 17088232746413,
           "sequencer_cost": 3279773626717
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903020485,
+          "protocol_fee": 903020485,
           "congestion_multiplier": 4894935591,
           "prover_cost": 194511799,
           "sequencer_cost": 37332981
@@ -31916,13 +31916,13 @@
           "slot_of_change": 370
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82197235877229,
+          "protocol_fee": 82197235877229,
           "congestion_multiplier": 4995249290,
           "prover_cost": 17260841280530,
           "sequencer_cost": 3312902676768
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926277692,
+          "protocol_fee": 926277692,
           "congestion_multiplier": 4995249290,
           "prover_cost": 194511799,
           "sequencer_cost": 37332981
@@ -31970,13 +31970,13 @@
           "slot_of_change": 370
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78934097352572,
+          "protocol_fee": 78934097352572,
           "congestion_multiplier": 4915429627,
           "prover_cost": 17058916749995,
           "sequencer_cost": 3100837066029
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896354692,
+          "protocol_fee": 896354692,
           "congestion_multiplier": 4915429627,
           "prover_cost": 193716538,
           "sequencer_cost": 35212284
@@ -32024,13 +32024,13 @@
           "slot_of_change": 370
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81778306297979,
+          "protocol_fee": 81778306297979,
           "congestion_multiplier": 5052861981,
           "prover_cost": 17074284867129,
           "sequencer_cost": 3103630562706
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927816919,
+          "protocol_fee": 927816919,
           "congestion_multiplier": 5052861981,
           "prover_cost": 193716538,
           "sequencer_cost": 35212284
@@ -32078,13 +32078,13 @@
           "slot_of_change": 370
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81339536207341,
+          "protocol_fee": 81339536207341,
           "congestion_multiplier": 5019023404,
           "prover_cost": 17125662546103,
           "sequencer_cost": 3112969597163
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920070293,
+          "protocol_fee": 920070293,
           "congestion_multiplier": 5019023404,
           "prover_cost": 193716538,
           "sequencer_cost": 35212284
@@ -32132,13 +32132,13 @@
           "slot_of_change": 375
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80166700143608,
+          "protocol_fee": 80166700143608,
           "congestion_multiplier": 4940079293,
           "prover_cost": 17216912443699,
           "sequencer_cost": 3129556293076
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 901997711,
+          "protocol_fee": 901997711,
           "congestion_multiplier": 4940079293,
           "prover_cost": 193716538,
           "sequencer_cost": 35212284
@@ -32186,13 +32186,13 @@
           "slot_of_change": 375
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78409097943826,
+          "protocol_fee": 78409097943826,
           "congestion_multiplier": 4879515331,
           "prover_cost": 17102327192295,
           "sequencer_cost": 3108727878237
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 888132874,
+          "protocol_fee": 888132874,
           "congestion_multiplier": 4879515331,
           "prover_cost": 193716538,
           "sequencer_cost": 35212284
@@ -32240,13 +32240,13 @@
           "slot_of_change": 375
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80881920861353,
+          "protocol_fee": 80881920861353,
           "congestion_multiplier": 4932742056,
           "prover_cost": 17269171571876,
           "sequencer_cost": 3297120272950
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 910645422,
+          "protocol_fee": 910645422,
           "congestion_multiplier": 4932742056,
           "prover_cost": 194432722,
           "sequencer_cost": 37122109
@@ -32294,13 +32294,13 @@
           "slot_of_change": 375
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 77724837430898,
+          "protocol_fee": 77724837430898,
           "congestion_multiplier": 4798886231,
           "prover_cost": 17179837234300,
           "sequencer_cost": 3280064095456
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 879650459,
+          "protocol_fee": 879650459,
           "congestion_multiplier": 4798886231,
           "prover_cost": 194432722,
           "sequencer_cost": 37122109
@@ -32348,13 +32348,13 @@
           "slot_of_change": 375
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80136292719423,
+          "protocol_fee": 80136292719423,
           "congestion_multiplier": 4935548795,
           "prover_cost": 17097769415586,
           "sequencer_cost": 3264395279629
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911295336,
+          "protocol_fee": 911295336,
           "congestion_multiplier": 4935548795,
           "prover_cost": 194432722,
           "sequencer_cost": 37122109
@@ -32402,13 +32402,13 @@
           "slot_of_change": 380
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80464238589482,
+          "protocol_fee": 80464238589482,
           "congestion_multiplier": 4912137616,
           "prover_cost": 17270475415077,
           "sequencer_cost": 3297369209491
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 905874364,
+          "protocol_fee": 905874364,
           "congestion_multiplier": 4912137616,
           "prover_cost": 194432722,
           "sequencer_cost": 37122109
@@ -32456,13 +32456,13 @@
           "slot_of_change": 380
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80943095581777,
+          "protocol_fee": 80943095581777,
           "congestion_multiplier": 4944470687,
           "prover_cost": 17230845431298,
           "sequencer_cost": 3289802846369
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913361243,
+          "protocol_fee": 913361243,
           "congestion_multiplier": 4944470687,
           "prover_cost": 194432722,
           "sequencer_cost": 37122109
@@ -32510,13 +32510,13 @@
           "slot_of_change": 380
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79898323174115,
+          "protocol_fee": 79898323174115,
           "congestion_multiplier": 4971601664,
           "prover_cost": 17093015401811,
           "sequencer_cost": 3024390612633
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903735766,
+          "protocol_fee": 903735766,
           "congestion_multiplier": 4971601664,
           "prover_cost": 193340345,
           "sequencer_cost": 34209103
@@ -32564,13 +32564,13 @@
           "slot_of_change": 380
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79505115974828,
+          "protocol_fee": 79505115974828,
           "congestion_multiplier": 4915301917,
           "prover_cost": 17253472730388,
           "sequencer_cost": 3052781486149
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890924789,
+          "protocol_fee": 890924789,
           "congestion_multiplier": 4915301917,
           "prover_cost": 193340345,
           "sequencer_cost": 34209103
@@ -32618,13 +32618,13 @@
           "slot_of_change": 380
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81062581686017,
+          "protocol_fee": 81062581686017,
           "congestion_multiplier": 4995593430,
           "prover_cost": 17237959016456,
           "sequencer_cost": 3050036532746
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909195079,
+          "protocol_fee": 909195079,
           "congestion_multiplier": 4995593430,
           "prover_cost": 193340345,
           "sequencer_cost": 34209103
@@ -32672,13 +32672,13 @@
           "slot_of_change": 385
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81195552294968,
+          "protocol_fee": 81195552294968,
           "congestion_multiplier": 4991741823,
           "prover_cost": 17282895300830,
           "sequencer_cost": 3057987433944
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908318648,
+          "protocol_fee": 908318648,
           "congestion_multiplier": 4991741823,
           "prover_cost": 193340345,
           "sequencer_cost": 34209103
@@ -32726,13 +32726,13 @@
           "slot_of_change": 385
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80586609966573,
+          "protocol_fee": 80586609966573,
           "congestion_multiplier": 4978048041,
           "prover_cost": 17212326136587,
           "sequencer_cost": 3045501122263
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 905202635,
+          "protocol_fee": 905202635,
           "congestion_multiplier": 4978048041,
           "prover_cost": 193340345,
           "sequencer_cost": 34209103
@@ -32780,13 +32780,13 @@
           "slot_of_change": 385
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 79420590774433,
+          "protocol_fee": 79420590774433,
           "congestion_multiplier": 4908290537,
           "prover_cost": 17181848367382,
           "sequencer_cost": 3139207628241
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 895762685,
+          "protocol_fee": 895762685,
           "congestion_multiplier": 4908290537,
           "prover_cost": 193789274,
           "sequencer_cost": 35406247
@@ -32834,13 +32834,13 @@
           "slot_of_change": 385
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81088610102805,
+          "protocol_fee": 81088610102805,
           "congestion_multiplier": 4953662123,
           "prover_cost": 17341390337466,
           "sequencer_cost": 3168356725521
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 906161650,
+          "protocol_fee": 906161650,
           "congestion_multiplier": 4953662123,
           "prover_cost": 193789274,
           "sequencer_cost": 35406247
@@ -32888,13 +32888,13 @@
           "slot_of_change": 385
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82700760868380,
+          "protocol_fee": 82700760868380,
           "congestion_multiplier": 5002023956,
           "prover_cost": 17472434896927,
           "sequencer_cost": 3192299206674
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917245965,
+          "protocol_fee": 917245965,
           "congestion_multiplier": 5002023956,
           "prover_cost": 193789274,
           "sequencer_cost": 35406247
@@ -32942,13 +32942,13 @@
           "slot_of_change": 390
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82300953068415,
+          "protocol_fee": 82300953068415,
           "congestion_multiplier": 4998607107,
           "prover_cost": 17402824496451,
           "sequencer_cost": 3179581046467
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916462839,
+          "protocol_fee": 916462839,
           "congestion_multiplier": 4998607107,
           "prover_cost": 193789274,
           "sequencer_cost": 35406247
@@ -32996,13 +32996,13 @@
           "slot_of_change": 390
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81976862860868,
+          "protocol_fee": 81976862860868,
           "congestion_multiplier": 4982462678,
           "prover_cost": 17404565655263,
           "sequencer_cost": 3179899164688
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912762608,
+          "protocol_fee": 912762608,
           "congestion_multiplier": 4982462678,
           "prover_cost": 193789274,
           "sequencer_cost": 35406247
@@ -33050,13 +33050,13 @@
           "slot_of_change": 390
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86258935113342,
+          "protocol_fee": 86258935113342,
           "congestion_multiplier": 5015962222,
           "prover_cost": 17641465952158,
           "sequencer_cost": 3837554605378
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 961017093,
+          "protocol_fee": 961017093,
           "congestion_multiplier": 5015962222,
           "prover_cost": 196544860,
           "sequencer_cost": 42754476
@@ -33104,13 +33104,13 @@
           "slot_of_change": 390
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85784371953158,
+          "protocol_fee": 85784371953158,
           "congestion_multiplier": 5015035213,
           "prover_cost": 17548460195070,
           "sequencer_cost": 3817323028682
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 960795260,
+          "protocol_fee": 960795260,
           "congestion_multiplier": 5015035213,
           "prover_cost": 196544860,
           "sequencer_cost": 42754476
@@ -33158,13 +33158,13 @@
           "slot_of_change": 390
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85083070552016,
+          "protocol_fee": 85083070552016,
           "congestion_multiplier": 4961105788,
           "prover_cost": 17641963173246,
           "sequencer_cost": 3837662766065
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947889984,
+          "protocol_fee": 947889984,
           "congestion_multiplier": 4961105788,
           "prover_cost": 196544860,
           "sequencer_cost": 42754476
@@ -33212,13 +33212,13 @@
           "slot_of_change": 395
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83227375829826,
+          "protocol_fee": 83227375829826,
           "congestion_multiplier": 4880524557,
           "prover_cost": 17615540082116,
           "sequencer_cost": 3831914941291
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928606949,
+          "protocol_fee": 928606949,
           "congestion_multiplier": 4880524557,
           "prover_cost": 196544860,
           "sequencer_cost": 42754476
@@ -33266,13 +33266,13 @@
           "slot_of_change": 395
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83093670860515,
+          "protocol_fee": 83093670860515,
           "congestion_multiplier": 4851819367,
           "prover_cost": 17718307334986,
           "sequencer_cost": 3854269939770
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921737816,
+          "protocol_fee": 921737816,
           "congestion_multiplier": 4851819367,
           "prover_cost": 196544860,
           "sequencer_cost": 42754476
@@ -33320,13 +33320,13 @@
           "slot_of_change": 395
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84469602054185,
+          "protocol_fee": 84469602054185,
           "congestion_multiplier": 4961630101,
           "prover_cost": 17679610636182,
           "sequencer_cost": 3642319980508
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934658174,
+          "protocol_fee": 934658174,
           "congestion_multiplier": 4961630101,
           "prover_cost": 195625316,
           "sequencer_cost": 40302358
@@ -33374,13 +33374,13 @@
           "slot_of_change": 395
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83883345923252,
+          "protocol_fee": 83883345923252,
           "congestion_multiplier": 4913676835,
           "prover_cost": 17772026580096,
           "sequencer_cost": 3661359338669
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 923344672,
+          "protocol_fee": 923344672,
           "congestion_multiplier": 4913676835,
           "prover_cost": 195625316,
           "sequencer_cost": 40302358
@@ -33428,13 +33428,13 @@
           "slot_of_change": 395
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85506861256764,
+          "protocol_fee": 85506861256764,
           "congestion_multiplier": 4976657691,
           "prover_cost": 17829079712924,
           "sequencer_cost": 3673113317301
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 938203599,
+          "protocol_fee": 938203599,
           "congestion_multiplier": 4976657691,
           "prover_cost": 195625316,
           "sequencer_cost": 40302358
@@ -33482,13 +33482,13 @@
           "slot_of_change": 400
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85263344463690,
+          "protocol_fee": 85263344463690,
           "congestion_multiplier": 4949470809,
           "prover_cost": 17900684008624,
           "sequencer_cost": 3687865099017
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931789461,
+          "protocol_fee": 931789461,
           "congestion_multiplier": 4949470809,
           "prover_cost": 195625316,
           "sequencer_cost": 40302358
@@ -33536,13 +33536,13 @@
           "slot_of_change": 400
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84958536318427,
+          "protocol_fee": 84958536318427,
           "congestion_multiplier": 4912133041,
           "prover_cost": 18006925878228,
           "sequencer_cost": 3709752848266
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922980448,
+          "protocol_fee": 922980448,
           "congestion_multiplier": 4912133041,
           "prover_cost": 195625316,
           "sequencer_cost": 40302358
@@ -33590,13 +33590,13 @@
           "slot_of_change": 400
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80731738810165,
+          "protocol_fee": 80731738810165,
           "congestion_multiplier": 4791901605,
           "prover_cost": 17821030258986,
           "sequencer_cost": 3469537708901
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 882147879,
+          "protocol_fee": 882147879,
           "congestion_multiplier": 4791901605,
           "prover_cost": 194728669,
           "sequencer_cost": 37911302
@@ -33644,13 +33644,13 @@
           "slot_of_change": 400
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82779169581585,
+          "protocol_fee": 82779169581585,
           "congestion_multiplier": 4901675878,
           "prover_cost": 17758874459230,
           "sequencer_cost": 3457436731127
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907685763,
+          "protocol_fee": 907685763,
           "congestion_multiplier": 4901675878,
           "prover_cost": 194728669,
           "sequencer_cost": 37911302
@@ -33698,13 +33698,13 @@
           "slot_of_change": 400
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83961689197627,
+          "protocol_fee": 83961689197627,
           "congestion_multiplier": 4930897376,
           "prover_cost": 17878662336757,
           "sequencer_cost": 3480757973059
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914483851,
+          "protocol_fee": 914483851,
           "congestion_multiplier": 4930897376,
           "prover_cost": 194728669,
           "sequencer_cost": 37911302
@@ -33752,13 +33752,13 @@
           "slot_of_change": 405
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83817841861960,
+          "protocol_fee": 83817841861960,
           "congestion_multiplier": 4926124546,
           "prover_cost": 17869728850500,
           "sequencer_cost": 3479018732006
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913373500,
+          "protocol_fee": 913373500,
           "congestion_multiplier": 4926124546,
           "prover_cost": 194728669,
           "sequencer_cost": 37911302
@@ -33806,13 +33806,13 @@
           "slot_of_change": 405
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82772878062135,
+          "protocol_fee": 82772878062135,
           "congestion_multiplier": 4867871690,
           "prover_cost": 17912720859986,
           "sequencer_cost": 3487388753038
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 899821557,
+          "protocol_fee": 899821557,
           "congestion_multiplier": 4867871690,
           "prover_cost": 194728669,
           "sequencer_cost": 37911302
@@ -33860,13 +33860,13 @@
           "slot_of_change": 405
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83870281936046,
+          "protocol_fee": 83870281936046,
           "congestion_multiplier": 4900920068,
           "prover_cost": 17882309967152,
           "sequencer_cost": 3617818338317
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916127754,
+          "protocol_fee": 916127754,
           "congestion_multiplier": 4900920068,
           "prover_cost": 195331172,
           "sequencer_cost": 39517976
@@ -33914,13 +33914,13 @@
           "slot_of_change": 405
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85924923939484,
+          "protocol_fee": 85924923939484,
           "congestion_multiplier": 4989290449,
           "prover_cost": 17914556707491,
           "sequencer_cost": 3624342263289
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936881463,
+          "protocol_fee": 936881463,
           "congestion_multiplier": 4989290449,
           "prover_cost": 195331172,
           "sequencer_cost": 39517976
@@ -33968,13 +33968,13 @@
           "slot_of_change": 405
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82139473199089,
+          "protocol_fee": 82139473199089,
           "congestion_multiplier": 4805913860,
           "prover_cost": 17950457659028,
           "sequencer_cost": 3631605481580
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 893815627,
+          "protocol_fee": 893815627,
           "congestion_multiplier": 4805913860,
           "prover_cost": 195331172,
           "sequencer_cost": 39517976
@@ -34022,13 +34022,13 @@
           "slot_of_change": 410
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83083837637834,
+          "protocol_fee": 83083837637834,
           "congestion_multiplier": 4848900604,
           "prover_cost": 17954049563836,
           "sequencer_cost": 3632332169525
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903911027,
+          "protocol_fee": 903911027,
           "congestion_multiplier": 4848900604,
           "prover_cost": 195331172,
           "sequencer_cost": 39517976
@@ -34076,13 +34076,13 @@
           "slot_of_change": 410
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85783081556893,
+          "protocol_fee": 85783081556893,
           "congestion_multiplier": 5005735976,
           "prover_cost": 17811557171947,
           "sequencer_cost": 3603504149577
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940743681,
+          "protocol_fee": 940743681,
           "congestion_multiplier": 5005735976,
           "prover_cost": 195331172,
           "sequencer_cost": 39517976
@@ -34130,13 +34130,13 @@
           "slot_of_change": 410
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83127031230202,
+          "protocol_fee": 83127031230202,
           "congestion_multiplier": 4968018373,
           "prover_cost": 17680930059992,
           "sequencer_cost": 3268325580251
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911889401,
+          "protocol_fee": 911889401,
           "congestion_multiplier": 4968018373,
           "prover_cost": 193956797,
           "sequencer_cost": 35852976
@@ -34184,13 +34184,13 @@
           "slot_of_change": 410
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83112996390324,
+          "protocol_fee": 83112996390324,
           "congestion_multiplier": 4933229063,
           "prover_cost": 17834305841329,
           "sequencer_cost": 3296677142518
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903894478,
+          "protocol_fee": 903894478,
           "congestion_multiplier": 4933229063,
           "prover_cost": 193956797,
           "sequencer_cost": 35852976
@@ -34238,13 +34238,13 @@
           "slot_of_change": 410
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82036751798232,
+          "protocol_fee": 82036751798232,
           "congestion_multiplier": 4879190947,
           "prover_cost": 17848585709044,
           "sequencer_cost": 3299316780635
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 891475990,
+          "protocol_fee": 891475990,
           "congestion_multiplier": 4879190947,
           "prover_cost": 193956797,
           "sequencer_cost": 35852976
@@ -34292,13 +34292,13 @@
           "slot_of_change": 415
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83353409932994,
+          "protocol_fee": 83353409932994,
           "congestion_multiplier": 4936720407,
           "prover_cost": 17870031151454,
           "sequencer_cost": 3303280977528
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904696823,
+          "protocol_fee": 904696823,
           "congestion_multiplier": 4936720407,
           "prover_cost": 193956797,
           "sequencer_cost": 35852976
@@ -34346,13 +34346,13 @@
           "slot_of_change": 415
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81965898698534,
+          "protocol_fee": 81965898698534,
           "congestion_multiplier": 4874673210,
           "prover_cost": 17853963196995,
           "sequencer_cost": 3300310811004
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890437770,
+          "protocol_fee": 890437770,
           "congestion_multiplier": 4874673210,
           "prover_cost": 193956797,
           "sequencer_cost": 35852976
@@ -34400,13 +34400,13 @@
           "slot_of_change": 415
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83955884406880,
+          "protocol_fee": 83955884406880,
           "congestion_multiplier": 4976951645,
           "prover_cost": 17900341584832,
           "sequencer_cost": 3210270761245
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907678130,
+          "protocol_fee": 907678130,
           "congestion_multiplier": 4976951645,
           "prover_cost": 193527216,
           "sequencer_cost": 34707425
@@ -34454,13 +34454,13 @@
           "slot_of_change": 415
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83404621991113,
+          "protocol_fee": 83404621991113,
           "congestion_multiplier": 4957949937,
           "prover_cost": 17868179631663,
           "sequencer_cost": 3204502794339
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 903341282,
+          "protocol_fee": 903341282,
           "congestion_multiplier": 4957949937,
           "prover_cost": 193527216,
           "sequencer_cost": 34707425
@@ -34508,13 +34508,13 @@
           "slot_of_change": 415
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83521520822728,
+          "protocol_fee": 83521520822728,
           "congestion_multiplier": 4934167152,
           "prover_cost": 18001391353720,
           "sequencer_cost": 3228393159466
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 897913227,
+          "protocol_fee": 897913227,
           "congestion_multiplier": 4934167152,
           "prover_cost": 193527216,
           "sequencer_cost": 34707425
@@ -34562,13 +34562,13 @@
           "slot_of_change": 420
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88866916019282,
+          "protocol_fee": 88866916019282,
           "congestion_multiplier": 5172977887,
           "prover_cost": 18057370695918,
           "sequencer_cost": 3238432568192
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952418109,
+          "protocol_fee": 952418109,
           "congestion_multiplier": 5172977887,
           "prover_cost": 193527216,
           "sequencer_cost": 34707425
@@ -34616,13 +34616,13 @@
           "slot_of_change": 420
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88241435889065,
+          "protocol_fee": 88241435889065,
           "congestion_multiplier": 5102170582,
           "prover_cost": 18239769187683,
           "sequencer_cost": 3271144153176
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936257430,
+          "protocol_fee": 936257430,
           "congestion_multiplier": 5102170582,
           "prover_cost": 193527216,
           "sequencer_cost": 34707425
@@ -34670,13 +34670,13 @@
           "slot_of_change": 420
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88853423245227,
+          "protocol_fee": 88853423245227,
           "congestion_multiplier": 5032332600,
           "prover_cost": 18355607046810,
           "sequencer_cost": 3679634619615
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944824742,
+          "protocol_fee": 944824742,
           "congestion_multiplier": 5032332600,
           "prover_cost": 195184733,
           "sequencer_cost": 39127472
@@ -34724,13 +34724,13 @@
           "slot_of_change": 420
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88733748356629,
+          "protocol_fee": 88733748356629,
           "congestion_multiplier": 4998713088,
           "prover_cost": 18485002679210,
           "sequencer_cost": 3705573758941
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936947280,
+          "protocol_fee": 936947280,
           "congestion_multiplier": 4998713088,
           "prover_cost": 195184733,
           "sequencer_cost": 39127472
@@ -34778,13 +34778,13 @@
           "slot_of_change": 420
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88419612661550,
+          "protocol_fee": 88419612661550,
           "congestion_multiplier": 4968618345,
           "prover_cost": 18559240795414,
           "sequencer_cost": 3720455813334
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929895715,
+          "protocol_fee": 929895715,
           "congestion_multiplier": 4968618345,
           "prover_cost": 195184733,
           "sequencer_cost": 39127472
@@ -34832,13 +34832,13 @@
           "slot_of_change": 425
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87474775191701,
+          "protocol_fee": 87474775191701,
           "congestion_multiplier": 4898726847,
           "prover_cost": 18690071396487,
           "sequencer_cost": 3746682611924
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913519284,
+          "protocol_fee": 913519284,
           "congestion_multiplier": 4898726847,
           "prover_cost": 195184733,
           "sequencer_cost": 39127472
@@ -34886,13 +34886,13 @@
           "slot_of_change": 425
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89853486888252,
+          "protocol_fee": 89853486888252,
           "congestion_multiplier": 4994332810,
           "prover_cost": 18738793334689,
           "sequencer_cost": 3756449596480
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935920928,
+          "protocol_fee": 935920928,
           "congestion_multiplier": 4994332810,
           "prover_cost": 195184733,
           "sequencer_cost": 39127472
@@ -34940,13 +34940,13 @@
           "slot_of_change": 425
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81483753856400,
+          "protocol_fee": 81483753856400,
           "congestion_multiplier": 4658280601,
           "prover_cost": 18701123336581,
           "sequencer_cost": 3572661209432
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 847213397,
+          "protocol_fee": 847213397,
           "congestion_multiplier": 4658280601,
           "prover_cost": 194441732,
           "sequencer_cost": 37146134
@@ -34994,13 +34994,13 @@
           "slot_of_change": 425
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84653937976348,
+          "protocol_fee": 84653937976348,
           "congestion_multiplier": 4809729888,
           "prover_cost": 18656349156548,
           "sequencer_cost": 3564107553413
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 882287214,
+          "protocol_fee": 882287214,
           "congestion_multiplier": 4809729888,
           "prover_cost": 194441732,
           "sequencer_cost": 37146134
@@ -35048,13 +35048,13 @@
           "slot_of_change": 425
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85604795463784,
+          "protocol_fee": 85604795463784,
           "congestion_multiplier": 4866005335,
           "prover_cost": 18591281432147,
           "sequencer_cost": 3551677020190
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 895319925,
+          "protocol_fee": 895319925,
           "congestion_multiplier": 4866005335,
           "prover_cost": 194441732,
           "sequencer_cost": 37146134
@@ -35102,13 +35102,13 @@
           "slot_of_change": 430
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87457248901238,
+          "protocol_fee": 87457248901238,
           "congestion_multiplier": 4920041542,
           "prover_cost": 18731770259833,
           "sequencer_cost": 3578515995368
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907834055,
+          "protocol_fee": 907834055,
           "congestion_multiplier": 4920041542,
           "prover_cost": 194441732,
           "sequencer_cost": 37146134
@@ -35156,13 +35156,13 @@
           "slot_of_change": 430
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88148229446950,
+          "protocol_fee": 88148229446950,
           "congestion_multiplier": 4923355547,
           "prover_cost": 18863818395164,
           "sequencer_cost": 3603742461307
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908601538,
+          "protocol_fee": 908601538,
           "congestion_multiplier": 4923355547,
           "prover_cost": 194441732,
           "sequencer_cost": 37146134
@@ -35210,13 +35210,13 @@
           "slot_of_change": 430
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92455258897058,
+          "protocol_fee": 92455258897058,
           "congestion_multiplier": 5041582565,
           "prover_cost": 18962489200872,
           "sequencer_cost": 3913514800695
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 953949848,
+          "protocol_fee": 953949848,
           "congestion_multiplier": 5041582565,
           "prover_cost": 195654243,
           "sequencer_cost": 40379497
@@ -35264,13 +35264,13 @@
           "slot_of_change": 430
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93101542132280,
+          "protocol_fee": 93101542132280,
           "congestion_multiplier": 5058845395,
           "prover_cost": 19013827461203,
           "sequencer_cost": 3924110089083
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 958024458,
+          "protocol_fee": 958024458,
           "congestion_multiplier": 5058845395,
           "prover_cost": 195654243,
           "sequencer_cost": 40379497
@@ -35318,13 +35318,13 @@
           "slot_of_change": 430
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92591940008242,
+          "protocol_fee": 92591940008242,
           "congestion_multiplier": 5032591852,
           "prover_cost": 19032861982301,
           "sequencer_cost": 3928038469965
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 951827736,
+          "protocol_fee": 951827736,
           "congestion_multiplier": 5032591852,
           "prover_cost": 195654243,
           "sequencer_cost": 40379497
@@ -35372,13 +35372,13 @@
           "slot_of_change": 435
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91974827409526,
+          "protocol_fee": 91974827409526,
           "congestion_multiplier": 4981280257,
           "prover_cost": 19149675274944,
           "sequencer_cost": 3952146620790
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939716469,
+          "protocol_fee": 939716469,
           "congestion_multiplier": 4981280257,
           "prover_cost": 195654243,
           "sequencer_cost": 40379497
@@ -35426,13 +35426,13 @@
           "slot_of_change": 435
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91008228424713,
+          "protocol_fee": 91008228424713,
           "congestion_multiplier": 4946530132,
           "prover_cost": 19115269266411,
           "sequencer_cost": 3945045842923
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931514267,
+          "protocol_fee": 931514267,
           "congestion_multiplier": 4946530132,
           "prover_cost": 195654243,
           "sequencer_cost": 40379497
@@ -35480,13 +35480,13 @@
           "slot_of_change": 435
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90163112717283,
+          "protocol_fee": 90163112717283,
           "congestion_multiplier": 4957553681,
           "prover_cost": 19169068126958,
           "sequencer_cost": 3613468776707
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913635444,
+          "protocol_fee": 913635444,
           "congestion_multiplier": 4957553681,
           "prover_cost": 194242851,
           "sequencer_cost": 36615785
@@ -35534,13 +35534,13 @@
           "slot_of_change": 435
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89980177892096,
+          "protocol_fee": 89980177892096,
           "congestion_multiplier": 4971641179,
           "prover_cost": 19062320232270,
           "sequencer_cost": 3593346244831
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916887665,
+          "protocol_fee": 916887665,
           "congestion_multiplier": 4971641179,
           "prover_cost": 194242851,
           "sequencer_cost": 36615785
@@ -35588,13 +35588,13 @@
           "slot_of_change": 435
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88711018574542,
+          "protocol_fee": 88711018574542,
           "congestion_multiplier": 4939506847,
           "prover_cost": 18946745638894,
           "sequencer_cost": 3571559834465
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909469177,
+          "protocol_fee": 909469177,
           "congestion_multiplier": 4939506847,
           "prover_cost": 194242851,
           "sequencer_cost": 36615785
@@ -35642,13 +35642,13 @@
           "slot_of_change": 440
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88603506447400,
+          "protocol_fee": 88603506447400,
           "congestion_multiplier": 4938273353,
           "prover_cost": 18929710448094,
           "sequencer_cost": 3568348612633
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909184414,
+          "protocol_fee": 909184414,
           "congestion_multiplier": 4938273353,
           "prover_cost": 194242851,
           "sequencer_cost": 36615785
@@ -35696,13 +35696,13 @@
           "slot_of_change": 440
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89488323809622,
+          "protocol_fee": 89488323809622,
           "congestion_multiplier": 4946178530,
           "prover_cost": 19080447798493,
           "sequencer_cost": 3596763385096
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911009392,
+          "protocol_fee": 911009392,
           "congestion_multiplier": 4946178530,
           "prover_cost": 194242851,
           "sequencer_cost": 36615785
@@ -35750,13 +35750,13 @@
           "slot_of_change": 440
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89658121739203,
+          "protocol_fee": 89658121739203,
           "congestion_multiplier": 4958672816,
           "prover_cost": 19076496865675,
           "sequencer_cost": 3572033582294
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912464064,
+          "protocol_fee": 912464064,
           "congestion_multiplier": 4958672816,
           "prover_cost": 194144351,
           "sequencer_cost": 36353118
@@ -35804,13 +35804,13 @@
           "slot_of_change": 440
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89251075602394,
+          "protocol_fee": 89251075602394,
           "congestion_multiplier": 4952916625,
           "prover_cost": 19017542785574,
           "sequencer_cost": 3560994555819
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 911137277,
+          "protocol_fee": 911137277,
           "congestion_multiplier": 4952916625,
           "prover_cost": 194144351,
           "sequencer_cost": 36353118
@@ -35858,13 +35858,13 @@
           "slot_of_change": 440
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87686294990873,
+          "protocol_fee": 87686294990873,
           "congestion_multiplier": 4887496076,
           "prover_cost": 18998545539024,
           "sequencer_cost": 3557437361691
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 896058006,
+          "protocol_fee": 896058006,
           "congestion_multiplier": 4887496076,
           "prover_cost": 194144351,
           "sequencer_cost": 36353118
@@ -35912,13 +35912,13 @@
           "slot_of_change": 445
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86453373922146,
+          "protocol_fee": 86453373922146,
           "congestion_multiplier": 4822486572,
           "prover_cost": 19049982269215,
           "sequencer_cost": 3567068780336
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 881073480,
+          "protocol_fee": 881073480,
           "congestion_multiplier": 4822486572,
           "prover_cost": 194144351,
           "sequencer_cost": 36353118
@@ -35966,13 +35966,13 @@
           "slot_of_change": 445
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88789772596877,
+          "protocol_fee": 88789772596877,
           "congestion_multiplier": 4910871104,
           "prover_cost": 19122648345688,
           "sequencer_cost": 3580675349052
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 901445891,
+          "protocol_fee": 901445891,
           "congestion_multiplier": 4910871104,
           "prover_cost": 194144351,
           "sequencer_cost": 36353118
@@ -36020,13 +36020,13 @@
           "slot_of_change": 445
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90490528044884,
+          "protocol_fee": 90490528044884,
           "congestion_multiplier": 4948342002,
           "prover_cost": 19224177625582,
           "sequencer_cost": 3694436837805
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915681164,
+          "protocol_fee": 915681164,
           "congestion_multiplier": 4948342002,
           "prover_cost": 194531049,
           "sequencer_cost": 37384313
@@ -36074,13 +36074,13 @@
           "slot_of_change": 445
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90393384245851,
+          "protocol_fee": 90393384245851,
           "congestion_multiplier": 4934242986,
           "prover_cost": 19272359080365,
           "sequencer_cost": 3703696185326
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912411386,
+          "protocol_fee": 912411386,
           "congestion_multiplier": 4934242986,
           "prover_cost": 194531049,
           "sequencer_cost": 37384313
@@ -36128,13 +36128,13 @@
           "slot_of_change": 445
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90639197506060,
+          "protocol_fee": 90639197506060,
           "congestion_multiplier": 4924427837,
           "prover_cost": 19373099809716,
           "sequencer_cost": 3723056194833
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 910135102,
+          "protocol_fee": 910135102,
           "congestion_multiplier": 4924427837,
           "prover_cost": 194531049,
           "sequencer_cost": 37384313
@@ -36182,13 +36182,13 @@
           "slot_of_change": 450
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90892134013633,
+          "protocol_fee": 90892134013633,
           "congestion_multiplier": 4934985412,
           "prover_cost": 19375038992890,
           "sequencer_cost": 3723428860436
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912583566,
+          "protocol_fee": 912583566,
           "congestion_multiplier": 4934985412,
           "prover_cost": 194531049,
           "sequencer_cost": 37384313
@@ -36236,13 +36236,13 @@
           "slot_of_change": 450
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92533097426974,
+          "protocol_fee": 92533097426974,
           "congestion_multiplier": 5002021194,
           "prover_cost": 19394434795301,
           "sequencer_cost": 3727156279539
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928130193,
+          "protocol_fee": 928130193,
           "congestion_multiplier": 5002021194,
           "prover_cost": 194531049,
           "sequencer_cost": 37384313
@@ -36290,13 +36290,13 @@
           "slot_of_change": 450
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90924110296948,
+          "protocol_fee": 90924110296948,
           "congestion_multiplier": 4923773527,
           "prover_cost": 19383531084927,
           "sequencer_cost": 3789088263590
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913724389,
+          "protocol_fee": 913724389,
           "congestion_multiplier": 4923773527,
           "prover_cost": 194791074,
           "sequencer_cost": 38077715
@@ -36344,13 +36344,13 @@
           "slot_of_change": 450
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91757710785649,
+          "protocol_fee": 91757710785649,
           "congestion_multiplier": 4977169548,
           "prover_cost": 19298618995705,
           "sequencer_cost": 3772489667633
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926158656,
+          "protocol_fee": 926158656,
           "congestion_multiplier": 4977169548,
           "prover_cost": 194791074,
           "sequencer_cost": 38077715
@@ -36398,13 +36398,13 @@
           "slot_of_change": 450
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90538602935327,
+          "protocol_fee": 90538602935327,
           "congestion_multiplier": 4909415546,
           "prover_cost": 19372234655851,
           "sequencer_cost": 3786880040195
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 910380863,
+          "protocol_fee": 910380863,
           "congestion_multiplier": 4909415546,
           "prover_cost": 194791074,
           "sequencer_cost": 38077715
@@ -36452,13 +36452,13 @@
           "slot_of_change": 455
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93183716399652,
+          "protocol_fee": 93183716399652,
           "congestion_multiplier": 5013571228,
           "prover_cost": 19420786777308,
           "sequencer_cost": 3796370997894
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934635471,
+          "protocol_fee": 934635471,
           "congestion_multiplier": 5013571228,
           "prover_cost": 194791074,
           "sequencer_cost": 38077715
@@ -36506,13 +36506,13 @@
           "slot_of_change": 455
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91264164210984,
+          "protocol_fee": 91264164210984,
           "congestion_multiplier": 4928141047,
           "prover_cost": 19434392749163,
           "sequencer_cost": 3799030690189
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914741448,
+          "protocol_fee": 914741448,
           "congestion_multiplier": 4928141047,
           "prover_cost": 194791074,
           "sequencer_cost": 38077715
@@ -36560,13 +36560,13 @@
           "slot_of_change": 455
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93346606021097,
+          "protocol_fee": 93346606021097,
           "congestion_multiplier": 4858496592,
           "prover_cost": 19714317899686,
           "sequencer_cost": 4478163248485
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934303846,
+          "protocol_fee": 934303846,
           "congestion_multiplier": 4858496592,
           "prover_cost": 197320115,
           "sequencer_cost": 44821824
@@ -36614,13 +36614,13 @@
           "slot_of_change": 455
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92585466864193,
+          "protocol_fee": 92585466864193,
           "congestion_multiplier": 4865304846,
           "prover_cost": 19519128081493,
           "sequencer_cost": 4433825327449
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935952410,
+          "protocol_fee": 935952410,
           "congestion_multiplier": 4865304846,
           "prover_cost": 197320115,
           "sequencer_cost": 44821824
@@ -36668,13 +36668,13 @@
           "slot_of_change": 455
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93167978253792,
+          "protocol_fee": 93167978253792,
           "congestion_multiplier": 4885345230,
           "prover_cost": 19540622823815,
           "sequencer_cost": 4438707919157
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940805027,
+          "protocol_fee": 940805027,
           "congestion_multiplier": 4885345230,
           "prover_cost": 197320115,
           "sequencer_cost": 44821824
@@ -36722,13 +36722,13 @@
           "slot_of_change": 460
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92934800312502,
+          "protocol_fee": 92934800312502,
           "congestion_multiplier": 4870194900,
           "prover_cost": 19568019753653,
           "sequencer_cost": 4444931209506
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937136497,
+          "protocol_fee": 937136497,
           "congestion_multiplier": 4870194900,
           "prover_cost": 197320115,
           "sequencer_cost": 44821824
@@ -36776,13 +36776,13 @@
           "slot_of_change": 460
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95611387449131,
+          "protocol_fee": 95611387449131,
           "congestion_multiplier": 4989224276,
           "prover_cost": 19530911470049,
           "sequencer_cost": 4436501957594
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 965958501,
+          "protocol_fee": 965958501,
           "congestion_multiplier": 4989224276,
           "prover_cost": 197320115,
           "sequencer_cost": 44821824
@@ -36830,13 +36830,13 @@
           "slot_of_change": 460
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93876326518570,
+          "protocol_fee": 93876326518570,
           "congestion_multiplier": 4928477757,
           "prover_cost": 19515433467189,
           "sequencer_cost": 4380928528840
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 948144702,
+          "protocol_fee": 948144702,
           "congestion_multiplier": 4928477757,
           "prover_cost": 197104590,
           "sequencer_cost": 44247089
@@ -36884,13 +36884,13 @@
           "slot_of_change": 460
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94603435362425,
+          "protocol_fee": 94603435362425,
           "congestion_multiplier": 4950195703,
           "prover_cost": 19558462365573,
           "sequencer_cost": 4390587885309
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 953386365,
+          "protocol_fee": 953386365,
           "congestion_multiplier": 4950195703,
           "prover_cost": 197104590,
           "sequencer_cost": 44247089
@@ -36938,13 +36938,13 @@
           "slot_of_change": 460
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92224109228107,
+          "protocol_fee": 92224109228107,
           "congestion_multiplier": 4883193007,
           "prover_cost": 19395541353264,
           "sequencer_cost": 4354014508039
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937215152,
+          "protocol_fee": 937215152,
           "congestion_multiplier": 4883193007,
           "prover_cost": 197104590,
           "sequencer_cost": 44247089
@@ -36992,13 +36992,13 @@
           "slot_of_change": 465
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91851407653109,
+          "protocol_fee": 91851407653109,
           "congestion_multiplier": 4886063880,
           "prover_cost": 19302888167782,
           "sequencer_cost": 4333215227088
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937908042,
+          "protocol_fee": 937908042,
           "congestion_multiplier": 4886063880,
           "prover_cost": 197104590,
           "sequencer_cost": 44247089
@@ -37046,13 +37046,13 @@
           "slot_of_change": 465
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94577503498522,
+          "protocol_fee": 94577503498522,
           "congestion_multiplier": 5010202851,
           "prover_cost": 19260516011507,
           "sequencer_cost": 4323703299589
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 967869191,
+          "protocol_fee": 967869191,
           "congestion_multiplier": 5010202851,
           "prover_cost": 197104590,
           "sequencer_cost": 44247089
@@ -37100,13 +37100,13 @@
           "slot_of_change": 465
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92635924541293,
+          "protocol_fee": 92635924541293,
           "congestion_multiplier": 5055957853,
           "prover_cost": 19039467654756,
           "sequencer_cost": 3800001580807
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 949327026,
+          "protocol_fee": 949327026,
           "congestion_multiplier": 5055957853,
           "prover_cost": 195115246,
           "sequencer_cost": 38942173
@@ -37154,13 +37154,13 @@
           "slot_of_change": 465
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 81373739774952,
+          "protocol_fee": 81373739774952,
           "congestion_multiplier": 4556798959,
           "prover_cost": 19071890816044,
           "sequencer_cost": 3806472773509
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 832495184,
+          "protocol_fee": 832495184,
           "congestion_multiplier": 4556798959,
           "prover_cost": 195115246,
           "sequencer_cost": 38942173
@@ -37208,13 +37208,13 @@
           "slot_of_change": 465
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 70110651217253,
+          "protocol_fee": 70110651217253,
           "congestion_multiplier": 4095140809,
           "prover_cost": 18883060469752,
           "sequencer_cost": 3768784975330
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 724440669,
+          "protocol_fee": 724440669,
           "congestion_multiplier": 4095140809,
           "prover_cost": 195115246,
           "sequencer_cost": 38942173
@@ -37262,13 +37262,13 @@
           "slot_of_change": 470
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 80809874947143,
+          "protocol_fee": 80809874947143,
           "congestion_multiplier": 4603148911,
           "prover_cost": 18696099815383,
           "sequencer_cost": 3731470340539
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 843343734,
+          "protocol_fee": 843343734,
           "congestion_multiplier": 4603148911,
           "prover_cost": 195115246,
           "sequencer_cost": 38942173
@@ -37316,13 +37316,13 @@
           "slot_of_change": 470
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86941082404750,
+          "protocol_fee": 86941082404750,
           "congestion_multiplier": 4880790949,
           "prover_cost": 18675558064579,
           "sequencer_cost": 3727370505032
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908327913,
+          "protocol_fee": 908327913,
           "congestion_multiplier": 4880790949,
           "prover_cost": 195115246,
           "sequencer_cost": 38942173
@@ -37370,13 +37370,13 @@
           "slot_of_change": 470
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88840463635765,
+          "protocol_fee": 88840463635765,
           "congestion_multiplier": 4898865933,
           "prover_cost": 18795193294010,
           "sequencer_cost": 3991038695601
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927058056,
+          "protocol_fee": 927058056,
           "congestion_multiplier": 4898865933,
           "prover_cost": 196129496,
           "sequencer_cost": 41646840
@@ -37424,13 +37424,13 @@
           "slot_of_change": 470
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88682725410865,
+          "protocol_fee": 88682725410865,
           "congestion_multiplier": 4901673003,
           "prover_cost": 18748323778161,
           "sequencer_cost": 3981086254652
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927725510,
+          "protocol_fee": 927725510,
           "congestion_multiplier": 4901673003,
           "prover_cost": 196129496,
           "sequencer_cost": 41646840
@@ -37478,13 +37478,13 @@
           "slot_of_change": 470
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90006282922826,
+          "protocol_fee": 90006282922826,
           "congestion_multiplier": 4947628216,
           "prover_cost": 18806624958229,
           "sequencer_cost": 3993466136146
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 938652573,
+          "protocol_fee": 938652573,
           "congestion_multiplier": 4947628216,
           "prover_cost": 196129496,
           "sequencer_cost": 41646840
@@ -37532,13 +37532,13 @@
           "slot_of_change": 475
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90006581974235,
+          "protocol_fee": 90006581974235,
           "congestion_multiplier": 4978827667,
           "prover_cost": 18659217294579,
           "sequencer_cost": 3962165064620
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946071064,
+          "protocol_fee": 946071064,
           "congestion_multiplier": 4978827667,
           "prover_cost": 196129496,
           "sequencer_cost": 41646840
@@ -37586,13 +37586,13 @@
           "slot_of_change": 475
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87981877937751,
+          "protocol_fee": 87981877937751,
           "congestion_multiplier": 4886212181,
           "prover_cost": 18674156787721,
           "sequencer_cost": 3965337370128
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924049293,
+          "protocol_fee": 924049293,
           "congestion_multiplier": 4886212181,
           "prover_cost": 196129496,
           "sequencer_cost": 41646840
@@ -37640,13 +37640,13 @@
           "slot_of_change": 475
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85134134958771,
+          "protocol_fee": 85134134958771,
           "congestion_multiplier": 4833031780,
           "prover_cost": 18554701016857,
           "sequencer_cost": 3655950985562
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 894319019,
+          "protocol_fee": 894319019,
           "congestion_multiplier": 4833031780,
           "prover_cost": 194913850,
           "sequencer_cost": 38405118
@@ -37694,13 +37694,13 @@
           "slot_of_change": 475
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86784619069796,
+          "protocol_fee": 86784619069796,
           "congestion_multiplier": 4897573550,
           "prover_cost": 18601205700020,
           "sequencer_cost": 3665114099648
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909377838,
+          "protocol_fee": 909377838,
           "congestion_multiplier": 4897573550,
           "prover_cost": 194913850,
           "sequencer_cost": 38405118
@@ -37748,13 +37748,13 @@
           "slot_of_change": 475
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84237471101052,
+          "protocol_fee": 84237471101052,
           "congestion_multiplier": 4817605498,
           "prover_cost": 18433462765066,
           "sequencer_cost": 3632062640192
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890719775,
+          "protocol_fee": 890719775,
           "congestion_multiplier": 4817605498,
           "prover_cost": 194913850,
           "sequencer_cost": 38405118
@@ -37802,13 +37802,13 @@
           "slot_of_change": 480
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85529025118195,
+          "protocol_fee": 85529025118195,
           "congestion_multiplier": 4901332901,
           "prover_cost": 18314419800193,
           "sequencer_cost": 3608606846194
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 910254966,
+          "protocol_fee": 910254966,
           "congestion_multiplier": 4901332901,
           "prover_cost": 194913850,
           "sequencer_cost": 38405118
@@ -37856,13 +37856,13 @@
           "slot_of_change": 480
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86185554043074,
+          "protocol_fee": 86185554043074,
           "congestion_multiplier": 4939928417,
           "prover_cost": 18274217923269,
           "sequencer_cost": 3600685614188
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 919260032,
+          "protocol_fee": 919260032,
           "congestion_multiplier": 4939928417,
           "prover_cost": 194913850,
           "sequencer_cost": 38405118
@@ -37910,13 +37910,13 @@
           "slot_of_change": 480
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88898168530726,
+          "protocol_fee": 88898168530726,
           "congestion_multiplier": 4996731730,
           "prover_cost": 18323052111438,
           "sequencer_cost": 3919663828860
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952175304,
+          "protocol_fee": 952175304,
           "congestion_multiplier": 4996731730,
           "prover_cost": 196255536,
           "sequencer_cost": 41982947
@@ -37964,13 +37964,13 @@
           "slot_of_change": 480
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88716462835329,
+          "protocol_fee": 88716462835329,
           "congestion_multiplier": 4966625300,
           "prover_cost": 18424386759826,
           "sequencer_cost": 3941341317604
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 945002794,
+          "protocol_fee": 945002794,
           "congestion_multiplier": 4966625300,
           "prover_cost": 196255536,
           "sequencer_cost": 41982947
@@ -38018,13 +38018,13 @@
           "slot_of_change": 480
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88707833198211,
+          "protocol_fee": 88707833198211,
           "congestion_multiplier": 4945614682,
           "prover_cost": 18520695928195,
           "sequencer_cost": 3961943756616
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939997256,
+          "protocol_fee": 939997256,
           "congestion_multiplier": 4945614682,
           "prover_cost": 196255536,
           "sequencer_cost": 41982947
@@ -38072,13 +38072,13 @@
           "slot_of_change": 485
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91254572648347,
+          "protocol_fee": 91254572648347,
           "congestion_multiplier": 5059702162,
           "prover_cost": 18516993072340,
           "sequencer_cost": 3961151642395
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 967177284,
+          "protocol_fee": 967177284,
           "congestion_multiplier": 5059702162,
           "prover_cost": 196255536,
           "sequencer_cost": 41982947
@@ -38126,13 +38126,13 @@
           "slot_of_change": 485
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91907750198939,
+          "protocol_fee": 91907750198939,
           "congestion_multiplier": 5091213677,
           "prover_cost": 18505889893203,
           "sequencer_cost": 3958776452422
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 974684540,
+          "protocol_fee": 974684540,
           "congestion_multiplier": 5091213677,
           "prover_cost": 196255536,
           "sequencer_cost": 41982947
@@ -38180,13 +38180,13 @@
           "slot_of_change": 485
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85819460461627,
+          "protocol_fee": 85819460461627,
           "congestion_multiplier": 4932603993,
           "prover_cost": 18336961476748,
           "sequencer_cost": 3485591894434
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 909662938,
+          "protocol_fee": 909662938,
           "congestion_multiplier": 4932603993,
           "prover_cost": 194366804,
           "sequencer_cost": 36946326
@@ -38234,13 +38234,13 @@
           "slot_of_change": 485
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86749229271452,
+          "protocol_fee": 86749229271452,
           "congestion_multiplier": 4957321333,
           "prover_cost": 18419851196391,
           "sequencer_cost": 3501348034582
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915380383,
+          "protocol_fee": 915380383,
           "congestion_multiplier": 4957321333,
           "prover_cost": 194366804,
           "sequencer_cost": 36946326
@@ -38288,13 +38288,13 @@
           "slot_of_change": 485
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86693927075802,
+          "protocol_fee": 86693927075802,
           "congestion_multiplier": 4956380172,
           "prover_cost": 18412487617524,
           "sequencer_cost": 3499948324448
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915162681,
+          "protocol_fee": 915162681,
           "congestion_multiplier": 4956380172,
           "prover_cost": 194366804,
           "sequencer_cost": 36946326
@@ -38342,13 +38342,13 @@
           "slot_of_change": 490
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86188224095780,
+          "protocol_fee": 86188224095780,
           "congestion_multiplier": 4928581668,
           "prover_cost": 18434610024811,
           "sequencer_cost": 3504153474992
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908732522,
+          "protocol_fee": 908732522,
           "congestion_multiplier": 4928581668,
           "prover_cost": 194366804,
           "sequencer_cost": 36946326
@@ -38396,13 +38396,13 @@
           "slot_of_change": 490
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86107030593071,
+          "protocol_fee": 86107030593071,
           "congestion_multiplier": 4924095674,
           "prover_cost": 18438298180748,
           "sequencer_cost": 3504854540239
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907694852,
+          "protocol_fee": 907694852,
           "congestion_multiplier": 4924095674,
           "prover_cost": 194366804,
           "sequencer_cost": 36946326
@@ -38450,13 +38450,13 @@
           "slot_of_change": 490
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85763128177404,
+          "protocol_fee": 85763128177404,
           "congestion_multiplier": 4923552109,
           "prover_cost": 18408999575414,
           "sequencer_cost": 3449542332600
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904521586,
+          "protocol_fee": 904521586,
           "congestion_multiplier": 4923552109,
           "prover_cost": 194154969,
           "sequencer_cost": 36381433
@@ -38504,13 +38504,13 @@
           "slot_of_change": 490
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88403923167240,
+          "protocol_fee": 88403923167240,
           "congestion_multiplier": 5028996328,
           "prover_cost": 18479221282798,
           "sequencer_cost": 3462700720229
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928830317,
+          "protocol_fee": 928830317,
           "congestion_multiplier": 5028996328,
           "prover_cost": 194154969,
           "sequencer_cost": 36381433
@@ -38558,13 +38558,13 @@
           "slot_of_change": 490
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88532186159475,
+          "protocol_fee": 88532186159475,
           "congestion_multiplier": 5021930144,
           "prover_cost": 18538545820785,
           "sequencer_cost": 3473817158377
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927201304,
+          "protocol_fee": 927201304,
           "congestion_multiplier": 5021930144,
           "prover_cost": 194154969,
           "sequencer_cost": 36381433
@@ -38612,13 +38612,13 @@
           "slot_of_change": 495
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86064896439158,
+          "protocol_fee": 86064896439158,
           "congestion_multiplier": 4934475554,
           "prover_cost": 18422484458236,
           "sequencer_cost": 3452069176818
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907039837,
+          "protocol_fee": 907039837,
           "congestion_multiplier": 4934475554,
           "prover_cost": 194154969,
           "sequencer_cost": 36381433
@@ -38666,13 +38666,13 @@
           "slot_of_change": 495
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85363750447135,
+          "protocol_fee": 85363750447135,
           "congestion_multiplier": 4900471118,
           "prover_cost": 18431701164030,
           "sequencer_cost": 3453796235188
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 899200577,
+          "protocol_fee": 899200577,
           "congestion_multiplier": 4900471118,
           "prover_cost": 194154969,
           "sequencer_cost": 36381433
@@ -38720,13 +38720,13 @@
           "slot_of_change": 495
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88431921841066,
+          "protocol_fee": 88431921841066,
           "congestion_multiplier": 4981905597,
           "prover_cost": 18440521648181,
           "sequencer_cost": 3767920949843
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937481660,
+          "protocol_fee": 937481660,
           "congestion_multiplier": 4981905597,
           "prover_cost": 195491068,
           "sequencer_cost": 39944363
@@ -38774,13 +38774,13 @@
           "slot_of_change": 495
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87987356997785,
+          "protocol_fee": 87987356997785,
           "congestion_multiplier": 4964264639,
           "prover_cost": 18429465187366,
           "sequencer_cost": 3765661801695
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933328353,
+          "protocol_fee": 933328353,
           "congestion_multiplier": 4964264639,
           "prover_cost": 195491068,
           "sequencer_cost": 39944363
@@ -38828,13 +38828,13 @@
           "slot_of_change": 495
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89379377732684,
+          "protocol_fee": 89379377732684,
           "congestion_multiplier": 5039465558,
           "prover_cost": 18372510986653,
           "sequencer_cost": 3754024445109
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 951033314,
+          "protocol_fee": 951033314,
           "congestion_multiplier": 5039465558,
           "prover_cost": 195491068,
           "sequencer_cost": 39944363
@@ -38882,13 +38882,13 @@
           "slot_of_change": 500
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86508641377285,
+          "protocol_fee": 86508641377285,
           "congestion_multiplier": 4917151955,
           "prover_cost": 18337670758015,
           "sequencer_cost": 3746905599455
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922236358,
+          "protocol_fee": 922236358,
           "congestion_multiplier": 4917151955,
           "prover_cost": 195491068,
           "sequencer_cost": 39944363
@@ -38936,13 +38936,13 @@
           "slot_of_change": 500
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88690548034682,
+          "protocol_fee": 88690548034682,
           "congestion_multiplier": 5030808605,
           "prover_cost": 18270072039709,
           "sequencer_cost": 3733093266391
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 948995161,
+          "protocol_fee": 948995161,
           "congestion_multiplier": 5030808605,
           "prover_cost": 195491068,
           "sequencer_cost": 39944363
@@ -38990,13 +38990,13 @@
           "slot_of_change": 500
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89834163824199,
+          "protocol_fee": 89834163824199,
           "congestion_multiplier": 4987370859,
           "prover_cost": 18521344529735,
           "sequencer_cost": 4008329043706
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952869179,
+          "protocol_fee": 952869179,
           "congestion_multiplier": 4987370859,
           "prover_cost": 196455531,
           "sequencer_cost": 42516266
@@ -39044,13 +39044,13 @@
           "slot_of_change": 500
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91458332299173,
+          "protocol_fee": 91458332299173,
           "congestion_multiplier": 5039975446,
           "prover_cost": 18610676647911,
           "sequencer_cost": 4027662009692
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 965440192,
+          "protocol_fee": 965440192,
           "congestion_multiplier": 5039975446,
           "prover_cost": 196455531,
           "sequencer_cost": 42516266
@@ -39098,13 +39098,13 @@
           "slot_of_change": 500
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88246883475809,
+          "protocol_fee": 88246883475809,
           "congestion_multiplier": 4903183816,
           "prover_cost": 18586515737118,
           "sequencer_cost": 4022433184091
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932750850,
+          "protocol_fee": 932750850,
           "congestion_multiplier": 4903183816,
           "prover_cost": 196455531,
           "sequencer_cost": 42516266
@@ -39152,13 +39152,13 @@
           "slot_of_change": 505
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90623503457646,
+          "protocol_fee": 90623503457646,
           "congestion_multiplier": 5010707019,
           "prover_cost": 18575372047751,
           "sequencer_cost": 4020021503142
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 958445863,
+          "protocol_fee": 958445863,
           "congestion_multiplier": 5010707019,
           "prover_cost": 196455531,
           "sequencer_cost": 42516266
@@ -39206,13 +39206,13 @@
           "slot_of_change": 505
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89928799652094,
+          "protocol_fee": 89928799652094,
           "congestion_multiplier": 4958867655,
           "prover_cost": 18674346998477,
           "sequencer_cost": 4041441339535
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946057717,
+          "protocol_fee": 946057717,
           "congestion_multiplier": 4958867655,
           "prover_cost": 196455531,
           "sequencer_cost": 42516266
@@ -39260,13 +39260,13 @@
           "slot_of_change": 505
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89007404450666,
+          "protocol_fee": 89007404450666,
           "congestion_multiplier": 4955252409,
           "prover_cost": 18691803942143,
           "sequencer_cost": 3811792611883
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 930746334,
+          "protocol_fee": 930746334,
           "congestion_multiplier": 4955252409,
           "prover_cost": 195459334,
           "sequencer_cost": 39859740
@@ -39314,13 +39314,13 @@
           "slot_of_change": 505
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86717746965321,
+          "protocol_fee": 86717746965321,
           "congestion_multiplier": 4853506118,
           "prover_cost": 18691803942143,
           "sequencer_cost": 3811792611883
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 906803491,
+          "protocol_fee": 906803491,
           "congestion_multiplier": 4853506118,
           "prover_cost": 195459334,
           "sequencer_cost": 39859740
@@ -39368,13 +39368,13 @@
           "slot_of_change": 505
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89624397916461,
+          "protocol_fee": 89624397916461,
           "congestion_multiplier": 4942843086,
           "prover_cost": 18880610881513,
           "sequencer_cost": 3850295738644
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927826183,
+          "protocol_fee": 927826183,
           "congestion_multiplier": 4942843086,
           "prover_cost": 195459334,
           "sequencer_cost": 39859740
@@ -39422,13 +39422,13 @@
           "slot_of_change": 510
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91495342288655,
+          "protocol_fee": 91495342288655,
           "congestion_multiplier": 5039641794,
           "prover_cost": 18812885551894,
           "sequencer_cost": 3836484609880
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 950604766,
+          "protocol_fee": 950604766,
           "congestion_multiplier": 5039641794,
           "prover_cost": 195459334,
           "sequencer_cost": 39859740
@@ -39476,13 +39476,13 @@
           "slot_of_change": 510
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88332163405141,
+          "protocol_fee": 88332163405141,
           "congestion_multiplier": 4921433088,
           "prover_cost": 18709980812297,
           "sequencer_cost": 3815499394791
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922788003,
+          "protocol_fee": 922788003,
           "congestion_multiplier": 4921433088,
           "prover_cost": 195459334,
           "sequencer_cost": 39859740
@@ -39530,13 +39530,13 @@
           "slot_of_change": 510
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88930790733554,
+          "protocol_fee": 88930790733554,
           "congestion_multiplier": 4993387574,
           "prover_cost": 18694442145180,
           "sequencer_cost": 3575069412980
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 925046791,
+          "protocol_fee": 925046791,
           "congestion_multiplier": 4993387574,
           "prover_cost": 194457213,
           "sequencer_cost": 37187418
@@ -39584,13 +39584,13 @@
           "slot_of_change": 510
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89837737192110,
+          "protocol_fee": 89837737192110,
           "congestion_multiplier": 5054687267,
           "prover_cost": 18599585247982,
           "sequencer_cost": 3556929262600
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939246535,
+          "protocol_fee": 939246535,
           "congestion_multiplier": 5054687267,
           "prover_cost": 194457213,
           "sequencer_cost": 37187418
@@ -39638,13 +39638,13 @@
           "slot_of_change": 510
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88780023094413,
+          "protocol_fee": 88780023094413,
           "congestion_multiplier": 5011756967,
           "prover_cost": 18577294105633,
           "sequencer_cost": 3552666370957
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929301962,
+          "protocol_fee": 929301962,
           "congestion_multiplier": 5011756967,
           "prover_cost": 194457213,
           "sequencer_cost": 37187418
@@ -39692,13 +39692,13 @@
           "slot_of_change": 515
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90560920547220,
+          "protocol_fee": 90560920547220,
           "congestion_multiplier": 5074225592,
           "prover_cost": 18659395705572,
           "sequencer_cost": 3568367236296
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 943772483,
+          "protocol_fee": 943772483,
           "congestion_multiplier": 5074225592,
           "prover_cost": 194457213,
           "sequencer_cost": 37187418
@@ -39746,13 +39746,13 @@
           "slot_of_change": 515
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89745451393777,
+          "protocol_fee": 89745451393777,
           "congestion_multiplier": 5043190801,
           "prover_cost": 18633310811931,
           "sequencer_cost": 3563378838960
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936583441,
+          "protocol_fee": 936583441,
           "congestion_multiplier": 5043190801,
           "prover_cost": 194457213,
           "sequencer_cost": 37187418
@@ -39800,13 +39800,13 @@
           "slot_of_change": 515
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88491101864928,
+          "protocol_fee": 88491101864928,
           "congestion_multiplier": 4985073679,
           "prover_cost": 18624440099945,
           "sequencer_cost": 3581197487007
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924324159,
+          "protocol_fee": 924324159,
           "congestion_multiplier": 4985073679,
           "prover_cost": 194539559,
           "sequencer_cost": 37407008
@@ -39854,13 +39854,13 @@
           "slot_of_change": 515
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86515038139511,
+          "protocol_fee": 86515038139511,
           "congestion_multiplier": 4889071337,
           "prover_cost": 18658025074164,
           "sequencer_cost": 3587655368405
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 902056745,
+          "protocol_fee": 902056745,
           "congestion_multiplier": 4889071337,
           "prover_cost": 194539559,
           "sequencer_cost": 37407008
@@ -39908,13 +39908,13 @@
           "slot_of_change": 515
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85086837748670,
+          "protocol_fee": 85086837748670,
           "congestion_multiplier": 4825252337,
           "prover_cost": 18656160637062,
           "sequencer_cost": 3587296865415
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 887254147,
+          "protocol_fee": 887254147,
           "congestion_multiplier": 4825252337,
           "prover_cost": 194539559,
           "sequencer_cost": 37407008
@@ -39962,13 +39962,13 @@
           "slot_of_change": 520
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88783730076756,
+          "protocol_fee": 88783730076756,
           "congestion_multiplier": 4983869717,
           "prover_cost": 18691675719157,
           "sequencer_cost": 3594125877298
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924044904,
+          "protocol_fee": 924044904,
           "congestion_multiplier": 4983869717,
           "prover_cost": 194539559,
           "sequencer_cost": 37407008
@@ -40016,13 +40016,13 @@
           "slot_of_change": 520
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88381154776162,
+          "protocol_fee": 88381154776162,
           "congestion_multiplier": 4970167672,
           "prover_cost": 18671138542773,
           "sequencer_cost": 3590176889620
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920866761,
+          "protocol_fee": 920866761,
           "congestion_multiplier": 4970167672,
           "prover_cost": 194539559,
           "sequencer_cost": 37407008
@@ -40070,13 +40070,13 @@
           "slot_of_change": 520
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89029676880626,
+          "protocol_fee": 89029676880626,
           "congestion_multiplier": 4979756691,
           "prover_cost": 18600953666800,
           "sequencer_cost": 3769679470456
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935044865,
+          "protocol_fee": 935044865,
           "congestion_multiplier": 4979756691,
           "prover_cost": 195358748,
           "sequencer_cost": 39591511
@@ -40124,13 +40124,13 @@
           "slot_of_change": 520
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88462037943462,
+          "protocol_fee": 88462037943462,
           "congestion_multiplier": 4948450800,
           "prover_cost": 18628897136666,
           "sequencer_cost": 3775342509383
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927689538,
+          "protocol_fee": 927689538,
           "congestion_multiplier": 4948450800,
           "prover_cost": 195358748,
           "sequencer_cost": 39591511
@@ -40178,13 +40178,13 @@
           "slot_of_change": 520
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87528901558569,
+          "protocol_fee": 87528901558569,
           "congestion_multiplier": 4931803985,
           "prover_cost": 18510432035078,
           "sequencer_cost": 3751334306932
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 923778364,
+          "protocol_fee": 923778364,
           "congestion_multiplier": 4931803985,
           "prover_cost": 195358748,
           "sequencer_cost": 39591511
@@ -40232,13 +40232,13 @@
           "slot_of_change": 525
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87419697362573,
+          "protocol_fee": 87419697362573,
           "congestion_multiplier": 4933181426,
           "prover_cost": 18480863300996,
           "sequencer_cost": 3745341891068
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 924101994,
+          "protocol_fee": 924101994,
           "congestion_multiplier": 4933181426,
           "prover_cost": 195358748,
           "sequencer_cost": 39591511
@@ -40286,13 +40286,13 @@
           "slot_of_change": 525
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85191693372884,
+          "protocol_fee": 85191693372884,
           "congestion_multiplier": 4849803848,
           "prover_cost": 18399905136655,
           "sequencer_cost": 3728934865087
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904512411,
+          "protocol_fee": 904512411,
           "congestion_multiplier": 4849803848,
           "prover_cost": 195358748,
           "sequencer_cost": 39591511
@@ -40340,13 +40340,13 @@
           "slot_of_change": 525
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85401342592488,
+          "protocol_fee": 85401342592488,
           "congestion_multiplier": 4847029167,
           "prover_cost": 18448867794775,
           "sequencer_cost": 3750429101646
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904562139,
+          "protocol_fee": 904562139,
           "congestion_multiplier": 4847029167,
           "prover_cost": 195408489,
           "sequencer_cost": 39724155
@@ -40394,13 +40394,13 @@
           "slot_of_change": 525
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85658738407510,
+          "protocol_fee": 85658738407510,
           "congestion_multiplier": 4882932927,
           "prover_cost": 18333369204130,
           "sequencer_cost": 3726949651288
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913004285,
+          "protocol_fee": 913004285,
           "congestion_multiplier": 4882932927,
           "prover_cost": 195408489,
           "sequencer_cost": 39724155
@@ -40448,13 +40448,13 @@
           "slot_of_change": 525
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86661132148979,
+          "protocol_fee": 86661132148979,
           "congestion_multiplier": 4958227123,
           "prover_cost": 18195087465312,
           "sequencer_cost": 3698838665656
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 930708408,
+          "protocol_fee": 930708408,
           "congestion_multiplier": 4958227123,
           "prover_cost": 195408489,
           "sequencer_cost": 39724155
@@ -40502,13 +40502,13 @@
           "slot_of_change": 530
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87835868021750,
+          "protocol_fee": 87835868021750,
           "congestion_multiplier": 5017098166,
           "prover_cost": 18171465436194,
           "sequencer_cost": 3694036596151
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944550912,
+          "protocol_fee": 944550912,
           "congestion_multiplier": 5017098166,
           "prover_cost": 195408489,
           "sequencer_cost": 39724155
@@ -40556,13 +40556,13 @@
           "slot_of_change": 530
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88196286388112,
+          "protocol_fee": 88196286388112,
           "congestion_multiplier": 5037211727,
           "prover_cost": 18155126212597,
           "sequencer_cost": 3690715031903
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 949280267,
+          "protocol_fee": 949280267,
           "congestion_multiplier": 5037211727,
           "prover_cost": 195408489,
           "sequencer_cost": 39724155
@@ -40610,13 +40610,13 @@
           "slot_of_change": 530
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89181437234700,
+          "protocol_fee": 89181437234700,
           "congestion_multiplier": 5017843689,
           "prover_cost": 18321874047096,
           "sequencer_cost": 3874469118830
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 954316380,
+          "protocol_fee": 954316380,
           "congestion_multiplier": 5017843689,
           "prover_cost": 196059461,
           "sequencer_cost": 41460078
@@ -40664,13 +40664,13 @@
           "slot_of_change": 530
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86570572324069,
+          "protocol_fee": 86570572324069,
           "congestion_multiplier": 4906847999,
           "prover_cost": 18290780454803,
           "sequencer_cost": 3867893854595
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927952735,
+          "protocol_fee": 927952735,
           "congestion_multiplier": 4906847999,
           "prover_cost": 196059461,
           "sequencer_cost": 41460078
@@ -40718,13 +40718,13 @@
           "slot_of_change": 530
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86548361821022,
+          "protocol_fee": 86548361821022,
           "congestion_multiplier": 4903111319,
           "prover_cost": 18303594127748,
           "sequencer_cost": 3870603521739
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927065201,
+          "protocol_fee": 927065201,
           "congestion_multiplier": 4903111319,
           "prover_cost": 196059461,
           "sequencer_cost": 41460078
@@ -40772,13 +40772,13 @@
           "slot_of_change": 535
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89769800198545,
+          "protocol_fee": 89769800198545,
           "congestion_multiplier": 5076728478,
           "prover_cost": 18176360783305,
           "sequencer_cost": 3843697886286
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 968302668,
+          "protocol_fee": 968302668,
           "congestion_multiplier": 5076728478,
           "prover_cost": 196059461,
           "sequencer_cost": 41460078
@@ -40826,13 +40826,13 @@
           "slot_of_change": 535
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86900702433878,
+          "protocol_fee": 86900702433878,
           "congestion_multiplier": 4961429922,
           "prover_cost": 18107553306878,
           "sequencer_cost": 3829147385509
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940917008,
+          "protocol_fee": 940917008,
           "congestion_multiplier": 4961429922,
           "prover_cost": 196059461,
           "sequencer_cost": 41460078
@@ -40880,13 +40880,13 @@
           "slot_of_change": 535
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85025821090673,
+          "protocol_fee": 85025821090673,
           "congestion_multiplier": 4890134458,
           "prover_cost": 18179843140307,
           "sequencer_cost": 3676938948211
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913527965,
+          "protocol_fee": 913527965,
           "congestion_multiplier": 4890134458,
           "prover_cost": 195326489,
           "sequencer_cost": 39505488
@@ -40934,13 +40934,13 @@
           "slot_of_change": 535
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87744871042246,
+          "protocol_fee": 87744871042246,
           "congestion_multiplier": 5018150307,
           "prover_cost": 18163497195827,
           "sequencer_cost": 3673632921891
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 943590180,
+          "protocol_fee": 943590180,
           "congestion_multiplier": 5018150307,
           "prover_cost": 195326489,
           "sequencer_cost": 39505488
@@ -40988,13 +40988,13 @@
           "slot_of_change": 535
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86914518804543,
+          "protocol_fee": 86914518804543,
           "congestion_multiplier": 4964602951,
           "prover_cost": 18234612536226,
           "sequencer_cost": 3688016256385
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 931015549,
+          "protocol_fee": 931015549,
           "congestion_multiplier": 4964602951,
           "prover_cost": 195326489,
           "sequencer_cost": 39505488
@@ -41042,13 +41042,13 @@
           "slot_of_change": 540
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88588019435392,
+          "protocol_fee": 88588019435392,
           "congestion_multiplier": 5018714157,
           "prover_cost": 18335458944327,
           "sequencer_cost": 3708412806722
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 943722590,
+          "protocol_fee": 943722590,
           "congestion_multiplier": 5018714157,
           "prover_cost": 195326489,
           "sequencer_cost": 39505488
@@ -41096,13 +41096,13 @@
           "slot_of_change": 540
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87608260220864,
+          "protocol_fee": 87608260220864,
           "congestion_multiplier": 4979434522,
           "prover_cost": 18311655198826,
           "sequencer_cost": 3703598413206
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 934498476,
+          "protocol_fee": 934498476,
           "congestion_multiplier": 4979434522,
           "prover_cost": 195326489,
           "sequencer_cost": 39505488
@@ -41150,13 +41150,13 @@
           "slot_of_change": 540
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86721794395467,
+          "protocol_fee": 86721794395467,
           "congestion_multiplier": 4997748788,
           "prover_cost": 18192983537308,
           "sequencer_cost": 3499673772293
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927355259,
+          "protocol_fee": 927355259,
           "congestion_multiplier": 4997748788,
           "prover_cost": 194545778,
           "sequencer_cost": 37423590
@@ -41204,13 +41204,13 @@
           "slot_of_change": 540
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87265391382281,
+          "protocol_fee": 87265391382281,
           "congestion_multiplier": 5039703424,
           "prover_cost": 18116893422210,
           "sequencer_cost": 3485036778884
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937087450,
+          "protocol_fee": 937087450,
           "congestion_multiplier": 5039703424,
           "prover_cost": 194545778,
           "sequencer_cost": 37423590
@@ -41258,13 +41258,13 @@
           "slot_of_change": 540
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87950373934285,
+          "protocol_fee": 87950373934285,
           "congestion_multiplier": 5033955728,
           "prover_cost": 18285116597758,
           "sequencer_cost": 3517396849685
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 935754160,
+          "protocol_fee": 935754160,
           "congestion_multiplier": 5033955728,
           "prover_cost": 194545778,
           "sequencer_cost": 37423590
@@ -41312,13 +41312,13 @@
           "slot_of_change": 545
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86176503714132,
+          "protocol_fee": 86176503714132,
           "congestion_multiplier": 4938365367,
           "prover_cost": 18351181797422,
           "sequencer_cost": 3530105410986
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 913580125,
+          "protocol_fee": 913580125,
           "congestion_multiplier": 4938365367,
           "prover_cost": 194545778,
           "sequencer_cost": 37423590
@@ -41366,13 +41366,13 @@
           "slot_of_change": 545
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84308778472503,
+          "protocol_fee": 84308778472503,
           "congestion_multiplier": 4832972384,
           "prover_cost": 18447107472498,
           "sequencer_cost": 3548558050624
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 889132181,
+          "protocol_fee": 889132181,
           "congestion_multiplier": 4832972384,
           "prover_cost": 194545778,
           "sequencer_cost": 37423590
@@ -41420,13 +41420,13 @@
           "slot_of_change": 545
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84835805091858,
+          "protocol_fee": 84835805091858,
           "congestion_multiplier": 4910858141,
           "prover_cost": 18329634465678,
           "sequencer_cost": 3362741496543
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 897195394,
+          "protocol_fee": 897195394,
           "congestion_multiplier": 4910858141,
           "prover_cost": 193848147,
           "sequencer_cost": 35563241
@@ -41474,13 +41474,13 @@
           "slot_of_change": 545
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86296046606086,
+          "protocol_fee": 86296046606086,
           "congestion_multiplier": 4952713444,
           "prover_cost": 18447701005255,
           "sequencer_cost": 3384401898595
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 906797477,
+          "protocol_fee": 906797477,
           "congestion_multiplier": 4952713444,
           "prover_cost": 193848147,
           "sequencer_cost": 35563241
@@ -41528,13 +41528,13 @@
           "slot_of_change": 545
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88430732505335,
+          "protocol_fee": 88430732505335,
           "congestion_multiplier": 5042389832,
           "prover_cost": 18484670402351,
           "sequencer_cost": 3391184277477
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927370262,
+          "protocol_fee": 927370262,
           "congestion_multiplier": 5042389832,
           "prover_cost": 193848147,
           "sequencer_cost": 35563241
@@ -41582,13 +41582,13 @@
           "slot_of_change": 550
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87700871449884,
+          "protocol_fee": 87700871449884,
           "congestion_multiplier": 4989782525,
           "prover_cost": 18573825746434,
           "sequencer_cost": 3407540652491
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915301546,
+          "protocol_fee": 915301546,
           "congestion_multiplier": 4989782525,
           "prover_cost": 193848147,
           "sequencer_cost": 35563241
@@ -41636,13 +41636,13 @@
           "slot_of_change": 550
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87276567698799,
+          "protocol_fee": 87276567698799,
           "congestion_multiplier": 4978817298,
           "prover_cost": 18534904087050,
           "sequencer_cost": 3400400112980
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912785998,
+          "protocol_fee": 912785998,
           "congestion_multiplier": 4978817298,
           "prover_cost": 193848147,
           "sequencer_cost": 35563241
@@ -41690,13 +41690,13 @@
           "slot_of_change": 550
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88369744909195,
+          "protocol_fee": 88369744909195,
           "congestion_multiplier": 4824671544,
           "prover_cost": 18980756638040,
           "sequencer_cost": 4124428720992
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914976804,
+          "protocol_fee": 914976804,
           "congestion_multiplier": 4824671544,
           "prover_cost": 196525995,
           "sequencer_cost": 42704170
@@ -41744,13 +41744,13 @@
           "slot_of_change": 550
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90481885602863,
+          "protocol_fee": 90481885602863,
           "congestion_multiplier": 4951722051,
           "prover_cost": 18809589439540,
           "sequencer_cost": 4087234897635
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 945371118,
+          "protocol_fee": 945371118,
           "congestion_multiplier": 4951722051,
           "prover_cost": 196525995,
           "sequencer_cost": 42704170
@@ -41798,13 +41798,13 @@
           "slot_of_change": 550
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89110137037553,
+          "protocol_fee": 89110137037553,
           "congestion_multiplier": 4882860822,
           "prover_cost": 18852951559600,
           "sequencer_cost": 4096657281410
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928897435,
+          "protocol_fee": 928897435,
           "congestion_multiplier": 4882860822,
           "prover_cost": 196525995,
           "sequencer_cost": 42704170
@@ -41852,13 +41852,13 @@
           "slot_of_change": 555
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91440250227176,
+          "protocol_fee": 91440250227176,
           "congestion_multiplier": 5010290719,
           "prover_cost": 18731200508278,
           "sequencer_cost": 4070201353310
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 959382510,
+          "protocol_fee": 959382510,
           "congestion_multiplier": 5010290719,
           "prover_cost": 196525995,
           "sequencer_cost": 42704170
@@ -41906,13 +41906,13 @@
           "slot_of_change": 555
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89654115732477,
+          "protocol_fee": 89654115732477,
           "congestion_multiplier": 4959479868,
           "prover_cost": 18600994155518,
           "sequencer_cost": 4041908128166
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947227022,
+          "protocol_fee": 947227022,
           "congestion_multiplier": 4959479868,
           "prover_cost": 196525995,
           "sequencer_cost": 42704170
@@ -41960,13 +41960,13 @@
           "slot_of_change": 555
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87454992620768,
+          "protocol_fee": 87454992620768,
           "congestion_multiplier": 4894614664,
           "prover_cost": 18494182688924,
           "sequencer_cost": 3961182026428
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928150479,
+          "protocol_fee": 928150479,
           "congestion_multiplier": 4894614664,
           "prover_cost": 196276782,
           "sequencer_cost": 42039601
@@ -42014,13 +42014,13 @@
           "slot_of_change": 555
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90439716202868,
+          "protocol_fee": 90439716202868,
           "congestion_multiplier": 5017866624,
           "prover_cost": 18538675609606,
           "sequencer_cost": 3970711755893
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 957523441,
+          "protocol_fee": 957523441,
           "congestion_multiplier": 5017866624,
           "prover_cost": 196276782,
           "sequencer_cost": 42039601
@@ -42068,13 +42068,13 @@
           "slot_of_change": 555
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89301241573499,
+          "protocol_fee": 89301241573499,
           "congestion_multiplier": 4932773283,
           "prover_cost": 18701378358393,
           "sequencer_cost": 4005560292592
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 937244303,
+          "protocol_fee": 937244303,
           "congestion_multiplier": 4932773283,
           "prover_cost": 196276782,
           "sequencer_cost": 42039601
@@ -42122,13 +42122,13 @@
           "slot_of_change": 560
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90115102078578,
+          "protocol_fee": 90115102078578,
           "congestion_multiplier": 4964646337,
           "prover_cost": 18720099687024,
           "sequencer_cost": 4009570125940
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 944840174,
+          "protocol_fee": 944840174,
           "congestion_multiplier": 4964646337,
           "prover_cost": 196276782,
           "sequencer_cost": 42039601
@@ -42176,13 +42176,13 @@
           "slot_of_change": 560
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88238111455931,
+          "protocol_fee": 88238111455931,
           "congestion_multiplier": 4906135958,
           "prover_cost": 18604751739841,
           "sequencer_cost": 3984864291524
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 930896193,
+          "protocol_fee": 930896193,
           "congestion_multiplier": 4906135958,
           "prover_cost": 196276782,
           "sequencer_cost": 42039601
@@ -42230,13 +42230,13 @@
           "slot_of_change": 560
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90177246971783,
+          "protocol_fee": 90177246971783,
           "congestion_multiplier": 4907441770,
           "prover_cost": 18656447868101,
           "sequencer_cost": 4421886335335
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 957632585,
+          "protocol_fee": 957632585,
           "congestion_multiplier": 4907441770,
           "prover_cost": 198121178,
           "sequencer_cost": 46957992
@@ -42284,13 +42284,13 @@
           "slot_of_change": 560
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90412109214085,
+          "protocol_fee": 90412109214085,
           "congestion_multiplier": 4940340405,
           "prover_cost": 18548865840780,
           "sequencer_cost": 4396387617686
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 965695355,
+          "protocol_fee": 965695355,
           "congestion_multiplier": 4940340405,
           "prover_cost": 198121178,
           "sequencer_cost": 46957992
@@ -42338,13 +42338,13 @@
           "slot_of_change": 560
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95554954195639,
+          "protocol_fee": 95554954195639,
           "congestion_multiplier": 5132825809,
           "prover_cost": 18690916977803,
           "sequencer_cost": 4430056083739
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1012869519,
+          "protocol_fee": 1012869519,
           "congestion_multiplier": 5132825809,
           "prover_cost": 198121178,
           "sequencer_cost": 46957992
@@ -42392,13 +42392,13 @@
           "slot_of_change": 565
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94564660074884,
+          "protocol_fee": 94564660074884,
           "congestion_multiplier": 5089994824,
           "prover_cost": 18690916977803,
           "sequencer_cost": 4430056083739
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1002372536,
+          "protocol_fee": 1002372536,
           "congestion_multiplier": 5089994824,
           "prover_cost": 198121178,
           "sequencer_cost": 46957992
@@ -42446,13 +42446,13 @@
           "slot_of_change": 565
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91780811755531,
+          "protocol_fee": 91780811755531,
           "congestion_multiplier": 4989042098,
           "prover_cost": 18599778647803,
           "sequencer_cost": 4408454793992
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 977631126,
+          "protocol_fee": 977631126,
           "congestion_multiplier": 4989042098,
           "prover_cost": 198121178,
           "sequencer_cost": 46957992
@@ -42500,13 +42500,13 @@
           "slot_of_change": 565
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91426454057038,
+          "protocol_fee": 91426454057038,
           "congestion_multiplier": 4975105247,
           "prover_cost": 18541032675966,
           "sequencer_cost": 4458724164668
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 978336291,
+          "protocol_fee": 978336291,
           "congestion_multiplier": 4975105247,
           "prover_cost": 198403901,
           "sequencer_cost": 47711920
@@ -42554,13 +42554,13 @@
           "slot_of_change": 565
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91022247641562,
+          "protocol_fee": 91022247641562,
           "congestion_multiplier": 4958718038,
           "prover_cost": 18535472450468,
           "sequencer_cost": 4457387048650
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 974303140,
+          "protocol_fee": 974303140,
           "congestion_multiplier": 4958718038,
           "prover_cost": 198403901,
           "sequencer_cost": 47711920
@@ -42608,13 +42608,13 @@
           "slot_of_change": 565
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89701939942403,
+          "protocol_fee": 89701939942403,
           "congestion_multiplier": 4910658410,
           "prover_cost": 18491094904797,
           "sequencer_cost": 4446715192410
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 962474905,
+          "protocol_fee": 962474905,
           "congestion_multiplier": 4910658410,
           "prover_cost": 198403901,
           "sequencer_cost": 47711920
@@ -42662,13 +42662,13 @@
           "slot_of_change": 570
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93024052475824,
+          "protocol_fee": 93024052475824,
           "congestion_multiplier": 5053056335,
           "prover_cost": 18502196533108,
           "sequencer_cost": 4449384897991
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 997521287,
+          "protocol_fee": 997521287,
           "congestion_multiplier": 5053056335,
           "prover_cost": 198403901,
           "sequencer_cost": 47711920
@@ -42716,13 +42716,13 @@
           "slot_of_change": 570
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91747993285699,
+          "protocol_fee": 91747993285699,
           "congestion_multiplier": 5025040732,
           "prover_cost": 18375407094324,
           "sequencer_cost": 4418894733586
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 990626204,
+          "protocol_fee": 990626204,
           "congestion_multiplier": 5025040732,
           "prover_cost": 198403901,
           "sequencer_cost": 47711920
@@ -42770,13 +42770,13 @@
           "slot_of_change": 570
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88203473364905,
+          "protocol_fee": 88203473364905,
           "congestion_multiplier": 4949767110,
           "prover_cost": 18224868160616,
           "sequencer_cost": 4106441759131
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 954259795,
+          "protocol_fee": 954259795,
           "congestion_multiplier": 4949767110,
           "prover_cost": 197172042,
           "sequencer_cost": 44426961
@@ -42824,13 +42824,13 @@
           "slot_of_change": 570
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88943272947682,
+          "protocol_fee": 88943272947682,
           "congestion_multiplier": 4943066312,
           "prover_cost": 18408958666122,
           "sequencer_cost": 4147921177945
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952640889,
+          "protocol_fee": 952640889,
           "congestion_multiplier": 4943066312,
           "prover_cost": 197172042,
           "sequencer_cost": 44426961
@@ -42878,13 +42878,13 @@
           "slot_of_change": 570
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89816843634532,
+          "protocol_fee": 89816843634532,
           "congestion_multiplier": 4942771985,
           "prover_cost": 18591152939384,
           "sequencer_cost": 4188973336205
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952569780,
+          "protocol_fee": 952569780,
           "congestion_multiplier": 4942771985,
           "prover_cost": 197172042,
           "sequencer_cost": 44426961
@@ -42932,13 +42932,13 @@
           "slot_of_change": 575
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90269062400974,
+          "protocol_fee": 90269062400974,
           "congestion_multiplier": 4943999021,
           "prover_cost": 18678944414209,
           "sequencer_cost": 4208754580993
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 952866231,
+          "protocol_fee": 952866231,
           "congestion_multiplier": 4943999021,
           "prover_cost": 197172042,
           "sequencer_cost": 44426961
@@ -42986,13 +42986,13 @@
           "slot_of_change": 575
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89491713966837,
+          "protocol_fee": 89491713966837,
           "congestion_multiplier": 4918637192,
           "prover_cost": 18637942457497,
           "sequencer_cost": 4199515987563
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946738838,
+          "protocol_fee": 946738838,
           "congestion_multiplier": 4918637192,
           "prover_cost": 197172042,
           "sequencer_cost": 44426961
@@ -43040,13 +43040,13 @@
           "slot_of_change": 575
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94329885282470,
+          "protocol_fee": 94329885282470,
           "congestion_multiplier": 5068680035,
           "prover_cost": 18809981589344,
           "sequencer_cost": 4374413467059
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 991734985,
+          "protocol_fee": 991734985,
           "congestion_multiplier": 5068680035,
           "prover_cost": 197758290,
           "sequencer_cost": 45990291
@@ -43094,13 +43094,13 @@
           "slot_of_change": 575
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94330029919464,
+          "protocol_fee": 94330029919464,
           "congestion_multiplier": 5041425804,
           "prover_cost": 18936859830500,
           "sequencer_cost": 4403920028996
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 985091804,
+          "protocol_fee": 985091804,
           "congestion_multiplier": 5041425804,
           "prover_cost": 197758290,
           "sequencer_cost": 45990291
@@ -43148,13 +43148,13 @@
           "slot_of_change": 575
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93006482822579,
+          "protocol_fee": 93006482822579,
           "congestion_multiplier": 4967984528,
           "prover_cost": 19016730559562,
           "sequencer_cost": 4422494613515
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 967190598,
+          "protocol_fee": 967190598,
           "congestion_multiplier": 4967984528,
           "prover_cost": 197758290,
           "sequencer_cost": 45990291
@@ -43202,13 +43202,13 @@
           "slot_of_change": 580
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90480245712482,
+          "protocol_fee": 90480245712482,
           "congestion_multiplier": 4884911400,
           "prover_cost": 18895798744245,
           "sequencer_cost": 4394370941038
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 946941641,
+          "protocol_fee": 946941641,
           "congestion_multiplier": 4884911400,
           "prover_cost": 197758290,
           "sequencer_cost": 45990291
@@ -43256,13 +43256,13 @@
           "slot_of_change": 580
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91634935109910,
+          "protocol_fee": 91634935109910,
           "congestion_multiplier": 4925440167,
           "prover_cost": 18939360768063,
           "sequencer_cost": 4404501642269
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 956820470,
+          "protocol_fee": 956820470,
           "congestion_multiplier": 4925440167,
           "prover_cost": 197758290,
           "sequencer_cost": 45990291
@@ -43310,13 +43310,13 @@
           "slot_of_change": 580
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89630360591843,
+          "protocol_fee": 89630360591843,
           "congestion_multiplier": 5061344619,
           "prover_cost": 18542864605723,
           "sequencer_cost": 3526269897919
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939539320,
+          "protocol_fee": 939539320,
           "congestion_multiplier": 5061344619,
           "prover_cost": 194373316,
           "sequencer_cost": 36963694
@@ -43364,13 +43364,13 @@
           "slot_of_change": 580
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86885276311250,
+          "protocol_fee": 86885276311250,
           "congestion_multiplier": 4962942608,
           "prover_cost": 18421285343468,
           "sequencer_cost": 3503149344443
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916775293,
+          "protocol_fee": 916775293,
           "congestion_multiplier": 4962942608,
           "prover_cost": 194373316,
           "sequencer_cost": 36963694
@@ -43418,13 +43418,13 @@
           "slot_of_change": 580
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86030675924879,
+          "protocol_fee": 86030675924879,
           "congestion_multiplier": 4910229180,
           "prover_cost": 18485987238734,
           "sequencer_cost": 3515453610827
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 904580726,
+          "protocol_fee": 904580726,
           "congestion_multiplier": 4910229180,
           "prover_cost": 194373316,
           "sequencer_cost": 36963694
@@ -43472,13 +43472,13 @@
           "slot_of_change": 585
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86925215421655,
+          "protocol_fee": 86925215421655,
           "congestion_multiplier": 4956418461,
           "prover_cost": 18460143883526,
           "sequencer_cost": 3510539017129
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915266017,
+          "protocol_fee": 915266017,
           "congestion_multiplier": 4956418461,
           "prover_cost": 194373316,
           "sequencer_cost": 36963694
@@ -43526,13 +43526,13 @@
           "slot_of_change": 585
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87125707818229,
+          "protocol_fee": 87125707818229,
           "congestion_multiplier": 4985767931,
           "prover_cost": 18366476050522,
           "sequencer_cost": 3492726340018
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922055635,
+          "protocol_fee": 922055635,
           "congestion_multiplier": 4985767931,
           "prover_cost": 194373316,
           "sequencer_cost": 36963694
@@ -43580,13 +43580,13 @@
           "slot_of_change": 585
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 88478719010577,
+          "protocol_fee": 88478719010577,
           "congestion_multiplier": 4929449478,
           "prover_cost": 18588148400703,
           "sequencer_cost": 3928674761304
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933190889,
+          "protocol_fee": 933190889,
           "congestion_multiplier": 4929449478,
           "prover_cost": 196050428,
           "sequencer_cost": 41435992
@@ -43634,13 +43634,13 @@
           "slot_of_change": 585
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93622290092576,
+          "protocol_fee": 93622290092576,
           "congestion_multiplier": 5128776456,
           "prover_cost": 18719183641045,
           "sequencer_cost": 3956369549966
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 980528339,
+          "protocol_fee": 980528339,
           "congestion_multiplier": 5128776456,
           "prover_cost": 196050428,
           "sequencer_cost": 41435992
@@ -43688,13 +43688,13 @@
           "slot_of_change": 585
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91533820700563,
+          "protocol_fee": 91533820700563,
           "congestion_multiplier": 5050398902,
           "prover_cost": 18655754081443,
           "sequencer_cost": 3942963475054
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 961914734,
+          "protocol_fee": 961914734,
           "congestion_multiplier": 5050398902,
           "prover_cost": 196050428,
           "sequencer_cost": 41435992
@@ -43742,13 +43742,13 @@
           "slot_of_change": 590
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90003853891976,
+          "protocol_fee": 90003853891976,
           "congestion_multiplier": 4983095349,
           "prover_cost": 18653890262463,
           "sequencer_cost": 3942569549934
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 945931054,
+          "protocol_fee": 945931054,
           "congestion_multiplier": 4983095349,
           "prover_cost": 196050428,
           "sequencer_cost": 41435992
@@ -43796,13 +43796,13 @@
           "slot_of_change": 590
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87817911922633,
+          "protocol_fee": 87817911922633,
           "congestion_multiplier": 4901513673,
           "prover_cost": 18581423753823,
           "sequencer_cost": 3927253482008
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 926556514,
+          "protocol_fee": 926556514,
           "congestion_multiplier": 4901513673,
           "prover_cost": 196050428,
           "sequencer_cost": 41435992
@@ -43850,13 +43850,13 @@
           "slot_of_change": 590
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87173837962188,
+          "protocol_fee": 87173837962188,
           "congestion_multiplier": 4935406288,
           "prover_cost": 18483920729668,
           "sequencer_cost": 3667245291224
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 919760965,
+          "protocol_fee": 919760965,
           "congestion_multiplier": 4935406288,
           "prover_cost": 195021685,
           "sequencer_cost": 38692676
@@ -43904,13 +43904,13 @@
           "slot_of_change": 590
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87116221851405,
+          "protocol_fee": 87116221851405,
           "congestion_multiplier": 4921399944,
           "prover_cost": 18537680775759,
           "sequencer_cost": 3677911387382
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916487482,
+          "protocol_fee": 916487482,
           "congestion_multiplier": 4921399944,
           "prover_cost": 195021685,
           "sequencer_cost": 38692676
@@ -43958,13 +43958,13 @@
           "slot_of_change": 590
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86386101121862,
+          "protocol_fee": 86386101121862,
           "congestion_multiplier": 4914198711,
           "prover_cost": 18416135821559,
           "sequencer_cost": 3653796635567
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914804450,
+          "protocol_fee": 914804450,
           "congestion_multiplier": 4914198711,
           "prover_cost": 195021685,
           "sequencer_cost": 38692676
@@ -44012,13 +44012,13 @@
           "slot_of_change": 595
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84257054064567,
+          "protocol_fee": 84257054064567,
           "congestion_multiplier": 4821547964,
           "prover_cost": 18397739329626,
           "sequencer_cost": 3650146736317
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 893150640,
+          "protocol_fee": 893150640,
           "congestion_multiplier": 4821547964,
           "prover_cost": 195021685,
           "sequencer_cost": 38692676
@@ -44066,13 +44066,13 @@
           "slot_of_change": 595
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86003352576448,
+          "protocol_fee": 86003352576448,
           "congestion_multiplier": 4927277856,
           "prover_cost": 18273479817874,
           "sequencer_cost": 3625493411082
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917861234,
+          "protocol_fee": 917861234,
           "congestion_multiplier": 4927277856,
           "prover_cost": 195021685,
           "sequencer_cost": 38692676
@@ -44120,13 +44120,13 @@
           "slot_of_change": 595
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86454475715543,
+          "protocol_fee": 86454475715543,
           "congestion_multiplier": 4900377410,
           "prover_cost": 18365928527863,
           "sequencer_cost": 3799740749052
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921199499,
+          "protocol_fee": 921199499,
           "congestion_multiplier": 4900377410,
           "prover_cost": 195694717,
           "sequencer_cost": 40487427
@@ -44174,13 +44174,13 @@
           "slot_of_change": 595
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86069930790141,
+          "protocol_fee": 86069930790141,
           "congestion_multiplier": 4899337344,
           "prover_cost": 18289114785752,
           "sequencer_cost": 3783848696247
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920953854,
+          "protocol_fee": 920953854,
           "congestion_multiplier": 4899337344,
           "prover_cost": 195694717,
           "sequencer_cost": 40487427
@@ -44228,13 +44228,13 @@
           "slot_of_change": 595
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87420296891290,
+          "protocol_fee": 87420296891290,
           "congestion_multiplier": 4952989425,
           "prover_cost": 18323931757102,
           "sequencer_cost": 3791052005603
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 933625517,
+          "protocol_fee": 933625517,
           "congestion_multiplier": 4952989425,
           "prover_cost": 195694717,
           "sequencer_cost": 40487427
@@ -44282,13 +44282,13 @@
           "slot_of_change": 600
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87731844565030,
+          "protocol_fee": 87731844565030,
           "congestion_multiplier": 4982151580,
           "prover_cost": 18254566096746,
           "sequencer_cost": 3776700892026
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940513097,
+          "protocol_fee": 940513097,
           "congestion_multiplier": 4982151580,
           "prover_cost": 195694717,
           "sequencer_cost": 40487427
@@ -44336,13 +44336,13 @@
           "slot_of_change": 600
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86053356974737,
+          "protocol_fee": 86053356974737,
           "congestion_multiplier": 4883310307,
           "prover_cost": 18361060534214,
           "sequencer_cost": 3798733606189
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 917168554,
+          "protocol_fee": 917168554,
           "congestion_multiplier": 4883310307,
           "prover_cost": 195694717,
           "sequencer_cost": 40487427
@@ -44390,13 +44390,13 @@
           "slot_of_change": 600
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86897872260360,
+          "protocol_fee": 86897872260360,
           "congestion_multiplier": 4956685292,
           "prover_cost": 18278931512413,
           "sequencer_cost": 3683359121252
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 928299642,
+          "protocol_fee": 928299642,
           "congestion_multiplier": 4956685292,
           "prover_cost": 195267446,
           "sequencer_cost": 39348040
@@ -44444,13 +44444,13 @@
           "slot_of_change": 600
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86299174152702,
+          "protocol_fee": 86299174152702,
           "congestion_multiplier": 4954572979,
           "prover_cost": 18162691927156,
           "sequencer_cost": 3659935862824
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 927804061,
+          "protocol_fee": 927804061,
           "congestion_multiplier": 4954572979,
           "prover_cost": 195267446,
           "sequencer_cost": 39348040
@@ -44498,13 +44498,13 @@
           "slot_of_change": 600
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86873163735224,
+          "protocol_fee": 86873163735224,
           "congestion_multiplier": 4976496188,
           "prover_cost": 18182694377753,
           "sequencer_cost": 3663966525601
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932947585,
+          "protocol_fee": 932947585,
           "congestion_multiplier": 4976496188,
           "prover_cost": 195267446,
           "sequencer_cost": 39348040
@@ -44552,13 +44552,13 @@
           "slot_of_change": 605
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85266227291588,
+          "protocol_fee": 85266227291588,
           "congestion_multiplier": 4902940944,
           "prover_cost": 18182694377753,
           "sequencer_cost": 3663966525601
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915690386,
+          "protocol_fee": 915690386,
           "congestion_multiplier": 4902940944,
           "prover_cost": 195267446,
           "sequencer_cost": 39348040
@@ -44606,13 +44606,13 @@
           "slot_of_change": 605
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85861012089307,
+          "protocol_fee": 85861012089307,
           "congestion_multiplier": 4962000558,
           "prover_cost": 18036598692854,
           "sequencer_cost": 3634527010869
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929546686,
+          "protocol_fee": 929546686,
           "congestion_multiplier": 4962000558,
           "prover_cost": 195267446,
           "sequencer_cost": 39348040
@@ -44660,13 +44660,13 @@
           "slot_of_change": 605
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82051347653247,
+          "protocol_fee": 82051347653247,
           "congestion_multiplier": 4865381990,
           "prover_cost": 17886503434662,
           "sequencer_cost": 3340725317290
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 890434435,
+          "protocol_fee": 890434435,
           "congestion_multiplier": 4865381990,
           "prover_cost": 194107215,
           "sequencer_cost": 36254089
@@ -44714,13 +44714,13 @@
           "slot_of_change": 605
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 78123266334620,
+          "protocol_fee": 78123266334620,
           "congestion_multiplier": 4643529346,
           "prover_cost": 18067175842376,
           "sequencer_cost": 3374470139960
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 839328171,
+          "protocol_fee": 839328171,
           "congestion_multiplier": 4643529346,
           "prover_cost": 194107215,
           "sequencer_cost": 36254089
@@ -44768,13 +44768,13 @@
           "slot_of_change": 605
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83653390998753,
+          "protocol_fee": 83653390998753,
           "congestion_multiplier": 4899493676,
           "prover_cost": 18076214253194,
           "sequencer_cost": 3376158275819
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 898292448,
+          "protocol_fee": 898292448,
           "congestion_multiplier": 4899493676,
           "prover_cost": 194107215,
           "sequencer_cost": 36254089
@@ -44822,13 +44822,13 @@
           "slot_of_change": 610
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85114188440818,
+          "protocol_fee": 85114188440818,
           "congestion_multiplier": 4974729924,
           "prover_cost": 18043737006274,
           "sequencer_cost": 3370092385892
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 915623968,
+          "protocol_fee": 915623968,
           "congestion_multiplier": 4974729924,
           "prover_cost": 194107215,
           "sequencer_cost": 36254089
@@ -44876,13 +44876,13 @@
           "slot_of_change": 610
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84119909878286,
+          "protocol_fee": 84119909878286,
           "congestion_multiplier": 4919655952,
           "prover_cost": 18083521242178,
           "sequencer_cost": 3377523027917
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 902937056,
+          "protocol_fee": 902937056,
           "congestion_multiplier": 4919655952,
           "prover_cost": 194107215,
           "sequencer_cost": 36254089
@@ -44930,13 +44930,13 @@
           "slot_of_change": 610
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86312335598951,
+          "protocol_fee": 86312335598951,
           "congestion_multiplier": 5012696155,
           "prover_cost": 18175601651348,
           "sequencer_cost": 3334209295065
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 920540911,
+          "protocol_fee": 920540911,
           "congestion_multiplier": 5012696155,
           "prover_cost": 193846972,
           "sequencer_cost": 35560109
@@ -44984,13 +44984,13 @@
           "slot_of_change": 610
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85236190010834,
+          "protocol_fee": 85236190010834,
           "congestion_multiplier": 4957117716,
           "prover_cost": 18201084326467,
           "sequencer_cost": 3338883944844
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 907790824,
+          "protocol_fee": 907790824,
           "congestion_multiplier": 4957117716,
           "prover_cost": 193846972,
           "sequencer_cost": 35560109
@@ -45038,13 +45038,13 @@
           "slot_of_change": 610
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 83683090112539,
+          "protocol_fee": 83683090112539,
           "congestion_multiplier": 4904050956,
           "prover_cost": 18112334669223,
           "sequencer_cost": 3322603332087
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 895616933,
+          "protocol_fee": 895616933,
           "congestion_multiplier": 4904050956,
           "prover_cost": 193846972,
           "sequencer_cost": 35560109
@@ -45092,13 +45092,13 @@
           "slot_of_change": 615
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82796244060434,
+          "protocol_fee": 82796244060434,
           "congestion_multiplier": 4864994528,
           "prover_cost": 18101474613885,
           "sequencer_cost": 3320611117570
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 886657112,
+          "protocol_fee": 886657112,
           "congestion_multiplier": 4864994528,
           "prover_cost": 193846972,
           "sequencer_cost": 35560109
@@ -45146,13 +45146,13 @@
           "slot_of_change": 615
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82624428545644,
+          "protocol_fee": 82624428545644,
           "congestion_multiplier": 4839231950,
           "prover_cost": 18185126257500,
           "sequencer_cost": 3335956529130
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 880746994,
+          "protocol_fee": 880746994,
           "congestion_multiplier": 4839231950,
           "prover_cost": 193846972,
           "sequencer_cost": 35560109
@@ -45200,13 +45200,13 @@
           "slot_of_change": 615
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 84206290241292,
+          "protocol_fee": 84206290241292,
           "congestion_multiplier": 4869461508,
           "prover_cost": 18330094108233,
           "sequencer_cost": 3431665266477
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 891864355,
+          "protocol_fee": 891864355,
           "congestion_multiplier": 4869461508,
           "prover_cost": 194141762,
           "sequencer_cost": 36346215
@@ -45254,13 +45254,13 @@
           "slot_of_change": 615
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86310821583815,
+          "protocol_fee": 86310821583815,
           "congestion_multiplier": 4941975531,
           "prover_cost": 18442594502003,
           "sequencer_cost": 3452727007431
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 908577965,
+          "protocol_fee": 908577965,
           "congestion_multiplier": 4941975531,
           "prover_cost": 194141762,
           "sequencer_cost": 36346215
@@ -45308,13 +45308,13 @@
           "slot_of_change": 615
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87658717917881,
+          "protocol_fee": 87658717917881,
           "congestion_multiplier": 5003536460,
           "prover_cost": 18442594502003,
           "sequencer_cost": 3452727007431
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 922767019,
+          "protocol_fee": 922767019,
           "congestion_multiplier": 5003536460,
           "prover_cost": 194141762,
           "sequencer_cost": 36346215
@@ -45362,13 +45362,13 @@
           "slot_of_change": 620
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87589705255363,
+          "protocol_fee": 87589705255363,
           "congestion_multiplier": 4997584168,
           "prover_cost": 18455513765223,
           "sequencer_cost": 3455145684968
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 921395087,
+          "protocol_fee": 921395087,
           "congestion_multiplier": 4997584168,
           "prover_cost": 194141762,
           "sequencer_cost": 36346215
@@ -45416,13 +45416,13 @@
           "slot_of_change": 620
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 85965605375466,
+          "protocol_fee": 85965605375466,
           "congestion_multiplier": 4914044003,
           "prover_cost": 18499914143035,
           "sequencer_cost": 3463458093701
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 902140084,
+          "protocol_fee": 902140084,
           "congestion_multiplier": 4914044003,
           "prover_cost": 194141762,
           "sequencer_cost": 36346215
@@ -45470,13 +45470,13 @@
           "slot_of_change": 620
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87304908592788,
+          "protocol_fee": 87304908592788,
           "congestion_multiplier": 4876920421,
           "prover_cost": 18645235057663,
           "sequencer_cost": 3873903620620
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 916653086,
+          "protocol_fee": 916653086,
           "congestion_multiplier": 4876920421,
           "prover_cost": 195764620,
           "sequencer_cost": 40673838
@@ -45524,13 +45524,13 @@
           "slot_of_change": 620
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 87587030008051,
+          "protocol_fee": 87587030008051,
           "congestion_multiplier": 4869612002,
           "prover_cost": 18740814694995,
           "sequencer_cost": 3893762115403
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 914925094,
+          "protocol_fee": 914925094,
           "congestion_multiplier": 4869612002,
           "prover_cost": 195764620,
           "sequencer_cost": 40673838
@@ -45578,13 +45578,13 @@
           "slot_of_change": 620
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 86815574179872,
+          "protocol_fee": 86815574179872,
           "congestion_multiplier": 4859692708,
           "prover_cost": 18623486996307,
           "sequencer_cost": 3869385045587
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 912579792,
+          "protocol_fee": 912579792,
           "congestion_multiplier": 4859692708,
           "prover_cost": 195764620,
           "sequencer_cost": 40673838
@@ -45632,13 +45632,13 @@
           "slot_of_change": 625
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89194355307615,
+          "protocol_fee": 89194355307615,
           "congestion_multiplier": 4946018873,
           "prover_cost": 18715192580485,
           "sequencer_cost": 3888438631850
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 932990617,
+          "protocol_fee": 932990617,
           "congestion_multiplier": 4946018873,
           "prover_cost": 195764620,
           "sequencer_cost": 40673838
@@ -45686,13 +45686,13 @@
           "slot_of_change": 625
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89224705359899,
+          "protocol_fee": 89224705359899,
           "congestion_multiplier": 4977756065,
           "prover_cost": 18572187666883,
           "sequencer_cost": 3858726630320
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 940494510,
+          "protocol_fee": 940494510,
           "congestion_multiplier": 4977756065,
           "prover_cost": 195764620,
           "sequencer_cost": 40673838
@@ -45740,13 +45740,13 @@
           "slot_of_change": 625
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91562952226784,
+          "protocol_fee": 91562952226784,
           "congestion_multiplier": 4959662297,
           "prover_cost": 18764930328393,
           "sequencer_cost": 4358999288072
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 964851751,
+          "protocol_fee": 964851751,
           "congestion_multiplier": 4959662297,
           "prover_cost": 197736917,
           "sequencer_cost": 45933295
@@ -45794,13 +45794,13 @@
           "slot_of_change": 625
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90691947846801,
+          "protocol_fee": 90691947846801,
           "congestion_multiplier": 4898071038,
           "prover_cost": 18880100327519,
           "sequencer_cost": 4385752701776
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 949843796,
+          "protocol_fee": 949843796,
           "congestion_multiplier": 4898071038,
           "prover_cost": 197736917,
           "sequencer_cost": 45933295
@@ -45848,13 +45848,13 @@
           "slot_of_change": 625
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 82385853157595,
+          "protocol_fee": 82385853157595,
           "congestion_multiplier": 4534689147,
           "prover_cost": 18914145905006,
           "sequencer_cost": 4393661318831
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 861298453,
+          "protocol_fee": 861298453,
           "congestion_multiplier": 4534689147,
           "prover_cost": 197736917,
           "sequencer_cost": 45933295
@@ -45902,13 +45902,13 @@
           "slot_of_change": 630
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 89123625076693,
+          "protocol_fee": 89123625076693,
           "congestion_multiplier": 4816501685,
           "prover_cost": 18950152195843,
           "sequencer_cost": 4402025399772
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929967774,
+          "protocol_fee": 929967774,
           "congestion_multiplier": 4816501685,
           "prover_cost": 197736917,
           "sequencer_cost": 45933295
@@ -45956,13 +45956,13 @@
           "slot_of_change": 630
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91432634450849,
+          "protocol_fee": 91432634450849,
           "congestion_multiplier": 4894236227,
           "prover_cost": 19053039076491,
           "sequencer_cost": 4425925506602
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 948909367,
+          "protocol_fee": 948909367,
           "congestion_multiplier": 4894236227,
           "prover_cost": 197736917,
           "sequencer_cost": 45933295
@@ -46010,13 +46010,13 @@
           "slot_of_change": 630
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92637881468346,
+          "protocol_fee": 92637881468346,
           "congestion_multiplier": 4973080376,
           "prover_cost": 18953285330183,
           "sequencer_cost": 4363102136735
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 965647920,
+          "protocol_fee": 965647920,
           "congestion_multiplier": 4973080376,
           "prover_cost": 197567132,
           "sequencer_cost": 45480536
@@ -46064,13 +46064,13 @@
           "slot_of_change": 630
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91470111850915,
+          "protocol_fee": 91470111850915,
           "congestion_multiplier": 4901420044,
           "prover_cost": 19058105928414,
           "sequencer_cost": 4387232147345
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 948231043,
+          "protocol_fee": 948231043,
           "congestion_multiplier": 4901420044,
           "prover_cost": 197567132,
           "sequencer_cost": 45480536
@@ -46118,13 +46118,13 @@
           "slot_of_change": 630
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91063981032312,
+          "protocol_fee": 91063981032312,
           "congestion_multiplier": 4863123261,
           "prover_cost": 19161579452266,
           "sequencer_cost": 4411052057463
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 938923099,
+          "protocol_fee": 938923099,
           "congestion_multiplier": 4863123261,
           "prover_cost": 197567132,
           "sequencer_cost": 45480536
@@ -46172,13 +46172,13 @@
           "slot_of_change": 635
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90812502419357,
+          "protocol_fee": 90812502419357,
           "congestion_multiplier": 4851298969,
           "prover_cost": 19167331183247,
           "sequencer_cost": 4412376122885
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 936049233,
+          "protocol_fee": 936049233,
           "congestion_multiplier": 4851298969,
           "prover_cost": 197567132,
           "sequencer_cost": 45480536
@@ -46226,13 +46226,13 @@
           "slot_of_change": 635
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90307120794814,
+          "protocol_fee": 90307120794814,
           "congestion_multiplier": 4825652932,
           "prover_cost": 19188439877648,
           "sequencer_cost": 4417235406542
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 929816023,
+          "protocol_fee": 929816023,
           "congestion_multiplier": 4825652932,
           "prover_cost": 197567132,
           "sequencer_cost": 45480536
@@ -46280,13 +46280,13 @@
           "slot_of_change": 635
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 93167567783203,
+          "protocol_fee": 93167567783203,
           "congestion_multiplier": 4933365666,
           "prover_cost": 19233469713806,
           "sequencer_cost": 4453005365056
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 957540858,
+          "protocol_fee": 957540858,
           "congestion_multiplier": 4933365666,
           "prover_cost": 197674293,
           "sequencer_cost": 45766297
@@ -46334,13 +46334,13 @@
           "slot_of_change": 635
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92006737123252,
+          "protocol_fee": 92006737123252,
           "congestion_multiplier": 4892514653,
           "prover_cost": 19193164072988,
           "sequencer_cost": 4443673651253
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 947596063,
+          "protocol_fee": 947596063,
           "congestion_multiplier": 4892514653,
           "prover_cost": 197674293,
           "sequencer_cost": 45766297
@@ -46388,13 +46388,13 @@
           "slot_of_change": 635
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91733464935236,
+          "protocol_fee": 91733464935236,
           "congestion_multiplier": 4858443606,
           "prover_cost": 19305135023142,
           "sequencer_cost": 4469597587453
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 939301787,
+          "protocol_fee": 939301787,
           "congestion_multiplier": 4858443606,
           "prover_cost": 197674293,
           "sequencer_cost": 45766297
@@ -46442,13 +46442,13 @@
           "slot_of_change": 640
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92944586112767,
+          "protocol_fee": 92944586112767,
           "congestion_multiplier": 4904302666,
           "prover_cost": 19330265676592,
           "sequencer_cost": 4475415931013
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 950465744,
+          "protocol_fee": 950465744,
           "congestion_multiplier": 4904302666,
           "prover_cost": 197674293,
           "sequencer_cost": 45766297
@@ -46496,13 +46496,13 @@
           "slot_of_change": 640
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92742797830685,
+          "protocol_fee": 92742797830685,
           "congestion_multiplier": 4871282399,
           "prover_cost": 19452818860569,
           "sequencer_cost": 4503789905853
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 942427271,
+          "protocol_fee": 942427271,
           "congestion_multiplier": 4871282399,
           "prover_cost": 197674293,
           "sequencer_cost": 45766297
@@ -46550,13 +46550,13 @@
           "slot_of_change": 640
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104867099106619,
+          "protocol_fee": 104867099106619,
           "congestion_multiplier": 4955829811,
           "prover_cost": 20199646338176,
           "sequencer_cost": 6309860929043
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1061475159,
+          "protocol_fee": 1061475159,
           "congestion_multiplier": 4955829811,
           "prover_cost": 204462820,
           "sequencer_cost": 63869037
@@ -46604,13 +46604,13 @@
           "slot_of_change": 640
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105732516206493,
+          "protocol_fee": 105732516206493,
           "congestion_multiplier": 5014400185,
           "prover_cost": 20069197828168,
           "sequencer_cost": 6269112098951
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1077191456,
+          "protocol_fee": 1077191456,
           "congestion_multiplier": 5014400185,
           "prover_cost": 204462820,
           "sequencer_cost": 63869037
@@ -46658,13 +46658,13 @@
           "slot_of_change": 640
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106660787270049,
+          "protocol_fee": 106660787270049,
           "congestion_multiplier": 5049239278,
           "prover_cost": 20071205364002,
           "sequencer_cost": 6269739202600
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1086539894,
+          "protocol_fee": 1086539894,
           "congestion_multiplier": 5049239278,
           "prover_cost": 204462820,
           "sequencer_cost": 63869037
@@ -46712,13 +46712,13 @@
           "slot_of_change": 645
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 100731604616487,
+          "protocol_fee": 100731604616487,
           "congestion_multiplier": 4857033114,
           "prover_cost": 19900065015456,
           "sequencer_cost": 6216279266688
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1034964857,
+          "protocol_fee": 1034964857,
           "congestion_multiplier": 4857033114,
           "prover_cost": 204462820,
           "sequencer_cost": 63869037
@@ -46766,13 +46766,13 @@
           "slot_of_change": 645
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106523942730624,
+          "protocol_fee": 106523942730624,
           "congestion_multiplier": 5076375470,
           "prover_cost": 19912012827811,
           "sequencer_cost": 6220011462446
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1093821399,
+          "protocol_fee": 1093821399,
           "congestion_multiplier": 5076375470,
           "prover_cost": 204462820,
           "sequencer_cost": 63869037
@@ -46820,13 +46820,13 @@
           "slot_of_change": 645
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110959287185873,
+          "protocol_fee": 110959287185873,
           "congestion_multiplier": 4944080691,
           "prover_cost": 20457765660676,
           "sequencer_cost": 7675352285161
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1139364913,
+          "protocol_fee": 1139364913,
           "congestion_multiplier": 4944080691,
           "prover_cost": 210066782,
           "sequencer_cost": 78812935
@@ -46874,13 +46874,13 @@
           "slot_of_change": 645
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 112712267261374,
+          "protocol_fee": 112712267261374,
           "congestion_multiplier": 5017608671,
           "prover_cost": 20400644416575,
           "sequencer_cost": 7653921515119
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1160605655,
+          "protocol_fee": 1160605655,
           "congestion_multiplier": 5017608671,
           "prover_cost": 210066782,
           "sequencer_cost": 78812935
@@ -46928,13 +46928,13 @@
           "slot_of_change": 645
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 113385125056922,
+          "protocol_fee": 113385125056922,
           "congestion_multiplier": 5054525423,
           "prover_cost": 20335571793887,
           "sequencer_cost": 7629507543842
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1171270156,
+          "protocol_fee": 1171270156,
           "congestion_multiplier": 5054525423,
           "prover_cost": 210066782,
           "sequencer_cost": 78812935
@@ -46982,13 +46982,13 @@
           "slot_of_change": 650
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 110115315306812,
+          "protocol_fee": 110115315306812,
           "congestion_multiplier": 4957288651,
           "prover_cost": 20234399950837,
           "sequencer_cost": 7591549853367
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1143180425,
+          "protocol_fee": 1143180425,
           "congestion_multiplier": 4957288651,
           "prover_cost": 210066782,
           "sequencer_cost": 78812935
@@ -47036,13 +47036,13 @@
           "slot_of_change": 650
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 109542112911673,
+          "protocol_fee": 109542112911673,
           "congestion_multiplier": 4922123023,
           "prover_cost": 20309546909469,
           "sequencer_cost": 7619743517828
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1133021788,
+          "protocol_fee": 1133021788,
           "congestion_multiplier": 4922123023,
           "prover_cost": 210066782,
           "sequencer_cost": 78812935
@@ -47090,13 +47090,13 @@
           "slot_of_change": 650
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 107088401058012,
+          "protocol_fee": 107088401058012,
           "congestion_multiplier": 4989548246,
           "prover_cost": 19973852943482,
           "sequencer_cost": 6868384455145
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1111076108,
+          "protocol_fee": 1111076108,
           "congestion_multiplier": 4989548246,
           "prover_cost": 207235056,
           "sequencer_cost": 71261666
@@ -47144,13 +47144,13 @@
           "slot_of_change": 650
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 106042953019227,
+          "protocol_fee": 106042953019227,
           "congestion_multiplier": 4943489127,
           "prover_cost": 20009871540397,
           "sequencer_cost": 6880770126145
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1098248795,
+          "protocol_fee": 1098248795,
           "congestion_multiplier": 4943489127,
           "prover_cost": 207235056,
           "sequencer_cost": 71261666
@@ -47198,13 +47198,13 @@
           "slot_of_change": 650
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104195961998913,
+          "protocol_fee": 104195961998913,
           "congestion_multiplier": 4881778148,
           "prover_cost": 19973920323323,
           "sequencer_cost": 6868407624969
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1081062489,
+          "protocol_fee": 1081062489,
           "congestion_multiplier": 4881778148,
           "prover_cost": 207235056,
           "sequencer_cost": 71261666
@@ -47252,13 +47252,13 @@
           "slot_of_change": 655
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104893882474211,
+          "protocol_fee": 104893882474211,
           "congestion_multiplier": 4914812701,
           "prover_cost": 19938032839659,
           "sequencer_cost": 6856067039724
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1090262504,
+          "protocol_fee": 1090262504,
           "congestion_multiplier": 4914812701,
           "prover_cost": 207235056,
           "sequencer_cost": 71261666
@@ -47306,13 +47306,13 @@
           "slot_of_change": 655
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 105295679690440,
+          "protocol_fee": 105295679690440,
           "congestion_multiplier": 4938453746,
           "prover_cost": 19894266802844,
           "sequencer_cost": 6841017266013
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1096846458,
+          "protocol_fee": 1096846458,
           "congestion_multiplier": 4938453746,
           "prover_cost": 207235056,
           "sequencer_cost": 71261666
@@ -47360,13 +47360,13 @@
           "slot_of_change": 655
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102938128153978,
+          "protocol_fee": 102938128153978,
           "congestion_multiplier": 4965769800,
           "prover_cost": 19604258378670,
           "sequencer_cost": 6352399062455
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1078936417,
+          "protocol_fee": 1078936417,
           "congestion_multiplier": 4965769800,
           "prover_cost": 205480211,
           "sequencer_cost": 66582080
@@ -47414,13 +47414,13 @@
           "slot_of_change": 655
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104265256448033,
+          "protocol_fee": 104265256448033,
           "congestion_multiplier": 5007257633,
           "prover_cost": 19651422962208,
           "sequencer_cost": 6367681877568
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1090223692,
+          "protocol_fee": 1090223692,
           "congestion_multiplier": 5007257633,
           "prover_cost": 205480211,
           "sequencer_cost": 66582080
@@ -47468,13 +47468,13 @@
           "slot_of_change": 655
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 104426190443505,
+          "protocol_fee": 104426190443505,
           "congestion_multiplier": 4998191679,
           "prover_cost": 19726383684681,
           "sequencer_cost": 6391971519847
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1087757188,
+          "protocol_fee": 1087757188,
           "congestion_multiplier": 4998191679,
           "prover_cost": 205480211,
           "sequencer_cost": 66582080
@@ -47522,13 +47522,13 @@
           "slot_of_change": 660
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 103870507198438,
+          "protocol_fee": 103870507198438,
           "congestion_multiplier": 5007935725,
           "prover_cost": 19573710308814,
           "sequencer_cost": 6342500522731
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1090408175,
+          "protocol_fee": 1090408175,
           "congestion_multiplier": 5007935725,
           "prover_cost": 205480211,
           "sequencer_cost": 66582080
@@ -47576,13 +47576,13 @@
           "slot_of_change": 660
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 102442349148892,
+          "protocol_fee": 102442349148892,
           "congestion_multiplier": 4961129803,
           "prover_cost": 19532692225430,
           "sequencer_cost": 6329209367850
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1077674049,
+          "protocol_fee": 1077674049,
           "congestion_multiplier": 4961129803,
           "prover_cost": 205480211,
           "sequencer_cost": 66582080
@@ -47630,13 +47630,13 @@
           "slot_of_change": 660
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 97224294980917,
+          "protocol_fee": 97224294980917,
           "congestion_multiplier": 5050694705,
           "prover_cost": 19037906271499,
           "sequencer_cost": 4963975397006
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1021758311,
+          "protocol_fee": 1021758311,
           "congestion_multiplier": 5050694705,
           "prover_cost": 200074878,
           "sequencer_cost": 52167857
@@ -47684,13 +47684,13 @@
           "slot_of_change": 660
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95285846079672,
+          "protocol_fee": 95285846079672,
           "congestion_multiplier": 4975490239,
           "prover_cost": 19011290475687,
           "sequencer_cost": 4957035550066
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1002788530,
+          "protocol_fee": 1002788530,
           "congestion_multiplier": 4975490239,
           "prover_cost": 200074878,
           "sequencer_cost": 52167857
@@ -47738,13 +47738,13 @@
           "slot_of_change": 660
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94411219948862,
+          "protocol_fee": 94411219948862,
           "congestion_multiplier": 4930333454,
           "prover_cost": 19053207883172,
           "sequencer_cost": 4967965164725
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 991398059,
+          "protocol_fee": 991398059,
           "congestion_multiplier": 4930333454,
           "prover_cost": 200074878,
           "sequencer_cost": 52167857
@@ -47792,13 +47792,13 @@
           "slot_of_change": 665
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 96163334845322,
+          "protocol_fee": 96163334845322,
           "congestion_multiplier": 4988861748,
           "prover_cost": 19122048971208,
           "sequencer_cost": 4985914904704
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1006161396,
+          "protocol_fee": 1006161396,
           "congestion_multiplier": 4988861748,
           "prover_cost": 200074878,
           "sequencer_cost": 52167857
@@ -47846,13 +47846,13 @@
           "slot_of_change": 665
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 94227730736008,
+          "protocol_fee": 94227730736008,
           "congestion_multiplier": 4925379581,
           "prover_cost": 19040176390700,
           "sequencer_cost": 4964567311669
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 990148481,
+          "protocol_fee": 990148481,
           "congestion_multiplier": 4925379581,
           "prover_cost": 200074878,
           "sequencer_cost": 52167857
@@ -47900,13 +47900,13 @@
           "slot_of_change": 665
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92918839272645,
+          "protocol_fee": 92918839272645,
           "congestion_multiplier": 4856211810,
           "prover_cost": 19042586120141,
           "sequencer_cost": 5053299668632
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 978152068,
+          "protocol_fee": 978152068,
           "congestion_multiplier": 4856211810,
           "prover_cost": 200460371,
           "sequencer_cost": 53195838
@@ -47954,13 +47954,13 @@
           "slot_of_change": 665
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 95842837473538,
+          "protocol_fee": 95842837473538,
           "congestion_multiplier": 4981935324,
           "prover_cost": 19021663457807,
           "sequencer_cost": 5047747456240
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 1010042618,
+          "protocol_fee": 1010042618,
           "congestion_multiplier": 4981935324,
           "prover_cost": 200460371,
           "sequencer_cost": 53195838
@@ -48008,13 +48008,13 @@
           "slot_of_change": 665
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91170824248356,
+          "protocol_fee": 91170824248356,
           "congestion_multiplier": 4814344034,
           "prover_cost": 18889438659805,
           "sequencer_cost": 5012659179694
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 967532047,
+          "protocol_fee": 967532047,
           "congestion_multiplier": 4814344034,
           "prover_cost": 200460371,
           "sequencer_cost": 53195838
@@ -48062,13 +48062,13 @@
           "slot_of_change": 670
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91558870008821,
+          "protocol_fee": 91558870008821,
           "congestion_multiplier": 4832494068,
           "prover_cost": 18879998926312,
           "sequencer_cost": 5010154173187
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 972135916,
+          "protocol_fee": 972135916,
           "congestion_multiplier": 4832494068,
           "prover_cost": 200460371,
           "sequencer_cost": 53195838
@@ -48116,13 +48116,13 @@
           "slot_of_change": 670
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 91564874548351,
+          "protocol_fee": 91564874548351,
           "congestion_multiplier": 4859574542,
           "prover_cost": 18748758035034,
           "sequencer_cost": 4975326994346
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 979005046,
+          "protocol_fee": 979005046,
           "congestion_multiplier": 4859574542,
           "prover_cost": 200460371,
           "sequencer_cost": 53195838
@@ -48170,13 +48170,13 @@
           "slot_of_change": 670
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 90708737391252,
+          "protocol_fee": 90708737391252,
           "congestion_multiplier": 4931087654,
           "prover_cost": 18517869401280,
           "sequencer_cost": 4556848178765
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 974118591,
+          "protocol_fee": 974118591,
           "congestion_multiplier": 4931087654,
           "prover_cost": 198862881,
           "sequencer_cost": 48935865
@@ -48224,13 +48224,13 @@
           "slot_of_change": 670
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92858055272739,
+          "protocol_fee": 92858055272739,
           "congestion_multiplier": 5029464922,
           "prover_cost": 18493828566944,
           "sequencer_cost": 4550932248061
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 998496354,
+          "protocol_fee": 998496354,
           "congestion_multiplier": 5029464922,
           "prover_cost": 198862881,
           "sequencer_cost": 48935865
@@ -48278,13 +48278,13 @@
           "slot_of_change": 670
         },
         "mana_base_fee_components_in_fee_asset": {
-          "congestion_cost": 92133043710234,
+          "protocol_fee": 92133043710234,
           "congestion_multiplier": 4959622753,
           "prover_cost": 18673091728474,
           "sequencer_cost": 4595045044919
         },
         "mana_base_fee_components_in_wei": {
-          "congestion_cost": 981189552,
+          "protocol_fee": 981189552,
           "congestion_multiplier": 4959622753,
           "prover_cost": 198862881,
           "sequencer_cost": 48935865

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibBase.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibBase.sol
@@ -55,7 +55,7 @@ contract RewardLibBase is TestBase {
     // These tests call RewardLib directly instead of going through proposal, so seed the temp checkpoint
     // logs that proposal would normally write before handleRewardsAndFees reads them.
     FeeHeader memory feeHeader =
-      FeeHeader({excessMana: 0, manaUsed: 0, ethPerFeeAsset: 0, congestionCost: 0, proverCost: 0});
+      FeeHeader({excessMana: 0, manaUsed: 0, ethPerFeeAsset: 0, protocolFee: 0, proverCost: 0});
 
     for (uint256 i = 0; i < _count; i++) {
       wrapper.addFeeHeader(feeHeader);

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -128,6 +128,14 @@ contract RewardLibWrapper {
     currentEpoch = _epoch;
   }
 
+  function updateProtocolFeeRecipient(address _recipient) external returns (address) {
+    return RewardLib.updateProtocolFeeRecipient(_recipient);
+  }
+
+  function getProtocolFeeRecipient() external view returns (address) {
+    return RewardLib.getProtocolFeeRecipient();
+  }
+
   function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) external {
     RewardLib.handleRewardsAndFees(_args, _endEpoch);
   }

--- a/l1-contracts/test/rollup/libraries/rewardlib/waterfallIdentity.t.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/waterfallIdentity.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {RewardLibBase} from "./RewardLibBase.sol";
+import {Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {FeeHeader} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
+import {FeeLib, ManaMinFeeComponents} from "@aztec/core/libraries/rollup/FeeLib.sol";
+
+/**
+ * @title WaterfallIdentityTest
+ * @notice The AZIP waterfall identity: for randomized per-mana components (covering every
+ *         (mu, gas, price) combination the fee model can produce), mana used, and injected
+ *         priority tips,
+ *
+ *           fee - protocolFee == (sequencerCost + proverCost) * manaUsed + tips   EXACTLY
+ *           prover tranche    == proverCost * manaUsed                            EXACTLY
+ *           sequencer tranche == sequencerCost * manaUsed + tips                  EXACTLY
+ *           protocol tranche  == headerProtocolFee * manaUsed, paid to the live recipient
+ *
+ *         The header's per-mana protocol fee is produced by the real one-subtraction helper
+ *         (FeeLib.protocolFeePerMana) and the split by the real waterfall
+ *         (RewardLib.handleRewardsAndFees), so a wei of drift anywhere fails the exact asserts.
+ */
+contract WaterfallIdentityTest is RewardLibBase {
+  struct Vals {
+    uint256 s;
+    uint256 p;
+    uint256 c;
+    uint256 manaUsed;
+    uint256 tips;
+    uint256 headerProtocolFee;
+    uint256 fee;
+    uint256 protocolTranche;
+    uint256 proverTranche;
+    uint256 sequencerTranche;
+  }
+
+  /// @dev Bounds keep every header field inside its compressed width (proverCost uint63,
+  ///      protocolFee uint64, manaUsed uint32) so compression cannot saturate and mask a drift.
+  function test_waterfallIdentity(
+    uint64 _sequencerCost,
+    uint64 _proverCost,
+    uint64 _protocolFee,
+    uint32 _manaUsed,
+    uint96 _tips,
+    uint32 _sequencerBps
+  ) external prepare(0, _sequencerBps) {
+    Vals memory v;
+    v.s = bound(_sequencerCost, 0, 2 ** 62);
+    v.p = bound(_proverCost, 0, 2 ** 62);
+    v.c = bound(_protocolFee, 0, 2 ** 63);
+    v.manaUsed = _manaUsed;
+    v.tips = _tips;
+
+    // The real one-subtraction helper produces the header value from the components.
+    ManaMinFeeComponents memory components =
+      ManaMinFeeComponents({sequencerCost: v.s, proverCost: v.p, protocolFee: v.c, congestionMultiplier: 0});
+    v.headerProtocolFee = FeeLib.protocolFeePerMana(components);
+    v.fee = FeeLib.summedMinFee(components) * v.manaUsed + v.tips;
+
+    // Checkpoint 0 keeps the zeroed genesis header; checkpoint 1 carries the fuzzed values.
+    wrapper.addFeeHeader(
+      FeeHeader({
+        excessMana: 0, manaUsed: v.manaUsed, ethPerFeeAsset: 0, protocolFee: v.headerProtocolFee, proverCost: v.p
+      })
+    );
+    _setHeaders(2, sequencer);
+    args.headers[1].accumulatedFees = v.fee;
+    args.end = args.start + 1;
+
+    address recipient = makeAddr("protocolFeeRecipient");
+    wrapper.updateProtocolFeeRecipient(recipient);
+
+    deal(address(feeAsset), address(feePortal), v.fee);
+
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+
+    v.protocolTranche = feeAsset.balanceOf(recipient);
+    v.proverTranche = wrapper.getCollectiveProverRewardsForEpoch(Epoch.wrap(0));
+    v.sequencerTranche = wrapper.getSequencerRewards(sequencer);
+
+    assertEq(v.protocolTranche, v.headerProtocolFee * v.manaUsed, "protocol tranche mismatch");
+    assertEq(
+      v.fee - v.protocolTranche,
+      (v.s + v.p) * v.manaUsed + v.tips,
+      "fee - protocolFee must equal cost * manaUsed + tips"
+    );
+    assertEq(v.proverTranche, v.p * v.manaUsed, "prover tranche must be exactly proverCost * manaUsed");
+    assertEq(v.sequencerTranche, v.s * v.manaUsed + v.tips, "sequencer tranche must be cost remainder + tips");
+    assertEq(v.protocolTranche + v.proverTranche + v.sequencerTranche, v.fee, "waterfall must be exhaustive");
+  }
+
+  /// @notice After a recipient change, the very next waterfall run pays the NEW recipient and the
+  ///         old burn-address default receives nothing.
+  function test_waterfallPaysUpdatedRecipient() external prepare(0, 5000) {
+    uint256 manaUsed = 1e6;
+    uint256 protocolFeePerMana = 1e9;
+    uint256 fee = 5e9 * manaUsed;
+
+    wrapper.addFeeHeader(
+      FeeHeader({excessMana: 0, manaUsed: manaUsed, ethPerFeeAsset: 0, protocolFee: protocolFeePerMana, proverCost: 0})
+    );
+    _setHeaders(2, sequencer);
+    args.headers[1].accumulatedFees = fee;
+    args.end = args.start + 1;
+
+    address oldRecipient = wrapper.getProtocolFeeRecipient();
+    assertEq(oldRecipient, address(bytes20("CUAUHXICALLI")), "default must be the burn address");
+
+    address newRecipient = makeAddr("newRecipient");
+    assertEq(wrapper.updateProtocolFeeRecipient(newRecipient), oldRecipient, "must return the old recipient");
+
+    deal(address(feeAsset), address(feePortal), fee);
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+
+    assertEq(feeAsset.balanceOf(newRecipient), protocolFeePerMana * manaUsed, "new recipient must be paid");
+    assertEq(feeAsset.balanceOf(oldRecipient), 0, "old recipient must receive nothing");
+  }
+}

--- a/labs-patches/0006-feat-introduce-a-protocol-fee-margin-AZIP-23.patch
+++ b/labs-patches/0006-feat-introduce-a-protocol-fee-margin-AZIP-23.patch
@@ -1,0 +1,720 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: aminsammara <aminsammara1@gmail.com>
+Date: Fri, 28 Aug 2026 00:00:00 +0000
+Subject: [PATCH] feat: introduce a protocol fee margin (AZIP-23)
+
+---
+diff --git a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+index 3fc1008c01..86dfd888d7 100644
+--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
++++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+@@ -445,7 +445,7 @@ describe('NodePublicCallsSimulator', () => {
+ });
+ 
+ function makeFeeHeader(): FeeHeader {
+-  return { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, congestionCost: 0n, proverCost: 0n };
++  return { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, protocolFee: 0n, proverCost: 0n };
+ }
+ 
+ function makeProposedCheckpointData(args: {
+diff --git a/yarn-project/end-to-end/src/single-node/fees/fees_test.ts b/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
+index 8a0d733c7d..0e661ba2ba 100644
+--- a/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
++++ b/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
+@@ -381,13 +381,14 @@ export class FeesTest extends SingleNodeTestContext {
+       return feeHeader.manaUsed * feeHeader.proverCost;
+     };
+ 
+-    // RewardLib computes sequencerFee = checkpointFee - burn - proverFee where burn = manaUsed * congestionCost.
+-    // The fixture's typical case keeps congestionCost at zero, but reading it explicitly avoids latent bugs
+-    // when test load changes excess mana.
++    // RewardLib computes sequencerFee = checkpointFee - protocolFee - proverFee where
++    // protocolFee = manaUsed * feeHeader.protocolFee. The fixture's typical case keeps the
++    // protocol fee at zero, but reading it explicitly avoids latent bugs when test load changes
++    // excess mana.
+     this.getCommittedBurn = async (blockNumber: BlockNumber) => {
+       const block = await this.aztecNode.getBlock(blockNumber);
+       const feeHeader = await this.rollupContract.getFeeHeader(BigInt(block!.checkpointNumber));
+-      return feeHeader.manaUsed * feeHeader.congestionCost;
++      return feeHeader.manaUsed * feeHeader.protocolFee;
+     };
+   }
+ 
+diff --git a/yarn-project/ethereum/src/contracts/fee_asset_price_oracle.test.ts b/yarn-project/ethereum/src/contracts/fee_asset_price_oracle.test.ts
+index 4e56319a2a..a9066db971 100644
+--- a/yarn-project/ethereum/src/contracts/fee_asset_price_oracle.test.ts
++++ b/yarn-project/ethereum/src/contracts/fee_asset_price_oracle.test.ts
+@@ -112,7 +112,7 @@ describe('Uniswap Price Oracle', () => {
+       expect(modifier).toBe(49n);
+ 
+       const child = RollupContract.computeChildFeeHeader(
+-        { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: predictedParentE12, congestionCost: 0n, proverCost: 0n },
++        { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: predictedParentE12, protocolFee: 0n, proverCost: 0n },
+         0n,
+         modifier,
+         100n,
+diff --git a/yarn-project/ethereum/src/contracts/rollup.test.ts b/yarn-project/ethereum/src/contracts/rollup.test.ts
+index 52069c7496..95fd12af0e 100644
+--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
++++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
+@@ -22,7 +22,7 @@ import { type FeeHeader, RollupContract, TempCheckpointLogField } from './rollup
+ describe('compressFeeHeader', () => {
+   /** Creates a zero fee header with the given overrides. */
+   function makeFeeHeader(overrides: Partial<FeeHeader> = {}): FeeHeader {
+-    return { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 0n, congestionCost: 0n, proverCost: 0n, ...overrides };
++    return { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 0n, protocolFee: 0n, proverCost: 0n, ...overrides };
+   }
+ 
+   it('sets the preheat flag (bit 255)', () => {
+@@ -62,15 +62,15 @@ describe('compressFeeHeader', () => {
+     expect((result >> 80n) & ((1n << 48n) - 1n)).toBe(999n);
+   });
+ 
+-  it('packs congestionCost into bits [128:191]', () => {
+-    const header = makeFeeHeader({ congestionCost: 42n });
++  it('packs protocolFee into bits [128:191]', () => {
++    const header = makeFeeHeader({ protocolFee: 42n });
+     const result = RollupContract.compressFeeHeader(header);
+     expect((result >> 128n) & ((1n << 64n) - 1n)).toBe(42n);
+   });
+ 
+-  it('clamps congestionCost to 64 bits', () => {
++  it('clamps protocolFee to 64 bits', () => {
+     const maxValue = (1n << 64n) - 1n;
+-    const header = makeFeeHeader({ congestionCost: maxValue + 1n });
++    const header = makeFeeHeader({ protocolFee: maxValue + 1n });
+     const result = RollupContract.compressFeeHeader(header);
+     expect((result >> 128n) & maxValue).toBe(maxValue);
+   });
+@@ -93,7 +93,7 @@ describe('compressFeeHeader', () => {
+       manaUsed: 1000n,
+       excessMana: 2000n,
+       ethPerFeeAsset: 3000n,
+-      congestionCost: 4000n,
++      protocolFee: 4000n,
+       proverCost: 5000n,
+     });
+     const result = RollupContract.compressFeeHeader(header);
+@@ -122,7 +122,7 @@ describe('computeChildFeeHeader', () => {
+     manaUsed: 5000n,
+     excessMana: 3000n,
+     ethPerFeeAsset: 1000n,
+-    congestionCost: 100n,
++    protocolFee: 100n,
+     proverCost: 200n,
+   };
+ 
+@@ -144,9 +144,9 @@ describe('computeChildFeeHeader', () => {
+     expect(result.manaUsed).toBe(7777n);
+   });
+ 
+-  it('always sets congestionCost and proverCost to zero', () => {
++  it('always sets protocolFee and proverCost to zero', () => {
+     const result = RollupContract.computeChildFeeHeader(baseFeeHeader, 0n, 0n, manaTarget);
+-    expect(result.congestionCost).toBe(0n);
++    expect(result.protocolFee).toBe(0n);
+     expect(result.proverCost).toBe(0n);
+   });
+ 
+@@ -217,14 +217,14 @@ describe('computeChildFeeHeader', () => {
+       manaUsed: 8000n,
+       excessMana: 15000n,
+       ethPerFeeAsset: 5000n,
+-      congestionCost: 999n,
++      protocolFee: 999n,
+       proverCost: 888n,
+     };
+     const result = RollupContract.computeChildFeeHeader(parent, 42n, 250n, manaTarget);
+     expect(result.excessMana).toBe(13000n);
+     expect(result.manaUsed).toBe(42n);
+     expect(result.ethPerFeeAsset).toBe(5125n);
+-    expect(result.congestionCost).toBe(0n);
++    expect(result.protocolFee).toBe(0n);
+     expect(result.proverCost).toBe(0n);
+   });
+ });
+@@ -425,7 +425,7 @@ describe('Rollup', () => {
+         manaUsed: 12345n,
+         excessMana: 67890n,
+         ethPerFeeAsset: 1_000_000_000_000n,
+-        congestionCost: 99999n,
++        protocolFee: 99999n,
+         proverCost: 55555n,
+       } as FeeHeader,
+     };
+@@ -561,7 +561,7 @@ describe('Rollup', () => {
+         manaUsed: 12345n,
+         excessMana: 67890n,
+         ethPerFeeAsset: 1_000_000_000_000n,
+-        congestionCost: 99999n,
++        protocolFee: 99999n,
+         proverCost: 55555n,
+       };
+ 
+@@ -580,7 +580,7 @@ describe('Rollup', () => {
+       expect(result.manaUsed).toBe(feeHeader.manaUsed);
+       expect(result.excessMana).toBe(feeHeader.excessMana);
+       expect(result.ethPerFeeAsset).toBe(feeHeader.ethPerFeeAsset);
+-      expect(result.congestionCost).toBe(feeHeader.congestionCost);
++      expect(result.protocolFee).toBe(feeHeader.protocolFee);
+       expect(result.proverCost).toBe(feeHeader.proverCost);
+     });
+   });
+diff --git a/yarn-project/ethereum/src/contracts/rollup.ts b/yarn-project/ethereum/src/contracts/rollup.ts
+index af17f8d37c..e17fa5e771 100644
+--- a/yarn-project/ethereum/src/contracts/rollup.ts
++++ b/yarn-project/ethereum/src/contracts/rollup.ts
+@@ -114,7 +114,7 @@ export type FeeHeader = {
+   excessMana: bigint;
+   manaUsed: bigint;
+   ethPerFeeAsset: bigint;
+-  congestionCost: bigint;
++  protocolFee: bigint;
+   proverCost: bigint;
+ };
+ 
+@@ -177,7 +177,7 @@ export type TempCheckpointLogOverrideFields = {
+ export type ManaMinFeeComponents = {
+   sequencerCost: bigint;
+   proverCost: bigint;
+-  congestionCost: bigint;
++  protocolFee: bigint;
+   congestionMultiplier: bigint;
+ };
+ 
+@@ -432,6 +432,16 @@ export class RollupContract {
+     return this.rollup.read.getProvingCostPerManaInFeeAsset();
+   }
+ 
++  /** Returns the current protocol fee margin in basis points. Not memoized: governance can change it. */
++  getProtocolFeeMargin(): Promise<number> {
++    return this.rollup.read.getProtocolFeeMargin();
++  }
++
++  /** Returns the current recipient of the protocol fee tranche. Not memoized: governance can change it. */
++  async getProtocolFeeRecipient(): Promise<EthAddress> {
++    return EthAddress.fromString(await this.rollup.read.getProtocolFeeRecipient());
++  }
++
+   @memoize
+   getManaLimit(): Promise<bigint> {
+     return this.rollup.read.getManaLimit();
+@@ -636,7 +646,7 @@ export class RollupContract {
+       excessMana: result.excessMana,
+       manaUsed: result.manaUsed,
+       ethPerFeeAsset: result.ethPerFeeAsset,
+-      congestionCost: result.congestionCost,
++      protocolFee: result.protocolFee,
+       proverCost: result.proverCost,
+     };
+   }
+@@ -729,7 +739,7 @@ export class RollupContract {
+         excessMana: result.feeHeader.excessMana,
+         manaUsed: result.feeHeader.manaUsed,
+         ethPerFeeAsset: result.feeHeader.ethPerFeeAsset,
+-        congestionCost: result.feeHeader.congestionCost,
++        protocolFee: result.feeHeader.protocolFee,
+         proverCost: result.feeHeader.proverCost,
+       },
+     };
+@@ -1079,7 +1089,7 @@ export class RollupContract {
+     let value = BigInt(feeHeader.manaUsed) & ((1n << 32n) - 1n); // bits [0:31]
+     value |= (feeHeader.excessMana < MASK_48_BITS ? feeHeader.excessMana : MASK_48_BITS) << 32n; // bits [32:79]
+     value |= (BigInt(feeHeader.ethPerFeeAsset) & MASK_48_BITS) << 80n; // bits [80:127]
+-    value |= (feeHeader.congestionCost < MASK_64_BITS ? feeHeader.congestionCost : MASK_64_BITS) << 128n; // bits [128:191]
++    value |= (feeHeader.protocolFee < MASK_64_BITS ? feeHeader.protocolFee : MASK_64_BITS) << 128n; // bits [128:191]
+     value |= (feeHeader.proverCost < MASK_63_BITS ? feeHeader.proverCost : MASK_63_BITS) << 192n; // bits [192:254]
+     value |= 1n << 255n; // preheat flag
+     return value;
+@@ -1121,7 +1131,7 @@ export class RollupContract {
+       excessMana,
+       manaUsed: childManaUsed,
+       ethPerFeeAsset: newPrice,
+-      congestionCost: 0n,
++      protocolFee: 0n,
+       proverCost: 0n,
+     };
+   }
+@@ -1183,7 +1193,7 @@ export class RollupContract {
+     return {
+       sequencerCost: result.sequencerCost,
+       proverCost: result.proverCost,
+-      congestionCost: result.congestionCost,
++      protocolFee: result.protocolFee,
+       congestionMultiplier: result.congestionMultiplier,
+     };
+   }
+diff --git a/yarn-project/ethereum/src/test/chain_monitor.ts b/yarn-project/ethereum/src/test/chain_monitor.ts
+index c73e49f852..302cf4ab36 100644
+--- a/yarn-project/ethereum/src/test/chain_monitor.ts
++++ b/yarn-project/ethereum/src/test/chain_monitor.ts
+@@ -12,7 +12,7 @@ import type { ViemClient } from '../types.js';
+ 
+ /** L2 fee data reported by the chain monitor. */
+ export type L2FeeData = ManaMinFeeComponents & {
+-  /** Total minimum fee per mana in Fee Juice (sum of sequencerCost + proverCost + congestionCost). */
++  /** Total minimum fee per mana in Fee Juice (sum of sequencerCost + proverCost + protocolFee). */
+   minFeePerMana: bigint;
+   /** L1 base fee observed by the oracle. */
+   l1BaseFee: bigint;
+@@ -381,7 +381,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
+     return (
+       this.l2FeeData.sequencerCost !== newData.sequencerCost ||
+       this.l2FeeData.proverCost !== newData.proverCost ||
+-      this.l2FeeData.congestionCost !== newData.congestionCost ||
++      this.l2FeeData.protocolFee !== newData.protocolFee ||
+       this.l2FeeData.l1BaseFee !== newData.l1BaseFee ||
+       this.l2FeeData.l1BlobFee !== newData.l1BlobFee ||
+       this.l2FeeData.ethPerFeeAsset !== newData.ethPerFeeAsset
+diff --git a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+index e2823cd86c..a9fb3f839f 100644
+--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
++++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+@@ -374,6 +374,30 @@ export class RollupCheatCodes {
+     });
+   }
+ 
++  /**
++   * Sets the protocol fee margin (in basis points). Throws if the on-chain tx reverts
++   * (e.g. rate-limit cooldown or step cap) instead of silently succeeding.
++   * @param bps - The new protocol fee margin in basis points
++   */
++  public async setProtocolFeeMargin(bps: number) {
++    await this.asOwner(async (account, rollup) => {
++      const hash = await rollup.write.setProtocolFeeMargin([bps], {
++        account,
++        chain: this.client.chain,
++        gasLimit: 1000000n,
++      });
++      const receipt = await this.client.waitForTransactionReceipt({ hash });
++      if (receipt.status !== 'success') {
++        throw new Error(
++          `setProtocolFeeMargin(${bps}) reverted on L1 (tx ${hash}). ` +
++            `Likely FeeLib rate-limit (30-day cooldown or x3/2 step cap on the fee multiplier); ` +
++            `use clearProvingCostCooldown() between successive updates (it clears both cooldowns).`,
++        );
++      }
++      this.logger.warn(`Updated protocol fee margin to ${bps} bps`);
++    });
++  }
++
+   /**
+    * Resets the 30-day proving-cost update cooldown enforced by FeeLib.updateProvingCostPerMana
+    * by zeroing `FeeStore.provingCostLastUpdate` directly in contract storage. Use between
+@@ -384,7 +408,8 @@ export class RollupCheatCodes {
+    * l1-contracts/src/core/libraries/rollup/FeeLib.sol:
+    *   slot + 0: CompressedFeeConfig config          (uint256)
+    *   slot + 1: L1GasOracleValues l1GasOracleValues (14+14+4 bytes, packed)
+-   *   slot + 2: uint64 provingCostLastUpdate        (only member — zeroing the slot is safe)
++   *   slot + 2: uint64 provingCostLastUpdate + uint64 protocolMarginLastUpdate (packed --
++   *             zeroing the slot clears BOTH the proving-cost and protocol-fee-margin cooldowns)
+    * If the struct layout changes, update the offset below.
+    */
+   public async clearProvingCostCooldown() {
+diff --git a/yarn-project/prover-node/src/prover-node-publisher.test.ts b/yarn-project/prover-node/src/prover-node-publisher.test.ts
+index f7a1e248dc..6fb4f20eb0 100644
+--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
++++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
+@@ -73,7 +73,7 @@ describe('prover-node-publisher', () => {
+           excessMana: 0n, // unused
+           manaUsed: 0n, // unused
+           ethPerFeeAsset: 0n, // unused
+-          congestionCost: 0n, // unused
++          protocolFee: 0n, // unused
+           proverCost: 0n, // unused
+         },
+       }),
+@@ -244,7 +244,7 @@ describe('prover-node-publisher', () => {
+         blobCommitmentsHash: Buffer32.ZERO,
+         outHash: '0x',
+         slotNumber: SlotNumber(0),
+-        feeHeader: { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, congestionCost: 0n, proverCost: 0n },
++        feeHeader: { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, protocolFee: 0n, proverCost: 0n },
+       }),
+     );
+ 
+@@ -311,7 +311,7 @@ describe('prover-node-publisher', () => {
+           excessMana: 0n, // unused
+           manaUsed: 0n, // unused
+           ethPerFeeAsset: 0n, // unused
+-          congestionCost: 0n, // unused
++          protocolFee: 0n, // unused
+           proverCost: 0n, // unused
+         },
+       }),
+diff --git a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+index c2707c9072..5f9ccc0bfb 100644
+--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
++++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+@@ -264,7 +264,7 @@ describe('FeePredictor', () => {
+           excessMana: newExcessMana,
+           manaUsed: assumedManaUsed,
+           ethPerFeeAsset: decayEthPerFeeAsset(currentFeeHeader.ethPerFeeAsset, i + 1),
+-          congestionCost: 0n,
++          protocolFee: 0n,
+           proverCost: 0n,
+         };
+ 
+@@ -341,7 +341,7 @@ describe('FeePredictor', () => {
+         excessMana: newExcessMana,
+         manaUsed: 0n,
+         ethPerFeeAsset: decayedEthPerFeeAsset,
+-        congestionCost: 0n,
++        protocolFee: 0n,
+         proverCost: 0n,
+       };
+ 
+@@ -359,6 +359,33 @@ describe('FeePredictor', () => {
+       nextCheckpointOffset++;
+     }
+   }, 60_000);
++
++  it('slot 0 matches L1 getManaMinFeeAt with a nonzero protocol fee margin', async () => {
++    // Pin the comparison timestamp so before/after fees differ only by the margin.
++    const startSlot = await getPredictionStartSlot();
++    const timestamp = getTimestamp(startSlot + 1n);
++    const feeBefore = await rollup.getManaMinFeeAt(timestamp, true);
++
++    // The first-ever margin update bypasses the 30-day cooldown; from 0 the x3/2 step cap on the
++    // fee multiplier permits up to 5000 bps.
++    await rollupCheatCodes.setProtocolFeeMargin(5000);
++    expect(await rollup.getProtocolFeeMargin()).toBe(5000);
++
++    // The margin must move the pinned fee. If L1 scaled both the fakeExponential factor and the
++    // mulDiv divisor, mu would cancel silently and this catches it.
++    const l1Fee = await rollup.getManaMinFeeAt(timestamp, true);
++    expect(l1Fee).toBeGreaterThan(feeBefore);
++
++    // The predictor must agree with L1 exactly at mu != 0. This is the only check that catches
++    // the same factor+divisor double-scaling on the TS side of the mirror.
++    for (const manaUsage of Object.values(ManaUsageEstimate)) {
++      const predictor = new FeePredictor(rollup, dateProvider, feePredictorConfig);
++      const predicted = await predictor.getPredictedMinFees(manaUsage);
++      const predictionStartSlot = await getPredictionStartSlot();
++      const l1FeeAtStart = await rollup.getManaMinFeeAt(getTimestamp(predictionStartSlot), true);
++      expect(predicted[0].feePerL2Gas).toBe(l1FeeAtStart);
++    }
++  }, 60_000);
+ });
+ 
+ describe('FeePredictor state caching', () => {
+diff --git a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+index 86132e3b35..dc1b6389c6 100644
+--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
++++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+@@ -21,6 +21,7 @@ type FeeOracleState = {
+   manaLimit: bigint;
+   provingCostPerManaEth: bigint;
+   epochDuration: bigint;
++  protocolFeeMarginBps: bigint;
+   /** Pre-resolved L1 fees for each slot in the prediction window. */
+   l1FeesBySlot: L1FeeData[];
+ };
+@@ -75,11 +76,12 @@ export class FeePredictor {
+     const opts = { blockNumber };
+ 
+     // Cached constants don't need pinning
+-    const [manaTarget, manaLimit, provingCostPerManaEth, epochDuration] = await Promise.all([
++    const [manaTarget, manaLimit, provingCostPerManaEth, epochDuration, protocolFeeMarginBps] = await Promise.all([
+       this.rollupContract.getManaTarget(),
+       this.rollupContract.getManaLimit(),
+       this.rollupContract.getProvingCostPerMana(),
+       this.rollupContract.getEpochDuration(),
++      this.rollupContract.getProtocolFeeMargin(),
+     ]);
+ 
+     // First, compute the earliest possible nextSlot independently of the checkpoint, so we can
+@@ -115,6 +117,7 @@ export class FeePredictor {
+       manaLimit,
+       provingCostPerManaEth,
+       epochDuration: BigInt(epochDuration),
++      protocolFeeMarginBps: BigInt(protocolFeeMarginBps),
+       l1FeesBySlot,
+     };
+   }
+@@ -170,6 +173,7 @@ export class FeePredictor {
+         provingCostPerManaEth: state.provingCostPerManaEth,
+         excessMana,
+         ethPerFeeAsset,
++        protocolFeeMarginBps: state.protocolFeeMarginBps,
+       }),
+     );
+   }
+diff --git a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+index 1f6bf35348..7c73d4369e 100644
+--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
++++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+@@ -193,7 +193,7 @@ describe('CheckpointProposalJob', () => {
+     // Default rollup contract reads used by pipelined fee-header derivation. Tests that exercise
+     // the failure modes override these via jest.spyOn.
+     jest.spyOn(publisher.rollupContract, 'getCheckpoint').mockResolvedValue({
+-      feeHeader: { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 1n, congestionCost: 0n, proverCost: 0n },
++      feeHeader: { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 1n, protocolFee: 0n, proverCost: 0n },
+     } as any);
+     jest.spyOn(publisher.rollupContract, 'getManaTarget').mockResolvedValue(10_000n);
+     publisher.sendRequestsAt.mockResolvedValue({
+diff --git a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+index 4eff6b3476..d2078d8a9e 100644
+--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
++++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+@@ -261,7 +261,7 @@ describe('sequencer', () => {
+     rollupContract.isEscapeHatchOpen.mockResolvedValue(false);
+     // Default rollup reads used by pipelined fee-header derivation.
+     rollupContract.getCheckpoint.mockResolvedValue({
+-      feeHeader: { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 1n, congestionCost: 0n, proverCost: 0n },
++      feeHeader: { manaUsed: 0n, excessMana: 0n, ethPerFeeAsset: 1n, protocolFee: 0n, proverCost: 0n },
+     } as any);
+     rollupContract.getManaTarget.mockResolvedValue(10_000n);
+ 
+diff --git a/yarn-project/stdlib/src/checkpoint/simulation_overrides.test.ts b/yarn-project/stdlib/src/checkpoint/simulation_overrides.test.ts
+index 3c7e5bea83..d007259eea 100644
+--- a/yarn-project/stdlib/src/checkpoint/simulation_overrides.test.ts
++++ b/yarn-project/stdlib/src/checkpoint/simulation_overrides.test.ts
+@@ -38,7 +38,7 @@ describe('computePipelinedParentFeeHeader', () => {
+     manaUsed: 3000n,
+     excessMana: 1000n,
+     ethPerFeeAsset: 500n,
+-    congestionCost: 50n,
++    protocolFee: 50n,
+     proverCost: 10n,
+   };
+ 
+@@ -139,7 +139,7 @@ describe('buildCheckpointSimulationOverridesPlan', () => {
+     manaUsed: 3000n,
+     excessMana: 1000n,
+     ethPerFeeAsset: 500n,
+-    congestionCost: 50n,
++    protocolFee: 50n,
+     proverCost: 10n,
+   };
+ 
+diff --git a/yarn-project/stdlib/src/gas/README.md b/yarn-project/stdlib/src/gas/README.md
+index b98eef59ac..5d1779f772 100644
+--- a/yarn-project/stdlib/src/gas/README.md
++++ b/yarn-project/stdlib/src/gas/README.md
+@@ -56,28 +56,35 @@ Updates to `provingCostPerMana` are rate-limited on L1 (`FeeLib.updateProvingCos
+ at most one update every 30 days, each moving the value by at most ×1.5 (or ÷1.5), with a
+ floor of 2 wei per mana.
+ 
+-### Congestion Cost
++### Protocol Fee
+ 
+-An exponential surcharge when the network is congested (inspired by EIP-1559; the
+-implementation uses the `fakeExponential` Taylor series approximation from EIP-4844):
++The markup above operator cost: the governance-set protocol fee margin (basis points, applied
++through the congestion multiplier's factor) plus an exponential congestion surcharge when the
++network is congested (inspired by EIP-1559; the implementation uses the `fakeExponential`
++Taylor series approximation from EIP-4844):
+ 
+ ```
+-baseCost       = sequencerCost + proverCost
+-congestionCost = floor(baseCost * congestionMultiplier / MINIMUM_CONGESTION_MULTIPLIER) - baseCost
++baseCost    = sequencerCost + proverCost
++protocolFee = floor(baseCost * congestionMultiplier / MINIMUM_CONGESTION_MULTIPLIER) - baseCost
+ ```
+ 
+-When there is no congestion the multiplier equals `MINIMUM_CONGESTION_MULTIPLIER` (1e9)
+-and congestion cost is zero.
++At a zero margin and no congestion the multiplier equals `MINIMUM_CONGESTION_MULTIPLIER` (1e9)
++and the protocol fee is zero.
+ 
+ ### Congestion Multiplier
+ 
+ ```
+ excessMana           = max(0, prevExcessMana + prevManaUsed - manaTarget)
+ denominator          = manaTarget * 854,700,854 / 1e8    ≈ 8.547 * manaTarget
+-congestionMultiplier = fakeExponential(MINIMUM_CONGESTION_MULTIPLIER,
++congestionMultiplier = fakeExponential((10,000 + protocolFeeMarginBps) * 1e5,
+                                        min(excessMana, 100 * denominator), denominator)
+ ```
+ 
++The factor `(10,000 + protocolFeeMarginBps) * 1e5` equals `(1 + mu) * 1e9`, so the
++uncongested baseline is `(1 + mu) * MINIMUM_CONGESTION_MULTIPLIER` — exactly 1e9 at a zero
++margin. Only the factor scales with the margin; the divisor in the protocol fee formula stays
++`MINIMUM_CONGESTION_MULTIPLIER` (scaling both would cancel the margin).
++
+ Each additional `manaTarget` of excess mana multiplies the fee by `e^(1/8.547) ≈ 1.124`,
+ i.e. ~12.5%. The exponent is capped at 100 (multiplier ≤ ~2.7e43 × the minimum) to keep
+ the Taylor series from overflowing.
+@@ -85,7 +92,7 @@ the Taylor series from overflowing.
+ ### Total
+ 
+ ```
+-minFeePerMana = sequencerCost + proverCost + congestionCost
++minFeePerMana = sequencerCost + proverCost + protocolFee
+ ```
+ 
+ Each component is converted from ETH to the fee asset individually (rounding up) before
+diff --git a/yarn-project/stdlib/src/gas/fee_math.test.ts b/yarn-project/stdlib/src/gas/fee_math.test.ts
+index e77dfb8a2d..a501fe652e 100644
+--- a/yarn-project/stdlib/src/gas/fee_math.test.ts
++++ b/yarn-project/stdlib/src/gas/fee_math.test.ts
+@@ -65,12 +65,12 @@ describe('computeExcessMana', () => {
+ 
+ describe('computeCongestionMultiplier', () => {
+   it('returns MINIMUM_CONGESTION_MULTIPLIER when excess is zero', () => {
+-    expect(computeCongestionMultiplier(0n, 100_000_000n)).toBe(MINIMUM_CONGESTION_MULTIPLIER);
++    expect(computeCongestionMultiplier(0n, 100_000_000n, 0n)).toBe(MINIMUM_CONGESTION_MULTIPLIER);
+   });
+ 
+   it('increases with excess mana', () => {
+-    const low = computeCongestionMultiplier(100_000n, 100_000_000n);
+-    const high = computeCongestionMultiplier(200_000n, 100_000_000n);
++    const low = computeCongestionMultiplier(100_000n, 100_000_000n, 0n);
++    const high = computeCongestionMultiplier(200_000n, 100_000_000n, 0n);
+     expect(high).toBeGreaterThan(low);
+     expect(low).toBeGreaterThan(MINIMUM_CONGESTION_MULTIPLIER);
+   });
+@@ -78,11 +78,16 @@ describe('computeCongestionMultiplier', () => {
+   it('increases by ~12.5% per manaTarget of excess', () => {
+     // When excessMana = manaTarget, multiplier ≈ 1.125 * MINIMUM_CONGESTION_MULTIPLIER
+     const manaTarget = 100_000_000n;
+-    const multiplier = computeCongestionMultiplier(manaTarget, manaTarget);
++    const multiplier = computeCongestionMultiplier(manaTarget, manaTarget, 0n);
+     const ratio = Number(multiplier) / Number(MINIMUM_CONGESTION_MULTIPLIER);
+     expect(ratio).toBeGreaterThan(1.12);
+     expect(ratio).toBeLessThan(1.13);
+   });
++
++  it('scales the zero-excess baseline by exactly (10000 + bps) * 1e5', () => {
++    expect(computeCongestionMultiplier(0n, 100_000_000n, 5000n)).toBe(15_000n * 100_000n);
++    expect(computeCongestionMultiplier(0n, 100_000_000n, 65_535n)).toBe(75_535n * 100_000n);
++  });
+ });
+ 
+ describe('computeManaMinFee', () => {
+@@ -94,6 +99,7 @@ describe('computeManaMinFee', () => {
+     provingCostPerManaEth: 0n,
+     excessMana: 0n,
+     ethPerFeeAsset: 1_000_000_000_000n, // 1:1 ETH:FeeAsset
++    protocolFeeMarginBps: 0n,
+   };
+ 
+   it('returns zero when manaTarget is zero', () => {
+@@ -123,12 +129,36 @@ describe('computeManaMinFee', () => {
+     expect(high).toBeGreaterThan(low);
+   });
+ 
+-  it('has zero congestion cost when excess mana is zero', () => {
+-    // With zero excess, congestionMultiplier = MINIMUM_CONGESTION_MULTIPLIER,
+-    // so congestionCost = total * 1 - total = 0
++  it('has zero protocol fee when excess mana and margin are zero', () => {
++    // With zero excess and zero margin, congestionMultiplier = MINIMUM_CONGESTION_MULTIPLIER,
++    // so protocolFee = total * 1 - total = 0
+     const fee = computeManaMinFee(baseParams);
+     // The fee should equal just sequencer + prover costs
+     const feeWithExcess = computeManaMinFee({ ...baseParams, excessMana: baseParams.manaTarget });
+     expect(feeWithExcess).toBeGreaterThan(fee);
+   });
++
++  it('scales the fee by ~(1 + mu) at zero excess', () => {
++    const base = computeManaMinFee(baseParams);
++    const withMargin = computeManaMinFee({ ...baseParams, protocolFeeMarginBps: 5000n });
++    // fee = cost + (floor(cost * 3 / 2) - cost) converted per component; allow 1 wei of Ceil slack.
++    const expected = (base * 15_000n) / 10_000n;
++    expect(withMargin).toBeGreaterThanOrEqual(expected - 1n);
++    expect(withMargin).toBeLessThanOrEqual(expected + 1n);
++    expect(withMargin).toBeGreaterThan(base);
++  });
++
++  it('applies the margin on top of congestion multiplicatively', () => {
++    const congested = computeManaMinFee({ ...baseParams, excessMana: baseParams.manaTarget * 3n });
++    const congestedWithMargin = computeManaMinFee({
++      ...baseParams,
++      excessMana: baseParams.manaTarget * 3n,
++      protocolFeeMarginBps: 5000n,
++    });
++    expect(congestedWithMargin).toBeGreaterThan(congested);
++    // The margin scales the multiplier's factor, so the marked-up congested fee is ~1.5x.
++    const ratio = Number(congestedWithMargin) / Number(congested);
++    expect(ratio).toBeGreaterThan(1.49);
++    expect(ratio).toBeLessThan(1.51);
++  });
+ });
+diff --git a/yarn-project/stdlib/src/gas/fee_math.ts b/yarn-project/stdlib/src/gas/fee_math.ts
+index 35ff2842c9..6d1ffa8fa7 100644
+--- a/yarn-project/stdlib/src/gas/fee_math.ts
++++ b/yarn-project/stdlib/src/gas/fee_math.ts
+@@ -36,6 +36,7 @@ export type ManaMinFeeParams = {
+   provingCostPerManaEth: bigint;
+   excessMana: bigint;
+   ethPerFeeAsset: bigint;
++  protocolFeeMarginBps: bigint;
+ };
+ 
+ /**
+@@ -60,11 +61,21 @@ export function computeExcessMana(prevExcessMana: bigint, prevManaUsed: bigint,
+   return sum > manaTarget ? sum - manaTarget : 0n;
+ }
+ 
+-/** Computes the congestion multiplier from excess mana (1e9 = no congestion). */
+-export function computeCongestionMultiplier(excessMana: bigint, manaTarget: bigint): bigint {
++/**
++ * Computes the congestion multiplier from excess mana.
++ * The protocol fee margin scales only the fakeExponential factor: (10_000 + bps) * 1e5, which is
++ * (1 + mu) * 1e9 and exactly 1e9 at mu = 0. The uncongested baseline is therefore (1 + mu) * 1e9.
++ * The MINIMUM_CONGESTION_MULTIPLIER divisor in computeManaMinFee MUST NOT be scaled -- scaling
++ * both sites cancels the margin.
++ */
++export function computeCongestionMultiplier(
++  excessMana: bigint,
++  manaTarget: bigint,
++  protocolFeeMarginBps: bigint,
++): bigint {
+   const denominator = (manaTarget * MAGIC_CONGESTION_VALUE_MULTIPLIER) / MAGIC_CONGESTION_VALUE_DIVISOR;
+   const cappedNumerator = excessMana < denominator * 100n ? excessMana : denominator * 100n;
+-  return fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, cappedNumerator, denominator);
++  return fakeExponential((10_000n + protocolFeeMarginBps) * 100_000n, cappedNumerator, denominator);
+ }
+ 
+ /** Ceiling division for positive bigints. */
+@@ -81,11 +92,20 @@ function toFeeAsset(ethValue: bigint, ethPerFeeAsset: bigint): bigint {
+ }
+ 
+ /**
+- * Computes the full mana min fee (sequencer + prover + congestion) in fee asset terms.
++ * Computes the full mana min fee (sequencer + prover + protocol fee) in fee asset terms.
+  * Mirrors FeeLib.getManaMinFeeComponentsAt + summedMinFee.
+  */
+ export function computeManaMinFee(params: ManaMinFeeParams): bigint {
+-  const { l1BaseFee, l1BlobFee, manaTarget, epochDuration, provingCostPerManaEth, excessMana, ethPerFeeAsset } = params;
++  const {
++    l1BaseFee,
++    l1BlobFee,
++    manaTarget,
++    epochDuration,
++    provingCostPerManaEth,
++    excessMana,
++    ethPerFeeAsset,
++    protocolFeeMarginBps,
++  } = params;
+ 
+   if (manaTarget === 0n) {
+     return 0n;
+@@ -102,17 +122,18 @@ export function computeManaMinFee(params: ManaMinFeeParams): bigint {
+   // Total base cost in ETH (congestion is computed on this)
+   const totalEth = sequencerCostEth + proverCostEth;
+ 
+-  // Congestion multiplier and cost (in ETH)
+-  const congestionMul = computeCongestionMultiplier(excessMana, manaTarget);
+-  const congestionCostEth = (totalEth * congestionMul) / MINIMUM_CONGESTION_MULTIPLIER - totalEth;
++  // Congestion multiplier (scaled by the protocol fee margin) and protocol fee (in ETH).
++  // The divisor here stays MINIMUM_CONGESTION_MULTIPLIER; only the multiplier's factor scales.
++  const congestionMul = computeCongestionMultiplier(excessMana, manaTarget, protocolFeeMarginBps);
++  const protocolFeeEth = (totalEth * congestionMul) / MINIMUM_CONGESTION_MULTIPLIER - totalEth;
+ 
+   // Convert all components to fee asset
+   const clampedEthPerFeeAsset = ethPerFeeAsset < MIN_ETH_PER_FEE_ASSET ? MIN_ETH_PER_FEE_ASSET : ethPerFeeAsset;
+   const sequencerCost = toFeeAsset(sequencerCostEth, clampedEthPerFeeAsset);
+   const proverCost = toFeeAsset(proverCostEth, clampedEthPerFeeAsset);
+-  const congestionCost = toFeeAsset(congestionCostEth, clampedEthPerFeeAsset);
++  const protocolFee = toFeeAsset(protocolFeeEth, clampedEthPerFeeAsset);
+ 
+-  const total = sequencerCost + proverCost + congestionCost;
++  const total = sequencerCost + proverCost + protocolFee;
+ 
+   // Cap at uint128 max (matching FeeLib.summedMinFee)
+   const UINT128_MAX = (1n << 128n) - 1n;
+-- 
+2.50.1
+


### PR DESCRIPTION
Adds a governance-set margin `mu` on the mana base fee. The fee becomes `cost * (1 + mu) * congestionMultiplier`: operators still receive exactly `cost` from the fee waterfall plus the unchanged block inflation, and the markup above cost goes to a governance-set `protocolFeeRecipient`, which defaults to the current burn address.

- `mu` is a uint16 bps field packed into bits 224-239 of `CompressedFeeConfig` and deploys at 0, so the rollup is bit-identical to today.
- `setProtocolFeeMargin` is governance-only and rate-limited to x3/2 on the fee multiplier per 30-day window, matching `setProvingCostPerMana`. Decreases are immediate and unrestricted; setting the current value is a no-op.
- The `(1 + mu)` scaling is applied only to the `fakeExponential` factor in `congestionMultiplier`. The `mulDiv` divisor stays `MINIMUM_CONGESTION_MULTIPLIER` -- scaling both sites cancels the margin.
- The fee header's uint64 `congestionCost` field becomes `protocolFee` and carries `summedMinFee - sequencerCost - proverCost` as a single subtraction clamped at 0, so `fee - protocolFee = cost * manaUsed` holds to the wei.
- `RewardLib.BURN_ADDRESS` becomes the deploy-time default for a stored `protocolFeeRecipient`; `getBurnAddress()` is replaced by `getProtocolFeeRecipient()`.
- The TypeScript fee mirror is updated to match bit-exactly, with `mu` threaded through the L1 config read into the fee predictor.
