### PR TITLE
fix(bb.js): cache compressed browser CRS

### DIFF
--- a/barretenberg/ts/bb.js/src/crs/browser/cached_net_crs.test.ts
+++ b/barretenberg/ts/bb.js/src/crs/browser/cached_net_crs.test.ts
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const cache = new Map<string, Uint8Array>();
+const get = jest.fn((key: string) => Promise.resolve(cache.get(key)));
+const set = jest.fn((key: string, value: Uint8Array) => {
+  cache.set(key, value);
+  return Promise.resolve();
+});
+const downloadG1Data = jest.fn((numPoints: number) => Promise.resolve(new Uint8Array(numPoints * 32).fill(1)));
+const downloadG2Data = jest.fn(() => Promise.resolve(new Uint8Array(128).fill(2)));
+
+jest.unstable_mockModule('idb-keyval', () => ({ get, set }));
+jest.unstable_mockModule('../net_crs.js', () => ({
+  NetCrs: class {
+    constructor(private numPoints: number) {}
+    downloadG1Data() {
+      return downloadG1Data(this.numPoints);
+    }
+    downloadG2Data() {
+      return downloadG2Data();
+    }
+  },
+  NetGrumpkinCrs: class {},
+}));
+
+const { CachedNetCrs } = await import('./cached_net_crs.js');
+
+describe('CachedNetCrs', () => {
+  beforeEach(() => {
+    cache.clear();
+    cache.set('g2Data', new Uint8Array(128));
+    jest.clearAllMocks();
+  });
+
+  it('reuses compressed G1 data downloaded by an earlier initialization', async () => {
+    await CachedNetCrs.new(2);
+    const cached = await CachedNetCrs.new(2);
+
+    expect(downloadG1Data).toHaveBeenCalledTimes(1);
+    expect(cache.get('g1CompressedData')).toEqual(new Uint8Array(64).fill(1));
+    expect(cached.getG1Data()).toEqual(new Uint8Array(64).fill(1));
+  });
+
+  it('uses the prefix of a larger compressed cache entry', async () => {
+    cache.set('g1CompressedData', new Uint8Array(128).fill(3));
+
+    const cached = await CachedNetCrs.new(2);
+
+    expect(downloadG1Data).not.toHaveBeenCalled();
+    expect(cached.getG1Data()).toEqual(new Uint8Array(64).fill(3));
+  });
+});

--- a/barretenberg/ts/bb.js/src/crs/browser/cached_net_crs.ts
+++ b/barretenberg/ts/bb.js/src/crs/browser/cached_net_crs.ts
@@ -32,9 +32,15 @@ export class CachedNetCrs {
       this.g1Data =
         g1Uncompressed.length === uncompressedLength ? g1Uncompressed : g1Uncompressed.slice(0, uncompressedLength);
     } else {
-      // Download compressed from CDN
-      const netCrs = new NetCrs(this.numPoints);
-      this.g1Data = await netCrs.downloadG1Data();
+      const compressedLength = this.numPoints * 32;
+      const g1Compressed = await get('g1CompressedData');
+      if (g1Compressed && g1Compressed.length >= compressedLength) {
+        this.g1Data = g1Compressed.length === compressedLength ? g1Compressed : g1Compressed.slice(0, compressedLength);
+      } else {
+        const netCrs = new NetCrs(this.numPoints);
+        this.g1Data = await netCrs.downloadG1Data();
+        await set('g1CompressedData', this.g1Data);
+      }
     }
 
     if (!g2Data) {


### PR DESCRIPTION
## What

- Persist compressed BN254 G1 data in IndexedDB immediately after download.
- Reuse an exact cache entry or the prefix of a larger entry before fetching.

## Why

`Crs.new(size)` can preload CRS without constructing the WASM prover, but the compressed browser path currently writes nothing to IndexedDB until `srsInitSrs` decompresses it. Navigation or reload after preload therefore repeats the large range request. This makes the existing CRS loader durable while leaving normal `Barretenberg.new({ srsSize })` behavior unchanged.

## Verification

- Added focused cache reuse and larger-prefix tests.
- `cached_net_crs`: 2/2 passing.
- Prettier and ESLint pass on both changed files.

CI is awaiting a maintainer-added `ci-external` or `ci-external-once` label.