### PR TITLE
feat(fast-inbox): revert on unconsumed inbox bucket overwrite, ring to 4096

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -12,24 +12,24 @@
 
 ## No Validators
 
-| Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
-|----------------------|---------|-----------|---------------|--------------|
-| propose              | 197,433 |   223,617 |           996 |       15,936 |
-| submitEpochRootProof | 980,225 | 1,018,689 |        14,148 |      226,368 |
-| setupEpoch           |  32,042 |   113,837 |             - |            - |
+| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|-----------|-----------|---------------|--------------|
+| propose              |   199,674 |   225,858 |           996 |       15,936 |
+| submitEpochRootProof | 1,000,133 | 1,038,626 |        14,148 |      226,368 |
+| setupEpoch           |    32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,606.9 gas/second
+**Avg Gas Cost per Second**: 3,655.3 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
-| propose              |   325,847 |   353,664 |         4,516 |       72,256 |
-| submitEpochRootProof | 1,561,291 | 1,659,101 |        16,644 |      266,304 |
-| aggregate3           |   374,738 |   388,112 |             - |            - |
+| propose              |   328,086 |   355,904 |         4,516 |       72,256 |
+| submitEpochRootProof | 1,581,182 | 1,679,022 |        16,644 |      266,304 |
+| aggregate3           |   376,978 |   390,352 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,901.1 gas/second
+**Avg Gas Cost per Second**: 5,949.5 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -12,24 +12,24 @@
 
 ## No Validators
 
-| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
-|----------------------|-----------|-----------|---------------|--------------|
-| propose              |   199,674 |   225,858 |           996 |       15,936 |
-| submitEpochRootProof | 1,000,133 | 1,038,626 |        14,148 |      226,368 |
-| setupEpoch           |    32,042 |   113,837 |             - |            - |
+| Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|---------|-----------|---------------|--------------|
+| propose              | 197,740 |   223,924 |           996 |       15,936 |
+| submitEpochRootProof | 980,266 | 1,018,730 |        14,148 |      226,368 |
+| setupEpoch           |  32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,655.3 gas/second
+**Avg Gas Cost per Second**: 3,611.2 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
-| propose              |   328,086 |   355,904 |         4,516 |       72,256 |
-| submitEpochRootProof | 1,581,182 | 1,679,022 |        16,644 |      266,304 |
-| aggregate3           |   376,978 |   390,352 |             - |            - |
+| propose              |   326,159 |   353,977 |         4,516 |       72,256 |
+| submitEpochRootProof | 1,561,332 | 1,659,142 |        16,644 |      266,304 |
+| aggregate3           |   375,051 |   388,425 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,949.5 gas/second
+**Avg Gas Cost per Second**: 5,905.5 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,10 +2,10 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 183789,
-      "mean": 197433,
-      "median": 193178,
-      "max": 223617,
+      "min": 186030,
+      "mean": 199674,
+      "median": 195419,
+      "max": 225858,
       "calldata_size": 996,
       "calldata_gas": 15936
     },
@@ -18,10 +18,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 961606,
-      "mean": 980225,
-      "median": 970304,
-      "max": 1018689,
+      "min": 981430,
+      "mean": 1000133,
+      "median": 990239,
+      "max": 1038626,
       "calldata_size": 14148,
       "calldata_gas": 226368
     }
@@ -29,10 +29,10 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 303507,
-      "mean": 325847,
-      "median": 325300,
-      "max": 353664,
+      "min": 305747,
+      "mean": 328086,
+      "median": 327540,
+      "max": 355904,
       "calldata_size": 4516,
       "calldata_gas": 72256
     },
@@ -45,19 +45,19 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 1449505,
-      "mean": 1561291,
-      "median": 1568279,
-      "max": 1659101,
+      "min": 1469424,
+      "mean": 1581182,
+      "median": 1588142,
+      "max": 1679022,
       "calldata_size": 16644,
       "calldata_gas": 266304
     },
     "aggregate3": {
       "calls": 55,
-      "min": 363620,
-      "mean": 374738,
-      "median": 374423,
-      "max": 388112
+      "min": 365860,
+      "mean": 376978,
+      "median": 376662,
+      "max": 390352
     }
   }
 }

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,10 +2,10 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 186030,
-      "mean": 199674,
-      "median": 195419,
-      "max": 225858,
+      "min": 184096,
+      "mean": 197740,
+      "median": 193486,
+      "max": 223924,
       "calldata_size": 996,
       "calldata_gas": 15936
     },
@@ -18,10 +18,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 981430,
-      "mean": 1000133,
-      "median": 990239,
-      "max": 1038626,
+      "min": 961647,
+      "mean": 980266,
+      "median": 970345,
+      "max": 1018730,
       "calldata_size": 14148,
       "calldata_gas": 226368
     }
@@ -29,10 +29,10 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 305747,
-      "mean": 328086,
-      "median": 327540,
-      "max": 355904,
+      "min": 303820,
+      "mean": 326159,
+      "median": 325613,
+      "max": 353977,
       "calldata_size": 4516,
       "calldata_gas": 72256
     },
@@ -45,19 +45,19 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 1469424,
-      "mean": 1581182,
-      "median": 1588142,
-      "max": 1679022,
+      "min": 1449546,
+      "mean": 1561332,
+      "median": 1568320,
+      "max": 1659142,
       "calldata_size": 16644,
       "calldata_gas": 266304
     },
     "aggregate3": {
       "calls": 55,
-      "min": 365860,
-      "mean": 376978,
-      "median": 376662,
-      "max": 390352
+      "min": 363933,
+      "mean": 375051,
+      "median": 374735,
+      "max": 388425
     }
   }
 }

--- a/l1-contracts/gas_report.json
+++ b/l1-contracts/gas_report.json
@@ -3,36 +3,50 @@
     "contract": "src/core/messagebridge/Inbox.sol:Inbox",
     "deployment": {
       "gas": 0,
-      "size": 6140
+      "size": 6805
     },
     "functions": {
       "getBucket(uint256)": {
-        "calls": 4667,
-        "min": 7414,
-        "mean": 7414,
-        "median": 7414,
-        "max": 7414
+        "calls": 4675,
+        "min": 7436,
+        "mean": 7436,
+        "median": 7436,
+        "max": 7436
       },
       "getCurrentBucketSeq()": {
-        "calls": 4667,
-        "min": 408,
-        "mean": 1407,
-        "median": 408,
-        "max": 2408
+        "calls": 4679,
+        "min": 441,
+        "mean": 1441,
+        "median": 2441,
+        "max": 2441
       },
       "getFeeAssetPortal()": {
-        "calls": 2586,
+        "calls": 2589,
         "min": 212,
         "mean": 212,
         "median": 212,
         "max": 212
       },
+      "getProvenConsumedBucketSeq()": {
+        "calls": 4,
+        "min": 2403,
+        "mean": 2403,
+        "median": 2403,
+        "max": 2403
+      },
+      "getRingHeadroom()": {
+        "calls": 1,
+        "min": 2618,
+        "mean": 2618,
+        "median": 2618,
+        "max": 2618
+      },
       "sendL2Message((bytes32,uint256),bytes32,bytes32)": {
-        "calls": 37328,
+        "calls": 37393,
         "min": 43269,
-        "mean": 46585,
+        "mean": 46588,
         "median": 43269,
-        "max": 102022
+        "max": 102063
       }
     }
   },
@@ -60,7 +74,7 @@
     },
     "functions": {
       "owner()": {
-        "calls": 5172,
+        "calls": 5178,
         "min": 397,
         "mean": 397,
         "median": 397,
@@ -76,21 +90,21 @@
     },
     "functions": {
       "getCanonicalRollup()": {
-        "calls": 1708,
+        "calls": 1754,
         "min": 1073,
         "mean": 4073,
         "median": 4073,
         "max": 7073
       },
       "getRewardDistributor()": {
-        "calls": 2586,
+        "calls": 2589,
         "min": 420,
         "mean": 420,
         "median": 420,
         "max": 420
       },
       "owner()": {
-        "calls": 7758,
+        "calls": 7767,
         "min": 353,
         "mean": 353,
         "median": 353,
@@ -106,7 +120,7 @@
     },
     "functions": {
       "availableTo(address)": {
-        "calls": 854,
+        "calls": 877,
         "min": 20573,
         "mean": 20573,
         "median": 20573,
@@ -118,11 +132,11 @@
     "contract": "test/RollupWithPreheating.sol:RollupWithPreheating",
     "deployment": {
       "gas": 0,
-      "size": 42916
+      "size": 43852
     },
     "functions": {
       "archive()": {
-        "calls": 2333,
+        "calls": 2337,
         "min": 4641,
         "mean": 4641,
         "median": 4641,
@@ -136,28 +150,28 @@
         "max": 2509
       },
       "getCheckpoint(uint256)": {
-        "calls": 864,
-        "min": 27185,
-        "mean": 27185,
-        "median": 27185,
-        "max": 27185
+        "calls": 889,
+        "min": 27343,
+        "mean": 27343,
+        "median": 27343,
+        "max": 27343
       },
       "getCheckpointReward()": {
-        "calls": 2589,
-        "min": 1040,
-        "mean": 1045,
-        "median": 1040,
-        "max": 5540
+        "calls": 2592,
+        "min": 1128,
+        "mean": 1133,
+        "median": 1128,
+        "max": 5628
       },
       "getCollectiveProverRewardsForEpoch(uint256)": {
         "calls": 3,
-        "min": 5859,
-        "mean": 5859,
-        "median": 5859,
-        "max": 5859
+        "min": 5837,
+        "mean": 5837,
+        "median": 5837,
+        "max": 5837
       },
       "getCurrentEpoch()": {
-        "calls": 855,
+        "calls": 878,
         "min": 915,
         "mean": 915,
         "median": 915,
@@ -179,10 +193,10 @@
       },
       "getEpochProofPublicInputs(uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],bytes)": {
         "calls": 4,
-        "min": 18578,
-        "mean": 44270,
-        "median": 46301,
-        "max": 65899
+        "min": 16751,
+        "mean": 45593,
+        "median": 47624,
+        "max": 70374
       },
       "getEthPerFeeAsset()": {
         "calls": 2,
@@ -192,28 +206,28 @@
         "max": 11043
       },
       "getFeeAssetPortal()": {
-        "calls": 4660,
-        "min": 901,
-        "mean": 901,
-        "median": 901,
-        "max": 901
+        "calls": 4666,
+        "min": 566,
+        "mean": 1456,
+        "median": 566,
+        "max": 2566
       },
       "getInbox()": {
-        "calls": 9073,
-        "min": 878,
-        "mean": 878,
-        "median": 878,
-        "max": 878
+        "calls": 9089,
+        "min": 2543,
+        "mean": 2543,
+        "median": 2543,
+        "max": 2543
       },
       "getL1FeesAt(uint256)": {
         "calls": 2,
-        "min": 9130,
-        "mean": 9130,
-        "median": 9130,
-        "max": 9130
+        "min": 9086,
+        "mean": 9086,
+        "median": 9086,
+        "max": 9086
       },
       "getManaMinFeeAt(uint256,bool)": {
-        "calls": 2336,
+        "calls": 2340,
         "min": 27032,
         "mean": 28689,
         "median": 27032,
@@ -221,27 +235,27 @@
       },
       "getManaTarget()": {
         "calls": 1026,
-        "min": 5548,
-        "mean": 5548,
-        "median": 5548,
-        "max": 5548
+        "min": 5526,
+        "mean": 5526,
+        "median": 5526,
+        "max": 5526
       },
       "getOutbox()": {
         "calls": 2,
-        "min": 856,
-        "mean": 856,
-        "median": 856,
-        "max": 856
+        "min": 2521,
+        "mean": 2521,
+        "median": 2521,
+        "max": 2521
       },
       "getPendingCheckpointNumber()": {
-        "calls": 1679,
+        "calls": 1681,
         "min": 2462,
         "mean": 2462,
         "median": 2462,
         "max": 2462
       },
       "getProvenCheckpointNumber()": {
-        "calls": 1684,
+        "calls": 1685,
         "min": 2585,
         "mean": 2585,
         "median": 2585,
@@ -263,45 +277,45 @@
       },
       "getSequencerRewards(address)": {
         "calls": 2,
-        "min": 6025,
-        "mean": 6025,
-        "median": 6025,
-        "max": 6025
+        "min": 5981,
+        "mean": 5981,
+        "median": 5981,
+        "max": 5981
       },
       "getTimestampForSlot(uint256)": {
-        "calls": 2442,
+        "calls": 2448,
         "min": 2808,
         "mean": 2808,
         "median": 2808,
         "max": 2808
       },
       "getVersion()": {
-        "calls": 4919,
-        "min": 852,
-        "mean": 852,
-        "median": 852,
-        "max": 852
+        "calls": 4927,
+        "min": 499,
+        "mean": 1448,
+        "median": 499,
+        "max": 2499
       },
       "owner()": {
-        "calls": 5173,
+        "calls": 5179,
         "min": 533,
         "mean": 533,
         "median": 533,
         "max": 2533
       },
       "propose((bytes32,(int256),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256),uint256),(bytes,bytes),address[],(uint8,bytes32,bytes32),bytes)": {
-        "calls": 2339,
+        "calls": 2343,
         "min": 0,
-        "mean": 264835,
-        "median": 282349,
-        "max": 323459
+        "mean": 267091,
+        "median": 284590,
+        "max": 325700
       },
       "prune()": {
-        "calls": 6,
-        "min": 26711,
-        "mean": 33269,
-        "median": 33704,
-        "max": 38296
+        "calls": 7,
+        "min": 26689,
+        "mean": 33279,
+        "median": 33682,
+        "max": 38274
       },
       "setProvingCostPerMana(uint256)": {
         "calls": 1,
@@ -311,11 +325,11 @@
         "max": 52474
       },
       "submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
-        "calls": 861,
-        "min": 60147,
-        "mean": 366242,
-        "median": 370925,
-        "max": 407523
+        "calls": 884,
+        "min": 58286,
+        "mean": 386502,
+        "median": 391782,
+        "max": 430474
       },
       "updateManaTarget(uint256)": {
         "calls": 512,
@@ -334,7 +348,7 @@
     },
     "functions": {
       "isAllBeneficiariesAllowed()": {
-        "calls": 2586,
+        "calls": 2589,
         "min": 404,
         "mean": 404,
         "median": 404,

--- a/l1-contracts/gas_report.json
+++ b/l1-contracts/gas_report.json
@@ -7,28 +7,28 @@
     },
     "functions": {
       "getBucket(uint256)": {
-        "calls": 4675,
+        "calls": 4679,
         "min": 7436,
         "mean": 7436,
         "median": 7436,
         "max": 7436
       },
       "getCurrentBucketSeq()": {
-        "calls": 4679,
+        "calls": 4684,
         "min": 441,
         "mean": 1441,
         "median": 2441,
         "max": 2441
       },
       "getFeeAssetPortal()": {
-        "calls": 2589,
+        "calls": 2590,
         "min": 212,
         "mean": 212,
         "median": 212,
         "max": 212
       },
       "getProvenConsumedBucketSeq()": {
-        "calls": 4,
+        "calls": 6,
         "min": 2403,
         "mean": 2403,
         "median": 2403,
@@ -42,7 +42,7 @@
         "max": 2618
       },
       "sendL2Message((bytes32,uint256),bytes32,bytes32)": {
-        "calls": 37393,
+        "calls": 37409,
         "min": 43269,
         "mean": 46588,
         "median": 43269,
@@ -74,7 +74,7 @@
     },
     "functions": {
       "owner()": {
-        "calls": 5178,
+        "calls": 5180,
         "min": 397,
         "mean": 397,
         "median": 397,
@@ -90,21 +90,21 @@
     },
     "functions": {
       "getCanonicalRollup()": {
-        "calls": 1754,
+        "calls": 1728,
         "min": 1073,
         "mean": 4073,
         "median": 4073,
         "max": 7073
       },
       "getRewardDistributor()": {
-        "calls": 2589,
+        "calls": 2590,
         "min": 420,
         "mean": 420,
         "median": 420,
         "max": 420
       },
       "owner()": {
-        "calls": 7767,
+        "calls": 7770,
         "min": 353,
         "mean": 353,
         "median": 353,
@@ -120,7 +120,7 @@
     },
     "functions": {
       "availableTo(address)": {
-        "calls": 877,
+        "calls": 864,
         "min": 20573,
         "mean": 20573,
         "median": 20573,
@@ -132,11 +132,11 @@
     "contract": "test/RollupWithPreheating.sol:RollupWithPreheating",
     "deployment": {
       "gas": 0,
-      "size": 43852
+      "size": 43818
     },
     "functions": {
       "archive()": {
-        "calls": 2337,
+        "calls": 2339,
         "min": 4641,
         "mean": 4641,
         "median": 4641,
@@ -150,28 +150,28 @@
         "max": 2509
       },
       "getCheckpoint(uint256)": {
-        "calls": 889,
+        "calls": 876,
         "min": 27343,
         "mean": 27343,
         "median": 27343,
         "max": 27343
       },
       "getCheckpointReward()": {
-        "calls": 2592,
-        "min": 1128,
-        "mean": 1133,
-        "median": 1128,
-        "max": 5628
+        "calls": 2593,
+        "min": 1040,
+        "mean": 1045,
+        "median": 1040,
+        "max": 5540
       },
       "getCollectiveProverRewardsForEpoch(uint256)": {
         "calls": 3,
-        "min": 5837,
-        "mean": 5837,
-        "median": 5837,
-        "max": 5837
+        "min": 5859,
+        "mean": 5859,
+        "median": 5859,
+        "max": 5859
       },
       "getCurrentEpoch()": {
-        "calls": 878,
+        "calls": 865,
         "min": 915,
         "mean": 915,
         "median": 915,
@@ -193,10 +193,10 @@
       },
       "getEpochProofPublicInputs(uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],bytes)": {
         "calls": 4,
-        "min": 16751,
-        "mean": 45593,
-        "median": 47624,
-        "max": 70374
+        "min": 18578,
+        "mean": 44270,
+        "median": 46301,
+        "max": 65899
       },
       "getEthPerFeeAsset()": {
         "calls": 2,
@@ -206,46 +206,46 @@
         "max": 11043
       },
       "getFeeAssetPortal()": {
-        "calls": 4666,
-        "min": 566,
-        "mean": 1456,
-        "median": 566,
-        "max": 2566
+        "calls": 4668,
+        "min": 901,
+        "mean": 901,
+        "median": 901,
+        "max": 901
       },
       "getInbox()": {
-        "calls": 9089,
-        "min": 2543,
-        "mean": 2543,
-        "median": 2543,
-        "max": 2543
+        "calls": 9095,
+        "min": 878,
+        "mean": 878,
+        "median": 878,
+        "max": 878
       },
       "getL1FeesAt(uint256)": {
         "calls": 2,
-        "min": 9086,
-        "mean": 9086,
-        "median": 9086,
-        "max": 9086
+        "min": 9130,
+        "mean": 9130,
+        "median": 9130,
+        "max": 9130
       },
       "getManaMinFeeAt(uint256,bool)": {
-        "calls": 2340,
+        "calls": 2342,
         "min": 27032,
-        "mean": 28689,
+        "mean": 28687,
         "median": 27032,
         "max": 32050
       },
       "getManaTarget()": {
         "calls": 1026,
-        "min": 5526,
-        "mean": 5526,
-        "median": 5526,
-        "max": 5526
+        "min": 5548,
+        "mean": 5548,
+        "median": 5548,
+        "max": 5548
       },
       "getOutbox()": {
         "calls": 2,
-        "min": 2521,
-        "mean": 2521,
-        "median": 2521,
-        "max": 2521
+        "min": 856,
+        "mean": 856,
+        "median": 856,
+        "max": 856
       },
       "getPendingCheckpointNumber()": {
         "calls": 1681,
@@ -255,7 +255,7 @@
         "max": 2462
       },
       "getProvenCheckpointNumber()": {
-        "calls": 1685,
+        "calls": 1686,
         "min": 2585,
         "mean": 2585,
         "median": 2585,
@@ -277,45 +277,45 @@
       },
       "getSequencerRewards(address)": {
         "calls": 2,
-        "min": 5981,
-        "mean": 5981,
-        "median": 5981,
-        "max": 5981
+        "min": 6025,
+        "mean": 6025,
+        "median": 6025,
+        "max": 6025
       },
       "getTimestampForSlot(uint256)": {
-        "calls": 2448,
+        "calls": 2450,
         "min": 2808,
         "mean": 2808,
         "median": 2808,
         "max": 2808
       },
       "getVersion()": {
-        "calls": 4927,
-        "min": 499,
-        "mean": 1448,
-        "median": 499,
-        "max": 2499
+        "calls": 4929,
+        "min": 852,
+        "mean": 852,
+        "median": 852,
+        "max": 852
       },
       "owner()": {
-        "calls": 5179,
+        "calls": 5181,
         "min": 533,
         "mean": 533,
         "median": 533,
         "max": 2533
       },
       "propose((bytes32,(int256),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256),uint256),(bytes,bytes),address[],(uint8,bytes32,bytes32),bytes)": {
-        "calls": 2343,
+        "calls": 2345,
         "min": 0,
-        "mean": 267091,
-        "median": 284590,
-        "max": 325700
+        "mean": 265187,
+        "median": 282657,
+        "max": 323767
       },
       "prune()": {
         "calls": 7,
-        "min": 26689,
-        "mean": 33279,
-        "median": 33682,
-        "max": 38274
+        "min": 26711,
+        "mean": 33301,
+        "median": 33704,
+        "max": 38296
       },
       "setProvingCostPerMana(uint256)": {
         "calls": 1,
@@ -325,11 +325,11 @@
         "max": 52474
       },
       "submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
-        "calls": 884,
-        "min": 58286,
-        "mean": 386502,
-        "median": 391782,
-        "max": 430474
+        "calls": 871,
+        "min": 60147,
+        "mean": 376201,
+        "median": 381032,
+        "max": 417630
       },
       "updateManaTarget(uint256)": {
         "calls": 512,
@@ -348,7 +348,7 @@
     },
     "functions": {
       "isAllBeneficiariesAllowed()": {
-        "calls": 2589,
+        "calls": 2590,
         "min": 404,
         "mean": 404,
         "median": 404,

--- a/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
@@ -77,6 +77,16 @@ interface IInbox {
     returns (bytes32, uint256);
   // docs:end:send_l1_to_l2_message
 
+  /**
+   * @notice Records that the proven chain has consumed all messages up to and including bucket `_bucketSeq`,
+   * unlocking eviction of buckets at or below it when the ring wraps
+   * @dev Only callable by the rollup. Monotonic: a value at or below the current record is a no-op. Reverts with
+   * `Inbox__Unauthorized` if the caller is not the rollup, and with `Inbox__BucketOutOfWindow` if `_bucketSeq` is
+   * ahead of the current bucket.
+   * @param _bucketSeq - The sequence number of the newest bucket the proven chain has consumed
+   */
+  function markProvenConsumed(uint64 _bucketSeq) external;
+
   function getFeeAssetPortal() external view returns (address);
 
   function getState() external view returns (InboxState memory);
@@ -96,4 +106,20 @@ interface IInbox {
    * @return The bucket
    */
   function getBucket(uint256 _seq) external view returns (InboxBucket memory);
+
+  /**
+   * @notice Returns the sequence number of the newest bucket consumed by the proven chain
+   * @return The proven-consumed bucket sequence number
+   */
+  function getProvenConsumedBucketSeq() external view returns (uint64);
+
+  /**
+   * @notice Returns the number of buckets that can still be opened before `sendL2Message` reverts to protect an
+   * unconsumed bucket from being overwritten
+   * @dev Counts bucket openings, not messages: at zero, messages can still be absorbed into the current bucket
+   * until it fills or its L1 block passes. Equals the ring size at genesis and recovers as proofs advance the
+   * proven-consumed record.
+   * @return The number of buckets that can still be opened
+   */
+  function getRingHeadroom() external view returns (uint256);
 }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -27,6 +27,8 @@ library Errors {
   error Inbox__ContentTooLarge(bytes32 content); // 0x47452014
   error Inbox__SecretHashTooLarge(bytes32 secretHash); // 0xecde7e2c
   error Inbox__BucketOutOfWindow(uint256 seq, uint256 current); // 0xfee255b7
+  error Inbox__Unauthorized(); // 0xe5336a6b
+  error Inbox__WouldOverwriteUnconsumedBucket(uint64 evictedBucketSeq); // 0x2eb49c6d
 
   // Outbox
   error Outbox__Unauthorized(); // 0x2c9490c2

--- a/l1-contracts/src/core/libraries/compressed-data/CheckpointLog.sol
+++ b/l1-contracts/src/core/libraries/compressed-data/CheckpointLog.sol
@@ -34,10 +34,13 @@ struct TempCheckpointLog {
   bytes32 attestationsHash;
   bytes32 payloadDigest;
   Slot slotNumber;
-  // Streaming Inbox consumption count: the cumulative Inbox message count consumed as of this checkpoint (the
-  // child's parent-total origin). Declared next to the slot number so the two share one storage slot (4 + 8 of 32
-  // bytes): propose writes and reads that slot for the slot-progression check anyway.
+  // Streaming Inbox consumption counts. `inboxMsgTotal` is the cumulative Inbox message count
+  // consumed as of this checkpoint (the child's parent-total origin), read back by the child's propose;
+  // `inboxConsumedBucket` is the bucket sequence number the header's rolling hash corresponds to, read back on a
+  // proven-tip advance to release the Inbox ring up to it. Declared next to the slot number so the three share one
+  // storage slot (4 + 8 + 8 of 32 bytes): propose writes and reads that slot for the slot-progression check anyway.
   uint64 inboxMsgTotal;
+  uint64 inboxConsumedBucket;
   FeeHeader feeHeader;
   // The consensus Inbox rolling hash the checkpoint header committed to, in a slot of its own: epoch proofs anchor
   // both ends of their consumed chain segment against it.
@@ -52,6 +55,7 @@ struct CompressedTempCheckpointLog {
   bytes32 payloadDigest;
   CompressedSlot slotNumber;
   uint64 inboxMsgTotal;
+  uint64 inboxConsumedBucket;
   CompressedFeeHeader feeHeader;
   bytes32 inboxRollingHash;
 }
@@ -71,6 +75,7 @@ library CompressedTempCheckpointLogLib {
       payloadDigest: _checkpoint.payloadDigest,
       slotNumber: _checkpoint.slotNumber.compress(),
       inboxMsgTotal: _checkpoint.inboxMsgTotal,
+      inboxConsumedBucket: _checkpoint.inboxConsumedBucket,
       feeHeader: _checkpoint.feeHeader.compress(),
       inboxRollingHash: _checkpoint.inboxRollingHash
     });
@@ -89,6 +94,7 @@ library CompressedTempCheckpointLogLib {
       payloadDigest: _compressedCheckpoint.payloadDigest,
       slotNumber: _compressedCheckpoint.slotNumber.decompress(),
       inboxMsgTotal: _compressedCheckpoint.inboxMsgTotal,
+      inboxConsumedBucket: _compressedCheckpoint.inboxConsumedBucket,
       feeHeader: _compressedCheckpoint.feeHeader.decompress(),
       inboxRollingHash: _compressedCheckpoint.inboxRollingHash
     });

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -134,8 +134,13 @@ library EpochProofLib {
       rollupStore.tips = rollupStore.tips.updateProven(_args.end);
 
       // Unlock Inbox ring eviction up to the bucket the newly proven tip consumed; its temp-log record was
-      // validated against the Inbox at propose time.
-      _config.inbox.markProvenConsumed(STFLib.getInboxConsumedBucket(_args.end));
+      // validated against the Inbox at propose time. Equal start and end rolling hashes mean the epoch consumed
+      // no messages, so the bucket is the one already recorded and the cross-contract write is skipped: both
+      // values are trusted here (the start was checked against storage, the end is bound by the proof), and a
+      // rolling hash identifies exactly one bucket since every bucket absorbs at least one message.
+      if (_args.args.previousInboxRollingHash != _args.args.endInboxRollingHash) {
+        _config.inbox.markProvenConsumed(STFLib.getInboxConsumedBucket(_args.end));
+      }
 
       // Handle L2->L1 message processing.
       // The circuit outputs an empty out hash tree root if the epoch contains no messages.

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -133,6 +133,10 @@ library EpochProofLib {
     if (_args.end > rollupStore.tips.getProven()) {
       rollupStore.tips = rollupStore.tips.updateProven(_args.end);
 
+      // Unlock Inbox ring eviction up to the bucket the newly proven tip consumed; its temp-log record was
+      // validated against the Inbox at propose time.
+      _config.inbox.markProvenConsumed(STFLib.getInboxConsumedBucket(_args.end));
+
       // Handle L2->L1 message processing.
       // The circuit outputs an empty out hash tree root if the epoch contains no messages.
       // Since the out hash tree is append-only, with the first checkpoint at index 0, the second at index 1, and so on,

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -321,7 +321,8 @@ library ProposeLib {
         slotNumber: v.header.slotNumber,
         feeHeader: v.feeHeader,
         inboxRollingHash: v.header.inboxRollingHash,
-        inboxMsgTotal: v.consumedInboxMsgTotal.toUint64()
+        inboxMsgTotal: v.consumedInboxMsgTotal.toUint64(),
+        inboxConsumedBucket: _args.bucketHint.toUint64()
       })
     );
 

--- a/l1-contracts/src/core/libraries/rollup/STFLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/STFLib.sol
@@ -130,7 +130,8 @@ library STFLib {
         // Genesis Inbox consumption base case, matching the Inbox's genesis bucket-0 sentinel {0, 0, 0}, so
         // checkpoint 1 validates its consumption against it.
         inboxRollingHash: bytes32(0),
-        inboxMsgTotal: 0
+        inboxMsgTotal: 0,
+        inboxConsumedBucket: 0
       }).compress();
   }
 
@@ -321,6 +322,17 @@ library STFLib {
    */
   function getInboxRollingHash(uint256 _checkpointNumber) internal view returns (bytes32) {
     return getStorageTempCheckpointLog(_checkpointNumber).inboxRollingHash;
+  }
+
+  /**
+   * @notice Retrieves the sequence number of the newest Inbox bucket a checkpoint consumed
+   * @dev Gas-efficient accessor reading only the streaming-inbox bucket sequence. Reverts if the checkpoint is
+   *      stale.
+   * @param _checkpointNumber The checkpoint number to get the consumed bucket for
+   * @return The sequence number of the newest Inbox bucket consumed as of the checkpoint
+   */
+  function getInboxConsumedBucket(uint256 _checkpointNumber) internal view returns (uint64) {
+    return getStorageTempCheckpointLog(_checkpointNumber).inboxConsumedBucket;
   }
 
   /**

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -12,10 +12,13 @@ import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
-// Number of buckets in the rolling-hash ring. Sized far beyond normal consumption lag (the censorship
-// cutoff bounds it to roughly one Aztec slot); outages longer than the ring are handled by overwrite
-// protection on unconsumed buckets, not by growing the ring.
-uint256 constant INBOX_BUCKET_RING_SIZE = 1024;
+// Number of buckets in the rolling-hash ring. Eviction is gated on proven consumption, so the ring has to
+// cover the worst-case proving lag (~2 epochs of one bucket per L1 block, which is what MIN_BUCKET_RING_SIZE
+// below is derived from) with enough margin that adversarial bucket creation cannot cheaply exhaust it: a
+// forced rollover costs ~2.2M gas, so burning this much headroom takes ~250 continuously-owned L1 blocks
+// (~50 min, ~9B gas). Ring size bounds retention only — 2 storage slots per live bucket, no per-send gas — and
+// exhausting it halts sends rather than overwriting unconsumed buckets.
+uint256 constant INBOX_BUCKET_RING_SIZE = 4096;
 
 // Constructor floor for the bucket ring. The ring must cover the longest stall the chain recovers from on
 // its own: the prune-and-repropose window of 64 checkpoints (2 epochs = 384 L1 blocks) at the natural cadence
@@ -42,6 +45,12 @@ contract Inbox is IInbox {
   mapping(uint256 ringIndex => InboxBucket bucket) internal buckets;
 
   uint64 internal currentBucketSeq;
+
+  // Sequence number of the newest bucket consumed by the proven chain, pushed by the Rollup on every proven-tip
+  // advance. Anchoring eviction to proven consumption is prune-immune (the proven tip never rewinds) and
+  // fail-closed (the cache can only lag the truth). Shares a slot with currentBucketSeq so the overwrite check
+  // reads it warm.
+  uint64 internal provenConsumedBucketSeq;
 
   constructor(address _rollup, IERC20 _feeAsset, uint256 _version, uint256 _bucketRingSize) {
     ROLLUP = _rollup;
@@ -108,6 +117,22 @@ contract Inbox is IInbox {
     return (leaf, index);
   }
 
+  /**
+   * @notice Records that the proven chain has consumed all messages up to and including bucket `_bucketSeq`
+   *
+   * @dev Callable only by the ROLLUP. Monotonic: a value at or below the current record is a no-op. Reverts if
+   * `_bucketSeq` is ahead of the current bucket.
+   *
+   * @param _bucketSeq - The sequence number of the newest bucket the proven chain has consumed
+   */
+  function markProvenConsumed(uint64 _bucketSeq) external override(IInbox) {
+    require(msg.sender == ROLLUP, Errors.Inbox__Unauthorized());
+    require(_bucketSeq <= currentBucketSeq, Errors.Inbox__BucketOutOfWindow(_bucketSeq, currentBucketSeq));
+    if (_bucketSeq > provenConsumedBucketSeq) {
+      provenConsumedBucketSeq = _bucketSeq;
+    }
+  }
+
   function getFeeAssetPortal() external view override(IInbox) returns (address) {
     return FEE_ASSET_PORTAL;
   }
@@ -133,14 +158,34 @@ contract Inbox is IInbox {
     return buckets[_seq % BUCKET_RING_SIZE];
   }
 
+  function getProvenConsumedBucketSeq() external view override(IInbox) returns (uint64) {
+    return provenConsumedBucketSeq;
+  }
+
+  /**
+   * @notice Returns the number of buckets that can still be opened before sends revert to protect an unconsumed
+   * bucket from being overwritten
+   *
+   * @dev Counts bucket openings, not messages: at zero, messages can still be absorbed into the current bucket
+   * until it fills or its L1 block passes. Neither subtraction can underflow: `markProvenConsumed` keeps the
+   * record at or below `currentBucketSeq`, and opening bucket n requires `provenConsumedBucketSeq >= n -
+   * BUCKET_RING_SIZE`, so the unconsumed span never exceeds the ring.
+   *
+   * @return The number of buckets that can still be opened
+   */
+  function getRingHeadroom() external view override(IInbox) returns (uint256) {
+    return BUCKET_RING_SIZE - (currentBucketSeq - provenConsumedBucketSeq);
+  }
+
   /**
    * @notice Absorbs a message leaf into the consensus rolling hash and snapshots it into the bucket ring
    *
    * @dev A bucket only holds messages from a single L1 block, up to MAX_MSGS_PER_BUCKET; the first message
    * of a new L1 block — or the message after a full bucket, spilling over within the same block — opens the
    * next bucket, inheriting the rolling hash and cumulative count. Bucket 0 is the pristine genesis base
-   * case and never absorbs. Opening a bucket overwrites the ring entry from BUCKET_RING_SIZE buckets ago;
-   * protection against overwriting unconsumed buckets is not enforced yet.
+   * case and never absorbs. Opening a bucket overwrites the ring entry from BUCKET_RING_SIZE buckets ago; the
+   * open reverts unless the proven chain has consumed that entry, so in-flight messages are never destroyed —
+   * sends halt instead until proving catches up.
    *
    * @param _leaf - The message leaf to absorb
    *
@@ -157,6 +202,12 @@ contract Inbox is IInbox {
     // computed over timestamps, so co-timestamped blocks are indistinguishable to it.
     if (bucketSeq == 0 || bucket.timestamp < block.timestamp || bucket.msgCount == MAX_MSGS_PER_BUCKET) {
       bucketSeq += 1;
+      if (bucketSeq >= BUCKET_RING_SIZE) {
+        uint64 evictedBucketSeq = SafeCast.toUint64(bucketSeq - BUCKET_RING_SIZE);
+        require(
+          provenConsumedBucketSeq >= evictedBucketSeq, Errors.Inbox__WouldOverwriteUnconsumedBucket(evictedBucketSeq)
+        );
+      }
       currentBucketSeq = bucketSeq;
       bucket = InboxBucket({
         rollingHash: bucket.rollingHash,

--- a/l1-contracts/test/InboxBuckets.t.sol
+++ b/l1-contracts/test/InboxBuckets.t.sol
@@ -227,6 +227,8 @@ contract InboxBucketsTest is Test {
       vm.roll(block.number + 1);
       vm.warp(block.timestamp + 12);
       _send(ringInbox, i);
+      // Evicting a ring slot requires the proven chain to have consumed it, so keep consumption trailing the sends.
+      ringInbox.markProvenConsumed(uint64(i - 1));
     }
 
     uint256 current = ringInbox.getCurrentBucketSeq();

--- a/l1-contracts/test/InboxOverwriteProtection.t.sol
+++ b/l1-contracts/test/InboxOverwriteProtection.t.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {TestERC20} from "src/mock/TestERC20.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IInbox, MAX_MSGS_PER_BUCKET} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {MIN_BUCKET_RING_SIZE} from "@aztec/core/messagebridge/Inbox.sol";
+import {InboxHarness} from "./harnesses/InboxHarness.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+
+// Sends a batch of messages in one L1 transaction and lets a revert from any of them bubble out, taking the
+// whole batch with it. Models a portal or bridge that fans several messages out per call.
+contract RevertingBatchSender {
+  function sendMany(IInbox _inbox, uint256 _version, uint256 _count) external {
+    for (uint256 i = 0; i < _count; i++) {
+      _inbox.sendL2Message(
+        DataStructures.L2Actor({actor: bytes32(uint256(0x5000 + i)), version: _version}),
+        bytes32(uint256(0x6000 + i)),
+        bytes32(uint256(0x7000 + i))
+      );
+    }
+  }
+}
+
+// Same batch, but each send is wrapped in try/catch, so a revert on one message does not undo the others.
+contract CatchingBatchSender {
+  function sendMany(IInbox _inbox, uint256 _version, uint256 _count) external returns (uint256 succeeded) {
+    for (uint256 i = 0; i < _count; i++) {
+      try _inbox.sendL2Message(
+        DataStructures.L2Actor({actor: bytes32(uint256(0x5000 + i)), version: _version}),
+        bytes32(uint256(0x6000 + i)),
+        bytes32(uint256(0x7000 + i))
+      ) {
+        succeeded += 1;
+      } catch {}
+    }
+  }
+}
+
+/**
+ * Overwrite protection on the bucket ring: opening a bucket reuses the ring slot of the bucket
+ * BUCKET_RING_SIZE positions back, and the open is refused unless the proven chain has consumed that slot.
+ * The Inbox in these tests is owned by the test contract, which stands in for the rollup and pushes the
+ * proven-consumed record directly.
+ */
+contract InboxOverwriteProtectionTest is Test {
+  uint256 internal constant RING_SIZE = MIN_BUCKET_RING_SIZE;
+
+  InboxHarness internal inbox;
+  uint256 internal version = 0;
+
+  function setUp() public {
+    inbox = _deployInbox(address(this));
+  }
+
+  function _deployInbox(address _rollup) internal returns (InboxHarness) {
+    IERC20 feeAsset = new TestERC20("Fee Asset", "FA", address(this));
+    return new InboxHarness(_rollup, feeAsset, version, RING_SIZE);
+  }
+
+  function _send(InboxHarness _inbox, uint256 _salt) internal returns (bytes32 leaf, uint256 index) {
+    (leaf, index) = _inbox.sendL2Message(
+      DataStructures.L2Actor({actor: bytes32(uint256(0x1000 + _salt)), version: version}),
+      bytes32(uint256(0x2000 + _salt)),
+      bytes32(uint256(0x3000 + _salt))
+    );
+  }
+
+  // Sends without touching the return values: an intercepted revert leaves no returndata to decode, so a send
+  // fronted by `vm.expectRevert` must not be the one that assigns them.
+  function _sendExpectingOverwriteRevert(InboxHarness _inbox, uint256 _salt, uint64 _evicted) internal {
+    DataStructures.L2Actor memory recipient =
+      DataStructures.L2Actor({actor: bytes32(uint256(0x1000 + _salt)), version: version});
+    bytes32 content = bytes32(uint256(0x2000 + _salt));
+    bytes32 secretHash = bytes32(uint256(0x3000 + _salt));
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__WouldOverwriteUnconsumedBucket.selector, _evicted));
+    _inbox.sendL2Message(recipient, content, secretHash);
+  }
+
+  // Opens `_count` buckets, one per L1 block: a strictly larger block timestamp forces the message into a
+  // freshly opened bucket. The last bucket is left open in the current L1 block.
+  function _openBuckets(InboxHarness _inbox, uint256 _count) internal {
+    uint256 startSeq = _inbox.getCurrentBucketSeq();
+    for (uint256 i = 0; i < _count; i++) {
+      vm.roll(block.number + 1);
+      vm.warp(block.timestamp + 12);
+      _send(_inbox, startSeq + i);
+    }
+    assertEq(_inbox.getCurrentBucketSeq(), startSeq + _count, "buckets opened");
+  }
+
+  // Fills the ring exactly once. Opening bucket RING_SIZE evicts the genesis bucket, which is consumed from the
+  // start, so it is allowed; the next bucket opening is the first one that can be refused.
+  function _reachRingWall(InboxHarness _inbox) internal {
+    _openBuckets(_inbox, RING_SIZE);
+    assertEq(_inbox.getRingHeadroom(), 0, "ring wall reached");
+  }
+
+  function _assertBucketEq(IInbox.InboxBucket memory _actual, IInbox.InboxBucket memory _expected, string memory _err)
+    internal
+    pure
+  {
+    assertEq(_actual.rollingHash, _expected.rollingHash, _err);
+    assertEq(_actual.totalMsgCount, _expected.totalMsgCount, _err);
+    assertEq(_actual.timestamp, _expected.timestamp, _err);
+    assertEq(_actual.msgCount, _expected.msgCount, _err);
+  }
+
+  // With nothing proven-consumed, the ring fills to one wrap and then refuses the bucket that would overwrite
+  // bucket 1: its messages are still in flight, so the send is what has to fail, and it must fail without
+  // leaving a trace.
+  function testWrapIntoUnconsumedReverts() public {
+    _reachRingWall(inbox);
+
+    IInbox.InboxBucket memory head = inbox.getBucket(RING_SIZE);
+    IInbox.InboxBucket memory oldest = inbox.getBucket(1);
+    uint64 totalBefore = inbox.getTotalMessagesInserted();
+    assertEq(oldest.totalMsgCount, 1, "bucket 1 holds the first message");
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + 12);
+    _sendExpectingOverwriteRevert(inbox, 999, 1);
+
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE, "current bucket unchanged");
+    assertEq(inbox.getTotalMessagesInserted(), totalBefore, "no message inserted");
+    _assertBucketEq(inbox.getBucket(RING_SIZE), head, "head bucket untouched");
+    _assertBucketEq(inbox.getBucket(1), oldest, "oldest unconsumed bucket untouched");
+    assertEq(inbox.getRingHeadroom(), 0, "still no headroom");
+  }
+
+  // The check compares the proven-consumed record against the exact bucket being evicted: releasing bucket 1
+  // unlocks exactly one more opening, and the one after it stops on bucket 2.
+  function testExactBoundaryUnlocksOneBucket() public {
+    _reachRingWall(inbox);
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + 12);
+    _sendExpectingOverwriteRevert(inbox, 1000, 1);
+
+    inbox.markProvenConsumed(1);
+    _send(inbox, 1000);
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE + 1, "releasing the evicted bucket allowed the opening");
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + 12);
+    _sendExpectingOverwriteRevert(inbox, 1001, 2);
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE + 1, "one release unlocks one opening only");
+  }
+
+  // A halted send is resumable: once the proven chain releases the bucket, the same message goes in, extends the
+  // rolling-hash chain from the ring head, and takes the index the failed attempt left unused.
+  function testResumeAfterProvingPreservesChain() public {
+    _reachRingWall(inbox);
+
+    bytes32 headHash = inbox.getBucket(RING_SIZE).rollingHash;
+    uint64 totalBefore = inbox.getTotalMessagesInserted();
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + 12);
+    _sendExpectingOverwriteRevert(inbox, 1234, 1);
+
+    inbox.markProvenConsumed(1);
+    (bytes32 leaf, uint256 index) = _send(inbox, 1234);
+
+    IInbox.InboxBucket memory opened = inbox.getBucket(RING_SIZE + 1);
+    assertEq(opened.rollingHash, Hash.accumulateInboxRollingHash(headHash, leaf), "chain continues from the ring head");
+    assertEq(index, totalBefore, "the failed send consumed no index");
+    assertEq(opened.totalMsgCount, totalBefore + 1, "cumulative total advanced by one");
+  }
+
+  // Only proven consumption releases a bucket. L1 blocks going by does not, so a chain that stops proving keeps
+  // the Inbox halted for as long as it stalls rather than recovering on its own.
+  function testTimeAloneDoesNotUnlock() public {
+    _reachRingWall(inbox);
+
+    for (uint256 i = 0; i < 5; i++) {
+      vm.roll(block.number + 1);
+      vm.warp(block.timestamp + 12);
+      _sendExpectingOverwriteRevert(inbox, 2000 + i, 1);
+      assertEq(inbox.getCurrentBucketSeq(), RING_SIZE, "still at the ring wall");
+      assertEq(inbox.getRingHeadroom(), 0, "still no headroom");
+    }
+
+    inbox.markProvenConsumed(1);
+    _send(inbox, 2100);
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE + 1, "proven consumption is the only unlock");
+  }
+
+  // The proven-consumed record decides which ring slots may be overwritten, so only the rollup may move it.
+  function testMarkProvenConsumedOnlyRollup() public {
+    InboxHarness rollupOwned = _deployInbox(address(0xbeef));
+    _send(rollupOwned, 0);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__Unauthorized.selector));
+    rollupOwned.markProvenConsumed(1);
+    assertEq(rollupOwned.getProvenConsumedBucketSeq(), 0, "record unchanged");
+
+    vm.prank(address(0xbeef));
+    rollupOwned.markProvenConsumed(1);
+    assertEq(rollupOwned.getProvenConsumedBucketSeq(), 1, "the rollup moved the record");
+  }
+
+  // The record only moves forward: the rollup pushes it on every proven-tip advance, and a shorter epoch proof
+  // or a re-submission must not walk it back and re-lock slots the ring may already have reused.
+  function testMarkProvenConsumedMonotonic() public {
+    _openBuckets(inbox, 6);
+
+    inbox.markProvenConsumed(5);
+    assertEq(inbox.getProvenConsumedBucketSeq(), 5, "record set");
+
+    inbox.markProvenConsumed(3);
+    assertEq(inbox.getProvenConsumedBucketSeq(), 5, "a lower value is a no-op");
+
+    inbox.markProvenConsumed(5);
+    assertEq(inbox.getProvenConsumedBucketSeq(), 5, "an equal value is a no-op");
+
+    inbox.markProvenConsumed(6);
+    assertEq(inbox.getProvenConsumedBucketSeq(), 6, "a higher value advances");
+  }
+
+  // A record ahead of the newest bucket would release ring slots that hold nothing yet, so it is rejected
+  // rather than clamped: it can only come from the rollup and the Inbox disagreeing about the window.
+  function testMarkProvenConsumedAheadOfCurrentReverts() public {
+    _openBuckets(inbox, 3);
+    uint64 current = inbox.getCurrentBucketSeq();
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__BucketOutOfWindow.selector, current + 1, current));
+    inbox.markProvenConsumed(current + 1);
+    assertEq(inbox.getProvenConsumedBucketSeq(), 0, "record unchanged");
+  }
+
+  // Headroom counts bucket openings left, not messages: it drops by one per bucket opened, is untouched by a
+  // message absorbed into the open bucket, and rises by exactly what the proven chain releases.
+  function testRingHeadroomSemantics() public {
+    assertEq(inbox.getRingHeadroom(), RING_SIZE, "genesis: the whole ring is available");
+
+    _send(inbox, 0);
+    assertEq(inbox.getRingHeadroom(), RING_SIZE - 1, "the first message opened one bucket");
+
+    _send(inbox, 1);
+    assertEq(inbox.getRingHeadroom(), RING_SIZE - 1, "absorbing into the open bucket opens nothing");
+
+    _openBuckets(inbox, 3);
+    assertEq(inbox.getRingHeadroom(), RING_SIZE - 4, "one opening each");
+
+    inbox.markProvenConsumed(2);
+    assertEq(inbox.getRingHeadroom(), RING_SIZE - 2, "released two buckets");
+
+    inbox.markProvenConsumed(4);
+    assertEq(inbox.getRingHeadroom(), RING_SIZE, "released the remaining two");
+
+    // At zero headroom the wall applies to bucket openings only: a bucket still open in the current L1 block and
+    // below the per-bucket cap keeps absorbing, so messages are not blocked until a rollover is needed.
+    InboxHarness wallInbox = _deployInbox(address(this));
+    _reachRingWall(wallInbox);
+
+    uint64 totalBefore = wallInbox.getTotalMessagesInserted();
+    _send(wallInbox, 4242);
+    assertEq(wallInbox.getTotalMessagesInserted(), totalBefore + 1, "absorbed at zero headroom");
+    assertEq(wallInbox.getCurrentBucketSeq(), RING_SIZE, "no bucket opened");
+    assertEq(wallInbox.getRingHeadroom(), 0, "headroom still zero");
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + 12);
+    _sendExpectingOverwriteRevert(wallInbox, 4243, 1);
+  }
+
+  // A batching caller that lets a revert bubble loses the whole batch at the ring wall: the head bucket is full,
+  // so the batch's first send has to roll over into a slot that is not released yet.
+  function testRevertingBatchIsAtomic() public {
+    _reachRingWall(inbox);
+    for (uint256 i = 1; i < MAX_MSGS_PER_BUCKET; i++) {
+      _send(inbox, 3000 + i);
+    }
+    assertEq(inbox.getBucket(RING_SIZE).msgCount, MAX_MSGS_PER_BUCKET, "head bucket full");
+
+    uint64 totalBefore = inbox.getTotalMessagesInserted();
+    RevertingBatchSender sender = new RevertingBatchSender();
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__WouldOverwriteUnconsumedBucket.selector, uint64(1)));
+    sender.sendMany(inbox, version, 5);
+
+    assertEq(inbox.getTotalMessagesInserted(), totalBefore, "no message from the batch landed");
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE, "no bucket opened");
+  }
+
+  // A batching caller that swallows the revert keeps the sends that fit before the wall: the head bucket is one
+  // short of the per-bucket cap, so the first send absorbs and only the rollovers after it are refused.
+  function testCatchingBatchKeepsPreWallSends() public {
+    _reachRingWall(inbox);
+    for (uint256 i = 1; i < MAX_MSGS_PER_BUCKET - 1; i++) {
+      _send(inbox, 4000 + i);
+    }
+    assertEq(inbox.getBucket(RING_SIZE).msgCount, MAX_MSGS_PER_BUCKET - 1, "head bucket one short of full");
+
+    uint64 totalBefore = inbox.getTotalMessagesInserted();
+    CatchingBatchSender sender = new CatchingBatchSender();
+
+    uint256 succeeded = sender.sendMany(inbox, version, 5);
+
+    assertEq(succeeded, 1, "only the send that fit before the wall");
+    assertEq(inbox.getTotalMessagesInserted(), totalBefore + 1, "exactly one message landed");
+    assertEq(inbox.getCurrentBucketSeq(), RING_SIZE, "no bucket opened");
+  }
+
+  /// forge-config: default.fuzz.runs = 32
+  // Random interleavings of bucket openings and proven-consumption releases, starting at the ring wall so every
+  // run exercises both sides of the check, against a model of the ring: no sequence of the two overwrites a
+  // bucket the proven chain has not released, and every refused send names the exact bucket it would have
+  // destroyed.
+  function testFuzzNoUnconsumedOverwrite(uint256 _seed) public {
+    _reachRingWall(inbox);
+    uint256 modelCurrent = RING_SIZE;
+
+    uint256 modelProven = 0;
+    uint256 modelTotal = modelCurrent;
+
+    for (uint256 i = 0; i < 16; i++) {
+      uint256 entropy = uint256(keccak256(abi.encodePacked(_seed, i)));
+
+      if (entropy % 3 == 0) {
+        uint256 target = modelProven + ((entropy >> 8) % 8);
+        if (target > modelCurrent) {
+          target = modelCurrent;
+        }
+        inbox.markProvenConsumed(uint64(target));
+        modelProven = target;
+        continue;
+      }
+
+      vm.roll(block.number + 1);
+      vm.warp(block.timestamp + 12);
+
+      uint256 opening = modelCurrent + 1;
+      if (opening < RING_SIZE || modelProven >= opening - RING_SIZE) {
+        _send(inbox, 5000 + i);
+        modelCurrent = opening;
+        modelTotal += 1;
+      } else {
+        _sendExpectingOverwriteRevert(inbox, 5000 + i, uint64(opening - RING_SIZE));
+      }
+    }
+
+    assertEq(inbox.getCurrentBucketSeq(), modelCurrent, "current bucket tracks the model");
+    assertEq(inbox.getProvenConsumedBucketSeq(), modelProven, "proven-consumed record tracks the model");
+    assertEq(inbox.getRingHeadroom(), modelProven + RING_SIZE - modelCurrent, "headroom tracks the model");
+    assertEq(inbox.getTotalMessagesInserted(), modelTotal, "every allowed send landed and no refused one did");
+
+    if (modelProven < modelCurrent) {
+      // Every bucket in this run holds exactly one message, so the oldest unreleased bucket's cumulative total
+      // is its own sequence number: a wrapped-over slot would report someone else's.
+      IInbox.InboxBucket memory oldest = inbox.getBucket(modelProven + 1);
+      assertEq(oldest.msgCount, 1, "oldest unreleased bucket holds its own message");
+      assertEq(oldest.totalMsgCount, modelProven + 1, "oldest unreleased bucket was never overwritten");
+    }
+  }
+}

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -985,6 +985,25 @@ contract RollupTest is RollupBase {
     assertEq(inbox.getRingHeadroom(), INBOX_BUCKET_RING_SIZE, "the whole ring is available again");
   }
 
+  // An epoch that consumed no messages proves with equal start and end rolling hashes, and the proven-tip advance
+  // skips the Inbox write since the record could not move.
+  function testEmptyInboxEpochProofSkipsInboxWrite() public setUpFor("mixed_checkpoint_1") {
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, address(this));
+    uint64 provenConsumedBucket = inbox.getProvenConsumedBucketSeq();
+    assertGt(provenConsumedBucket, 0, "the first epoch consumed L1 to L2 messages");
+
+    // The next epoch's checkpoint references the same bucket, adding no messages.
+    _proposeCheckpointWithoutInboxMessages("mixed_checkpoint_2", EPOCH_DURATION);
+    assertEq(inbox.getCurrentBucketSeq(), provenConsumedBucket, "no new bucket was opened");
+
+    vm.expectCall(address(inbox), abi.encodeWithSelector(inbox.markProvenConsumed.selector), 0);
+    _proveCheckpoints("mixed_checkpoint_", 2, 2, address(this));
+
+    assertEq(rollup.getProvenCheckpointNumber(), 2, "second epoch proven");
+    assertEq(inbox.getProvenConsumedBucketSeq(), provenConsumedBucket, "record unchanged");
+  }
+
   // A prune rewinds the pending chain along with the temp-log records of what it consumed, but the buckets that
   // chain referenced are exactly the ones the replacement chain has to re-consume, so eviction stays locked.
   function testPruneDoesNotAdvanceProvenConsumed() public setUpFor("mixed_checkpoint_1") {

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -9,7 +9,7 @@ import {Math} from "@oz/utils/math/Math.sol";
 import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
 import {Registry} from "@aztec/governance/Registry.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
+import {Inbox, INBOX_BUCKET_RING_SIZE} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {ProposedHeader, ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
@@ -967,6 +967,74 @@ contract RollupTest is RollupBase {
     // Public-input layout: [previousArchive, endArchive, outHash, previousInboxRollingHash, endInboxRollingHash, ...]
     assertEq(publicInputs[4], wrongEnd, "supplied end rolling hash must pass through to the public inputs");
     assertNotEq(publicInputs[4], storedEnd, "wrong end must not be replaced by the stored value");
+  }
+
+  // Ring eviction is gated on proven consumption, not pending consumption: proposing records the consumed bucket
+  // in the checkpoint's temp log only, and the Inbox's record moves once the epoch proof makes that checkpoint the
+  // proven tip.
+  function testProvenConsumedBucketAdvancesOnEpochProof() public setUpFor("mixed_checkpoint_1") {
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+
+    uint64 consumedBucket = inbox.getCurrentBucketSeq();
+    assertGt(consumedBucket, 0, "checkpoint consumed L1 to L2 messages");
+    assertEq(inbox.getProvenConsumedBucketSeq(), 0, "pending consumption does not unlock eviction");
+
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, address(this));
+
+    assertEq(inbox.getProvenConsumedBucketSeq(), consumedBucket, "proven consumption caught up with the proposal");
+    assertEq(inbox.getRingHeadroom(), INBOX_BUCKET_RING_SIZE, "the whole ring is available again");
+  }
+
+  // A prune rewinds the pending chain along with the temp-log records of what it consumed, but the buckets that
+  // chain referenced are exactly the ones the replacement chain has to re-consume, so eviction stays locked.
+  function testPruneDoesNotAdvanceProvenConsumed() public setUpFor("mixed_checkpoint_1") {
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+    assertGt(inbox.getCurrentBucketSeq(), 0, "checkpoint consumed L1 to L2 messages");
+
+    CheckpointLog memory checkpoint = rollup.getCheckpoint(1);
+    Slot prunableAt = checkpoint.slotNumber + Epoch.wrap(2).toSlots();
+    vm.warp(Timestamp.unwrap(rollup.getTimestampForSlot(prunableAt)));
+
+    rollup.prune();
+
+    assertEq(rollup.getPendingCheckpointNumber(), 0, "pending chain pruned");
+    assertEq(inbox.getProvenConsumedBucketSeq(), 0, "a pruned chain's consumption never unlocks eviction");
+  }
+
+  // Re-proposing a checkpoint number after a prune overwrites its temp log wholesale, so proving the replacement
+  // records the replacement's consumption — the pruned proposal's stale record cannot leak into the Inbox.
+  function testProvenConsumedTracksReplacementChainAfterPrune() public setUpFor("mixed_checkpoint_1") {
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+    uint64 staleConsumedBucket = inbox.getCurrentBucketSeq();
+    assertGt(staleConsumedBucket, 0, "the pruned proposal consumed L1 to L2 messages");
+
+    CheckpointLog memory checkpoint = rollup.getCheckpoint(1);
+    Slot prunableAt = checkpoint.slotNumber + Epoch.wrap(2).toSlots();
+    uint256 replacementTimestamp = Timestamp.unwrap(rollup.getTimestampForSlot(prunableAt));
+
+    // An extra message in an L1 block before the replacement's slot opens one more bucket, so the replacement
+    // proposal consumes one bucket further than the pruned one did and the two temp-log records differ.
+    vm.warp(replacementTimestamp - 12);
+    vm.roll(block.number + 1);
+    bytes32[] memory contents = new bytes32[](1);
+    contents[0] = bytes32(uint256(0x1234));
+    _populateInbox(address(this), bytes32(uint256(0x5678)), contents);
+    uint64 replacementConsumedBucket = inbox.getCurrentBucketSeq();
+    assertEq(replacementConsumedBucket, staleConsumedBucket + 1, "the extra message opened one more bucket");
+
+    // The propose call prunes the stale chain and installs checkpoint 1 from the empty fixture, referencing the
+    // newest bucket.
+    _proposeCheckpoint("empty_checkpoint_1", Slot.unwrap(prunableAt));
+    assertEq(rollup.getPendingCheckpointNumber(), 1, "replacement chain proposed");
+
+    _proveCheckpoints("empty_checkpoint_", 1, 1, address(this));
+
+    assertEq(rollup.getProvenCheckpointNumber(), 1, "replacement checkpoint proven");
+    assertEq(
+      inbox.getProvenConsumedBucketSeq(),
+      replacementConsumedBucket,
+      "the replacement's consumption is recorded, not the pruned proposal's"
+    );
   }
 
   function _submitEpochProof(

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -135,12 +135,30 @@ contract RollupBase is DecoderBase {
     _proposeCheckpoint(_name, _slotNumber, _manaUsed, _extraBlobHashes, "");
   }
 
+  // Proposes without seeding the fixture's L1 to L2 messages, so the checkpoint references the bucket its parent
+  // already consumed and adds no messages.
+  function _proposeCheckpointWithoutInboxMessages(string memory _name, uint256 _slotNumber) internal {
+    bytes32[] memory extraBlobHashes = new bytes32[](0);
+    _proposeCheckpoint(_name, _slotNumber, 0, extraBlobHashes, "", false);
+  }
+
   function _proposeCheckpoint(
     string memory _name,
     uint256 _slotNumber,
     uint256 _manaUsed,
     bytes32[] memory _extraBlobHashes,
     bytes memory _revertMsg
+  ) private {
+    _proposeCheckpoint(_name, _slotNumber, _manaUsed, _extraBlobHashes, _revertMsg, true);
+  }
+
+  function _proposeCheckpoint(
+    string memory _name,
+    uint256 _slotNumber,
+    uint256 _manaUsed,
+    bytes32[] memory _extraBlobHashes,
+    bytes memory _revertMsg,
+    bool _seedInbox
   ) private {
     DecoderBase.Full memory full = load(_name);
     bytes memory blobCommitments = full.checkpoint.blobCommitments;
@@ -167,7 +185,9 @@ contract RollupBase is DecoderBase {
 
     // Seed the Inbox before jumping to the checkpoint's L1 block: propose rejects a bucket that is still
     // accumulating, and a bucket keeps accumulating for the whole L1 block that opened it.
-    _populateInbox(full.populate.sender, full.populate.recipient, full.populate.l1ToL2Content);
+    if (_seedInbox) {
+      _populateInbox(full.populate.sender, full.populate.recipient, full.populate.l1ToL2Content);
+    }
 
     // We jump to the time of the block, always past the L1 block the messages above landed in.
     vm.warp(max(block.timestamp + 1, Timestamp.unwrap(full.checkpoint.header.timestamp)));

--- a/l1-contracts/test/fees/MinimalFeeModel.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.sol
@@ -130,7 +130,8 @@ contract MinimalFeeModel {
         slotNumber: Slot.wrap(0),
         feeHeader: FeeLib.computeFeeHeader(checkpointNumber, _oracleInput.feeAssetPriceModifier, _manaUsed, 0, 0),
         inboxRollingHash: bytes32(0),
-        inboxMsgTotal: 0
+        inboxMsgTotal: 0,
+        inboxConsumedBucket: 0
       })
     );
     //    FeeLib.writeFeeHeader(++populatedThrough, _oracleInput.feeAssetPriceModifier, _manaUsed, 0, 0);

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -25,7 +25,7 @@ library TestConstants {
   uint256 internal constant AZTEC_TARGET_COMMITTEE_SIZE = 48;
   uint256 internal constant AZTEC_LAG_IN_EPOCHS_FOR_VALIDATOR_SET = 3;
   uint256 internal constant AZTEC_LAG_IN_EPOCHS_FOR_RANDAO = 2;
-  uint256 internal constant AZTEC_INBOX_BUCKET_RING_SIZE = 1024;
+  uint256 internal constant AZTEC_INBOX_BUCKET_RING_SIZE = 4096;
   uint256 internal constant AZTEC_PROOF_SUBMISSION_EPOCHS = 1;
   uint256 internal constant AZTEC_SLASHING_QUORUM = 17; // Must be > ROUND_SIZE / 2 (ROUND_SIZE derived from
     // EPOCH_DURATION)

--- a/l1-contracts/test/rollup/InboxRingDeadlock.t.sol
+++ b/l1-contracts/test/rollup/InboxRingDeadlock.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {TestERC20} from "src/mock/TestERC20.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IInbox, MAX_MSGS_PER_BUCKET} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {Slot} from "@aztec/core/libraries/TimeLib.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {MIN_BUCKET_RING_SIZE} from "@aztec/core/messagebridge/Inbox.sol";
+import {InboxHarness} from "../harnesses/InboxHarness.sol";
+import {ProposeLibHarness} from "./ProposeInboxConsumption.t.sol";
+
+/**
+ * Why unconsumed buckets must never be evicted, from the consumption side. A proposal can only reference a
+ * retained bucket, and it can only consume MAX_L1_TO_L2_MSGS_PER_CHECKPOINT messages beyond its parent's
+ * cumulative total. Those two limits close against each other: heavy traffic pushes the buckets whose delta from
+ * a stalled parent total still fits the cap out of the retained window, and every bucket left in the window is
+ * too far ahead of that parent to be consumed in one checkpoint. A chain whose consumption stalled at genesis
+ * then has no proposable cursor at all, and no amount of waiting produces one — the gap is permanent.
+ *
+ * With overwrite protection the gap cannot open: sends halt at the ring wall instead of evicting, so the oldest
+ * unconsumed bucket stays retained and stays proposable.
+ */
+contract InboxRingDeadlockTest is Test {
+  uint256 internal constant GENESIS_TIME = 100_000;
+  uint256 internal constant SLOT_DURATION = 72;
+  uint256 internal constant EPOCH_DURATION = 32;
+  uint256 internal constant ETHEREUM_SLOT_DURATION = 12;
+
+  // Far enough into the chain that the traffic below, which spans more L1 blocks than the ring holds buckets,
+  // lands entirely before the proposal's timestamp.
+  Slot internal constant SLOT = Slot.wrap(100);
+
+  ProposeLibHarness internal rollup;
+  InboxHarness internal inbox;
+  uint256 internal version = 0;
+
+  function setUp() public {
+    vm.warp(GENESIS_TIME);
+    rollup = new ProposeLibHarness(GENESIS_TIME, SLOT_DURATION, EPOCH_DURATION, ETHEREUM_SLOT_DURATION);
+
+    IERC20 feeAsset = new TestERC20("Fee Asset", "FA", address(this));
+    inbox = new InboxHarness(address(rollup), feeAsset, version, MIN_BUCKET_RING_SIZE);
+  }
+
+  // Sends one message, discarding the return values so a send fronted by `vm.expectRevert` has no returndata to
+  // decode.
+  function _send(uint256 _salt) internal {
+    inbox.sendL2Message(
+      DataStructures.L2Actor({actor: bytes32(uint256(0x1000 + _salt)), version: version}),
+      bytes32(uint256(0x2000 + _salt)),
+      bytes32(uint256(0x3000 + _salt))
+    );
+  }
+
+  // Drives the Inbox to `_targetBucketSeq` with the traffic shape that opens the cap-versus-window gap: four L1
+  // blocks of MAX_MSGS_PER_BUCKET messages each, taking the cumulative total to exactly the per-checkpoint cap, a
+  // fifth block with the one message past it, then one message per L1 block.
+  function _driveTraffic(uint256 _targetBucketSeq, bool _forceProvenConsumed) internal {
+    for (uint256 l1Block = 1; inbox.getCurrentBucketSeq() < _targetBucketSeq; l1Block++) {
+      vm.roll(block.number + 1);
+      vm.warp(block.timestamp + ETHEREUM_SLOT_DURATION);
+
+      uint256 count = l1Block <= 4 ? MAX_MSGS_PER_BUCKET : 1;
+      for (uint256 i = 0; i < count; i++) {
+        _send(inbox.getTotalMessagesInserted());
+      }
+
+      if (_forceProvenConsumed) {
+        uint64 newest = inbox.getCurrentBucketSeq();
+        vm.prank(address(rollup));
+        inbox.markProvenConsumed(newest);
+      }
+    }
+  }
+
+  // Standing in for a contract without overwrite protection: the proven-consumed record is pushed to the newest
+  // bucket every L1 block, ahead of any real consumption, so eviction is never refused and the retained window
+  // slides off the only buckets a chain stalled at genesis could have proposed. The same sequence doubles as the
+  // damage model for an unfaithful rollup: a consumption claim not backed by a proven checkpoint reproduces the
+  // unprotected behavior exactly.
+  function testDeadlockWithoutProtection() public {
+    _driveTraffic(MIN_BUCKET_RING_SIZE + 4, true);
+
+    uint256 current = inbox.getCurrentBucketSeq();
+    assertEq(current, MIN_BUCKET_RING_SIZE + 4, "traffic drove the ring past one wrap");
+
+    vm.warp(GENESIS_TIME + Slot.unwrap(SLOT) * SLOT_DURATION);
+
+    // The buckets whose delta from a parent total of zero fits the cap are buckets 0 through 4, and every one of
+    // them has been overwritten.
+    for (uint256 hint = 0; hint <= 4; hint++) {
+      vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__BucketOutOfWindow.selector, hint, current));
+      rollup.validateInboxConsumption(inbox, bytes32(0), hint, SLOT, 0);
+    }
+
+    // Every bucket still retained is too far ahead of that parent total to be consumed in one checkpoint, so no
+    // reference at all is proposable and the pending chain can never cross the gap.
+    for (uint256 hint = 5; hint <= current; hint++) {
+      IInbox.InboxBucket memory bucket = inbox.getBucket(hint);
+      assertGt(bucket.totalMsgCount, Constants.MAX_L1_TO_L2_MSGS_PER_CHECKPOINT, "bucket past the cap");
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Rollup__TooManyInboxMessagesConsumed.selector, bucket.totalMsgCount)
+      );
+      rollup.validateInboxConsumption(inbox, bucket.rollingHash, hint, SLOT, 0);
+    }
+  }
+
+  // The same traffic against the real contract: nothing is proven-consumed, so sends halt at the ring wall with
+  // the whole window intact.
+  function testProtectionPreventsDeadlock() public {
+    _driveTraffic(MIN_BUCKET_RING_SIZE, false);
+    assertEq(inbox.getCurrentBucketSeq(), MIN_BUCKET_RING_SIZE, "ring filled to one wrap");
+
+    vm.roll(block.number + 1);
+    vm.warp(block.timestamp + ETHEREUM_SLOT_DURATION);
+    vm.expectRevert(abi.encodeWithSelector(Errors.Inbox__WouldOverwriteUnconsumedBucket.selector, uint64(1)));
+    _send(0xdead);
+
+    assertEq(inbox.getCurrentBucketSeq(), MIN_BUCKET_RING_SIZE, "sends halted rather than evicting bucket 1");
+
+    vm.warp(GENESIS_TIME + Slot.unwrap(SLOT) * SLOT_DURATION);
+
+    // One bucket's delta is at most MAX_MSGS_PER_BUCKET and so always fits the per-checkpoint cap, so the oldest
+    // unconsumed bucket - which the protection never lets be evicted - always yields a proposable cursor. Here
+    // that cursor is bucket 4, whose delta is exactly the cap; the next bucket exceeds it, so mandatory
+    // consumption passes via the cap escape.
+    IInbox.InboxBucket memory cursor = inbox.getBucket(4);
+    uint256 consumed = rollup.validateInboxConsumption(inbox, cursor.rollingHash, 4, SLOT, 0);
+    assertEq(consumed, Constants.MAX_L1_TO_L2_MSGS_PER_CHECKPOINT, "a proposable cursor survives");
+  }
+}

--- a/l1-contracts/test/rollup/ProposeInboxConsumption.t.sol
+++ b/l1-contracts/test/rollup/ProposeInboxConsumption.t.sol
@@ -214,6 +214,9 @@ contract ProposeInboxConsumptionTest is Test {
         bytes32(uint256(0x2000 + i)),
         bytes32(uint256(0x3000 + i))
       );
+      // Evicting a ring slot requires the proven chain to have consumed it, so keep consumption trailing the sends.
+      vm.prank(address(rollup));
+      ringInbox.markProvenConsumed(uint64(i - 1));
     }
 
     // No proposal-time warp: the loop above has already moved past SLOT's proposal time, and the revert fires

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -120,7 +120,8 @@ contract RewardLibWrapper {
         slotNumber: Slot.wrap(0),
         feeHeader: _feeHeader,
         inboxRollingHash: bytes32(0),
-        inboxMsgTotal: 0
+        inboxMsgTotal: 0,
+        inboxConsumedBucket: 0
       })
     );
   }

--- a/yarn-project/ethereum/src/contracts/chain_state_override.ts
+++ b/yarn-project/ethereum/src/contracts/chain_state_override.ts
@@ -22,6 +22,7 @@ export type PendingCheckpointOverrideState = {
   payloadDigest?: Buffer32;
   slotNumber?: SlotNumber;
   inboxMsgTotal?: bigint;
+  inboxConsumedBucket?: bigint;
 };
 
 export type ChainTipsOverride = {
@@ -96,8 +97,8 @@ export class SimulationOverridesBuilder {
    * Overrides one or more `tempCheckpointLogs` cell fields for the configured pending checkpoint.
    * Any subset can be provided. The translator (`makeTempCheckpointLogOverride`) emits a stateDiff
    * entry per storage word touched, so fields in untouched words stay at their on-chain values;
-   * `slotNumber` and `inboxMsgTotal` share a word, so setting either zeroes the other unless it is
-   * supplied too.
+   * `slotNumber`, `inboxMsgTotal` and `inboxConsumedBucket` share a word, so setting any of them
+   * zeroes the others unless they are supplied too.
    *
    * `slotNumber` is required for `STFLib.canPruneAtTime`: when the simulation overrides `pending`
    * to a checkpoint that has no on-chain `tempCheckpointLogs` entry yet, the missing slotNumber falls
@@ -110,6 +111,7 @@ export class SimulationOverridesBuilder {
     payloadDigest?: Buffer32;
     slotNumber?: SlotNumber;
     inboxMsgTotal?: bigint;
+    inboxConsumedBucket?: bigint;
   }): this {
     this.assertPendingCheckpointNumber();
     this.pendingCheckpointState = { ...(this.pendingCheckpointState ?? {}), ...fields };
@@ -178,6 +180,7 @@ export async function buildSimulationOverridesStateOverride(
           payloadDigest: plan.pendingCheckpointState.payloadDigest,
           slotNumber: plan.pendingCheckpointState.slotNumber,
           inboxMsgTotal: plan.pendingCheckpointState.inboxMsgTotal,
+          inboxConsumedBucket: plan.pendingCheckpointState.inboxConsumedBucket,
           feeHeader: plan.pendingCheckpointState.feeHeader,
         }),
       ),

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -487,16 +487,17 @@ describe('Rollup', () => {
       );
     });
 
-    it('packs the inbox consumption count into the slot-number word', async () => {
+    it('packs the inbox consumption counts into the slot-number word', async () => {
       const checkpointNumber = CheckpointNumber(13);
       const override = await rollup.makeTempCheckpointLogOverride(checkpointNumber, {
         slotNumber: SlotNumber(7),
         inboxMsgTotal: 300n,
+        inboxConsumedBucket: 5n,
       });
       const { map, slotFor } = getDiffMap(checkpointNumber, override);
       expect(override[0].stateDiff).toHaveLength(1);
       expect(map.get(await slotFor(TempCheckpointLogField.SlotNumber))).toBe(
-        `0x${(7n | (300n << 32n)).toString(16).padStart(64, '0')}`.toLowerCase(),
+        `0x${(7n | (300n << 32n) | (5n << 96n)).toString(16).padStart(64, '0')}`.toLowerCase(),
       );
     });
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -160,8 +160,8 @@ export enum TempCheckpointLogField {
  * arbitrary `bytes32` value rather than a BN254 scalar. `slotNumber` carries the uint32 portion
  * of the on-chain `CompressedSlot`.
  *
- * `slotNumber` and `inboxMsgTotal` share a single storage word, so supplying either rewrites both;
- * the one left out lands as zero.
+ * `slotNumber`, `inboxMsgTotal` and `inboxConsumedBucket` share a single storage word, so supplying
+ * any one of them rewrites all three; the ones left out land as zero.
  */
 export type TempCheckpointLogOverrideFields = {
   headerHash?: Fr;
@@ -170,6 +170,8 @@ export type TempCheckpointLogOverrideFields = {
   slotNumber?: SlotNumber;
   /** Cumulative Inbox message count consumed as of this checkpoint. */
   inboxMsgTotal?: bigint;
+  /** Inbox bucket sequence number this checkpoint's rolling hash corresponds to. */
+  inboxConsumedBucket?: bigint;
   feeHeader?: FeeHeader;
 };
 
@@ -988,16 +990,21 @@ export class RollupContract {
         value: fields.payloadDigest.toString() as `0x${string}`,
       });
     }
-    if (fields.slotNumber !== undefined || fields.inboxMsgTotal !== undefined) {
-      // The L1 struct packs the slot number and the inbox consumption count into one word, so this
-      // diff always writes both. Widths are enforced here because the L1 writers cast through
+    if (
+      fields.slotNumber !== undefined ||
+      fields.inboxMsgTotal !== undefined ||
+      fields.inboxConsumedBucket !== undefined
+    ) {
+      // The L1 struct packs the slot number and the two inbox consumption counts into one word, so this
+      // diff always writes all three. Widths are enforced here because the L1 writers cast through
       // SafeCast and revert on overflow; a malformed override must surface rather than silently truncate
       // into a neighbouring field.
       const slotNumber = requireUintFits(BigInt(fields.slotNumber ?? 0), 32, 'slotNumber');
       const inboxMsgTotal = requireUintFits(fields.inboxMsgTotal ?? 0n, 64, 'inboxMsgTotal');
+      const inboxConsumedBucket = requireUintFits(fields.inboxConsumedBucket ?? 0n, 64, 'inboxConsumedBucket');
       stateDiff.push({
         slot: slotAt(TempCheckpointLogField.SlotNumber),
-        value: word(slotNumber | (inboxMsgTotal << 32n)),
+        value: word(slotNumber | (inboxMsgTotal << 32n) | (inboxConsumedBucket << 96n)),
       });
     }
     if (fields.feeHeader) {

--- a/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
+++ b/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
@@ -85,7 +85,9 @@ export async function buildCheckpointSimulationOverridesPlan(
     // `Rollup__TooManyInboxMessagesConsumed`. The remaining fields (headerHash, outHash,
     // payloadDigest) are not read by `canProposeAt` / `validateCheckpointHeader`, but mirroring the full
     // cell keeps the simulation byte-faithful with what the actual `propose()` send will observe,
-    // which is a defense against future reads taking dependencies on them.
+    // which is a defense against future reads taking dependencies on them. The parent's
+    // `inboxConsumedBucket` shares the word and stays zero: only a proven-tip advance reads it back, and a
+    // propose simulation never reaches that path.
     builder.withPendingTempCheckpointLogFields({
       headerHash: header.hash(),
       outHash: checkpointOutHash,


### PR DESCRIPTION
Stacked on #25314.

Opening an Inbox bucket whose ring slot still holds an entry the proven chain has not consumed now reverts, and the bucket ring grows from 1024 to 4096.

## Context

The Inbox stores rolling-hash buckets in a ring keyed `bucketSeq % BUCKET_RING_SIZE`, so opening bucket `n` overwrote bucket `n − RING_SIZE` unconditionally. If L2 stops consuming for long enough (outage, or a spam burst forcing rollover buckets), unconsumed buckets get destroyed — and worse: every retained bucket ends up past the 1024-message checkpoint cap while every under-cap bucket has fallen out of the `getBucket` window, so no bucket is proposable and the pending chain deadlocks permanently (pinned by `InboxRingDeadlock.t.sol`).

## Approach

- **Revert-on-overwrite anchored to proven consumption.** `_absorbIntoBucket` refuses to open bucket `n ≥ RING_SIZE` unless `provenConsumedBucketSeq ≥ n − RING_SIZE`, reverting `Inbox__WouldOverwriteUnconsumedBucket(evicted)`. Sends halt instead of destroying messages, and resume automatically once proving catches up. Anchoring to the *proven* tip is prune-immune (it never rewinds) and fail-closed (the record can only lag). No governance escape hatch — an override would recreate the deadlock.
- **`Inbox.markProvenConsumed(uint64)`**: ROLLUP-only, monotonic, never ahead of `currentBucketSeq`; packed in the same slot as `currentBucketSeq` so the check reads warm. Called from the single proven-tip-advancing branch of `submitEpochRootProof`, through the `RollupConfig` that #25314 threads down as a memory struct.
- **`TempCheckpointLog.inboxConsumedBucket` re-added** (it was dropped as write-only before this consumer existed). Propose stores the validated `bucketHint`; the proven-tip advance reads it back. It packs into the existing `slotNumber`/`inboxMsgTotal` word (offsets 0/4/12, struct still 8 words), so no extra storage. The TS state-override encoder follows.
- **Ring size 1024 → 4096.** The size is an economics knob, not a safety property: a forced rollover bucket costs ~2.2M gas, so exhausting headroom takes ~62 continuously-owned full 36M-gas L1 blocks (~12.5 min, ~2.2B gas) at 1024 vs ~250 blocks (~50 min, ~9B gas) at 4096, and the honest proving-lag floor (~385 buckets) gets ~10× margin. Ring size bounds retention only: +192 KiB of eventual state, no per-send or deploy gas. `MIN_BUCKET_RING_SIZE` stays 512.
- **Observability**: `getRingHeadroom()` (bucket openings left before sends halt) and `getProvenConsumedBucketSeq()`.

Gas: bucket-opening `sendL2Message` +41 pre-wrap, +393 on a wrapping open (steady state); absorb-into-open-bucket unchanged. `submitEpochRootProof` pays the Inbox write (a cold call plus the Inbox's own SLOAD/SSTORE — the Inbox address itself is an immutable after #25314) only when the epoch consumed messages — equal start/end rolling hashes skip it — so the message-less benchmark scenario reads 980,225 → 980,266, while the message-consuming `gas_report` fixtures pay it in full (mean 366,242 → 376,201). `propose` 197,433 → 197,740 (the temp-log read on proof is warm; the consumed-bucket field shares the slot-number word).

## How to review

Source: `Inbox.sol` (check + `markProvenConsumed` + headroom), `EpochProofLib.sol` (call site), `CheckpointLog.sol` / `ProposeLib.sol` / `STFLib.sol` (temp-log field). Tests: `InboxOverwriteProtection.t.sol` (wrap/boundary/resume/authority/headroom/batch atomicity/fuzz from the ring wall) and `rollup/InboxRingDeadlock.t.sol` (unprotected ring deadlocks, protected one keeps a proposable cursor); `Rollup.t.sol` covers proven-tip advance, pending-only propose not unlocking, and prune/re-propose/prove. Full forge suite 912/0/3.

Unrelated, pre-existing: `./bootstrap.sh gas_report` exits non-zero because three `RollupTest` cases fail only under `FORGE_GAS_REPORT=true`; identical on the base.

Fixes A-1390
Fixes A-1757
