### PR TITLE
fix(ci): only run the CLI acceptance test for v5 releases

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -26,10 +26,13 @@ jobs:
     # The auto acceptance test validates published releases, which are only cut from the
     # public aztec-packages repo. Don't let the workflow_run trigger fire in the private
     # mirror, where it runs against non-release branches (e.g. v5-next) and always fails.
+    #
+    # This repo only releases the v5 line, so later tags have no CLI to install.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run'
        && github.event.workflow_run.conclusion == 'success'
+       && startsWith(github.event.workflow_run.head_branch, 'v5.')
        && !contains(github.event.workflow_run.head_branch, '-commit.')
        && github.repository != 'AztecProtocol/aztec-packages-private')
     env:


### PR DESCRIPTION
## Problem

The Aztec CLI acceptance test auto-triggers on every `v*` tag, but this repo's release
flow no longer publishes the CLI for the next line: #25188 narrowed `release` to the
foundation packages, leaving the CLI, release image and install.aztec.network aliases to
the labs repo. Nightly tags are still cut for both lines, so every `v6.0.0-nightly.*` tag
starts an acceptance test with nothing to install and pages #team-fairies when it fails.

## Fix

Gate the `workflow_run` trigger on `v5.` tags, alongside the existing exclusions for
`-commit.` tags and the private mirror. `workflow_dispatch` is untouched, so any version
can still be tested by hand.