### PR TITLE
chore: labs submodule with a foundation patch series

### DIFF
--- a/.claude/tests/agents_symlink_test
+++ b/.claude/tests/agents_symlink_test
@@ -9,6 +9,9 @@
 # etc.), and letting a subdir shadow root skills/ is the designed behavior.
 # Agents, by contrast, are universal and need to be visible from every cwd.
 #
+# The labs/ submodule is a separate repository with its own root .claude/ layout and is
+# skipped, like noir/noir-repo.
+#
 # Runs from any cwd.
 
 set -uo pipefail
@@ -44,6 +47,7 @@ while IFS= read -r dir; do
   case "$dir" in
     "$ROOT"/node_modules/*|*"/node_modules/"*) continue;;
     "$ROOT"/noir/noir-repo/*) continue;;
+    "$ROOT"/labs/*) continue;;
   esac
   agents="$dir/agents"
   if [[ ! -e "$agents" ]]; then
@@ -66,7 +70,7 @@ while IFS= read -r dir; do
     continue
   fi
   pass "${dir#$ROOT/}/agents"
-done < <(find "$ROOT" -type d -name .claude -not -path "$ROOT/noir/*" -not -path "$ROOT/**/node_modules/*")
+done < <(find "$ROOT" -type d -name .claude -not -path "$ROOT/noir/*" -not -path "$ROOT/labs/*" -not -path "$ROOT/**/node_modules/*")
 
 echo
 if (( FAIL == 0 )); then
@@ -80,6 +84,7 @@ while IFS= read -r dir; do
   case "$dir" in
     "$ROOT"/node_modules/*|*"/node_modules/"*) continue;;
     "$ROOT"/noir/noir-repo/*) continue;;
+    "$ROOT"/labs/*) continue;;
   esac
   codex="$(dirname "$dir")/.codex"
   rel=${codex#$ROOT/}
@@ -119,7 +124,7 @@ while IFS= read -r dir; do
     fi
   done < <(find "$codex" -mindepth 1 -maxdepth 1)
   (( codex_ok )) && pass "$rel"
-done < <(find "$ROOT" -type d -name .claude -not -path "$ROOT/noir/*" -not -path "$ROOT/**/node_modules/*")
+done < <(find "$ROOT" -type d -name .claude -not -path "$ROOT/noir/*" -not -path "$ROOT/labs/*" -not -path "$ROOT/**/node_modules/*")
 
 echo
 if (( FAIL == 0 )); then

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,9 @@
 	path = noir/noir-repo
 	url = https://github.com/noir-lang/noir.git
 	shallow = true
+[submodule "labs"]
+	path = labs
+	url = https://github.com/aztec-labs-eng/aztec-node.git
+	branch = main
+	shallow = true
+	update = none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,25 @@ Follow Conventional Commits: `fix:`, `feat:`, `chore:`, `refactor:`, `docs:`, `t
 </commits_and_prs>
 
 <git_staging>
-When staging files, prefer `git add -u` or name specific files rather than `git add -A` or `git add .`. The aggregate flags will pick up unrelated untracked working directories (e.g. personal scratch projects at the repo root) and quietly stage them. Subagents must always name specific files in `git add` — never `-u`, `-A`, or `.` — because they lack the main conversation's context for judging which changes belong to the current task.
-</git_staging>
+When staging files, prefer `git add -u` or name specific files rather than `git add -A` or `git add .`. The aggregate flags will pick up unrelated untracked working directories (e.g. personal scratch projects at the repo root) and quietly stage them. `git add -u` and `git commit -a` also stage the `labs` gitlink whenever the patch series is applied (`git status` shows ` M labs`); unstage it with `git restore --staged labs` (see `<labs_submodule_patches>
+`labs/` (the aztec-node submodule) carries the foundation's patch series from `labs-patches/*.patch`, applied with `git am` by `labs-patches/bootstrap.sh apply` (run by the root bootstrap, the git hooks and `make labs-patched`), so `labs/` HEAD normally sits ahead of the recorded gitlink. Never `git add labs` by hand — that records a patch commit that does not exist upstream; move the pin with `labs-patches/bootstrap.sh bump <ref>`. To change a patch, commit inside `labs/` on top of the applied series and run `labs-patches/bootstrap.sh export`, then commit the regenerated `.patch` files. To send a patch to aztec-node, `labs-patches/bootstrap.sh upstream <n>` prepares the branch and prints the push/PR commands. See `labs-patches/README.md`.
 
-<lockfile_discipline>
-Never bulk-update lockfiles (`Cargo.lock`, `yarn.lock`). Use targeted updates only: `cargo update --precise <version> --package <name>` for Rust, and `yarn up <package>@<version>` in the relevant workspace for TypeScript. Bulk updates drag in unrelated transitive changes that make review impossible and frequently break reproducibility.
-</lockfile_discipline>
+The tooling, all in `labs-patches/bootstrap.sh` (foundation-owned; only the `.patch` contents ever go upstream):
+
+| Command | What it does |
+|---|---|
+| `apply` | Checks out the gitlink (`update = none` submodule) and `git am`s the series with a fixed committer identity, so the applied SHAs are identical everywhere. Idempotent; refuses to drop `labs/` commits that are not in the series (`LABS_PATCHES_FORCE=1` overrides); stashes uncommitted edits. |
+| `export` | Regenerates `*.patch` from the commits above the gitlink, skipping marker commits. Run it after committing inside `labs/`. |
+| `check` | Applies the committed series to the gitlink in a temporary worktree; CI runs it. |
+| `bump <ref>` | Fetches an aztec-node ref, stages the new gitlink and re-applies; refuses on unexported work. |
+| `upstream <n> [branch]` | Creates `fnd/<patch-slug>` in `labs/`'s repository with only patch `n` applied under your own identity, and prints the push and `gh pr create` commands. |
+| `status` | Base, checkout, series, whether it is applied, and unexported commits. |
+| `commit-use-local` | Commits the build's manifest rewrite as the marker commit (`labs-patches: use-local rewrite (never exported)`), staging only `package.json`/`yarn.lock`/`Nargo.toml`/`fnd-hashes`. Called by the build, not by hand. |
+| `check_staged` | The `pre-commit` hook: rejects a staged gitlink that is a series or marker commit. |
+| `test`, `test_cmds` | Run / list the tooling's tests: `tests/lifecycle_test` (a sandbox fixture exercising every command) and `check`; `make labs-patches-tests` runs them in CI. |
+
+State lives in `.git/modules/labs/labs-patches.state` (stamp of base + series, applied commits); the series is recognised by `git patch-id`, so a lost state file is re-derived from content. `post-merge`/`post-checkout` hooks re-run `apply` only when the gitlink or the series changed.
+</labs_submodule_patches>
 
 <standard_contract_repin>
 Never run `noir-projects/labs/noir-contracts/bootstrap.sh pin-standard-build` on your own initiative. The pin exists so ordinary source or bytecode changes do NOT move the standard contracts' canonical addresses, and CI does not fail when the bytecode drifts. A re-pin is a deliberate redeploy decision for a human to make: if a change seems to need one, leave the pin, rebuild against it, and ask. See the comment on `pin-standard-build` for why re-pinning is breaking.
@@ -108,7 +121,7 @@ Never append `; echo "EXIT: $?"` or similar exit-code suffixes to any command. T
 </bash_hygiene>
 
 <do_not_edit>
-Never edit vendored submodules (all paths listed in `.gitmodules`) or files that contain a `DO NOT EDIT` / `generated` header. Edit the upstream source or the generator input and regenerate. CI enforces this — hand edits to generated files will be overwritten or rejected.
+Never edit vendored submodules (all paths listed in `.gitmodules`, except `labs/`, whose edits go through the patch series described in `<labs_submodule_patches>`) or files that contain a `DO NOT EDIT` / `generated` header. Edit the upstream source or the generator input and regenerate. CI enforces this — hand edits to generated files will be overwritten or rejected.
 </do_not_edit>
 
 <editorial_test>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,11 @@
 /build-images/ @charlielye
 /ci3/ @charlielye
 
+# The labs submodule, its patch series and the scripts that drive it
+/labs @ludamad
+/labs-patches/ @ludamad
+/scripts/labs_* @ludamad
+
 # Notify the Noir team of divergences to upstream
 /noir/noir-repo.patch @TomAFrench
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,11 +5,6 @@
 /build-images/ @charlielye
 /ci3/ @charlielye
 
-# The labs submodule, its patch series and the scripts that drive it
-/labs @ludamad
-/labs-patches/ @ludamad
-/scripts/labs_* @ludamad
-
 # Notify the Noir team of divergences to upstream
 /noir/noir-repo.patch @TomAFrench
 

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ fast-foundation: barretenberg bb-tests \
 		fnd-release-tests \
 		ipc-runtime ipc-codegen-tests \
 		constants-codegen constants-codegen-tests \
+		labs-patches-tests \
 		claude-tests
 
 fast-labs: yarn-project yarn-project-tests \
@@ -398,6 +399,21 @@ wsdb: ipc-codegen ipc-runtime bb-cpp-native
 .PHONY: claude-tests
 claude-tests:
 	$(call test,$@,.claude)
+
+#==============================================================================
+# Labs (aztec-node, checked out as the labs/ submodule)
+#==============================================================================
+
+# Checks the submodule out at its gitlink with the labs-patches series applied (no-op when
+# already there).
+.PHONY: labs-patched labs-patches-tests
+labs-patched:
+	$(call run_command,$@,$(ROOT),./labs-patches/bootstrap.sh apply)
+
+# The tooling's sandbox lifecycle test and the series check. After labs-patched: check must
+# not race apply on the same submodule.
+labs-patches-tests: labs-patched
+	$(call test,$@,labs-patches)
 
 #==============================================================================
 # Labs Aztec Toolchain

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -313,15 +313,37 @@ set -euo pipefail
 ./noir-projects/labs/precommit.sh
 ./yarn-project/constants/precommit.sh
 ./docs/examples/ts/precommit.sh
+# Hooks are shared by every branch of this clone; older branches have no labs-patches.
+if [ -x ./labs-patches/bootstrap.sh ]; then ./labs-patches/bootstrap.sh check_staged; fi
 EOF
   chmod +x $hooks_dir/pre-commit
 
+  # A failed patch apply must not fail the git operation that triggered it: report and let
+  # the developer re-run apply.
   cat <<EOF >$hooks_dir/post-merge
 #!/usr/bin/env bash
 set -euo pipefail
 git submodule update --init --recursive
+if [ -x ./labs-patches/bootstrap.sh ]; then
+  ./labs-patches/bootstrap.sh apply || echo "labs-patches: apply failed; run ./labs-patches/bootstrap.sh apply" >&2
+fi
 EOF
   chmod +x $hooks_dir/post-merge
+
+  # Third argument is 1 for a branch checkout, 0 for a file checkout. Only a checkout that
+  # moved the labs gitlink or the series needs a re-apply; rebases and bisects step through
+  # many commits and would otherwise reset labs/ at each one.
+  cat <<EOF >$hooks_dir/post-checkout
+#!/usr/bin/env bash
+set -euo pipefail
+[ "\$3" = 1 ] || exit 0
+[ -x ./labs-patches/bootstrap.sh ] || exit 0
+if git rev-parse -q --verify "\$1^{commit}" >/dev/null && git diff --quiet "\$1" "\$2" -- labs labs-patches; then
+  exit 0
+fi
+./labs-patches/bootstrap.sh apply || echo "labs-patches: apply failed; run ./labs-patches/bootstrap.sh apply" >&2
+EOF
+  chmod +x $hooks_dir/post-checkout
 }
 
 function pull_submodules {
@@ -332,6 +354,8 @@ function pull_submodules {
     rm -rf noir/noir-repo
   fi
   denoise "git submodule update --init --recursive --depth 1 --jobs 8 && git -C noir/noir-repo fetch --tags &>/dev/null"
+  # labs is update=none: only labs-patches checks it out, so the patch series always sits on top.
+  denoise "./labs-patches/bootstrap.sh apply"
 }
 
 function start_txes {

--- a/l1-contracts/foundry.lock
+++ b/l1-contracts/foundry.lock
@@ -11,6 +11,9 @@
   "../bb-pilcom/powdr": {
     "rev": "c3006c11819d9b53fb183c9c12a10b83481bb631"
   },
+  "../labs": {
+    "rev": "9b17bcbe514ea1f5f72f8d7cc43e25ec2d10e466"
+  },
   "../noir/noir-repo": {
     "rev": "1fce7cac1b6b116b6af98875580b5122eb9fe051"
   },

--- a/labs-patches/README.md
+++ b/labs-patches/README.md
@@ -1,0 +1,44 @@
+# labs-patches
+
+The foundation's changes to the labs repo, kept as a `git format-patch` series that is applied on top of the `labs/` submodule (aztec-node) every time it is checked out.
+
+`labs/` is pinned to an upstream commit (the gitlink). `bootstrap.sh apply` checks that commit out and runs `git am` over `*.patch` in name order, so the patches become real commits in the submodule and `labs/` HEAD sits ahead of the gitlink. It is idempotent and runs from the root `bootstrap.sh`, the `post-merge`/`post-checkout` hooks and `make labs-patched`, so a fresh clone, a pull and a build all land on the same patched tree. It never discards commits that are not in the series: if the base or the series changed under work in progress, it stops and asks you to `export` or drop it (`LABS_PATCHES_FORCE=1` discards them — a last resort, not a workflow). Uncommitted tracked edits in `labs/` are stashed (`git -C labs stash list`) rather than reset when a re-apply is needed.
+
+The build then rewrites the labs manifests to consume this checkout (`labs-aztec-toolchain use-local`), records the content hashes of the foundation components labs consumes in `labs-aztec-toolchain/fnd-hashes` (`scripts/labs_fnd_hashes.sh`), refreshes the lockfiles, and commits the result on top as a marker commit (`bootstrap.sh commit-use-local`), so the labs tree is clean for ci3's cache hashing and yarn's immutable installs, and every labs cache key follows the foundation tree. Marker commits are recognised by their subject and are never exported.
+
+The `pre-commit` hook refuses a commit that stages a patched or marker commit as the gitlink: those commits exist only in your clone.
+
+## Changing the series
+
+```
+./labs-patches/bootstrap.sh apply     # patched labs/ checkout
+cd labs && <edit> && git commit       # one commit per patch, on top of what is there
+cd .. && ./labs-patches/bootstrap.sh export
+git add labs-patches && git commit    # the regenerated .patch files
+```
+
+To edit or drop an existing patch, `git rebase -i <gitlink>` inside `labs/` and export again. `status` lists commits in `labs/` that are not exported yet.
+
+## Moving the pin
+
+```
+./labs-patches/bootstrap.sh bump main        # or a tag / sha
+```
+
+fetches the ref, stages the new gitlink and re-applies the series. If a patch no longer applies, `apply` aborts the `am`; fix it up in `labs/` (`git am --3way` conflicts, or cherry-pick the remaining patches by hand), then `export`. Patches that upstream has absorbed simply disappear from the export.
+
+`bootstrap.sh check` verifies the series applies to the gitlink in a temporary worktree without touching `labs/`. CI runs it, together with `tests/lifecycle_test` (the tooling exercised end to end against a sandbox fixture: apply, export, marker commits, bumps, the guards), through `make labs-patches-tests`; `bootstrap.sh test` runs both locally.
+
+## Upstreaming a patch
+
+The series is a queue of things to upstream: every patch here is carried through every bump, so open the aztec-node PR early and let the patch drop out when it lands.
+
+```
+./labs-patches/bootstrap.sh upstream 3            # or a .patch path; optional branch name as 2nd arg
+git -C labs push origin fnd/<patch-slug>
+gh pr create --repo aztec-labs-eng/aztec-node --head fnd/<patch-slug> --base main --fill
+```
+
+`upstream` creates the branch in `labs/`'s repository at the recorded base with only that patch applied, under your own git identity (the series itself is applied with a fixed one). It pushes nothing; the two commands it prints do. When the PR is merged, `bump` past it and the patch disappears from the next `export`.
+
+Everything else in this directory (`bootstrap.sh`, the tests, `test_cmd_skip`) is the foundation's own tooling and never goes upstream.

--- a/labs-patches/bootstrap.sh
+++ b/labs-patches/bootstrap.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# The foundation's patch series on top of the labs submodule (labs/, aztec-node).
+#
+# labs/ is checked out at the commit recorded in this repo's index (the gitlink) and every
+# labs-patches/*.patch is applied on top with git am, in name order. The applied series is a
+# chain of real commits in the submodule, so labs/ HEAD normally sits ahead of the gitlink;
+# the gitlink must stay an upstream commit (see check_staged and bump).
+#
+# The build then commits the use-local rewrite (manifests pointing at this checkout) on top
+# as a marker commit, so the labs tree stays clean for ci3's cache hashing. Marker commits
+# are recognised by their subject and are never exported.
+#
+# Usage: ./bootstrap.sh <command>
+#   apply             (default) check out the gitlink and apply the series; no-op if applied
+#   export            regenerate the series from the commits in labs/ on top of the gitlink
+#   check             verify the series applies cleanly to the gitlink, without touching labs/
+#   bump <ref>        move the gitlink to an upstream ref (branch, tag or sha) and re-apply
+#   commit-use-local  commit the worktree's use-local rewrite as the marker commit
+#   check_staged      fail if a patched or marker commit is staged as the gitlink (pre-commit)
+#   status            show the base, the series, and what sits on top in labs/
+#   test              run the sandbox lifecycle test (tests/lifecycle_test) and check
+#
+# Deliberately dependency-free (no ci3): it runs from git hooks and from fresh clones.
+set -euo pipefail
+
+fnd_root=$(cd "$(dirname "$0")/.." && pwd)
+patch_dir=$fnd_root/labs-patches
+labs=$fnd_root/labs
+MARKER_SUBJECT="labs-patches: use-local rewrite (never exported)"
+# Fixed committer identity and author dates keep the applied SHAs identical on every machine,
+# and mark every commit this script makes so check_staged can tell them from upstream ones.
+# The caller's own identity is kept for commits meant to leave this clone (upstream).
+caller_committer_name=${GIT_COMMITTER_NAME:-}
+caller_committer_email=${GIT_COMMITTER_EMAIL:-}
+export GIT_COMMITTER_NAME=labs-patches
+export GIT_COMMITTER_EMAIL=labs-patches@localhost
+git_labs() { git -C "$labs" -c commit.gpgsign=false "$@"; }
+
+function die { echo "labs-patches: $*" >&2; exit 1; }
+
+# The commit the series applies to: the staged gitlink, which is HEAD's unless a bump is in
+# progress. Falls back to HEAD's during a gitlink merge conflict, when the index has no
+# stage-0 entry.
+function base_sha {
+  git -C "$fnd_root" rev-parse -q --verify :labs 2>/dev/null || git -C "$fnd_root" rev-parse HEAD:labs
+}
+
+# Series files, sorted; empty when there are none.
+function patches {
+  local f
+  for f in "$patch_dir"/*.patch; do [ -e "$f" ] && echo "$f"; done
+  return 0
+}
+
+# Identity of (base, series); a change in either means labs/ has to be rebuilt.
+function stamp {
+  { echo "base=$(base_sha)"; patches | xargs -r cat; } | git hash-object --stdin
+}
+
+function state_file { echo "$(git -C "$labs" rev-parse --absolute-git-dir)/labs-patches.state"; }
+function initialized { [ -e "$labs/.git" ]; }
+function recorded_head { sed -n 's/^head=//p' "$(state_file)" 2>/dev/null || true; }
+
+# Applied when the recorded patched head for the current (base, series) is HEAD or an
+# ancestor of it: commits on top (the use-local marker, work in progress) do not count.
+function is_applied {
+  initialized || return 1
+  local f; f=$(state_file)
+  [ -f "$f" ] || return 1
+  [ "$(sed -n 's/^stamp=//p' "$f")" = "$(stamp)" ] || return 1
+  local head; head=$(recorded_head)
+  [ -n "$head" ] && git_labs merge-base --is-ancestor "$head" HEAD 2>/dev/null
+}
+
+# Besides the stamp and the patched head, the state records the commits the series produced,
+# so that after the series is edited the previous versions of its commits are still known
+# and not mistaken for work in progress.
+# Only commits that match a series patch are recorded as applied: anything else above the
+# base is work in progress and must keep being reported as such.
+function write_state {
+  local base ids c applied=""
+  base=$(base_sha); ids=$(series_patch_ids)
+  for c in $(series_commits "$base"); do
+    echo "$ids" | grep -qx "$(commit_patch_id "$c")" && applied+="$c "
+  done
+  {
+    echo "stamp=$(stamp)"
+    echo "head=$(git_labs rev-parse HEAD)"
+    echo "applied=$applied"
+  } > "$(state_file)"
+}
+function recorded_applied { sed -n 's/^applied=//p' "$(state_file)" 2>/dev/null | tr ' ' '\n' || true; }
+
+# Patch ids of the series, so applied commits can be recognised by content rather than by
+# the recorded state: a cold checkout, a lost state file or a bump all still tell the series
+# apart from work in progress.
+function series_patch_ids {
+  local p
+  for p in $(patches); do
+    grep -q '^diff --git' "$p" || continue
+    git patch-id --stable < "$p" | cut -d' ' -f1
+  done
+}
+
+function commit_patch_id {
+  git_labs diff-tree -p --format= "$1" | git patch-id --stable | cut -d' ' -f1
+}
+
+# Every non-marker commit above $1, oldest first: what export turns into the series.
+function series_commits {
+  git_labs rev-list --reverse --invert-grep --grep="^$MARKER_SUBJECT\$" "$1..HEAD" 2>/dev/null || true
+}
+
+# Commits in labs/ above $1 that are neither part of the series nor marker commits: work
+# that would be lost by a reset.
+function unexported_commits {
+  local ids known c id
+  ids=$(series_patch_ids)
+  known=$(recorded_applied)
+  for c in $(series_commits "$1"); do
+    echo "$known" | grep -qx "$c" && continue
+    id=$(commit_patch_id "$c")
+    [ -n "$id" ] && echo "$ids" | grep -qx "$id" && continue
+    echo "$c"
+  done
+}
+
+# True when every patch of the series is present above the base, by patch id.
+function series_present {
+  local base=$1 ids id
+  ids=$(git_labs rev-list "$base..HEAD" 2>/dev/null | while read -r c; do commit_patch_id "$c"; done)
+  for id in $(series_patch_ids); do echo "$ids" | grep -qx "$id" || return 1; done
+}
+
+function am_series {
+  local dir=$1 p
+  for p in $(patches); do
+    # git am chokes on a patch without a diff (an empty commit); nothing to apply anyway.
+    grep -q '^diff --git' "$p" || continue
+    if ! git -C "$dir" -c commit.gpgsign=false am -q --3way --committer-date-is-author-date "$p"; then
+      git -C "$dir" am --abort || true
+      die "$(basename "$p") does not apply to $(base_sha); rebase the series (apply, fix up the commits in labs/, export)"
+    fi
+  done
+}
+
+# Uncommitted tracked edits in labs/ are usually the use-local rewrite (redone by the build),
+# but could be someone's work in progress: park them in the submodule's stash rather than
+# discarding, so `git -C labs stash pop` gets them back.
+function stash_worktree {
+  [ -n "$(git_labs status --porcelain --untracked-files=no)" ] || return 0
+  echo "labs-patches: stashing local modifications in labs/ (git -C labs stash list; the use-local rewrite is redone by the build)." >&2
+  git_labs -c user.name=labs-patches -c user.email=labs-patches@localhost stash push -q -m "labs-patches: worktree before re-apply"
+}
+
+function checkout_base {
+  # Fetches the commit if this clone does not have it yet.
+  git -C "$fnd_root" submodule update --init --checkout --depth 1 -- labs
+  local base; base=$(base_sha)
+  [ "$(git_labs rev-parse HEAD)" = "$base" ] || die "labs/ is at $(git_labs rev-parse HEAD), expected $base"
+}
+
+function apply {
+  local base; base=$(base_sha)
+  if ! initialized; then
+    echo "Checking out labs submodule at $base..."
+    checkout_base
+  elif is_applied; then
+    echo "labs patches already applied ($(patches | wc -l | tr -d ' ') on $base)."
+    return
+  elif git_labs merge-base --is-ancestor "$base" HEAD 2>/dev/null && series_present "$base"; then
+    # Same base, same series by content (e.g. the state file is gone): nothing to redo.
+    write_state
+    echo "labs patches already applied ($(patches | wc -l | tr -d ' ') on $base)."
+    return
+  else
+    # The series or the base changed: labs/ is rebuilt from the base. Refuse to discard commits
+    # that are not part of the current series, unless told to.
+    # Work in progress sits above the checkout we are leaving: the merge base with the new
+    # base, or the previously committed gitlink when a shallow fetch left no common history.
+    local from old
+    if ! from=$(git_labs merge-base "$base" HEAD 2>/dev/null); then
+      old=$(git -C "$fnd_root" rev-parse -q --verify HEAD:labs 2>/dev/null || true)
+      if [ -n "$old" ] && git_labs merge-base --is-ancestor "$old" HEAD 2>/dev/null; then from=$old; else from=$base; fi
+    fi
+    local lost; lost=$(unexported_commits "$from")
+    if [ -n "$lost" ] && [ "${LABS_PATCHES_FORCE:-0}" != 1 ]; then
+      echo "labs-patches: labs/ has commits that are not in the series and would be lost:" >&2
+      git_labs log --oneline --no-walk $lost >&2
+      die "export them (./labs-patches/bootstrap.sh export) or drop them (git -C labs reset --hard <commit>). LABS_PATCHES_FORCE=1 discards them; last resort."
+    fi
+    stash_worktree
+    checkout_base
+  fi
+  am_series "$labs"
+  write_state
+  echo "Applied $(patches | wc -l | tr -d ' ') labs patches on $base."
+}
+
+# Only commits are exported; marker commits are skipped. A built tree may carry the
+# use-local rewrite uncommitted (before commit-use-local ran), so dirt is a note, not an error.
+function export_series {
+  initialized || die "labs/ is not checked out"
+  local base; base=$(base_sha)
+  git_labs merge-base --is-ancestor "$base" HEAD || die "labs/ HEAD does not descend from the gitlink $base; run apply first"
+  if [ -n "$(git_labs status --porcelain --untracked-files=no)" ]; then
+    echo "labs-patches: note: uncommitted changes in labs/ are not exported:" >&2
+    git_labs status --short --untracked-files=no | sed 's/^/  /' >&2
+  fi
+  rm -f "$patch_dir"/*.patch
+  local n=1 c
+  for c in $(series_commits "$base"); do
+    # --zero-commit, --no-signature, --full-index and --no-numbered keep the files free of
+    # per-machine noise (git version, abbreviation length) and of series-length noise
+    # ("[PATCH 1/2]"), so a re-export of an unchanged patch is a no-op in git.
+    git_labs format-patch -q -1 --start-number "$n" --zero-commit --no-signature --no-stat --full-index --no-numbered \
+      -o "$patch_dir" "$c"
+    n=$((n + 1))
+  done
+  # The exported commits are the series now; record them as applied.
+  write_state
+  echo "Exported $(patches | wc -l | tr -d ' ') patches on $base:"
+  patches | xargs -rn1 basename
+}
+
+function check {
+  initialized || die "labs/ is not checked out; run apply first"
+  local base; base=$(base_sha)
+  git_labs worktree prune
+  local tmp; tmp=$(mktemp -d)
+  trap "rm -rf '$tmp'; git -C '$labs' worktree prune" EXIT
+  git_labs worktree add -q --detach "$tmp" "$base"
+  am_series "$tmp"
+  echo "labs patches apply cleanly to $base."
+}
+
+function bump {
+  local ref=${1:-}
+  [ -n "$ref" ] || die "usage: bump <upstream ref>"
+  initialized || checkout_base
+  local lost; lost=$(unexported_commits "$(base_sha)")
+  if [ -n "$lost" ]; then
+    echo "labs-patches: labs/ has commits that are not in the series:" >&2
+    git_labs log --oneline --no-walk $lost >&2
+    die "export or drop them before bumping"
+  fi
+  git_labs fetch -q --depth 1 origin "$ref"
+  local new; new=$(git_labs rev-parse FETCH_HEAD)
+  local old; old=$(base_sha)
+  git -C "$fnd_root" update-index --cacheinfo "160000,$new,labs"
+  echo "labs gitlink: $old -> $new"
+  apply
+}
+
+# Commits the worktree's use-local rewrite as the marker commit, amending the previous one
+# when it is HEAD, so the labs tree is clean for cache hashing. No-op on a clean tree.
+# Only the manifests, lockfiles and the foundation hash record are staged: use-local rewrites
+# package.json and Nargo.toml files, the build refreshes yarn.lock and writes
+# labs-aztec-toolchain/fnd-hashes. Any other tracked edit is left in the worktree (and
+# reported), so work in progress never disappears into the marker.
+function commit_use_local {
+  initialized || die "labs/ is not checked out"
+  local dirty; dirty=$({ git_labs status --porcelain --untracked-files=no; git_labs status --porcelain -- labs-aztec-toolchain/fnd-hashes; } | sort -u | sed 's/^...//')
+  if [ -z "$dirty" ]; then
+    echo "labs/ is clean; nothing to commit."
+    return
+  fi
+  local rewrite other
+  rewrite=$(echo "$dirty" | grep -E '(^|/)(package\.json|yarn\.lock|Nargo\.toml)$|^labs-aztec-toolchain/fnd-hashes$' || true)
+  other=$(echo "$dirty" | grep -vE '(^|/)(package\.json|yarn\.lock|Nargo\.toml)$|^labs-aztec-toolchain/fnd-hashes$' || true)
+  if [ -n "$other" ]; then
+    echo "labs-patches: leaving uncommitted edits in labs/ that are not part of the use-local rewrite:" >&2
+    echo "$other" | sed 's/^/  /' >&2
+  fi
+  if [ -z "$rewrite" ]; then
+    echo "labs/ has no use-local rewrite to commit."
+    return
+  fi
+  local amend=()
+  [ "$(git_labs log -1 --format=%s)" = "$MARKER_SUBJECT" ] && amend=(--amend)
+  echo "$rewrite" | xargs git -C "$labs" add --
+  git_labs -c user.name=labs-patches -c user.email=labs-patches@localhost \
+    commit -q ${amend[@]+"${amend[@]}"} -m "$MARKER_SUBJECT" -m "Manifests rewritten by labs-aztec-toolchain use-local to consume the foundation checkout this submodule sits in. Not part of the patch series."
+  echo "Committed the use-local rewrite as $(git_labs rev-parse --short HEAD)."
+}
+
+# A commit made by this script (the series, a marker) carries its committer identity; an
+# upstream commit never does. Any such commit between the old and the staged gitlink means
+# a patched head is being recorded, which no other clone could fetch.
+function check_staged {
+  git -C "$fnd_root" diff --cached --quiet -- labs && return 0
+  initialized || return 0
+  local old staged
+  old=$(git -C "$fnd_root" rev-parse -q --verify HEAD:labs 2>/dev/null || true)
+  staged=$(git -C "$fnd_root" rev-parse :labs)
+  git_labs cat-file -e "$staged" 2>/dev/null || return 0
+  # In a shallow clone the old gitlink may be unreachable; then judge the staged commit itself.
+  local commits
+  commits=$(git_labs rev-list "${old:+$old..}$staged" 2>/dev/null) || commits=$staged
+  if git_labs log --no-walk --format=%ce $commits 2>/dev/null | grep -q "^$GIT_COMMITTER_EMAIL\$"; then
+    die "the staged labs gitlink $staged includes commits made by labs-patches, which do not exist upstream. Unstage it (git restore --staged labs) and bump with labs-patches/bootstrap.sh bump <ref>."
+  fi
+}
+
+# Prepares one patch as an aztec-node branch: a branch in labs/'s repository at the recorded
+# base with just that patch applied under your own git identity, ready to push and open as the
+# upstream PR. Nothing is pushed; the commands to do so are printed. Once the PR lands and the
+# pin is bumped past it, the patch drops out of the next export on its own.
+function upstream {
+  local sel=${1:-} branch=${2:-}
+  [ -n "$sel" ] || die "usage: upstream <patch number or file> [branch]"
+  initialized || die "labs/ is not checked out; run apply first"
+  local p
+  if [ -f "$sel" ]; then p=$sel; else
+    p=$(patches | grep "/0*${sel#0}-[^/]*\.patch\$" | head -1)
+    [ -n "$p" ] || die "no patch matching '$sel' in $patch_dir"
+  fi
+  local slug; slug=$(basename "$p" .patch | sed 's/^[0-9]*-//')
+  branch=${branch:-fnd/$slug}
+  if git_labs show-ref -q --verify "refs/heads/$branch"; then
+    die "branch $branch already exists in labs/; pick another name or delete it"
+  fi
+  local base; base=$(base_sha)
+  git_labs worktree prune
+  local tmp; tmp=$(mktemp -d)
+  trap "rm -rf '$tmp'; git -C '$labs' worktree prune" EXIT
+  git_labs worktree add -q -b "$branch" "$tmp" "$base"
+  local ident=()
+  if [ -n "$caller_committer_name" ]; then
+    ident=("GIT_COMMITTER_NAME=$caller_committer_name" "GIT_COMMITTER_EMAIL=$caller_committer_email")
+  fi
+  if ! env -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL ${ident[@]+"${ident[@]}"} \
+      git -C "$tmp" -c commit.gpgsign=false am -q --3way "$p"; then
+    git -C "$tmp" am --abort || true
+    git_labs branch -q -D "$branch"
+    die "$(basename "$p") does not apply to $base"
+  fi
+  echo "Prepared $branch in labs/ ($(git -C "$tmp" rev-parse --short HEAD) on $base): $(basename "$p")"
+  echo "  git -C labs push origin $branch"
+  echo "  gh pr create --repo aztec-labs-eng/aztec-node --head $branch --base main --fill"
+}
+
+function status {
+  local base; base=$(base_sha)
+  echo "base:    $base"
+  if ! initialized; then echo "labs/:   not checked out"; return; fi
+  echo "labs/:   $(git_labs rev-parse HEAD)"
+  echo "series:"; patches | xargs -rn1 basename | sed 's/^/  /'
+  if is_applied; then echo "applied: yes"; else echo "applied: no"; fi
+  local extra; extra=$(unexported_commits "$base")
+  if [ -n "$extra" ]; then echo "unexported commits in labs/:"; git_labs log --oneline --no-walk $extra | sed 's/^/  /'; fi
+}
+
+# Test commands for the foundation test engine: the lifecycle test runs the tooling against
+# a sandbox fixture, and check verifies the committed series against the gitlink.
+# The paths are root-relative (the test engine runs from the repo root), and so is the hash
+# input: the Makefile invokes this from labs-patches/, hence the cd. The gitlink is part of
+# the hash so check is never served from the test cache across a pin bump.
+function test_cmds {
+  local inputs="labs-patches scripts/labs_test_cmds.sh scripts/labs_env.sh"
+  local h
+  # Uncommitted edits must not be served a cached result, as with cache_content_hash.
+  if [ -n "$(cd "$fnd_root" && git status --porcelain -- $inputs)" ]; then
+    h=disabled-cache
+  else
+    h=$(cd "$fnd_root" && { git rev-parse :labs; git ls-files -z -- $inputs | xargs -0 cat; } | git hash-object --stdin | cut -c1-16)
+  fi
+  [ -n "$h" ] || die "could not hash labs-patches"
+  echo "$h labs-patches/tests/lifecycle_test"
+  echo "$h labs-patches/bootstrap.sh check"
+}
+
+case "${1:-apply}" in
+  apply) apply ;;
+  export) export_series ;;
+  check) check ;;
+  bump) bump "${2:-}" ;;
+  commit-use-local) commit_use_local ;;
+  check_staged) check_staged ;;
+  status) status ;;
+  upstream) upstream "${2:-}" "${3:-}" ;;
+  test_cmds) test_cmds ;;
+  test) "$patch_dir/tests/lifecycle_test" && check ;;
+  *) die "unknown command: $1" ;;
+esac

--- a/labs-patches/tests/lifecycle_test
+++ b/labs-patches/tests/lifecycle_test
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Exercises labs-patches/bootstrap.sh against a sandbox: a fake upstream labs repo, a fake
+# foundation repo that carries it as the labs/ submodule (update=none), and a real patch
+# series exported from commits made in labs/. Covers the lifecycle the tooling exists for:
+# fresh apply, idempotency, export (marker excluded), commit-use-local scoping, a same-pin
+# and a forward bump, bumps refused on unexported work, uncommitted edits surviving a
+# re-apply, work in progress surviving a lost state file, a patch that no longer applies,
+# the pre-commit gitlink guard, and test_cmds from any cwd.
+#
+# Runs from any cwd; needs only git and bash.
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+script=$here/../bootstrap.sh
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+PASS=0
+function ok { echo "  ok  $1"; PASS=$((PASS + 1)); }
+function fail { echo "  FAIL  $1" >&2; exit 1; }
+function expect_fail { if "$@" >/dev/null 2>&1; then return 1; fi; }
+
+# The tooling exports a fixed committer identity (and the guard keys on it); the fixture's own
+# commits must not inherit it, or upstream commits would look like series commits.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@localhost GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@localhost
+g() { git -c commit.gpgsign=false "$@"; }
+
+# --- upstream labs repo with two commits (v1, v2)
+up=$tmp/upstream
+g init -q -b main "$up"
+echo "a=1" > "$up/config"; echo "x" > "$up/src"; g -C "$up" add -A; g -C "$up" commit -q -m "upstream v1"
+v1=$(git -C "$up" rev-parse HEAD)
+echo "y" > "$up/src"; g -C "$up" commit -qam "upstream v2"
+v2=$(git -C "$up" rev-parse HEAD)
+git -C "$up" checkout -q "$v1"   # bare-ish: leave main at v2, worktree irrelevant
+
+# --- foundation repo: the tooling under labs-patches/, labs/ as update=none submodule at v1
+fnd=$tmp/fnd
+g init -q -b next "$fnd"
+mkdir -p "$fnd/labs-patches"
+cp "$script" "$fnd/labs-patches/bootstrap.sh"
+g -C "$fnd" -c protocol.file.allow=always submodule add -q -b main "$up" labs
+git -C "$fnd/labs" checkout -q "$v1"
+git -C "$fnd" config -f .gitmodules submodule.labs.update none
+g -C "$fnd" add -A; g -C "$fnd" commit -q -m "foundation with labs at v1"
+[ "$(git -C "$fnd" rev-parse HEAD:labs)" = "$v1" ] || fail "fixture gitlink"
+lp=$fnd/labs-patches/bootstrap.sh
+export -n GIT_DIR GIT_WORK_TREE 2>/dev/null || true
+
+# 1. fresh apply with an empty series, then a real one exported from labs/ commits
+"$lp" apply >/dev/null
+[ "$(git -C "$fnd/labs" rev-parse HEAD)" = "$v1" ] || fail "apply: empty series leaves HEAD at base"
+ok "fresh apply (empty series)"
+echo "a=2" > "$fnd/labs/config"; g -C "$fnd/labs" commit -qam "patch one: config"
+echo "z" > "$fnd/labs/extra"; g -C "$fnd/labs" add extra; g -C "$fnd/labs" commit -qm "patch two: extra"
+"$lp" export >/dev/null
+[ "$(ls "$fnd/labs-patches"/*.patch | wc -l | tr -d ' ')" = 2 ] || fail "export: two patches"
+grep -q '^index [0-9a-f]\{40\}\.\.' "$fnd/labs-patches"/0001-*.patch || fail "export: full index"
+ok "export two patches"
+g -C "$fnd" add labs-patches; g -C "$fnd" commit -q -m "series"
+
+# 2. idempotent, and reproducible from scratch
+"$lp" apply | grep -q "already applied" || fail "apply: idempotent"
+patched=$(git -C "$fnd/labs" rev-parse HEAD)
+rm -f "$(git -C "$fnd/labs" rev-parse --absolute-git-dir)/labs-patches.state"
+"$lp" apply >/dev/null
+[ "$(git -C "$fnd/labs" rev-parse HEAD)" = "$patched" ] || fail "apply: reproducible SHA after cold apply"
+ok "idempotent and reproducible apply"
+
+# 3. commit-use-local stages only manifests/lockfiles and leaves other edits alone
+echo '{"portal":1}' > "$fnd/labs/package.json"; g -C "$fnd/labs" add package.json; g -C "$fnd/labs" commit -q -m "add manifest"
+"$lp" export >/dev/null; g -C "$fnd" add labs-patches; g -C "$fnd" commit -q -m "series v2"
+echo '{"portal":2}' > "$fnd/labs/package.json"
+mkdir -p "$fnd/labs/labs-aztec-toolchain"; echo "barretenberg/cpp=abc" > "$fnd/labs/labs-aztec-toolchain/fnd-hashes"
+echo "wip" >> "$fnd/labs/src"
+"$lp" commit-use-local >/dev/null
+git -C "$fnd/labs" ls-files --error-unmatch labs-aztec-toolchain/fnd-hashes >/dev/null 2>&1 || fail "commit-use-local: fnd-hashes not committed"
+[ "$(git -C "$fnd/labs" log -1 --format=%s)" = "labs-patches: use-local rewrite (never exported)" ] || fail "marker commit"
+git -C "$fnd/labs" status --porcelain | grep -q '^ M src$' || fail "commit-use-local: unrelated edit left in worktree"
+git -C "$fnd/labs" diff --quiet -- package.json || fail "commit-use-local: manifest committed"
+"$lp" apply | grep -q "already applied" || fail "apply: marker on top still counts as applied"
+"$lp" export >/dev/null
+! grep -l "never exported" "$fnd/labs-patches"/*.patch >/dev/null || fail "export: marker excluded"
+ok "commit-use-local scoping and marker handling"
+git -C "$fnd/labs" checkout -q -- src
+
+# 4. pre-commit guard: staging the patched head is refused, an upstream commit is fine
+git -C "$fnd" add labs
+expect_fail "$lp" check_staged || fail "check_staged: patched head accepted"
+git -C "$fnd" restore --staged labs
+git -C "$fnd" update-index --cacheinfo "160000,$v2,labs"
+"$lp" check_staged >/dev/null || fail "check_staged: upstream commit refused"
+git -C "$fnd" restore --staged labs
+ok "check_staged guard"
+
+# 5. same-pin bump is a no-op re-apply; forward bump moves the gitlink and re-applies
+"$lp" bump "$v1" >/dev/null || fail "bump: same pin"
+[ "$(git -C "$fnd" rev-parse :labs)" = "$v1" ] || fail "bump same pin: gitlink"
+"$lp" bump "$v2" >/dev/null || fail "bump: forward"
+[ "$(git -C "$fnd" rev-parse :labs)" = "$v2" ] || fail "bump forward: gitlink moved"
+git -C "$fnd/labs" merge-base --is-ancestor "$v2" HEAD || fail "bump forward: series on new base"
+[ "$(git -C "$fnd/labs" rev-list --count "$v2..HEAD")" = 3 ] || { git -C "$fnd/labs" log --oneline "$v2..HEAD" >&2; git -C "$fnd/labs" log --oneline -6 >&2; fail "bump forward: three patches applied"; }
+grep -q "a=2" "$fnd/labs/config" && grep -q "y" "$fnd/labs/src" && [ -f "$fnd/labs/extra" ] || fail "bump forward: content"
+"$lp" apply | grep -q "already applied" || fail "bump forward: applied state recorded"
+ok "same-pin and forward bump"
+g -C "$fnd" commit -q -m "bump to v2"
+
+# 6. bump refuses on unexported work; apply refuses when the series changes under it
+g -C "$fnd/labs" commit -q --allow-empty -m "wip: local"
+expect_fail "$lp" bump "$v1" || fail "bump: unexported work accepted"
+sed -i.bak 's/^+a=2$/+a=3/' "$fnd/labs-patches"/0001-*.patch && rm -f "$fnd/labs-patches"/*.bak
+expect_fail "$lp" apply || fail "apply: series change over unexported work accepted"
+git -C "$fnd" checkout -q -- labs-patches
+git -C "$fnd/labs" reset -q --hard HEAD~1
+ok "unexported work protected"
+
+# 7. uncommitted tracked edits survive a re-apply (stashed, not discarded)
+echo "keep me" >> "$fnd/labs/src"
+sed -i.bak 's/^+a=2$/+a=3/' "$fnd/labs-patches"/0001-*.patch && rm -f "$fnd/labs-patches"/*.bak
+"$lp" apply >/dev/null
+grep -q "a=3" "$fnd/labs/config" || fail "apply: changed series applied"
+git -C "$fnd/labs" stash list | grep -q "labs-patches: worktree" || fail "apply: edit not stashed"
+git -C "$fnd/labs" stash show -p | grep -q "keep me" || fail "apply: stash content"
+git -C "$fnd/labs" stash drop -q
+git -C "$fnd" checkout -q -- labs-patches
+ok "uncommitted edits stashed on re-apply"
+
+# 8. a patch that no longer applies fails loudly and leaves no am in progress
+cat > "$fnd/labs-patches/0009-conflict.patch" <<'EOF'
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: test <test@localhost>
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Subject: [PATCH] conflicting
+
+diff --git a/config b/config
+--- a/config
++++ b/config
+@@ -1 +1 @@
+-a=999
++a=3
+EOF
+expect_fail "$lp" apply || fail "apply: conflicting patch accepted"
+[ ! -d "$(git -C "$fnd/labs" rev-parse --absolute-git-dir)/rebase-apply" ] || fail "apply: am left in progress"
+rm "$fnd/labs-patches/0009-conflict.patch"
+"$lp" apply >/dev/null
+ok "conflicting patch reported"
+
+# 9. work in progress above a lost state file is not recorded as applied: after apply
+#    re-derives the state by content, a later series edit must still refuse to drop it
+g -C "$fnd/labs" commit -q --allow-empty -m "wip: after state loss"
+rm -f "$(git -C "$fnd/labs" rev-parse --absolute-git-dir)/labs-patches.state"
+"$lp" apply | grep -q "already applied" || fail "apply: series by content with wip on top"
+grep -q "wip" <("$lp" status) || fail "status: wip listed as unexported"
+sed -i.bak 's/^+a=2$/+a=3/' "$fnd/labs-patches"/0001-*.patch && rm -f "$fnd/labs-patches"/*.bak
+expect_fail "$lp" apply || fail "apply: dropped wip recorded as applied after state loss"
+git -C "$fnd" checkout -q -- labs-patches
+git -C "$fnd/labs" reset -q --hard HEAD~1
+ok "wip survives state-file loss"
+
+# 10. test_cmds is root-relative whichever directory it runs from
+n=$(cd "$fnd/labs-patches" && ./bootstrap.sh test_cmds | grep -c '^[0-9a-f]\{16\} labs-patches/')
+[ "$n" = 2 ] || fail "test_cmds from labs-patches/: $n commands"
+n=$(cd "$fnd" && labs-patches/bootstrap.sh test_cmds | grep -c '^[0-9a-f]\{16\} labs-patches/')
+[ "$n" = 2 ] || fail "test_cmds from root: $n commands"
+ok "test_cmds from any cwd"
+
+# 11. upstream prepares one patch as a branch at the recorded base, under the caller's identity
+base=$(git -C "$fnd" rev-parse HEAD:labs)
+out=$("$lp" upstream 1 fnd/one) && grep -q "Prepared fnd/one" <<<"$out" || fail "upstream: output"
+[ "$(git -C "$fnd/labs" rev-list --count "$base..fnd/one")" = 1 ] || fail "upstream: one commit above the base"
+[ "$(git -C "$fnd/labs" show fnd/one:config)" = "a=2" ] || fail "upstream: patch content"
+[ "$(git -C "$fnd/labs" log -1 --format=%cn fnd/one)" = "test" ] || fail "upstream: committer identity"
+expect_fail "$lp" upstream 1 fnd/one || fail "upstream: existing branch accepted"
+"$lp" upstream "$fnd/labs-patches"/0002-*.patch >/dev/null || fail "upstream: by path"
+git -C "$fnd/labs" show-ref -q --verify refs/heads/fnd/patch-two-extra || fail "upstream: default branch name"
+ok "upstream branch"
+
+# 12. check verifies without touching labs/
+before=$(git -C "$fnd/labs" rev-parse HEAD)
+"$lp" check >/dev/null || fail "check"
+[ "$(git -C "$fnd/labs" rev-parse HEAD)" = "$before" ] || fail "check moved labs/"
+ok "check"
+
+echo "labs-patches lifecycle: $PASS checks passed"


### PR DESCRIPTION
- Submodules in labs `aztec-labs-eng/aztec-node` repo and builds from it instead of the in-tree copy
- Adds a `labs-patches` series

AI Summary:
```
**Stack** (merge in order): #25306 labs submodule + patch-series tooling → #25318 build and test labs from the submodule → #25321 delete the in-tree labs copies

Adds `aztec-labs-eng/aztec-node` as the shallow `labs/` submodule (tracking `main`, `update = none`) and `labs-patches/`, the foundation's patch series on top of it. **Nothing builds from `labs/` yet**: CI clones and checks it out, applies an (empty) series, and runs the tooling's lifecycle test. Experiments on labs code land here as patches first; upstream later.

`labs-patches/bootstrap.sh`:
- `apply` (root bootstrap, `post-merge`/`post-checkout` hooks, `make labs-patched`) checks the submodule out at the gitlink and `git am`s the series; fixed committer identity and author dates make the applied SHAs identical on every machine. The series is recognised by *content* (patch ids, plus the commits the state records as applied), so cold applies, bumps across shallow fetches and edited series still tell it apart from work in progress — which `apply` and `bump` refuse to discard (`LABS_PATCHES_FORCE=1` is the last resort); uncommitted edits are stashed, never reset.
- `export` regenerates the series from commits in `labs/`; `bump <ref>` moves the pin and re-applies; `check` verifies the series in a temporary worktree; `commit-use-local` records a build's manifest rewrite as a marker commit the series ignores (used by #25318).
- The pre-commit hook refuses staging a patched or marker head as the gitlink (they exist only in your clone); hooks are guarded so older branches keep committing.
- `labs-patches/tests/lifecycle_test` (12 checks) runs with `check` under `make labs-patches-tests`, in `fast-foundation`.

Also: CLAUDE.md rules for the submodule (never `git add labs` by hand; `git add -u`/`commit -a` stage the gitlink), CODEOWNERS for the new files, and the `.claude` layout test exempts `labs/` like `noir/noir-repo`.
```