### PR TITLE
fix: copy foundry binaries instead of moving foundryup symlinks

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -207,12 +207,15 @@ function install_foundry {
   # Install foundry to temp location and move to version directory
   FOUNDRY_DIR="$temp_foundry_dir" timeout 30 "$foundry_home/bin/foundryup" -i "$foundry_version"
 
-  # Move the foundry binaries into internal-bin (off PATH); aztec-forge etc.
+  # Copy the foundry binaries into internal-bin (off PATH); aztec-forge etc.
   # symlinks in version_bin_path expose them under aztec-prefixed names.
+  # foundryup's bin/ entries are symlinks to binaries elsewhere in its install
+  # tree; moving one out would leave a dangling link once the temp directory is
+  # removed.
   for binary in forge cast anvil chisel; do
-    if [ -f "$temp_foundry_dir/bin/$binary" ]; then
-      mv "$temp_foundry_dir/bin/$binary" "$version_internal_bin_path/$binary"
-    fi
+    # Unlink first: cp refuses a destination that is executing or a dangling symlink.
+    rm -f "$version_internal_bin_path/$binary"
+    cp -Lp "$temp_foundry_dir/bin/$binary" "$version_internal_bin_path/$binary"
   done
 
   # Cleanup temp directory

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
     && $FOUNDRY_BIN_DIR/foundryup -i $FOUNDRY_VERSION \
     && mkdir -p /opt/foundry/bin \
     && for t in forge cast anvil chisel; do \
-        mv $FOUNDRY_BIN_DIR/$t /opt/foundry/bin/$t; \
+        cp -Lp $FOUNDRY_BIN_DIR/$t /opt/foundry/bin/$t; \
         strip /opt/foundry/bin/$t; \
     done \
     && rm -rf $FOUNDRY_BIN_DIR

--- a/scripts/setup-container.sh
+++ b/scripts/setup-container.sh
@@ -163,8 +163,10 @@ curl -L https://foundry.paradigm.xyz | bash
 $HOME/.foundry/bin/foundryup -i v1.4.1
 
 mkdir -p /opt/foundry/bin
+# foundryup's bin/ entries are symlinks to binaries elsewhere in its install
+# tree; moving one out would leave a dangling link once $HOME/.foundry is removed.
 for t in forge cast anvil chisel; do
-    mv $HOME/.foundry/bin/$t /opt/foundry/bin/$t
+    cp -Lp $HOME/.foundry/bin/$t /opt/foundry/bin/$t
     strip /opt/foundry/bin/$t
 done
 rm -rf $HOME/.foundry

--- a/spartan/scripts/install_deps.sh
+++ b/spartan/scripts/install_deps.sh
@@ -130,7 +130,7 @@ if ! command -v cast &> /dev/null; then
   curl -L https://foundry.paradigm.xyz | bash
   FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
   "$FOUNDRY_BIN_DIR/foundryup" -i "$FOUNDRY_VERSION"
-  sudo mv "$FOUNDRY_BIN_DIR/cast" /usr/local/bin/cast
+  sudo cp -L "$FOUNDRY_BIN_DIR/cast" /usr/local/bin/cast
   sudo chmod +x /usr/local/bin/cast
 fi
 


### PR DESCRIPTION
## Problem

foundryup changed where it puts binaries. `foundryup -i <version>` now unpacks the real executables into `$FOUNDRY_DIR/versions/foundry-rs/foundry/v<version>/` and leaves `$FOUNDRY_DIR/bin/{forge,cast,anvil,chisel}` as absolute symlinks pointing at them. Nothing in this repo changed to trigger it: the installer is fetched unpinned from `foundry.paradigm.xyz` at runtime, so every toolchain install picked the new layout up at once.

Our install scripts relocated those `bin/` entries with `mv` and then deleted the tree they came from — `rm -rf` on the mktemp directory in the CLI installer, on `$HOME/.foundry` in the container setup script. `mv` moves the symlink itself rather than its target, and the link stores an absolute path, so deleting the source left four dangling links behind. Every existence check that follows dereferences, so they all saw nothing: the CLI installer aborted with `Error: expected bundled binary 'forge' missing from ~/.aztec/versions/<version>/internal-bin`, which is what broke `aztec-up` for users and failed the release acceptance job on both Linux and macOS.

## Fix

Copy instead of move. Copying resolves the link and writes the real executable at the destination, so the result no longer depends on the source tree outliving it — the property the old code silently relied on. `-L` states the dereference explicitly (it is already the default for a plain file copy, but flips to preserving links under `-r`/`-a`), and `-p` keeps the source's mode, since a freshly created `cp` destination otherwise takes its permissions from the caller's umask and can land non-executable for other users.

The CLI installer also unlinks each destination before copying, because `cp` refuses to write through a path that is currently executing or is itself a dangling symlink — the two states a re-install can legitimately encounter, and both of which a rename handled for free.

The same move-then-delete pattern existed in four places: the `aztec-up` CLI installer, the dev container setup script, the CI build image, and the spartan dependency installer. All four are fixed together since they consume the same foundryup output. The spartan one copies without `-p`, as it is the only site crossing a `sudo` boundary and preserving ownership there would leave a user-writable binary in `/usr/local/bin`.