### PR TITLE
chore(ci): fail PRs that modify labs-owned paths

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -24,6 +24,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Labs-owned code has moved to aztec-labs-eng/aztec-node and must not change here.
+  # The path list mirrors what the root Makefile's fast-labs target builds.
+  labs-ownership-guard:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && github.event.pull_request.base.ref == 'next'
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Fail if the PR modifies labs-owned paths
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          labs_paths='^(aztec-up|docs|labs-aztec-toolchain|noir-projects/labs|playground|release-image|spartan|yarn-project)/'
+          offending=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
+            | grep -E "$labs_paths" || true)
+          if [ -n "$offending" ]; then
+            echo "Labs-owned files modified by this PR:"
+            echo "$offending" | sed 's/^/  /'
+            echo "::error::This PR tries to modify labs-owned code"
+            echo "Labs-owned code now lives in https://github.com/aztec-labs-eng/aztec-node - make the change there instead."
+            exit 1
+          fi
+          echo "No labs-owned paths modified."
+
   # The main CI job for Aztec pull requests. It gatekeeps merges to next, intended for the merge queue.
   #
   # This orchestrates AWS EC2 spot instances then remotely runs ./bootstrap.sh


### PR DESCRIPTION
Labs-owned code has moved to [aztec-labs-eng/aztec-node](https://github.com/aztec-labs-eng/aztec-node); changes to it should land there, not here.

This adds a `labs-ownership-guard` job to `ci3.yml` that fails loudly ("This PR tries to modify labs-owned code") when a PR targeting `next` touches any labs-owned path. The path list mirrors what the root Makefile's `fast-labs` target builds:

- `yarn-project/`
- `noir-projects/labs/`
- `aztec-up/`
- `docs/`
- `playground/`
- `release-image/`
- `spartan/`
- `labs-aztec-toolchain/`

Notes:
- Changed files come from the GitHub PR files API, so no checkout or diff-depth handling is needed.
- Scoped to PRs targeting `next` — release/staging branch backports that still carry labs paths are unaffected.
- `labs-aztec-toolchain/` is included as labs-owned; easy to drop from the list if foundation still needs to touch it while the monorepo build depends on it.
- No override label for now; one can be added if a legitimate cross-cutting change comes up.