### PR TITLE
refactor(ethereum): read vkTreeRoot and protocolContractsHash via their getters

### DIFF
--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -362,12 +362,12 @@ describe('Rollup', () => {
   });
 
   describe('getVkTreeRoot and getProtocolContractsHash', () => {
-    it('reads vkTreeRoot from storage', async () => {
+    it('reads vkTreeRoot', async () => {
       const result = await rollup.getVkTreeRoot();
       expect(result).toEqual(vkTreeRoot);
     });
 
-    it('reads protocolContractsHash from storage', async () => {
+    it('reads protocolContractsHash', async () => {
       const result = await rollup.getProtocolContractsHash();
       expect(result).toEqual(protocolContractsHash);
     });

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -429,16 +429,12 @@ export class RollupContract {
 
   @memoize
   async getVkTreeRoot(): Promise<Fr> {
-    const slot = BigInt(RollupContract.stfStorageSlot) + 3n;
-    const value = await this.client.getStorageAt({ address: this.address, slot: `0x${slot.toString(16)}` });
-    return Fr.fromString(value ?? '0x0');
+    return Fr.fromString(await this.rollup.read.getVkTreeRoot());
   }
 
   @memoize
   async getProtocolContractsHash(): Promise<Fr> {
-    const slot = BigInt(RollupContract.stfStorageSlot) + 4n;
-    const value = await this.client.getStorageAt({ address: this.address, slot: `0x${slot.toString(16)}` });
-    return Fr.fromString(value ?? '0x0');
+    return Fr.fromString(await this.rollup.read.getProtocolContractsHash());
   }
 
   /**


### PR DESCRIPTION
`RollupContract.getVkTreeRoot` and `getProtocolContractsHash` read raw storage at `keccak256("aztec.stf.storage") + 3` and `+ 4` instead of calling the contract.

`IRollup` has exposed `getVkTreeRoot()` and `getProtocolContractsHash()` since #22563, so the slot arithmetic was never necessary. This switches both to the ABI getters.

### Why it matters

The slot offsets hardcode the field order of `RollupStore.config`. Reordering or removing a field there does not break the read — it returns a wrong-but-well-formed `bytes32`, which surfaces downstream as a spurious VK mismatch in `checkRollupCompatibility` rather than as an error at the read site.

That is not hypothetical: a change on the `next` line moves these values out of `RollupStore` entirely (they are constructor-only and have no setter, so they belong in immutables). A node still doing the raw read would see zeroes against such a rollup and sit in standby forever. Landing the getter read on the v5 line first means node binaries cut from it work against a rollup deployed from either version.

### Scope

Two functions in `yarn-project/ethereum/src/contracts/rollup.ts`, plus two test descriptions that said "from storage". The remaining `stfStorageSlot` consumers use offsets `+0` (tips), `+1` (archives) and `+2` (tempCheckpointLogs) and are untouched.

The existing tests in `rollup.test.ts` cover both getters against a real anvil deployment, so they exercise the new path unchanged.