### PR TITLE
feat(p2p): update preferred peers at runtime via admin API

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -151,7 +151,7 @@ export class P2PClient extends WithTracer implements P2P {
 
   public async updateP2PConfig(config: Partial<P2PConfig>): Promise<void> {
     await this.txPool.updateConfig(config);
-    this.p2pService.updateConfig(config);
+    await this.p2pService.updateConfig(config);
   }
 
   public getL2Tips(): Promise<LocalL2Tips> {

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -40,7 +40,9 @@ import {
 export class DummyP2PService implements P2PService {
   private allNodesCheckpointReceivedCallback?: P2PCheckpointReceivedCallback;
 
-  updateConfig(_config: Partial<P2PReqRespConfig>): void {}
+  updateConfig(_config: Partial<P2PReqRespConfig>): Promise<void> {
+    return Promise.resolve();
+  }
 
   /** Returns an empty array for peers. */
   getPeers(): PeerInfo[] {
@@ -274,6 +276,9 @@ export class DummyPeerManager implements PeerManagerInterface {
   public goodbyeReceived(_peerId: PeerId, _reason: GoodByeReason): void {}
   public penalizePeer(_peerId: PeerId, _penalty: PeerErrorSeverity): void {}
   public addPreferredPeer(_peerId: PeerId): void {}
+  public updatePreferredPeers(_enrs: string[]): Promise<void> {
+    return Promise.resolve();
+  }
   public handleAuthRequestFromPeer(_authRequest: AuthRequest, _peerId: PeerId): Promise<StatusMessage> {
     return Promise.resolve(StatusMessage.random());
   }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -1769,6 +1769,26 @@ describe('LibP2PService', () => {
       await ipService.stop();
     });
   });
+
+  describe('updateConfig', () => {
+    it('hands preferred peers over to the peer manager', async () => {
+      const peerManager = mock<PeerManagerInterface>();
+      const service = createTestLibP2PService({ peerManager, node: mock<PubSubLibp2p>() });
+
+      await service.updateConfig({ preferredPeers: ['enr:-preferred-peer'] });
+
+      expect(peerManager.updatePreferredPeers).toHaveBeenCalledWith(['enr:-preferred-peer']);
+    });
+
+    it('leaves preferred peers alone when the update does not carry them', async () => {
+      const peerManager = mock<PeerManagerInterface>();
+      const service = createTestLibP2PService({ peerManager, node: mock<PubSubLibp2p>() });
+
+      await service.updateConfig({ skipIncomingProposals: true });
+
+      expect(peerManager.updatePreferredPeers).not.toHaveBeenCalled();
+    });
+  });
 });
 
 /** Mock type for tx objects used in block txs validation tests. */

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -321,8 +321,13 @@ export class LibP2PService extends WithTracer implements P2PService {
     };
   }
 
-  public updateConfig(config: Partial<P2PReqRespConfig & Pick<P2PConfig, 'skipIncomingProposals'>>) {
+  public async updateConfig(
+    config: Partial<P2PReqRespConfig & Pick<P2PConfig, 'skipIncomingProposals' | 'preferredPeers'>>,
+  ): Promise<void> {
     this.reqresp.updateConfig(config);
+    if (config.preferredPeers !== undefined) {
+      await this.peerManager.updatePreferredPeers(config.preferredPeers);
+    }
     this.config = merge(this.config, config);
   }
 

--- a/yarn-project/p2p/src/services/peer-manager/interface.ts
+++ b/yarn-project/p2p/src/services/peer-manager/interface.ts
@@ -15,6 +15,15 @@ export interface PeerManagerInterface {
   addTrustedPeer(peerId: PeerId): void;
   addPrivatePeer(peerId: PeerId): void;
   addPreferredPeer(peerId: PeerId): void;
+
+  /**
+   * Replaces the set of preferred peers with the ones encoded in the given ENRs, adding the new peers to the
+   * gossipsub direct-peer set and dropping the ones no longer preferred.
+   * @param enrs - The ENRs of the peers that should be preferred from now on.
+   * @throws If any of the given ENRs is malformed or carries no TCP address; no state is mutated in that case.
+   */
+  updatePreferredPeers(enrs: string[]): Promise<void>;
+
   goodbyeReceived(peerId: PeerId, reason: GoodByeReason): void;
   penalizePeer(peerId: PeerId, penalty: PeerErrorSeverity): void;
   handleAuthRequestFromPeer(authRequest: AuthRequest, peerId: PeerId): Promise<StatusMessage>;

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -20,7 +20,7 @@ import { jest } from '@jest/globals';
 import type { PeerId } from '@libp2p/interface';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
-import { multiaddr } from '@multiformats/multiaddr';
+import { type Multiaddr, multiaddr } from '@multiformats/multiaddr';
 import { type ENR, SignableENR } from '@nethermindeth/enr';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import { generatePrivateKey } from 'viem/accounts';
@@ -943,6 +943,115 @@ describe('PeerManager', () => {
       const isPreferredPeer = (newPeerManager as any).isPreferredPeer.bind(newPeerManager);
 
       expect(isPreferredPeer(peerId)).toBe(true);
+    });
+
+    describe('updatePreferredPeers', () => {
+      const createPreferredPeer = async (port: number, withTcpAddress = true) => {
+        const peerId = await createSecp256k1PeerId();
+        const enr = SignableENR.createFromPeerId(peerId);
+        if (withTcpAddress) {
+          enr.setLocationMultiaddr(multiaddr(`/ip4/127.0.0.1/tcp/${port}`));
+        }
+        return { peerId, enr: enr.encodeTxt() };
+      };
+
+      let node: any;
+      let manager: PeerManager;
+
+      beforeEach(() => {
+        node = createMockLibP2PNode([], []);
+        manager = createMockPeerManager('test', node, 3);
+      });
+
+      it('adds new preferred peers as direct peers', async () => {
+        const peer = await createPreferredPeer(9001);
+
+        await manager.updatePreferredPeers([peer.enr]);
+
+        expect(node.services.pubsub.direct.has(peer.peerId.toString())).toBe(true);
+        expect(manager.isAuthenticatedPeer(peer.peerId)).toBe(true);
+
+        const [mergedPeerId, mergedData] = node.peerStore.merge.mock.calls[0];
+        expect(mergedPeerId.toString()).toEqual(peer.peerId.toString());
+        expect(mergedData.multiaddrs.map((addr: Multiaddr) => addr.toString())).toEqual(['/ip4/127.0.0.1/tcp/9001']);
+      });
+
+      it('removes peers that are no longer preferred', async () => {
+        const kept = await createPreferredPeer(9001);
+        const dropped = await createPreferredPeer(9002);
+
+        await manager.updatePreferredPeers([kept.enr, dropped.enr]);
+        await manager.updatePreferredPeers([kept.enr]);
+
+        expect(node.services.pubsub.direct.has(kept.peerId.toString())).toBe(true);
+        expect(node.services.pubsub.direct.has(dropped.peerId.toString())).toBe(false);
+        expect(manager.isAuthenticatedPeer(kept.peerId)).toBe(true);
+        expect(manager.isAuthenticatedPeer(dropped.peerId)).toBe(false);
+      });
+
+      it('disconnects a removed peer that is no longer authenticated when only validators are allowed', async () => {
+        const validatorOnlyNode = createMockLibP2PNode([], []);
+        validatorOnlyNode.getConnections.mockImplementation((peerId?: PeerId) =>
+          peerId ? [{ remotePeer: peerId }] : [],
+        );
+        const validatorOnlyManager = createMockPeerManager('test', validatorOnlyNode, 3, [], [], [], {
+          p2pAllowOnlyValidators: true,
+        });
+        const dropped = await createPreferredPeer(9002);
+
+        await validatorOnlyManager.updatePreferredPeers([dropped.enr]);
+        await validatorOnlyManager.updatePreferredPeers([]);
+        await validatorOnlyManager.heartbeat();
+
+        expect(validatorOnlyNode.hangUp).toHaveBeenCalledWith(peerIdFromString(dropped.peerId.toString()));
+      });
+
+      it('keeps a removed peer connected when validator-only mode is off', async () => {
+        node.getConnections.mockImplementation((peerId?: PeerId) => (peerId ? [{ remotePeer: peerId }] : []));
+        const dropped = await createPreferredPeer(9002);
+
+        await manager.updatePreferredPeers([dropped.enr]);
+        await manager.updatePreferredPeers([]);
+        await manager.heartbeat();
+
+        expect(node.hangUp).not.toHaveBeenCalled();
+      });
+
+      it('rejects the whole update when an ENR is invalid, leaving the preferred set untouched', async () => {
+        const existing = await createPreferredPeer(9001);
+        const incoming = await createPreferredPeer(9002);
+        await manager.updatePreferredPeers([existing.enr]);
+
+        await expect(manager.updatePreferredPeers([incoming.enr, 'not-an-enr'])).rejects.toThrow();
+
+        expect(manager.isAuthenticatedPeer(existing.peerId)).toBe(true);
+        expect(manager.isAuthenticatedPeer(incoming.peerId)).toBe(false);
+        expect(node.services.pubsub.direct.has(existing.peerId.toString())).toBe(true);
+        expect(node.services.pubsub.direct.has(incoming.peerId.toString())).toBe(false);
+      });
+
+      it('rejects an update carrying an ENR without a TCP address', async () => {
+        const noTcpAddress = await createPreferredPeer(0, false);
+
+        await expect(manager.updatePreferredPeers([noTcpAddress.enr])).rejects.toThrow('no TCP address');
+
+        expect(manager.isAuthenticatedPeer(noTcpAddress.peerId)).toBe(false);
+        expect(node.services.pubsub.direct.size).toBe(0);
+      });
+
+      it('re-applies the updated list on the next validator heartbeat', async () => {
+        const validatorAddresses = [EthAddress.random()];
+        mockEpochCache.getRegisteredValidators.mockResolvedValue(validatorAddresses);
+        manager.registerThisValidatorAddresses(validatorAddresses);
+
+        const peer = await createPreferredPeer(9001);
+        await manager.updatePreferredPeers([peer.enr]);
+        node.services.pubsub.direct.clear();
+
+        await manager.heartbeat();
+
+        expect(node.services.pubsub.direct.has(peer.peerId.toString())).toBe(true);
+      });
     });
   });
 

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -47,6 +47,11 @@ type CachedPeer = {
   addedUnixMs: number;
 };
 
+type DirectPeer = {
+  peerId: PeerId;
+  multiaddrTcp: Multiaddr;
+};
+
 type TimedOutPeer = {
   peerId: string;
   timeoutUntilMs: number;
@@ -251,17 +256,9 @@ export class PeerManager implements PeerManagerInterface {
 
     const directPeers = compactArray(
       await Promise.all(
-        preferredPeersEnrs.map(async enr => {
+        this.config.preferredPeers.map(async enr => {
           try {
-            const peerId = await enr.peerId();
-            const address = enr.getLocationMultiaddr('tcp');
-            if (address === undefined) {
-              throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr.encodeTxt()}`);
-            }
-            return {
-              id: peerId,
-              addrs: [address],
-            };
+            return await resolveDirectPeer(enr);
           } catch (err) {
             // A malformed configured ENR shouldn't abort preferred-peer setup — skip it and log.
             this.logger.warn(`Skipping preferred peer with invalid ENR`, { err });
@@ -271,15 +268,61 @@ export class PeerManager implements PeerManagerInterface {
       ),
     );
 
-    await Promise.all(
-      directPeers.map(peer => {
-        this.libP2PNode.services.pubsub.direct.add(peer.id.toString());
-
-        return this.libP2PNode.peerStore.merge(peer.id, { multiaddrs: peer.addrs });
-      }),
-    );
+    await Promise.all(directPeers.map(peer => this.addDirectPeer(peer)));
 
     this.initializedPreferredPeers = true;
+  }
+
+  /**
+   * Replaces the set of preferred peers with the ones encoded in the given ENRs. New peers are added to the
+   * gossipsub direct-peer set (gossipsub dials them on its next direct-connect tick) and to the peer store,
+   * while peers that are no longer preferred are dropped from both.
+   * @param enrs - The ENRs of the peers that should be preferred from now on.
+   * @throws If any of the given ENRs is malformed or carries no TCP address; no state is mutated in that case.
+   */
+  public async updatePreferredPeers(enrs: string[]): Promise<void> {
+    const resolved = await Promise.all(enrs.map(enr => resolveDirectPeer(enr)));
+
+    const updatedPeerIds = new Set(resolved.map(peer => peer.peerId.toString()));
+    const removed = Array.from(this.preferredPeers).filter(peerIdStr => !updatedPeerIds.has(peerIdStr));
+    const added = resolved.filter(peer => !this.preferredPeers.has(peer.peerId.toString()));
+
+    for (const peerIdStr of removed) {
+      this.preferredPeers.delete(peerIdStr);
+      this.libP2PNode.services.pubsub.direct.delete(peerIdStr);
+    }
+
+    await Promise.all(added.map(peer => this.addDirectPeer(peer)));
+
+    // Peer authorization is only evaluated when a connection is established, so a peer that just lost its
+    // preferred status would otherwise stay connected indefinitely despite no longer being allowed in.
+    if (this.config.p2pAllowOnlyValidators) {
+      for (const peerIdStr of removed) {
+        const peerId = peerIdFromString(peerIdStr);
+        if (this.libP2PNode.getConnections(peerId).length > 0 && !this.isAuthenticatedPeer(peerId)) {
+          this.markPeerForDisconnect(peerId);
+        }
+      }
+    }
+
+    // PeerManager holds its own reference to the config, so it needs updating independently of the p2p service,
+    // and the validator-gated direct peer setup needs to run again against the new set.
+    this.config = { ...this.config, preferredPeers: enrs };
+    this.initializedPreferredPeers = false;
+
+    this.logger.info(`Updated preferred peers to ${this.preferredPeers.size} peers`, {
+      added: added.map(peer => peer.peerId.toString()),
+      removed,
+      preferredPeerCount: this.preferredPeers.size,
+    });
+  }
+
+  /** Registers a peer as preferred and as a gossipsub direct peer, and records its address in the peer store. */
+  private async addDirectPeer(peer: DirectPeer): Promise<void> {
+    const peerIdStr = peer.peerId.toString();
+    this.preferredPeers.add(peerIdStr);
+    this.libP2PNode.services.pubsub.direct.add(peerIdStr);
+    await this.libP2PNode.peerStore.merge(peer.peerId, { multiaddrs: [peer.multiaddrTcp] });
   }
 
   /**
@@ -1176,6 +1219,20 @@ export class PeerManager implements PeerManagerInterface {
       this.authenticatedValidatorAddressToPeerId.delete(address);
     }
   }
+}
+
+/**
+ * Decodes an ENR string into the peer id and TCP address needed to register it as a gossipsub direct peer.
+ * @throws If the ENR cannot be decoded or does not advertise a TCP address.
+ */
+async function resolveDirectPeer(enr: string): Promise<DirectPeer> {
+  const decoded = ENR.decodeTxt(enr);
+  const peerId = await decoded.peerId();
+  const multiaddrTcp = decoded.getLocationMultiaddr('tcp');
+  if (multiaddrTcp === undefined) {
+    throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr}`);
+  }
+  return { peerId, multiaddrTcp };
 }
 
 /**

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -14,6 +14,7 @@ import type { PeerId } from '@libp2p/interface';
 import type { ENR } from '@nethermindeth/enr';
 import type EventEmitter from 'events';
 
+import type { P2PConfig } from '../config.js';
 import type { BatchTxRequesterLibP2PService } from './reqresp/batch-tx-requester/interface.js';
 import type { P2PReqRespConfig } from './reqresp/config.js';
 import type { StatusMessage } from './reqresp/index.js';
@@ -162,7 +163,13 @@ export interface P2PService {
 
   handleAuthRequestFromPeer(authRequest: AuthRequest, peerId: PeerId): Promise<StatusMessage>;
 
-  updateConfig(config: Partial<P2PReqRespConfig>): void;
+  /**
+   * Applies a runtime configuration update to the p2p stack. Preferred peers are re-resolved from their
+   * ENRs, so an invalid entry rejects the whole update.
+   */
+  updateConfig(
+    config: Partial<P2PReqRespConfig & Pick<P2PConfig, 'skipIncomingProposals' | 'preferredPeers'>>,
+  ): Promise<void>;
 
   /** If node running this P2P stack is validator, passes in validator address to P2P layer */
   registerThisValidatorAddresses(address: EthAddress[]): void;

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -93,6 +93,8 @@ export type AztecNodeAdminConfig = Omit<ValidatorClientFullConfig, keyof L1Contr
     maxPendingTxCount: number;
     // Keep in sync with P2PConfig.skipIncomingProposals (circular dep prevents Pick<P2PConfig, ...> here)
     skipIncomingProposals?: boolean;
+    // Keep in sync with P2PConfig.preferredPeers (circular dep prevents Pick<P2PConfig, ...> here)
+    preferredPeers?: string[];
   };
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
@@ -105,7 +107,13 @@ export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConf
       skipValidateCheckpointAttestations: true,
     }),
   )
-  .merge(z.object({ maxPendingTxCount: z.number(), skipIncomingProposals: z.boolean().optional() }));
+  .merge(
+    z.object({
+      maxPendingTxCount: z.number(),
+      skipIncomingProposals: z.boolean().optional(),
+      preferredPeers: z.array(z.string()).optional(),
+    }),
+  );
 
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {
   getConfig: z.function({ input: z.tuple([]), output: AztecNodeAdminConfigSchema }),


### PR DESCRIPTION
## Context

The `preferredPeers` list (ENRs given gossipsub direct-peering and exemption from the validator-only auth handshake) was only read at node startup, so changing it required a restart.

## Approach

Expose it through the existing admin config path: `preferredPeers` is added to `AztecNodeAdminConfig`, and `setConfig` forwards it via `updateP2PConfig` into a new `PeerManager.updatePreferredPeers` that treats the list as the full desired state.

- All ENRs are resolved up front; the update is rejected before any mutation if one is malformed or lacks a TCP address (an explicit admin call should fail loudly, unlike startup's warn-and-skip).
- Added peers go into the preferred set, gossipsub's `direct` set, and the peer store; gossipsub dials them on its next direct-connect tick.
- Removed peers are dropped from both, and when `p2pAllowOnlyValidators` is on and they hold no other authentication they are marked for disconnect, since auth is only evaluated at connect time.
- The field round-trips through `getConfig`.

Note that gossipsub direct peering is symmetric by design, so for full effect both ends should update their lists; a one-sided update still yields one-directional preferential forwarding.

## API changes

- `AztecNodeAdmin.setConfig` accepts `preferredPeers?: string[]` and `getConfig` returns it.
- `P2PService.updateConfig` now returns `Promise<void>` (ENR resolution is async).