### PR TITLE
fix(ci): serialize bb-avm-sim-cross-copy after bb-cdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,10 @@ bb-ts-cross-copy: bb-ts bb-cpp-cross
 bb-avm-sim: ipc-codegen ipc-runtime bb-cpp-native
 	$(call build,$@,barretenberg/ts,build_bb_avm_sim)
 
-bb-avm-sim-cross-copy: bb-avm-sim bb-cpp-cross
+# Ordered after bb-cdb for the same reason bb-cdb is ordered after bb-avm-sim:
+# all three regenerate the same barretenberg/ts workspaces and install into the
+# same node_modules.
+bb-avm-sim-cross-copy: bb-avm-sim bb-cdb bb-cpp-cross
 	$(call build,$@,barretenberg/ts,cross_copy_bb_avm_sim)
 
 # Generated @aztec/cdb server bindings. Ordered after bb-avm-sim rather than run


### PR DESCRIPTION
The v6.0.0-nightly.20260824 release failed in `bb-avm-sim-cross-copy` with:

```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
```

Under `make -j`, `bb-avm-sim-cross-copy` and `bb-cdb` both become runnable the moment `bb-avm-sim` finishes (they launched in the same second in the failing run), and both run `npm_install_deps` into the shared `barretenberg/ts/node_modules`. On a cache hit that extraction rewrites the tree with no locking, so `bb-cdb` transiently clobbered `.yarn-state.yml` right as cross-copy's `yarn workspace @aztec/bb-avm-sim build` read it.

The Makefile already serializes `bb-cdb` after `bb-avm-sim` for exactly this hazard — the cross-copy target was just left out of the chain. This extends it to `bb-avm-sim` → `bb-cdb` → `bb-avm-sim-cross-copy`.

Failing run: http://ci.aztec-labs.com/69fa44227f1a1fea