### PR TITLE
feat: fee provider refreshes in the background

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -571,6 +571,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     await tryStop(this.automineSequencer);
     await tryStop(this.proverNode);
     await tryStop(this.p2pClient);
+    await tryStop(this.feeProvider);
     await tryStop(this.worldStateSynchronizer);
     await tryStop(this.blockSource);
     await tryStop(this.blobClient);

--- a/yarn-project/aztec-node/src/factory.ts
+++ b/yarn-project/aztec-node/src/factory.ts
@@ -251,6 +251,8 @@ export async function createAztecNodeService(
 
     const globalVariableBuilder = new GlobalVariableBuilder(publicClient, globalVariableBuilderConfig);
     const feeProvider = new FeeProviderImpl(dateProvider, publicClient, globalVariableBuilderConfig);
+    await feeProvider.start();
+    started.push(feeProvider);
 
     const collectOffenses = !config.disableValidator || config.enableOffenseCollection;
 

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
@@ -9,7 +9,6 @@ import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
-import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
 import { FEE_ORACLE_LAG, type GasFees, ManaUsageEstimate, computeExcessMana } from '@aztec/stdlib/gas';
 
@@ -118,20 +117,27 @@ describe('FeePredictor', () => {
     return afterCheckpoint > BigInt(currentSlot) ? afterCheckpoint : BigInt(currentSlot);
   }
 
+  /** Builds a predictor and refreshes it against the current L1 block, mirroring how FeeProviderImpl drives it. */
+  async function makeRefreshedPredictor(): Promise<FeePredictor> {
+    const predictor = new FeePredictor(rollup, dateProvider, feePredictorConfig);
+    await predictor.refreshState(await publicClient.getBlockNumber({ cacheTime: 0 }));
+    return predictor;
+  }
+
   it('slot 0 matches L1 getManaMinFeeAt for all ManaUsageEstimate values', async () => {
     const startSlot = await getPredictionStartSlot();
     const l1Fee = await rollup.getManaMinFeeAt(getTimestamp(startSlot), true);
 
     for (const manaUsage of Object.values(ManaUsageEstimate)) {
-      const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-      const predicted = await predictor.getPredictedMinFees(manaUsage);
+      const predictor = await makeRefreshedPredictor();
+      const predicted = predictor.getPredictedMinFees(manaUsage);
       expect(predicted[0].feePerL2Gas).toBe(l1Fee);
     }
   });
 
   it('all slots match L1 with ManaUsageEstimate.None and zero congestion', async () => {
-    const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-    const predicted = await predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predictor = await makeRefreshedPredictor();
+    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -164,8 +170,8 @@ describe('FeePredictor', () => {
     await cheatCodes.mine();
     await rollupCheatCodes.updateL1GasFeeOracle();
 
-    const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-    const predicted = await predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predictor = await makeRefreshedPredictor();
+    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -195,8 +201,8 @@ describe('FeePredictor', () => {
     await cheatCodes.mine();
     await rollupCheatCodes.advanceSlots(3);
 
-    const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-    const predicted = await predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predictor = await makeRefreshedPredictor();
+    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const l1Fee = await rollup.getManaMinFeeAt(getTimestamp(startSlot), true);
@@ -204,8 +210,8 @@ describe('FeePredictor', () => {
   });
 
   it('returns exactly FEE_ORACLE_LAG entries', async () => {
-    const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-    const predicted = await predictor.getPredictedMinFees(ManaUsageEstimate.Target);
+    const predictor = await makeRefreshedPredictor();
+    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.Target);
     expect(predicted.length).toBe(FEE_ORACLE_LAG);
   });
 
@@ -233,8 +239,8 @@ describe('FeePredictor', () => {
       const assumedManaUsed =
         estimate === ManaUsageEstimate.None ? 0n : estimate === ManaUsageEstimate.Target ? manaTarget : manaLimit;
 
-      const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-      const predicted = await predictor.getPredictedMinFees(estimate);
+      const predictor = await makeRefreshedPredictor();
+      const predicted = predictor.getPredictedMinFees(estimate);
 
       const startSlot = await getPredictionStartSlot();
       const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -306,8 +312,8 @@ describe('FeePredictor', () => {
 
     // Step through 6 successive slots, creating a fresh predictor each time.
     for (let step = 0; step < 6; step++) {
-      const predictor = new FeePredictor(rollup, publicClient, dateProvider, feePredictorConfig);
-      const predicted = await predictor.getPredictedMinFees(ManaUsageEstimate.None);
+      const predictor = await makeRefreshedPredictor();
+      const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
 
       expect(predicted.length).toBe(FEE_ORACLE_LAG);
 
@@ -356,63 +362,39 @@ describe('FeePredictor', () => {
 });
 
 describe('FeePredictor state caching', () => {
-  it('recovers from a transient L1 read failure without waiting for a new L1 block', async () => {
-    const blockNumber = 1n;
-    const getBlockNumber = jest.fn<() => Promise<bigint>>(() => Promise.resolve(blockNumber));
-    const state = { manaTarget: 1n } as unknown;
-    const fetchState = jest
-      .fn<() => Promise<unknown>>()
-      .mockRejectedValueOnce(new Error('L1 RPC request failed'))
-      .mockResolvedValue(state);
-
+  it('getState() returns undefined until refreshState() has been called', () => {
     const predictor: FeePredictor = Object.create(FeePredictor.prototype);
-    Reflect.set(predictor, 'publicClient', { getBlockNumber });
-    Reflect.set(predictor, 'cachedL1BlockNumber', undefined);
-    Reflect.set(predictor, 'cachedState', undefined);
-    Reflect.set(predictor, 'fetchState', fetchState);
-
-    const getState = Reflect.get(FeePredictor.prototype, 'getState') as () => Promise<unknown>;
-
-    await expect(getState.call(predictor)).rejects.toThrow('L1 RPC request failed');
-    // Same L1 block: must recompute rather than replay the cached rejection.
-    await expect(getState.call(predictor)).resolves.toBe(state);
-    expect(fetchState).toHaveBeenCalledTimes(2);
+    expect(predictor.getState()).toBeUndefined();
   });
 
-  it('does not clear the block marker when a stale fetch for an older block rejects', async () => {
-    const blockN = 1n;
-    const blockNext = 2n;
-    const getBlockNumber = jest
-      .fn<() => Promise<bigint>>()
-      .mockResolvedValueOnce(blockN)
-      .mockResolvedValueOnce(blockNext);
-
-    const fetchN = promiseWithResolvers<unknown>();
+  it('refreshState() caches the fetched state for getState() to return, with no further I/O', async () => {
     const state = { manaTarget: 1n } as unknown;
-    const fetchState = jest
-      .fn<() => Promise<unknown>>()
-      .mockImplementationOnce(() => fetchN.promise)
-      .mockResolvedValue(state);
+    const fetchState = jest.fn<() => Promise<unknown>>().mockResolvedValue(state);
 
     const predictor: FeePredictor = Object.create(FeePredictor.prototype);
-    Reflect.set(predictor, 'publicClient', { getBlockNumber });
-    Reflect.set(predictor, 'cachedL1BlockNumber', undefined);
-    Reflect.set(predictor, 'cachedState', undefined);
     Reflect.set(predictor, 'fetchState', fetchState);
 
-    const getState = Reflect.get(FeePredictor.prototype, 'getState') as () => Promise<unknown>;
+    await expect(predictor.refreshState(1n)).resolves.toBe(state);
+    expect(predictor.getState()).toBe(state);
+    expect(predictor.getState()).toBe(state);
+    expect(fetchState).toHaveBeenCalledTimes(1);
+  });
 
-    // Fetch for block N stays in flight; the block N+1 call advances the marker meanwhile.
-    const callN = getState.call(predictor);
-    const callNext = getState.call(predictor);
+  it('preserves the last known-good state if refreshState() fails', async () => {
+    const goodState = { manaTarget: 1n } as unknown;
+    const fetchState = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValueOnce(goodState)
+      .mockRejectedValueOnce(new Error('L1 RPC request failed'));
 
-    // The stale N fetch now rejects. It must NOT clear the marker (which now points at N+1).
-    fetchN.reject(new Error('stale L1 RPC request failed'));
+    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
+    Reflect.set(predictor, 'fetchState', fetchState);
 
-    await expect(callN).rejects.toThrow('stale L1 RPC request failed');
-    await expect(callNext).resolves.toBe(state);
+    await predictor.refreshState(1n);
+    expect(predictor.getState()).toBe(goodState);
 
-    expect(Reflect.get(predictor, 'cachedL1BlockNumber')).toBe(blockNext);
-    expect(fetchState).toHaveBeenCalledTimes(2);
+    await expect(predictor.refreshState(2n)).rejects.toThrow('L1 RPC request failed');
+    // The failed refresh must not have clobbered the last known-good state.
+    expect(predictor.getState()).toBe(goodState);
   });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
@@ -28,12 +28,10 @@ type FeeOracleState = {
 /**
  * Predicts min fees for LAG upcoming slots based on the L1 oracle state.
  * A new oracle update can activate at startSlot + LAG, so only the first LAG entries
- * are guaranteed stable. Caches L1 queries per L1 block and recomputes predictions
- * for each mana usage estimate.
+ * are guaranteed stable.
  */
 export class FeePredictor {
-  private cachedState: Promise<FeeOracleState> | undefined;
-  private cachedL1BlockNumber: bigint | undefined;
+  private cachedState: FeeOracleState | undefined;
 
   private readonly slotDuration: number;
   private readonly l1GenesisTime: bigint;
@@ -41,7 +39,6 @@ export class FeePredictor {
 
   constructor(
     private readonly rollupContract: RollupContract,
-    private readonly publicClient: { getBlockNumber: (opts?: { cacheTime?: number }) => Promise<bigint> },
     private readonly dateProvider: DateProvider,
     config: { slotDuration: number; l1GenesisTime: bigint; ethereumSlotDuration: number },
   ) {
@@ -50,30 +47,27 @@ export class FeePredictor {
     this.ethereumSlotDuration = config.ethereumSlotDuration;
   }
 
-  /** Returns predicted min fees for each slot in the prediction window. */
-  async getPredictedMinFees(manaUsage: ManaUsageEstimate): Promise<GasFees[]> {
-    const state = await this.getState();
+  /** Returns predicted min fees for each slot in the prediction window, from the cached state. */
+  getPredictedMinFees(manaUsage: ManaUsageEstimate): GasFees[] {
+    const state = this.getState();
+    if (state === undefined) {
+      throw new Error('FeePredictor.refreshState() must be called before getPredictedMinFees()');
+    }
     return this.computePredictions(state, manaUsage);
   }
 
-  /** Fetches and caches rollup state. Refreshes when L1 block number advances. */
-  private async getState(): Promise<FeeOracleState> {
-    const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
-    if (this.cachedL1BlockNumber === undefined || blockNumber > this.cachedL1BlockNumber) {
-      this.cachedL1BlockNumber = blockNumber;
-      // Reset the cached block number on failure so a transient L1 RPC error does not leave a
-      // rejected promise cached for this block, which would replay the same rejection on every
-      // subsequent call until the next L1 block arrives. Only clear it if it still points at the
-      // block this attempt was for, so a stale rejection from an older block cannot wipe a marker
-      // a newer call already advanced (which would also defeat the monotonic block-number guard).
-      this.cachedState = this.fetchState(blockNumber).catch(err => {
-        if (this.cachedL1BlockNumber === blockNumber) {
-          this.cachedL1BlockNumber = undefined;
-        }
-        throw err;
-      });
-    }
-    return this.cachedState!;
+  /** Returns whatever rollup state is currently cached, or undefined if refreshState() has never been called. */
+  getState(): FeeOracleState | undefined {
+    return this.cachedState;
+  }
+
+  /**
+   * Fetches and caches rollup state for the given L1 block.
+   */
+  async refreshState(blockNumber: bigint): Promise<FeeOracleState> {
+    const state = await this.fetchState(blockNumber);
+    this.cachedState = state;
+    return state;
   }
 
   private async fetchState(blockNumber: bigint): Promise<FeeOracleState> {

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
@@ -1,4 +1,6 @@
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
 
 import { jest } from '@jest/globals';
@@ -7,31 +9,24 @@ import { FeeProviderImpl } from './fee_provider.js';
 
 describe('FeeProviderImpl', () => {
   function makeProvider(currentMinFees: GasFees, predictedMinFees: GasFees[]) {
-    const blockNumber = 1n;
-    const getBlockNumber = jest.fn<() => Promise<bigint>>(() => Promise.resolve(blockNumber));
-    const getPredictedMinFees = jest.fn<(manaUsage: ManaUsageEstimate) => Promise<GasFees[]>>(() =>
-      Promise.resolve(predictedMinFees),
-    );
+    const getPredictedMinFees = jest.fn<(manaUsage: ManaUsageEstimate) => GasFees[]>(() => predictedMinFees);
     const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
 
-    Reflect.set(provider, 'publicClient', { getBlockNumber });
-    Reflect.set(provider, 'currentL1BlockNumber', blockNumber);
-    Reflect.set(provider, 'currentMinFees', Promise.resolve(currentMinFees));
+    Reflect.set(provider, 'currentMinFees', currentMinFees);
     Reflect.set(provider, 'feePredictor', { getPredictedMinFees });
 
-    return { provider, getBlockNumber, getPredictedMinFees };
+    return { provider, getPredictedMinFees };
   }
 
   it('prepends current min fees to predicted future fees', async () => {
     const currentMinFees = new GasFees(1, 2);
     const predictedMinFees = [new GasFees(3, 4), new GasFees(5, 6)];
-    const { provider, getBlockNumber, getPredictedMinFees } = makeProvider(currentMinFees, predictedMinFees);
+    const { provider, getPredictedMinFees } = makeProvider(currentMinFees, predictedMinFees);
 
     await expect(provider.getPredictedMinFees(ManaUsageEstimate.Limit)).resolves.toEqual([
       currentMinFees,
       ...predictedMinFees,
     ]);
-    expect(getBlockNumber).toHaveBeenCalledWith({ cacheTime: 0 });
     expect(getPredictedMinFees).toHaveBeenCalledWith(ManaUsageEstimate.Limit);
   });
 
@@ -43,61 +38,126 @@ describe('FeeProviderImpl', () => {
     expect(getPredictedMinFees).toHaveBeenCalledWith(ManaUsageEstimate.Target);
   });
 
-  it('recovers from a transient L1 read failure without waiting for a new L1 block', async () => {
-    const blockNumber = 1n;
-    const getBlockNumber = jest.fn<() => Promise<bigint>>(() => Promise.resolve(blockNumber));
-    const computeCurrentMinFees = jest
-      .fn<() => Promise<GasFees>>()
-      .mockRejectedValueOnce(new Error('L1 RPC request failed'))
-      .mockResolvedValue(new GasFees(0, 42));
+  describe('background refresh loop', () => {
+    function makeBackgroundProvider() {
+      const getBlockNumber = jest.fn<() => Promise<bigint>>().mockResolvedValue(1n);
+      const computeCurrentMinFees = jest.fn<() => Promise<GasFees>>().mockResolvedValue(new GasFees(0, 42));
+      const feePredictorRefreshState = jest
+        .fn<(blockNumber: bigint) => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const getPredictedMinFees = jest.fn<(manaUsage: ManaUsageEstimate) => GasFees[]>().mockReturnValue([]);
 
-    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
-    Reflect.set(provider, 'publicClient', { getBlockNumber });
-    Reflect.set(provider, 'currentL1BlockNumber', undefined);
-    Reflect.set(provider, 'currentMinFees', Promise.resolve(new GasFees(0, 0)));
-    Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
+      const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
+      Reflect.set(provider, 'publicClient', { getBlockNumber });
+      Reflect.set(provider, 'currentL1BlockNumber', undefined);
+      Reflect.set(provider, 'currentMinFees', new GasFees(0, 0));
+      Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
+      Reflect.set(provider, 'feePredictor', {
+        refreshState: feePredictorRefreshState,
+        getPredictedMinFees,
+      });
+      Reflect.set(provider, 'log', createLogger('test:fee-provider'));
 
-    // First call fails on the transient L1 read.
-    await expect(provider.getCurrentMinFees()).rejects.toThrow('L1 RPC request failed');
+      return { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState, getPredictedMinFees };
+    }
 
-    // A subsequent call at the SAME L1 block must recompute rather than replay the cached rejection.
-    await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
-    expect(computeCurrentMinFees).toHaveBeenCalledTimes(2);
-  });
+    it('warms the cache on start() and serves it with no further L1 calls', async () => {
+      const { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState } = makeBackgroundProvider();
 
-  it('does not clear the block marker when a stale computation for an older block rejects', async () => {
-    const blockN = 1n;
-    const blockNext = 2n;
-    const getBlockNumber = jest
-      .fn<() => Promise<bigint>>()
-      .mockResolvedValueOnce(blockN)
-      .mockResolvedValueOnce(blockNext);
+      // A long polling interval so the loop's scheduled tick never fires again during this test.
+      await provider.start(60_000);
 
-    const computeN = promiseWithResolvers<GasFees>();
-    const computeCurrentMinFees = jest
-      .fn<() => Promise<GasFees>>()
-      .mockImplementationOnce(() => computeN.promise)
-      .mockResolvedValue(new GasFees(0, 42));
+      // start() performs the required warmup, then RunningPromise begins with an immediate tick.
+      // The second block-number check is a cheap no-op since the block has not advanced.
+      expect(getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(computeCurrentMinFees).toHaveBeenCalledTimes(1);
+      expect(feePredictorRefreshState).toHaveBeenCalledWith(1n);
 
-    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
-    Reflect.set(provider, 'publicClient', { getBlockNumber });
-    Reflect.set(provider, 'currentL1BlockNumber', undefined);
-    Reflect.set(provider, 'currentMinFees', Promise.resolve(new GasFees(0, 0)));
-    Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
+      getBlockNumber.mockClear();
+      computeCurrentMinFees.mockClear();
 
-    // Call at block N starts a computation that stays in flight.
-    const callN = provider.getCurrentMinFees();
-    // Call at block N+1 advances the marker while the N computation is still pending.
-    const callNext = provider.getCurrentMinFees();
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+      await expect(provider.getPredictedMinFees()).resolves.toEqual([new GasFees(0, 42)]);
 
-    // The stale N computation now rejects. It must NOT clear the marker (which now points at N+1).
-    computeN.reject(new Error('stale L1 RPC request failed'));
+      expect(getBlockNumber).not.toHaveBeenCalled();
+      expect(computeCurrentMinFees).not.toHaveBeenCalled();
 
-    await expect(callN).rejects.toThrow('stale L1 RPC request failed');
-    await expect(callNext).resolves.toEqual(new GasFees(0, 42));
+      await provider.stop();
+    });
 
-    // Marker still reflects the newer block; the N+1 computation ran exactly once (no spurious recompute).
-    expect(Reflect.get(provider, 'currentL1BlockNumber')).toBe(blockNext);
-    expect(computeCurrentMinFees).toHaveBeenCalledTimes(2);
+    it('fails to start if the initial cache refresh fails', async () => {
+      const { provider, getBlockNumber } = makeBackgroundProvider();
+      getBlockNumber.mockRejectedValue(new Error('L1 unavailable'));
+
+      const startError = await provider.start(60_000).then(
+        () => undefined,
+        err => err,
+      );
+      await provider.stop();
+
+      expect(startError).toEqual(new Error('L1 unavailable'));
+    });
+
+    it('keeps serving the last known-good fees when a background tick fails, and retries the same block', async () => {
+      const { provider, getBlockNumber, computeCurrentMinFees } = makeBackgroundProvider();
+      await provider.start(60_000);
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+
+      getBlockNumber.mockResolvedValue(2n);
+      computeCurrentMinFees.mockRejectedValueOnce(new Error('transient L1 error'));
+      const refreshFromL1 = Reflect.get(FeeProviderImpl.prototype, 'refreshFromL1') as () => Promise<void>;
+
+      await expect(refreshFromL1.call(provider)).rejects.toThrow('transient L1 error');
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+
+      computeCurrentMinFees.mockResolvedValueOnce(new GasFees(0, 99));
+      await refreshFromL1.call(provider);
+
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 99));
+
+      await provider.stop();
+    });
+
+    it('serves the cached fees until the complete refresh has succeeded', async () => {
+      const { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState } = makeBackgroundProvider();
+      await provider.start(60_000);
+
+      getBlockNumber.mockResolvedValueOnce(2n);
+      const computeGate = promiseWithResolvers<GasFees>();
+      computeCurrentMinFees.mockReturnValueOnce(computeGate.promise);
+      const predictorGate = promiseWithResolvers<unknown>();
+      feePredictorRefreshState.mockReturnValueOnce(predictorGate.promise);
+
+      const refreshFromL1 = Reflect.get(FeeProviderImpl.prototype, 'refreshFromL1') as () => Promise<void>;
+      const tick = refreshFromL1.call(provider);
+      await sleep(0);
+
+      const whileCurrentFeesRefresh = await Promise.race([provider.getCurrentMinFees(), sleep(0, new GasFees(0, 999))]);
+      expect(whileCurrentFeesRefresh).toEqual(new GasFees(0, 42));
+      expect(feePredictorRefreshState).not.toHaveBeenCalledWith(2n);
+
+      computeGate.resolve(new GasFees(0, 77));
+      await sleep(0);
+
+      expect(feePredictorRefreshState).toHaveBeenCalledWith(2n);
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+
+      predictorGate.resolve(undefined);
+      await tick;
+      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 77));
+
+      await provider.stop();
+    });
+
+    it('stops polling once stopped', async () => {
+      const { provider, getBlockNumber } = makeBackgroundProvider();
+      await provider.start(10);
+      await provider.stop();
+
+      getBlockNumber.mockClear();
+      await sleep(50);
+
+      expect(getBlockNumber).not.toHaveBeenCalled();
+    });
   });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
@@ -1,6 +1,8 @@
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { SlotNumber } from '@aztec/foundation/branded-types';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { RunningPromise } from '@aztec/foundation/running-promise';
 import type { DateProvider } from '@aztec/foundation/timer';
 import { getNextL1SlotTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
@@ -9,15 +11,22 @@ import type { FeeProvider } from '@aztec/stdlib/tx';
 import { FeePredictor } from './fee_predictor.js';
 import type { GlobalVariableBuilderConfig } from './global_builder.js';
 
-/** Provides current and predicted fee information based on on-chain state. */
+/** Default interval for the background L1 refresh loop, well below L1's block time. */
+const DEFAULT_REFRESH_POLLING_INTERVAL_MS = 1000;
+
+/**
+ * Provides current and predicted fee information based on on-chain state.
+ */
 export class FeeProviderImpl implements FeeProvider {
-  private currentMinFees: Promise<GasFees> = Promise.resolve(new GasFees(0, 0));
+  private currentMinFees = new GasFees(0, 0);
   private currentL1BlockNumber: bigint | undefined = undefined;
+  private refreshLoop: RunningPromise | undefined;
 
   private readonly rollupContract: RollupContract;
   private readonly feePredictor: FeePredictor;
   private readonly ethereumSlotDuration: number;
   private readonly l1GenesisTime: bigint;
+  private readonly log: Logger = createLogger('sequencer-client:fee-provider');
 
   constructor(
     private readonly dateProvider: DateProvider,
@@ -28,11 +37,37 @@ export class FeeProviderImpl implements FeeProvider {
     this.l1GenesisTime = config.l1GenesisTime;
 
     this.rollupContract = new RollupContract(this.publicClient, config.rollupAddress);
-    this.feePredictor = new FeePredictor(this.rollupContract, this.publicClient, this.dateProvider, {
+    this.feePredictor = new FeePredictor(this.rollupContract, this.dateProvider, {
       slotDuration: config.slotDuration,
       l1GenesisTime: config.l1GenesisTime,
       ethereumSlotDuration: config.ethereumSlotDuration,
     });
+  }
+
+  public async start(pollingIntervalMs = DEFAULT_REFRESH_POLLING_INTERVAL_MS): Promise<void> {
+    await this.refreshFromL1();
+    this.refreshLoop = new RunningPromise(() => this.refreshFromL1(), this.log, pollingIntervalMs);
+    this.refreshLoop.start();
+  }
+
+  public async stop(): Promise<void> {
+    await this.refreshLoop?.stop();
+  }
+
+  /**
+   * Checks the current L1 block number and, if it has advanced, refreshes both the current and
+   * predicted min fees for that block.
+   */
+  private async refreshFromL1(): Promise<void> {
+    const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
+    if (this.currentL1BlockNumber !== undefined && blockNumber <= this.currentL1BlockNumber) {
+      return;
+    }
+
+    const currentMinFees = await this.computeCurrentMinFees();
+    await this.feePredictor.refreshState(blockNumber);
+    this.currentMinFees = currentMinFees;
+    this.currentL1BlockNumber = blockNumber;
   }
 
   /**
@@ -57,41 +92,13 @@ export class FeeProviderImpl implements FeeProvider {
     return new GasFees(0, await this.rollupContract.getManaMinFeeAt(timestamp, true));
   }
 
-  public async getCurrentMinFees(): Promise<GasFees> {
-    // Get the current block number
-    const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
-
-    // If the L1 block number has changed then chain a new promise to get the current min fees.
-    // We chain off the previous promise's settlement (via a swallowing catch) rather than its
-    // fulfillment, so a prior rejection does not short-circuit the new computation. If the new
-    // computation fails (e.g. a transient L1 RPC error), reset the cached block number so the
-    // next call recomputes instead of permanently replaying the rejected promise — otherwise a
-    // single transient failure would wedge fee estimation until the next L1 block arrives. Only
-    // clear it if it still points at the block this attempt was for, so a stale rejection from an
-    // older block cannot wipe a marker a newer call already advanced (which would also defeat the
-    // monotonic block-number guard).
-    if (this.currentL1BlockNumber === undefined || blockNumber > this.currentL1BlockNumber) {
-      this.currentL1BlockNumber = blockNumber;
-      this.currentMinFees = this.currentMinFees
-        .catch(() => undefined)
-        .then(() =>
-          this.computeCurrentMinFees().catch(err => {
-            if (this.currentL1BlockNumber === blockNumber) {
-              this.currentL1BlockNumber = undefined;
-            }
-            throw err;
-          }),
-        );
-    }
-    return this.currentMinFees;
+  public getCurrentMinFees(): Promise<GasFees> {
+    return Promise.resolve(this.currentMinFees);
   }
 
-  public async getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]> {
-    const [currentMinFees, predictedMinFees] = await Promise.all([
-      this.getCurrentMinFees(),
-      this.feePredictor.getPredictedMinFees(manaUsage ?? ManaUsageEstimate.Target),
-    ]);
-
-    return [currentMinFees, ...predictedMinFees];
+  public getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]> {
+    const currentMinFees = this.currentMinFees;
+    const predictedMinFees = this.feePredictor.getPredictedMinFees(manaUsage ?? ManaUsageEstimate.Target);
+    return Promise.resolve([currentMinFees, ...predictedMinFees]);
   }
 }


### PR DESCRIPTION
This PR makes the fee provider refresh its L1 state in the background which should speed up requests (at the expense of increased latency in reading the latest fees)