### PR TITLE
feat(node): update log level via admin API

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -18,7 +18,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { first } from '@aztec/foundation/iterable';
 import { BadRequestError } from '@aztec/foundation/json-rpc';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger, getLogLevel, setLogLevel } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { count } from '@aztec/foundation/string';
 import { Timer } from '@aztec/foundation/timer';
@@ -802,12 +802,14 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   }
 
   public getConfig(): Promise<AztecNodeAdminConfig> {
-    const schema = AztecNodeAdminConfigSchema;
-    const keys = schema.keyof().options;
-    return Promise.resolve(pick(this.config, ...keys));
+    const keys = AztecNodeAdminConfigSchema.omit({ logLevel: true }).keyof().options;
+    return Promise.resolve({ ...pick(this.config, ...keys), logLevel: getLogLevel() });
   }
 
   public async setConfig(config: Partial<AztecNodeAdminConfig>): Promise<void> {
+    if (config.logLevel !== undefined) {
+      setLogLevel(config.logLevel);
+    }
     const newConfig = { ...this.config, ...config };
     // If the sequencer is currently paused via pauseSequencer(), record the caller's desired
     // minTxsPerBlock as the restore value (so resumeSequencer applies it) and keep the freeze

--- a/yarn-project/foundation/src/log/index.ts
+++ b/yarn-project/foundation/src/log/index.ts
@@ -1,5 +1,6 @@
 export * from './console.js';
 export * from './libp2p_logger.js';
+export * from './log-filters.js';
 export * from './log_fn.js';
 export * from './noir_debug_log_util.js';
 export * from './pino-logger.js';

--- a/yarn-project/foundation/src/log/libp2p_logger.ts
+++ b/yarn-project/foundation/src/log/libp2p_logger.ts
@@ -1,8 +1,7 @@
 import type { ComponentLogger, Logger } from '@libp2p/interface';
 
-import { getLogLevelFromFilters } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';
-import { type LoggerBindings, logFilters, logger } from './pino-logger.js';
+import { type LoggerBindings, createPinoChild } from './pino-logger.js';
 
 /**
  * Creates a libp2p compatible logger that wraps our pino logger.
@@ -28,12 +27,7 @@ function replaceFormatting(message: string) {
 
 function createLibp2pLogger(component: string, bindings?: LoggerBindings): Logger {
   // Create a direct pino logger instance for libp2p that supports string interpolation
-  const actor = bindings?.actor;
-  const instanceId = bindings?.instanceId;
-  const log = logger.child(
-    { module: component, ...(actor && { actor }), ...(instanceId && { instanceId }) },
-    { level: getLogLevelFromFilters(logFilters, component) },
-  );
+  const log = createPinoChild(component, bindings);
 
   const logIfEnabled = (level: LogLevel, message: string, ...args: unknown[]) => {
     if (!log.isLevelEnabled(level)) {
@@ -48,7 +42,7 @@ function createLibp2pLogger(component: string, bindings?: LoggerBindings): Logge
     logIfEnabled('trace', message, ...args);
   };
 
-  return Object.assign(logFn, {
+  const libp2pLogger = Object.assign(logFn, {
     enabled: log.isLevelEnabled('debug'),
     error(message: string, ...args: unknown[]) {
       // We write error outputs as debug as they are often expected, e.g. connection errors can happen in happy paths
@@ -71,6 +65,9 @@ function createLibp2pLogger(component: string, bindings?: LoggerBindings): Logge
       logIfEnabled('trace', message, ...args);
     },
   });
+  // Redefine as a getter so the flag tracks live level changes made via setLogLevel.
+  Object.defineProperty(libp2pLogger, 'enabled', { get: () => log.isLevelEnabled('debug'), enumerable: true });
+  return libp2pLogger;
 }
 
 function formatArgs(message: string, args: unknown[]) {

--- a/yarn-project/foundation/src/log/log-filters.test.ts
+++ b/yarn-project/foundation/src/log/log-filters.test.ts
@@ -1,4 +1,4 @@
-import { parseLogLevelEnvVar } from './log-filters.js';
+import { formatLogLevelSpec, isValidLogLevelSpec, parseLogLevelEnvVar } from './log-filters.js';
 
 describe('parseEnv', () => {
   const defaultLevel = 'info';
@@ -46,5 +46,29 @@ describe('parseEnv', () => {
     const defaultLevel = 'info';
     const env = 'debug;warn:module1;error:';
     expect(() => parseLogLevelEnvVar(env, defaultLevel)).toThrow('Invalid log filter statement: error');
+  });
+});
+
+describe('formatLogLevelSpec', () => {
+  it('renders a level without filters', () => {
+    expect(formatLogLevelSpec('info', [])).toBe('info');
+  });
+
+  it('round-trips through parseLogLevelEnvVar', () => {
+    const [level, filters] = parseLogLevelEnvVar('debug;warn:module1,module2;error:module3', 'info');
+    const spec = formatLogLevelSpec(level, filters);
+    expect(parseLogLevelEnvVar(spec, 'info')).toEqual([level, filters]);
+  });
+});
+
+describe('isValidLogLevelSpec', () => {
+  it('accepts valid specs', () => {
+    expect(isValidLogLevelSpec('info')).toBe(true);
+    expect(isValidLogLevelSpec('debug;trace:sequencer,p2p;warn:archiver')).toBe(true);
+  });
+
+  it('rejects invalid specs', () => {
+    expect(isValidLogLevelSpec('loud')).toBe(false);
+    expect(isValidLogLevelSpec('debug;trace:')).toBe(false);
   });
 });

--- a/yarn-project/foundation/src/log/log-filters.ts
+++ b/yarn-project/foundation/src/log/log-filters.ts
@@ -46,6 +46,25 @@ export function parseLogLevelEnvVar(
   return [level, parseFilters(logLevelEnvVar.slice(level.length + 1))];
 }
 
+/**
+ * Renders a default level and per-module filters into the `LOG_LEVEL` env var format.
+ * Inverse of {@link parseLogLevelEnvVar}: parsing the returned string yields the same level and filters.
+ */
+export function formatLogLevelSpec(defaultLevel: LogLevel, filters: LogFilters): string {
+  const statements = [...filters].reverse().map(([module, level]) => `${level}:${module}`);
+  return [defaultLevel, ...statements].join(';');
+}
+
+/** Returns whether the given string is a valid log level spec in the `LOG_LEVEL` env var format. */
+export function isValidLogLevelSpec(spec: string): boolean {
+  try {
+    parseLogLevelEnvVar(spec, 'info');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function assertValidLogLevel(level: string): asserts level is LogLevel {
   if (!LogLevels.includes(level as LogLevel)) {
     throw new Error(`Invalid log level: ${level}`);

--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -2,14 +2,17 @@ import { build as buildPrettyStream } from 'pino-pretty';
 import { Writable } from 'stream';
 import { inspect } from 'util';
 
+import { createLibp2pComponentLogger } from './libp2p_logger.js';
 import {
   createLogger,
   getActorColor,
+  getLogLevel,
   logger,
   overwriteLoggingStream,
   pinoPrettyOpts,
   registerLoggingStream,
   resetActorColors,
+  setLogLevel,
 } from './pino-logger.js';
 
 /** Set LOG_TEST_LOGS=1 to print captured log output to console when running tests. */
@@ -367,6 +370,71 @@ describe('pino-logger', () => {
       const entries = capturingStream.getJsonLines();
       expect(entries).toHaveLength(1);
       expect((entries[0] as { msg: string }).msg).toBe('total failure: [unserializable error]');
+    });
+  });
+
+  describe('setLogLevel', () => {
+    let originalSpec: string;
+
+    beforeEach(() => {
+      originalSpec = getLogLevel();
+    });
+
+    afterEach(() => {
+      setLogLevel(originalSpec);
+      // Restore the suite-wide capture level set in beforeAll.
+      logger.level = 'trace';
+    });
+
+    it('updates the level of existing loggers', () => {
+      const testLogger = createLogger('set-level-existing');
+      expect(testLogger.isLevelEnabled('debug')).toBe(true);
+
+      setLogLevel('warn');
+      expect(testLogger.isLevelEnabled('debug')).toBe(false);
+      expect(testLogger.isLevelEnabled('warn')).toBe(true);
+      expect(testLogger.level).toBe('warn');
+
+      capturingStream.clear();
+      testLogger.debug('should not appear');
+      testLogger.warn('should appear');
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ msg: 'should appear' });
+    });
+
+    it('applies per-module filters to existing and new loggers', () => {
+      const moduleA = createLogger('filter-module-a');
+      const moduleB = createLogger('filter-module-b');
+
+      setLogLevel('warn;debug:filter-module-a');
+      expect(moduleA.isLevelEnabled('debug')).toBe(true);
+      expect(moduleB.isLevelEnabled('debug')).toBe(false);
+
+      const newMatching = createLogger('filter-module-a:child');
+      const newOther = createLogger('unrelated-module');
+      expect(newMatching.isLevelEnabled('debug')).toBe(true);
+      expect(newOther.isLevelEnabled('debug')).toBe(false);
+    });
+
+    it('updates the level of libp2p loggers', () => {
+      const libp2pLogger = createLibp2pComponentLogger('libp2p-level-test').forComponent('sub');
+      expect(libp2pLogger.enabled).toBe(true);
+
+      setLogLevel('warn');
+      expect(libp2pLogger.enabled).toBe(false);
+    });
+
+    it('round-trips the spec via getLogLevel', () => {
+      setLogLevel('warn;debug:module1;trace:module2');
+      expect(getLogLevel()).toBe('warn;debug:module1;trace:module2');
+    });
+
+    it('throws on an invalid spec leaving levels untouched', () => {
+      const testLogger = createLogger('invalid-spec-test');
+      expect(() => setLogLevel('loud')).toThrow('Invalid log level: loud');
+      expect(getLogLevel()).toBe(originalSpec);
+      expect(testLogger.isLevelEnabled('trace')).toBe(true);
     });
   });
 

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -10,7 +10,7 @@ import { parseBooleanEnv } from '../config/parse-env.js';
 import { AWSCloudLoggerConfig } from './aws-logger-config.js';
 import { convertBigintsToStrings } from './bigint-utils.js';
 import { GoogleCloudLoggerConfig } from './gcloud-logger-config.js';
-import { getLogLevelFromFilters, parseLogLevelEnvVar } from './log-filters.js';
+import { type LogFilters, formatLogLevelSpec, getLogLevelFromFilters, parseLogLevelEnvVar } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';
 import type { LogData, LogFn } from './log_fn.js';
 
@@ -57,10 +57,7 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
   const actor = resolvedBindings?.actor;
   const instanceId = resolvedBindings?.instanceId;
 
-  const pinoLogger = logger.child(
-    { module, ...(actor && { actor }), ...(instanceId && { instanceId }) },
-    { level: getLogLevelFromFilters(logFilters, module) },
-  );
+  const pinoLogger = createPinoChild(module, { actor, instanceId });
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
@@ -85,7 +82,9 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
     /** Log as trace. Use for when we want to denial-of-service any recipient of the logs. */
     trace: (msg: string, data?: unknown) => logFn('trace', msg, data),
     /** Level of the logger */
-    level: pinoLogger.level as LogLevel,
+    get level() {
+      return pinoLogger.level as LogLevel;
+    },
     /** Whether the given level is enabled for this logger. */
     isLevelEnabled: (level: LogLevel) => isLevelEnabled(pinoLogger, level),
     /** Module name for the logger. */
@@ -128,9 +127,64 @@ function isLevelEnabled(logger: pino.Logger<'verbose', boolean>, level: LogLevel
     : logger.levels.values[level] >= logger.levels.values[logger.level];
 }
 
-// Load log levels from environment variables.
+// Load log levels from environment variables. These exports reflect the startup configuration;
+// the current values (mutable via setLogLevel) are tracked separately below.
 const defaultLogLevel = process.env.NODE_ENV === 'test' ? 'silent' : 'info';
 export const [logLevel, logFilters] = parseLogLevelEnvVar(process.env.LOG_LEVEL, defaultLogLevel);
+
+let currentLogLevel: LogLevel = logLevel;
+let currentLogFilters: LogFilters = logFilters;
+
+// Registry of live pino child loggers so setLogLevel can update their levels in place: pino children do not follow
+// changes to their parent's level after creation. Entries are weakly held since some code paths create short-lived
+// loggers (e.g. per-tx validators); the module name is kept alongside to recompute the per-module filter level.
+type RegisteredPinoChild = { ref: WeakRef<pino.Logger<'verbose'>>; module: string };
+const registeredPinoChildren = new Set<RegisteredPinoChild>();
+const pinoChildFinalizer = new FinalizationRegistry<RegisteredPinoChild>(entry => registeredPinoChildren.delete(entry));
+
+/**
+ * Creates a pino child logger with the current per-module filter level applied, registered so later setLogLevel calls
+ * update it in place. Internal to the logging module: use createLogger unless a raw pino instance is required.
+ */
+export function createPinoChild(module: string, bindings: LoggerBindings = {}): pino.Logger<'verbose'> {
+  const { actor, instanceId } = bindings;
+  const child = logger.child(
+    { module, ...(actor && { actor }), ...(instanceId && { instanceId }) },
+    { level: getLogLevelFromFilters(currentLogFilters, module) },
+  );
+  const entry = { ref: new WeakRef(child), module };
+  registeredPinoChildren.add(entry);
+  pinoChildFinalizer.register(child, entry);
+  return child;
+}
+
+/**
+ * Updates the log level and per-module filters of all loggers created via createLogger, and of loggers created
+ * afterwards. Accepts the same format as the `LOG_LEVEL` env var (e.g. `info` or `debug;trace:sequencer,p2p`).
+ * Only affects the current process: spawned processes such as prover agents keep their own configuration.
+ * @param spec - Log level spec in `LOG_LEVEL` env var format. Throws if invalid, leaving current levels untouched.
+ */
+export function setLogLevel(spec: string): void {
+  const [newLevel, newFilters] = parseLogLevelEnvVar(spec, defaultLogLevel);
+  const previous = getLogLevel();
+  currentLogLevel = newLevel;
+  currentLogFilters = newFilters;
+  logger.level = newLevel;
+  for (const entry of registeredPinoChildren) {
+    const child = entry.ref.deref();
+    if (child === undefined) {
+      registeredPinoChildren.delete(entry);
+    } else {
+      child.level = getLogLevelFromFilters(newFilters, entry.module) ?? newLevel;
+    }
+  }
+  logger.info({ module: 'logger' }, `Updated log level from ${previous} to ${getLogLevel()}`);
+}
+
+/** Returns the current log level and per-module filters in the `LOG_LEVEL` env var format. */
+export function getLogLevel(): string {
+  return formatLogLevelSpec(currentLogLevel, currentLogFilters);
+}
 
 // Define custom logging levels for pino.
 const customLevels = { verbose: 25 };

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -34,11 +34,13 @@ describe('AztecNodeAdminApiSchema', () => {
     expect(config).toMatchObject({
       coinbase: expect.any(EthAddress),
       maxPendingTxCount: expect.any(Number),
+      logLevel: 'info',
     });
   });
 
   it('setConfig', async () => {
-    await context.client.setConfig({ coinbase: EthAddress.random() });
+    await context.client.setConfig({ coinbase: EthAddress.random(), logLevel: 'debug;trace:p2p' });
+    await expect(context.client.setConfig({ logLevel: 'loud' })).rejects.toThrow();
   });
 
   it('startSnapshotUpload', async () => {
@@ -83,8 +85,9 @@ describe('AztecNodeAdminApiSchema', () => {
 
 class MockAztecNodeAdmin implements AztecNodeAdmin {
   constructor() {}
-  setConfig(config: Partial<SequencerConfig & ProverConfig & SlasherConfig>): Promise<void> {
+  setConfig(config: Partial<SequencerConfig & ProverConfig & SlasherConfig & { logLevel: string }>): Promise<void> {
     expect(config.coinbase).toBeInstanceOf(EthAddress);
+    expect(config.logLevel).toBe('debug;trace:p2p');
     return Promise.resolve();
   }
   getSlashOffenses(): Promise<Offense[]> {
@@ -98,9 +101,13 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
     ]);
   }
   getConfig(): Promise<
-    ValidatorClientFullConfig & SequencerConfig & ProverConfig & SlasherConfig & { maxPendingTxCount: number }
+    ValidatorClientFullConfig &
+      SequencerConfig &
+      ProverConfig &
+      SlasherConfig & { maxPendingTxCount: number; logLevel: string }
   > {
     return Promise.resolve({
+      logLevel: 'info',
       realProofs: false,
       proverTestDelayType: 'fixed',
       proverTestDelayMs: 100,

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -1,5 +1,6 @@
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { createSafeJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';
+import { isValidLogLevelSpec } from '@aztec/foundation/log';
 
 import { z } from 'zod';
 
@@ -93,6 +94,12 @@ export type AztecNodeAdminConfig = Omit<ValidatorClientFullConfig, keyof L1Contr
     maxPendingTxCount: number;
     // Keep in sync with P2PConfig.skipIncomingProposals (circular dep prevents Pick<P2PConfig, ...> here)
     skipIncomingProposals?: boolean;
+    /**
+     * Log level spec in `LOG_LEVEL` env var format (e.g. `info` or `debug;trace:sequencer,p2p`). Setting it updates
+     * all loggers in the node process immediately; spawned processes keep their own configuration. Not persisted:
+     * a restart reverts to the `LOG_LEVEL` env var.
+     */
+    logLevel?: string;
   };
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
@@ -105,7 +112,13 @@ export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConf
       skipValidateCheckpointAttestations: true,
     }),
   )
-  .merge(z.object({ maxPendingTxCount: z.number(), skipIncomingProposals: z.boolean().optional() }));
+  .merge(
+    z.object({
+      maxPendingTxCount: z.number(),
+      skipIncomingProposals: z.boolean().optional(),
+      logLevel: z.string().refine(isValidLogLevelSpec, 'Invalid log level spec').optional(),
+    }),
+  );
 
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {
   getConfig: z.function({ input: z.tuple([]), output: AztecNodeAdminConfigSchema }),


### PR DESCRIPTION
Allow changing the log level of a running node at runtime through the node admin API, instead of only via the `LOG_LEVEL` env var at startup.

## Context

Diagnosing issues on a live node often requires more verbose logging, but until now the only way to change the log level was restarting the node with a different `LOG_LEVEL` — losing the state you were trying to observe.

## Approach

- Adds an optional `logLevel` key to `AztecNodeAdminConfig`, so it flows through the existing `aztecAdmin_setConfig` / `aztecAdmin_getConfig` methods with their auth and merge semantics. The value uses the same spec format as the `LOG_LEVEL` env var (e.g. `debug;trace:sequencer,p2p`) and is validated at the RPC boundary.
- Pino child loggers bake in their level at creation and do not follow later changes to the parent, so `@aztec/foundation/log` now keeps a registry of all live child loggers (weakly held via `WeakRef`/`FinalizationRegistry`, since some paths create short-lived per-tx loggers). A new `setLogLevel` re-levels the root and every registered child per the new filters; loggers created afterwards pick up the new levels too. libp2p component loggers go through the same registry.
- No transport changes needed: all transports are already registered at `trace`, so gating happens entirely at the logger.

The change only affects the node's own process — spawned prover agents and external binaries keep their configuration — and is not persisted: a restart reverts to the `LOG_LEVEL` env var.

## API changes

`AztecNodeAdmin.setConfig` accepts an optional `logLevel` string and `getConfig` reports the current spec. `@aztec/foundation/log` exports new `setLogLevel`, `getLogLevel`, `formatLogLevelSpec`, and `isValidLogLevelSpec` functions.

Example:

```bash
curl -s http://node:8880/ -H 'x-api-key: ...' \
  -d '{"jsonrpc":"2.0","id":1,"method":"aztecAdmin_setConfig","params":[{"logLevel":"debug;trace:p2p"}]}'
```