### PR TITLE
fix(aztec-nr): clarify fragmented balance error

### DIFF
--- a/noir-projects/labs/aztec-nr/balance-set/src/balance_set.nr
+++ b/noir-projects/labs/aztec-nr/balance-set/src/balance_set.nr
@@ -64,7 +64,7 @@ impl BalanceSet<&mut PrivateContext> {
 
         // try_sub may have subtracted more or less than amount. We must ensure that we subtracted at least as much as
         // we needed, and then create a new note for the owner for the change (if any).
-        assert(subtracted >= amount, "Balance too low");
+        assert(subtracted >= amount, "Balance too low or too fragmented: selected notes do not cover the amount");
         self.add(subtracted - amount)
     }
 


### PR DESCRIPTION
Closes #24984.

## Summary

Clarify the `BalanceSet::sub` assertion when the selected notes do not cover the requested amount. The previous `Balance too low` message was also emitted when the total balance was sufficient but too fragmented to fit within the note-read limit.

The new message names both possible causes without hard-coding the current note limit, so it remains accurate if the protocol constant changes. The subtraction behavior is unchanged.

## Testing

Using the repository-built `nargo 1.0.0-beta.26` artifact in the ARM64 `aztecprotocol/build:3.0` container:

- `nargo fmt --check --package balance_set`
- `nargo check --package balance_set --deny-warnings`
- `nargo test --package balance_set` (package currently contains no test functions; compilation succeeds)