### PR TITLE
perf(l1): hold the rollup config in immutables instead of storage

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -14,22 +14,22 @@
 
 | Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|-----------|---------------|--------------|
-| propose              | 199,366 |   225,550 |           996 |       15,936 |
-| submitEpochRootProof | 991,032 | 1,029,525 |        14,148 |      226,368 |
+| propose              | 197,781 |   223,965 |           996 |       15,936 |
+| submitEpochRootProof | 980,266 | 1,018,730 |        14,148 |      226,368 |
 | setupEpoch           |  32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,643.2 gas/second
+**Avg Gas Cost per Second**: 3,611.8 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
-| propose              |   327,774 |   355,591 |         4,516 |       72,256 |
-| submitEpochRootProof | 1,572,081 | 1,669,921 |        16,644 |      266,304 |
-| aggregate3           |   376,665 |   390,039 |             - |            - |
+| propose              |   326,198 |   354,016 |         4,516 |       72,256 |
+| submitEpochRootProof | 1,561,332 | 1,659,142 |        16,644 |      266,304 |
+| aggregate3           |   375,090 |   388,464 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,937.3 gas/second
+**Avg Gas Cost per Second**: 5,906.0 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -14,22 +14,22 @@
 
 | Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|-----------|---------------|--------------|
-| propose              | 197,781 |   223,965 |           996 |       15,936 |
+| propose              | 197,740 |   223,924 |           996 |       15,936 |
 | submitEpochRootProof | 980,266 | 1,018,730 |        14,148 |      226,368 |
 | setupEpoch           |  32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,611.8 gas/second
+**Avg Gas Cost per Second**: 3,611.2 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
-| propose              |   326,198 |   354,016 |         4,516 |       72,256 |
+| propose              |   326,159 |   353,977 |         4,516 |       72,256 |
 | submitEpochRootProof | 1,561,332 | 1,659,142 |        16,644 |      266,304 |
-| aggregate3           |   375,090 |   388,464 |             - |            - |
+| aggregate3           |   375,051 |   388,425 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,906.0 gas/second
+**Avg Gas Cost per Second**: 5,905.5 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -14,22 +14,22 @@
 
 | Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|-----------|---------------|--------------|
-| propose              | 197,740 |   223,924 |           996 |       15,936 |
-| submitEpochRootProof | 980,266 | 1,018,730 |        14,148 |      226,368 |
+| propose              | 197,433 |   223,617 |           996 |       15,936 |
+| submitEpochRootProof | 980,225 | 1,018,689 |        14,148 |      226,368 |
 | setupEpoch           |  32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,611.2 gas/second
+**Avg Gas Cost per Second**: 3,606.9 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
-| propose              |   326,159 |   353,977 |         4,516 |       72,256 |
-| submitEpochRootProof | 1,561,332 | 1,659,142 |        16,644 |      266,304 |
-| aggregate3           |   375,051 |   388,425 |             - |            - |
+| propose              |   325,847 |   353,664 |         4,516 |       72,256 |
+| submitEpochRootProof | 1,561,291 | 1,659,101 |        16,644 |      266,304 |
+| aggregate3           |   374,738 |   388,112 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,905.5 gas/second
+**Avg Gas Cost per Second**: 5,901.1 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,10 +2,10 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 184137,
-      "mean": 197781,
-      "median": 193527,
-      "max": 223965,
+      "min": 184096,
+      "mean": 197740,
+      "median": 193486,
+      "max": 223924,
       "calldata_size": 996,
       "calldata_gas": 15936
     },
@@ -29,10 +29,10 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 303859,
-      "mean": 326198,
-      "median": 325652,
-      "max": 354016,
+      "min": 303820,
+      "mean": 326159,
+      "median": 325613,
+      "max": 353977,
       "calldata_size": 4516,
       "calldata_gas": 72256
     },
@@ -54,10 +54,10 @@
     },
     "aggregate3": {
       "calls": 55,
-      "min": 363972,
-      "mean": 375090,
-      "median": 374774,
-      "max": 388464
+      "min": 363933,
+      "mean": 375051,
+      "median": 374735,
+      "max": 388425
     }
   }
 }

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,10 +2,10 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 185722,
-      "mean": 199366,
-      "median": 195111,
-      "max": 225550,
+      "min": 184137,
+      "mean": 197781,
+      "median": 193527,
+      "max": 223965,
       "calldata_size": 996,
       "calldata_gas": 15936
     },
@@ -18,10 +18,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 972329,
-      "mean": 991032,
-      "median": 981138,
-      "max": 1029525,
+      "min": 961647,
+      "mean": 980266,
+      "median": 970345,
+      "max": 1018730,
       "calldata_size": 14148,
       "calldata_gas": 226368
     }
@@ -29,10 +29,10 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 305434,
-      "mean": 327774,
-      "median": 327227,
-      "max": 355591,
+      "min": 303859,
+      "mean": 326198,
+      "median": 325652,
+      "max": 354016,
       "calldata_size": 4516,
       "calldata_gas": 72256
     },
@@ -45,19 +45,19 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 1460323,
-      "mean": 1572081,
-      "median": 1579041,
-      "max": 1669921,
+      "min": 1449546,
+      "mean": 1561332,
+      "median": 1568320,
+      "max": 1659142,
       "calldata_size": 16644,
       "calldata_gas": 266304
     },
     "aggregate3": {
       "calls": 55,
-      "min": 365547,
-      "mean": 376665,
-      "median": 376350,
-      "max": 390039
+      "min": 363972,
+      "mean": 375090,
+      "median": 374774,
+      "max": 388464
     }
   }
 }

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,10 +2,10 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 184096,
-      "mean": 197740,
-      "median": 193486,
-      "max": 223924,
+      "min": 183789,
+      "mean": 197433,
+      "median": 193178,
+      "max": 223617,
       "calldata_size": 996,
       "calldata_gas": 15936
     },
@@ -18,10 +18,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 961647,
-      "mean": 980266,
-      "median": 970345,
-      "max": 1018730,
+      "min": 961606,
+      "mean": 980225,
+      "median": 970304,
+      "max": 1018689,
       "calldata_size": 14148,
       "calldata_gas": 226368
     }
@@ -29,10 +29,10 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 303820,
-      "mean": 326159,
-      "median": 325613,
-      "max": 353977,
+      "min": 303507,
+      "mean": 325847,
+      "median": 325300,
+      "max": 353664,
       "calldata_size": 4516,
       "calldata_gas": 72256
     },
@@ -45,19 +45,19 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 1449546,
-      "mean": 1561332,
-      "median": 1568320,
-      "max": 1659142,
+      "min": 1449505,
+      "mean": 1561291,
+      "median": 1568279,
+      "max": 1659101,
       "calldata_size": 16644,
       "calldata_gas": 266304
     },
     "aggregate3": {
       "calls": 55,
-      "min": 363933,
-      "mean": 375051,
-      "median": 374735,
-      "max": 388425
+      "min": 363620,
+      "mean": 374738,
+      "median": 374423,
+      "max": 388112
     }
   }
 }

--- a/l1-contracts/gas_report.json
+++ b/l1-contracts/gas_report.json
@@ -76,7 +76,7 @@
     },
     "functions": {
       "getCanonicalRollup()": {
-        "calls": 1780,
+        "calls": 1708,
         "min": 1073,
         "mean": 4073,
         "median": 4073,
@@ -106,7 +106,7 @@
     },
     "functions": {
       "availableTo(address)": {
-        "calls": 890,
+        "calls": 854,
         "min": 20573,
         "mean": 20573,
         "median": 20573,
@@ -118,7 +118,7 @@
     "contract": "test/RollupWithPreheating.sol:RollupWithPreheating",
     "deployment": {
       "gas": 0,
-      "size": 42950
+      "size": 42916
     },
     "functions": {
       "archive()": {
@@ -136,7 +136,7 @@
         "max": 2509
       },
       "getCheckpoint(uint256)": {
-        "calls": 900,
+        "calls": 864,
         "min": 27185,
         "mean": 27185,
         "median": 27185,
@@ -144,20 +144,20 @@
       },
       "getCheckpointReward()": {
         "calls": 2589,
-        "min": 1128,
-        "mean": 1133,
-        "median": 1128,
-        "max": 5628
+        "min": 1040,
+        "mean": 1045,
+        "median": 1040,
+        "max": 5540
       },
       "getCollectiveProverRewardsForEpoch(uint256)": {
         "calls": 3,
-        "min": 5837,
-        "mean": 5837,
-        "median": 5837,
-        "max": 5837
+        "min": 5859,
+        "mean": 5859,
+        "median": 5859,
+        "max": 5859
       },
       "getCurrentEpoch()": {
-        "calls": 891,
+        "calls": 855,
         "min": 915,
         "mean": 915,
         "median": 915,
@@ -179,10 +179,10 @@
       },
       "getEpochProofPublicInputs(uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],bytes)": {
         "calls": 4,
-        "min": 16751,
-        "mean": 45593,
-        "median": 47624,
-        "max": 70374
+        "min": 18578,
+        "mean": 44270,
+        "median": 46301,
+        "max": 65899
       },
       "getEthPerFeeAsset()": {
         "calls": 2,
@@ -193,24 +193,24 @@
       },
       "getFeeAssetPortal()": {
         "calls": 4660,
-        "min": 566,
-        "mean": 1456,
-        "median": 566,
-        "max": 2566
+        "min": 901,
+        "mean": 901,
+        "median": 901,
+        "max": 901
       },
       "getInbox()": {
         "calls": 9073,
-        "min": 2543,
-        "mean": 2543,
-        "median": 2543,
-        "max": 2543
+        "min": 878,
+        "mean": 878,
+        "median": 878,
+        "max": 878
       },
       "getL1FeesAt(uint256)": {
         "calls": 2,
-        "min": 9086,
-        "mean": 9086,
-        "median": 9086,
-        "max": 9086
+        "min": 9130,
+        "mean": 9130,
+        "median": 9130,
+        "max": 9130
       },
       "getManaMinFeeAt(uint256,bool)": {
         "calls": 2336,
@@ -221,17 +221,17 @@
       },
       "getManaTarget()": {
         "calls": 1026,
-        "min": 5526,
-        "mean": 5526,
-        "median": 5526,
-        "max": 5526
+        "min": 5548,
+        "mean": 5548,
+        "median": 5548,
+        "max": 5548
       },
       "getOutbox()": {
         "calls": 2,
-        "min": 2521,
-        "mean": 2521,
-        "median": 2521,
-        "max": 2521
+        "min": 856,
+        "mean": 856,
+        "median": 856,
+        "max": 856
       },
       "getPendingCheckpointNumber()": {
         "calls": 1679,
@@ -263,10 +263,10 @@
       },
       "getSequencerRewards(address)": {
         "calls": 2,
-        "min": 5981,
-        "mean": 5981,
-        "median": 5981,
-        "max": 5981
+        "min": 6025,
+        "mean": 6025,
+        "median": 6025,
+        "max": 6025
       },
       "getTimestampForSlot(uint256)": {
         "calls": 2442,
@@ -277,10 +277,10 @@
       },
       "getVersion()": {
         "calls": 4919,
-        "min": 499,
-        "mean": 1447,
-        "median": 499,
-        "max": 2499
+        "min": 852,
+        "mean": 852,
+        "median": 852,
+        "max": 852
       },
       "owner()": {
         "calls": 5173,
@@ -292,16 +292,16 @@
       "propose((bytes32,(int256),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256),uint256),(bytes,bytes),address[],(uint8,bytes32,bytes32),bytes)": {
         "calls": 2339,
         "min": 0,
-        "mean": 266764,
-        "median": 284282,
-        "max": 325392
+        "mean": 264835,
+        "median": 282349,
+        "max": 323459
       },
       "prune()": {
         "calls": 6,
-        "min": 26689,
-        "mean": 33247,
-        "median": 33682,
-        "max": 38274
+        "min": 26711,
+        "mean": 33269,
+        "median": 33704,
+        "max": 38296
       },
       "setProvingCostPerMana(uint256)": {
         "calls": 1,
@@ -311,11 +311,11 @@
         "max": 52474
       },
       "submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
-        "calls": 897,
-        "min": 58286,
-        "mean": 374005,
-        "median": 379619,
-        "max": 418311
+        "calls": 861,
+        "min": 60147,
+        "mean": 366242,
+        "median": 370925,
+        "max": 407523
       },
       "updateManaTarget(uint256)": {
         "calls": 512,

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -90,24 +90,15 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    */
   function validateHeaderWithAttestations(
     ProposedHeader calldata _header,
-    CommitteeAttestations memory _attestations,
+    CommitteeAttestations calldata _attestations,
     address[] calldata _signers,
-    Signature memory _attestationsAndSignersSignature,
+    Signature calldata _attestationsAndSignersSignature,
     bytes32 _digest,
     bytes32 _blobsHash,
-    CheckpointHeaderValidationFlags memory _flags
+    CheckpointHeaderValidationFlags calldata _flags
   ) external override(IRollup) {
     RollupOperationsExtLib.validateHeaderWithAttestations(
-      ValidateHeaderArgs({
-        header: _header,
-        digest: _digest,
-        manaMinFee: getManaMinFeeAt(Timestamp.wrap(block.timestamp), true),
-        blobsHashesCommitment: _blobsHash,
-        flags: _flags
-      }),
-      _attestations,
-      _signers,
-      _attestationsAndSignersSignature
+      _header, _attestations, _signers, _attestationsAndSignersSignature, _digest, _blobsHash, _flags
     );
   }
 

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -13,7 +13,8 @@ import {
   EthPerFeeAssetE12,
   CheckpointHeaderValidationFlags,
   FeeHeader,
-  RollupConfigInput
+  RollupConfigInput,
+  RollupStore
 } from "@aztec/core/interfaces/IRollup.sol";
 import {IStaking, AttesterConfig, Exit, AttesterView, Status} from "@aztec/core/interfaces/IStaking.sol";
 import {IValidatorSelection, IEmperor} from "@aztec/core/interfaces/IValidatorSelection.sol";
@@ -28,7 +29,6 @@ import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributo
 import {CompressedSlot, CompressedTimestamp, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
 import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 import {ChainTipsLib, CompressedChainTips} from "./libraries/compressed-data/Tips.sol";
-import {ValidateHeaderArgs} from "./libraries/rollup/ProposeLib.sol";
 import {RewardExtLib, RewardConfig} from "./libraries/rollup/RewardExtLib.sol";
 import {DepositArgs} from "./libraries/StakingQueue.sol";
 import {
@@ -46,7 +46,6 @@ import {
   ValidatorOperationsExtLib,
   EthValue,
   STFLib,
-  RollupStore,
   IInbox,
   IOutbox
 } from "./RollupCore.sol";

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -301,7 +301,9 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     ProposedHeader[] calldata _headers,
     bytes calldata _blobPublicInputs
   ) external view override(IRollup) returns (bytes32[] memory) {
-    return EpochProofExtLib.getEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs);
+    return EpochProofExtLib.getEpochProofPublicInputs(
+      _start, _end, _args, _headers, _blobPublicInputs, _getRollupConfig()
+    );
   }
 
   /**
@@ -540,36 +542,39 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     return RewardExtLib.getProvingCostPerMana().toFeeAsset(getEthPerFeeAsset());
   }
 
+  // The config getters below go through {_getRollupConfig} rather than reading their immutable
+  // directly. Each direct read inlines a 32-byte push into this contract's runtime code, and Rollup
+  // sits close to the EIP-170 limit; sharing one assembly across all of them is ~95 bytes cheaper.
   function getVersion() external view override(IHaveVersion) returns (uint256) {
-    return STFLib.getStorage().config.version;
+    return _getRollupConfig().version;
   }
 
   function getInbox() external view override(IRollup) returns (IInbox) {
-    return STFLib.getStorage().config.inbox;
+    return _getRollupConfig().inbox;
   }
 
   function getOutbox() external view override(IRollup) returns (IOutbox) {
-    return STFLib.getStorage().config.outbox;
+    return _getRollupConfig().outbox;
   }
 
   function getFeeAsset() external view override(IRollup) returns (IERC20) {
-    return STFLib.getStorage().config.feeAsset;
+    return _getRollupConfig().feeAsset;
   }
 
   function getFeeAssetPortal() external view override(IRollup) returns (IFeeJuicePortal) {
-    return STFLib.getStorage().config.feeAssetPortal;
+    return _getRollupConfig().feeAssetPortal;
   }
 
   function getVkTreeRoot() external view override(IRollup) returns (bytes32) {
-    return STFLib.getStorage().config.vkTreeRoot;
+    return _getRollupConfig().vkTreeRoot;
   }
 
   function getProtocolContractsHash() external view override(IRollup) returns (bytes32) {
-    return STFLib.getStorage().config.protocolContractsHash;
+    return _getRollupConfig().protocolContractsHash;
   }
 
   function getEpochProofVerifier() external view override(IRollup) returns (IVerifier) {
-    return STFLib.getStorage().config.epochProofVerifier;
+    return _getRollupConfig().epochProofVerifier;
   }
 
   function getRewardDistributor() external view override(IRollup) returns (IRewardDistributor) {

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -6,7 +6,6 @@ pragma solidity >=0.8.27;
 import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {
   IRollupCore,
-  RollupStore,
   RollupConfig,
   SubmitEpochRootProofArgs,
   RollupConfigInput

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -7,6 +7,7 @@ import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {
   IRollupCore,
   RollupStore,
+  RollupConfig,
   SubmitEpochRootProofArgs,
   RollupConfigInput
 } from "@aztec/core/interfaces/IRollup.sol";
@@ -189,6 +190,18 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
    */
   uint256 public immutable L1_BLOCK_AT_GENESIS;
 
+  // The deployment-time rollup configuration. Every value is fixed at construction, so it is held in
+  // immutables rather than storage; {_getRollupConfig} assembles it for the libraries, which cannot read
+  // a contract's immutables themselves.
+  bytes32 internal immutable VK_TREE_ROOT;
+  bytes32 internal immutable PROTOCOL_CONTRACTS_HASH;
+  uint32 internal immutable VERSION;
+  IERC20 internal immutable FEE_ASSET;
+  IFeeJuicePortal internal immutable FEE_ASSET_PORTAL;
+  IVerifier internal immutable EPOCH_PROOF_VERIFIER;
+  IInbox internal immutable INBOX;
+  IOutbox internal immutable OUTBOX;
+
   /**
    * @dev Storage gap to ensure checkBlob is in its own storage slot
    */
@@ -259,7 +272,20 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
 
     L1_BLOCK_AT_GENESIS = block.number;
 
-    _initializeStore(_feeAsset, _epochProofVerifier, _genesisState, _config);
+    // Immutables must be assigned directly in the constructor body, so the store setup cannot be
+    // factored out into a helper the way the slasher and reward setup are.
+    VK_TREE_ROOT = _genesisState.vkTreeRoot;
+    PROTOCOL_CONTRACTS_HASH = _genesisState.protocolContractsHash;
+    VERSION = _config.version;
+    FEE_ASSET = _feeAsset;
+    EPOCH_PROOF_VERIFIER = _epochProofVerifier;
+
+    IInbox inbox = IInbox(address(new Inbox(address(this), _feeAsset, _config.version, INBOX_BUCKET_RING_SIZE)));
+    INBOX = inbox;
+    OUTBOX = IOutbox(address(new Outbox(address(this), _config.version)));
+    FEE_ASSET_PORTAL = IFeeJuicePortal(inbox.getFeeAssetPortal());
+
+    STFLib.initialize(_genesisState);
 
     FeeLib.initialize(_config.manaTarget, _config.provingCostPerMana, _config.initialEthPerFeeAsset);
   }
@@ -354,7 +380,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
    * @return The amount of rewards claimed
    */
   function claimSequencerRewards(address _coinbase) external override(IRollupCore) returns (uint256) {
-    return RewardExtLib.claimSequencerRewards(_coinbase);
+    return RewardExtLib.claimSequencerRewards(_coinbase, FEE_ASSET);
   }
 
   /**
@@ -370,7 +396,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
     override(IRollupCore)
     returns (uint256)
   {
-    return RewardExtLib.claimProverRewards(_coinbase, _epochs);
+    return RewardExtLib.claimProverRewards(_coinbase, _epochs, FEE_ASSET);
   }
 
   /**
@@ -470,7 +496,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
    * @param _args Contains the epoch range, public inputs, fees, attestations, and the ZK proof
    */
   function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args) external override(IRollupCore) {
-    EpochProofExtLib.submitEpochRootProof(_args);
+    EpochProofExtLib.submitEpochRootProof(_args, _getRollupConfig());
   }
 
   /**
@@ -493,7 +519,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
     bytes calldata _blobInput
   ) external override(IRollupCore) {
     RollupOperationsExtLib.propose(
-      _args, _attestations, _signers, _attestationsAndSignersSignature, _blobInput, checkBlob
+      _args, _attestations, _signers, _attestationsAndSignersSignature, _blobInput, checkBlob, INBOX
     );
   }
 
@@ -610,23 +636,16 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
     RewardExtLib.initializeConfig(rewardConfig);
   }
 
-  function _initializeStore(
-    IERC20 _feeAsset,
-    IVerifier _epochProofVerifier,
-    GenesisState memory _genesisState,
-    RollupConfigInput memory _config
-  ) internal {
-    STFLib.initialize(_genesisState);
-    RollupStore storage rollupStore = STFLib.getStorage();
-
-    rollupStore.config.feeAsset = _feeAsset;
-    rollupStore.config.epochProofVerifier = _epochProofVerifier;
-    rollupStore.config.version = _config.version;
-
-    IInbox inbox = IInbox(address(new Inbox(address(this), _feeAsset, _config.version, INBOX_BUCKET_RING_SIZE)));
-
-    rollupStore.config.inbox = inbox;
-    rollupStore.config.outbox = IOutbox(address(new Outbox(address(this), _config.version)));
-    rollupStore.config.feeAssetPortal = IFeeJuicePortal(inbox.getFeeAssetPortal());
+  function _getRollupConfig() internal view returns (RollupConfig memory) {
+    return RollupConfig({
+      vkTreeRoot: VK_TREE_ROOT,
+      protocolContractsHash: PROTOCOL_CONTRACTS_HASH,
+      version: VERSION,
+      feeAsset: FEE_ASSET,
+      feeAssetPortal: FEE_ASSET_PORTAL,
+      epochProofVerifier: EPOCH_PROOF_VERIFIER,
+      inbox: INBOX,
+      outbox: OUTBOX
+    });
   }
 }

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -86,6 +86,12 @@ struct RollupConfigInput {
   uint256 ethereumSlotDuration;
 }
 
+/**
+ * @notice The rollup's deployment-time configuration.
+ * @dev Every field is fixed at construction, so the values live in the Rollup's immutables rather than
+ *      in storage. This struct is assembled in memory and threaded down into the libraries, which cannot
+ *      read the contract's immutables themselves.
+ */
 struct RollupConfig {
   bytes32 vkTreeRoot;
   bytes32 protocolContractsHash;
@@ -102,7 +108,6 @@ struct RollupStore {
   mapping(uint256 checkpointNumber => bytes32 archive) archives;
   // The following represents a circular buffer. Key is `checkpointNumber % size`.
   mapping(uint256 circularIndex => CompressedTempCheckpointLog temp) tempCheckpointLogs;
-  RollupConfig config;
 }
 
 interface IRollupCore {

--- a/l1-contracts/src/core/libraries/rollup/EpochProofExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofExtLib.sol
@@ -2,7 +2,7 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {SubmitEpochRootProofArgs, PublicInputArgs, RollupConfig} from "@aztec/core/interfaces/IRollup.sol";
 import {ProposedHeader} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
 import {EpochProofLib} from "./EpochProofLib.sol";
 
@@ -20,8 +20,8 @@ import {EpochProofLib} from "./EpochProofLib.sol";
  *      - Epoch proof public input computation
  */
 library EpochProofExtLib {
-  function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args) external {
-    EpochProofLib.submitEpochRootProof(_args);
+  function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args, RollupConfig memory _config) external {
+    EpochProofLib.submitEpochRootProof(_args, _config);
   }
 
   function getEpochProofPublicInputs(
@@ -29,8 +29,9 @@ library EpochProofExtLib {
     uint256 _end,
     PublicInputArgs calldata _args,
     ProposedHeader[] calldata _headers,
-    bytes calldata _blobPublicInputs
+    bytes calldata _blobPublicInputs,
+    RollupConfig memory _config
   ) external view returns (bytes32[] memory) {
-    return EpochProofLib.getEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs);
+    return EpochProofLib.getEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs, _config);
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -4,7 +4,13 @@ pragma solidity >=0.8.27;
 
 import {BlobLib} from "@aztec-blob-lib/BlobLib.sol";
 import {IEscapeHatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
-import {SubmitEpochRootProofArgs, PublicInputArgs, IRollupCore, RollupStore} from "@aztec/core/interfaces/IRollup.sol";
+import {
+  SubmitEpochRootProofArgs,
+  PublicInputArgs,
+  IRollupCore,
+  RollupStore,
+  RollupConfig
+} from "@aztec/core/interfaces/IRollup.sol";
 import {CompressedTempCheckpointLog} from "@aztec/core/libraries/compressed-data/CheckpointLog.sol";
 import {CompressedFeeHeader, FeeHeaderLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {ChainTipsLib, CompressedChainTips} from "@aztec/core/libraries/compressed-data/Tips.sol";
@@ -101,8 +107,9 @@ library EpochProofLib {
    *              - attestations: Committee attestations for the last checkpoint in the epoch
    *              - blobInputs: Batched blob data for EIP-4844 point evaluation precompile
    *              - proof: The validity proof bytes for the root rollup circuit
+   * @param _config The rollup's deployment-time configuration
    */
-  function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args) internal {
+  function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args, RollupConfig memory _config) internal {
     if (STFLib.canPruneAtTime(Timestamp.wrap(block.timestamp))) {
       STFLib.prune();
     }
@@ -118,7 +125,7 @@ library EpochProofLib {
     // ensuring committee agreement on the epoch's validity alongside the cryptographic proof verification below.
     verifyLastCheckpointAttestationsAndOutHash(_args.end, _args.attestations, _args.args.outHash);
 
-    require(verifyEpochRootProof(_args), Errors.Rollup__InvalidProof());
+    require(verifyEpochRootProof(_args, _config), Errors.Rollup__InvalidProof());
 
     RollupStore storage rollupStore = STFLib.getStorage();
 
@@ -136,11 +143,11 @@ library EpochProofLib {
         // the number of checkpoints proven in this epoch so off-chain consumers can map a tx's
         // position-within-epoch directly to the smallest proof that covers it.
         uint256 numCheckpointsInEpoch = _args.end - _args.start + 1;
-        rollupStore.config.outbox.insert(endEpoch, numCheckpointsInEpoch, _args.args.outHash);
+        _config.outbox.insert(endEpoch, numCheckpointsInEpoch, _args.args.outHash);
       }
     }
 
-    RewardLib.handleRewardsAndFees(_args, endEpoch);
+    RewardLib.handleRewardsAndFees(_args, endEpoch, _config);
 
     emit IRollupCore.L2ProofVerified(_args.end, _args.args.proverId);
   }
@@ -162,16 +169,18 @@ library EpochProofLib {
    * @param  _args - Array of public inputs to the proof (previousArchive, endArchive, endTimestamp, outHash, proverId)
    * @param  _headers - The proposed checkpoint headers supplying the fee recipient and value for each checkpoint
    * @param _blobPublicInputs- The blob public inputs for the proof
+   * @param _config - The rollup's deployment-time configuration
    */
   function getEpochProofPublicInputs(
     uint256 _start,
     uint256 _end,
     PublicInputArgs calldata _args,
     ProposedHeader[] calldata _headers,
-    bytes calldata _blobPublicInputs
+    bytes calldata _blobPublicInputs,
+    RollupConfig memory _config
   ) internal view returns (bytes32[] memory) {
     verifyHeaders(_start, _end, _headers);
-    return computeEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs);
+    return computeEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs, _config);
   }
 
   /**
@@ -240,13 +249,15 @@ library EpochProofLib {
    * @param  _args - Array of public inputs to the proof (previousArchive, endArchive, endTimestamp, outHash, proverId)
    * @param  _headers - The proposed checkpoint headers supplying the fee recipient and value for each checkpoint
    * @param _blobPublicInputs- The blob public inputs for the proof
+   * @param _config - The rollup's deployment-time configuration
    */
   function computeEpochProofPublicInputs(
     uint256 _start,
     uint256 _end,
     PublicInputArgs calldata _args,
     ProposedHeader[] calldata _headers,
-    bytes calldata _blobPublicInputs
+    bytes calldata _blobPublicInputs,
+    RollupConfig memory _config
   ) private view returns (bytes32[] memory) {
     RollupStore storage rollupStore = STFLib.getStorage();
 
@@ -339,15 +350,15 @@ library EpochProofLib {
     publicInputs[offset] = bytes32(block.chainid);
     offset += 1;
 
-    publicInputs[offset] = bytes32(uint256(rollupStore.config.version));
+    publicInputs[offset] = bytes32(uint256(_config.version));
     offset += 1;
 
     // vk_tree_root
-    publicInputs[offset] = rollupStore.config.vkTreeRoot;
+    publicInputs[offset] = _config.vkTreeRoot;
     offset += 1;
 
     // protocol_contracts_hash
-    publicInputs[offset] = rollupStore.config.protocolContractsHash;
+    publicInputs[offset] = _config.protocolContractsHash;
     offset += 1;
 
     // prover_id: id of current epoch's prover
@@ -486,17 +497,20 @@ library EpochProofLib {
    *      - Rollup__InvalidArchive: End archive root mismatch in public inputs
    *
    * @param _args The epoch proof submission arguments containing proof data and public inputs
+   * @param _config The rollup's deployment-time configuration
    * @return True if both blob proof and validity proof verification succeed
    */
-  function verifyEpochRootProof(SubmitEpochRootProofArgs calldata _args) private view returns (bool) {
-    RollupStore storage rollupStore = STFLib.getStorage();
-
+  function verifyEpochRootProof(SubmitEpochRootProofArgs calldata _args, RollupConfig memory _config)
+    private
+    view
+    returns (bool)
+  {
     BlobLib.validateBatchedBlob(_args.blobInputs);
 
     bytes32[] memory publicInputs =
-      computeEpochProofPublicInputs(_args.start, _args.end, _args.args, _args.headers, _args.blobInputs);
+      computeEpochProofPublicInputs(_args.start, _args.end, _args.args, _args.headers, _args.blobInputs, _config);
 
-    require(rollupStore.config.epochProofVerifier.verify(_args.proof, publicInputs), Errors.Rollup__InvalidProof());
+    require(_config.epochProofVerifier.verify(_args.proof, publicInputs), Errors.Rollup__InvalidProof());
 
     return true;
   }

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -39,6 +39,17 @@ struct ProposePayload {
   bytes32 headerHash;
 }
 
+/**
+ * @notice The caller-supplied context for a proposal, bundled to keep `propose` off the stack limit.
+ * @param inbox - The Inbox the header's streaming message consumption is validated against
+ * @param checkBlob - Whether to run blob related checks. Hardcoded to true in RollupCore, exists only to be
+ *        overridden in tests
+ */
+struct ProposeConfig {
+  IInbox inbox;
+  bool checkBlob;
+}
+
 struct InterimProposeValues {
   ProposedHeader header;
   bytes32[] blobHashes;
@@ -168,8 +179,7 @@ library ProposeLib {
    * @param _blobsInput - The bytes to verify our input blob commitments match real blobs:
    *        - input[:1] - num blobs in checkpoint
    *        - input[1:] - blob commitments (48 bytes * num blobs in checkpoint)
-   * @param _checkBlob - Whether to skip blob related checks. Hardcoded to true in RollupCore, exists only to be
-   *          overridden in tests
+   * @param _config - The Inbox to validate message consumption against, and the blob check flag
    */
   function propose(
     ProposeArgs calldata _args,
@@ -177,7 +187,7 @@ library ProposeLib {
     address[] memory _signers,
     Signature calldata _attestationsAndSignersSignature,
     bytes calldata _blobsInput,
-    bool _checkBlob
+    ProposeConfig memory _config
   ) internal {
     // Prune unproven checkpoints if the proof submission window has passed
     if (STFLib.canPruneAtTime(Timestamp.wrap(block.timestamp))) {
@@ -192,7 +202,7 @@ library ProposeLib {
     // Validate blob commitments against actual blob data and extract hashes
     // TODO(#13430): The below blobsHashesCommitment known as blobsHash elsewhere in the code. The name is confusingly
     // similar to blobCommitmentsHash, see comment in BlobLib.sol -> validateBlobs().
-    (v.blobHashes, v.blobsHashesCommitment, v.blobCommitments) = BlobLib.validateBlobs(_blobsInput, _checkBlob);
+    (v.blobHashes, v.blobsHashesCommitment, v.blobCommitments) = BlobLib.validateBlobs(_blobsInput, _config.checkBlob);
 
     v.header = _args.header;
 
@@ -269,7 +279,7 @@ library ProposeLib {
     // child validates against it and, since temp-log records rewind with the pending chain on a prune, the record
     // stays prune-consistent.
     v.consumedInboxMsgTotal = validateInboxConsumption(
-      rollupStore.config.inbox,
+      _config.inbox,
       v.header.inboxRollingHash,
       _args.bucketHint,
       v.header.slotNumber,

--- a/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
@@ -20,6 +20,7 @@ import {
   IValidatorSelection
 } from "@aztec/core/reward-boost/RewardBooster.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 library RewardExtLib {
   function initializeConfig(RewardConfig memory _config) external {
@@ -30,12 +31,12 @@ library RewardExtLib {
     RewardLib.updateConfig(_config);
   }
 
-  function claimSequencerRewards(address _sequencer) external returns (uint256) {
-    return RewardLib.claimSequencerRewards(_sequencer);
+  function claimSequencerRewards(address _sequencer, IERC20 _feeAsset) external returns (uint256) {
+    return RewardLib.claimSequencerRewards(_sequencer, _feeAsset);
   }
 
-  function claimProverRewards(address _prover, Epoch[] memory _epochs) external returns (uint256) {
-    return RewardLib.claimProverRewards(_prover, _epochs);
+  function claimProverRewards(address _prover, Epoch[] memory _epochs, IERC20 _feeAsset) external returns (uint256) {
+    return RewardLib.claimProverRewards(_prover, _epochs, _feeAsset);
   }
 
   function deployRewardBooster(RewardBoostConfig memory _config) external returns (IBoosterCore) {

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -2,7 +2,7 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {RollupStore, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {RollupConfig, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {CompressedFeeHeader, FeeHeaderLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
@@ -105,22 +105,20 @@ library RewardLib {
     rewardStorage.config.checkpointReward = _config.checkpointReward;
   }
 
-  function claimSequencerRewards(address _sequencer) internal returns (uint256) {
+  function claimSequencerRewards(address _sequencer, IERC20 _feeAsset) internal returns (uint256) {
     RewardStorage storage rewardStorage = getStorage();
-    RollupStore storage rollupStore = STFLib.getStorage();
     uint256 amount = rewardStorage.sequencerRewards[_sequencer];
 
     if (amount > 0) {
       rewardStorage.sequencerRewards[_sequencer] = 0;
-      rollupStore.config.feeAsset.safeTransfer(_sequencer, amount);
+      _feeAsset.safeTransfer(_sequencer, amount);
     }
 
     return amount;
   }
 
-  function claimProverRewards(address _prover, Epoch[] memory _epochs) internal returns (uint256) {
+  function claimProverRewards(address _prover, Epoch[] memory _epochs, IERC20 _feeAsset) internal returns (uint256) {
     Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    RollupStore storage rollupStore = STFLib.getStorage();
 
     RewardStorage storage rewardStorage = getStorage();
 
@@ -145,14 +143,15 @@ library RewardLib {
     }
 
     if (accumulatedRewards > 0) {
-      rollupStore.config.feeAsset.safeTransfer(_prover, accumulatedRewards);
+      _feeAsset.safeTransfer(_prover, accumulatedRewards);
     }
 
     return accumulatedRewards;
   }
 
-  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) internal {
-    RollupStore storage rollupStore = STFLib.getStorage();
+  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch, RollupConfig memory _config)
+    internal
+  {
     RewardStorage storage rewardStorage = getStorage();
 
     uint256 length = _args.end - _args.start + 1;
@@ -241,11 +240,11 @@ library RewardLib {
       $er.longestProvenLength = length.toUint128();
 
       if (t.feesToClaim > 0) {
-        rollupStore.config.feeAssetPortal.distributeFees(address(this), t.feesToClaim);
+        _config.feeAssetPortal.distributeFees(address(this), t.feesToClaim);
       }
 
       if (t.totalBurn > 0) {
-        rollupStore.config.feeAsset.safeTransfer(BURN_ADDRESS, t.totalBurn);
+        _config.feeAsset.safeTransfer(BURN_ADDRESS, t.totalBurn);
       }
     }
   }

--- a/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
@@ -4,6 +4,7 @@
 pragma solidity >=0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
 import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {Timestamp, TimeLib, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {BlobLib} from "@aztec-blob-lib/BlobLib.sol";
@@ -11,6 +12,7 @@ import {AttestationLib} from "@aztec/core/libraries/rollup/AttestationLib.sol";
 import {
   ProposeLib,
   ProposeArgs,
+  ProposeConfig,
   CommitteeAttestations,
   ValidateHeaderArgs,
   ValidatorSelectionLib
@@ -61,9 +63,17 @@ library RollupOperationsExtLib {
     address[] calldata _signers,
     Signature calldata _attestationsAndSignersSignature,
     bytes calldata _blobInput,
-    bool _checkBlob
+    bool _checkBlob,
+    IInbox _inbox
   ) external {
-    ProposeLib.propose(_args, _attestations, _signers, _attestationsAndSignersSignature, _blobInput, _checkBlob);
+    ProposeLib.propose(
+      _args,
+      _attestations,
+      _signers,
+      _attestationsAndSignersSignature,
+      _blobInput,
+      ProposeConfig({inbox: _inbox, checkBlob: _checkBlob})
+    );
   }
 
   function prune() external {

--- a/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
@@ -17,6 +17,9 @@ import {
   ValidateHeaderArgs,
   ValidatorSelectionLib
 } from "./ProposeLib.sol";
+import {CheckpointHeaderValidationFlags} from "@aztec/core/interfaces/IRollup.sol";
+import {FeeLib} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {ProposedHeader} from "./ProposedHeaderLib.sol";
 import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 
 /**
@@ -38,22 +41,39 @@ library RollupOperationsExtLib {
   using TimeLib for Slot;
   using AttestationLib for CommitteeAttestations;
 
+  /**
+   * @dev Assembles `ValidateHeaderArgs` here rather than in the Rollup: building that struct
+   *      (which embeds a full `ProposedHeader`) in the Rollup's own code costs several hundred
+   *      bytes of runtime bytecode it cannot spare.
+   */
   function validateHeaderWithAttestations(
-    ValidateHeaderArgs calldata _args,
+    ProposedHeader calldata _header,
     CommitteeAttestations calldata _attestations,
     address[] calldata _signers,
-    Signature calldata _attestationsAndSignersSignature
+    Signature calldata _attestationsAndSignersSignature,
+    bytes32 _digest,
+    bytes32 _blobsHash,
+    CheckpointHeaderValidationFlags calldata _flags
   ) external {
-    ProposeLib.validateHeader(_args);
+    ProposeLib.validateHeader(
+      ValidateHeaderArgs({
+        header: _header,
+        digest: _digest,
+        manaMinFee: FeeLib.summedMinFee(ProposeLib.getManaMinFeeComponentsAt(Timestamp.wrap(block.timestamp), true)),
+        blobsHashesCommitment: _blobsHash,
+        flags: _flags
+      })
+    );
+
     if (_attestations.isEmpty()) {
       return; // No attestations to validate
     }
 
-    Slot slot = _args.header.slotNumber;
+    Slot slot = _header.slotNumber;
     Epoch epoch = slot.epochFromSlot();
-    ValidatorSelectionLib.verifyAttestations(epoch, _attestations, _args.digest);
+    ValidatorSelectionLib.verifyAttestations(epoch, _attestations, _digest);
     ValidatorSelectionLib.verifyProposer(
-      slot, epoch, _attestations, _signers, _args.digest, _attestationsAndSignersSignature, false
+      slot, epoch, _attestations, _signers, _digest, _attestationsAndSignersSignature, false
     );
   }
 

--- a/l1-contracts/src/core/libraries/rollup/STFLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/STFLib.sol
@@ -93,20 +93,14 @@ library STFLib {
   bytes32 private constant STF_STORAGE_POSITION = keccak256("aztec.stf.storage");
 
   /**
-   * @notice Initializes the rollup state with genesis configuration
-   * @dev Sets up the initial state of the rollup including verification keys and the genesis archive root.
-   *      This function should only be called once during rollup deployment.
+   * @notice Writes the genesis archive root at checkpoint 0
+   * @dev Should only be called once during rollup deployment. The remaining genesis fields
+   *      (vkTreeRoot, protocolContractsHash) are held in the Rollup's immutables.
    *
-   * @param _genesisState The initial state configuration containing:
-   *        - vkTreeRoot: Root of the verification key tree for circuit verification
-   *        - protocolContractsHash: Root containing protocol contract addresses and configurations
-   *        - genesisArchiveRoot: Initial archive root representing the genesis state
+   * @param _genesisState The initial state configuration; only `genesisArchiveRoot` is read here
    */
   function initialize(GenesisState memory _genesisState) internal {
     RollupStore storage rollupStore = STFLib.getStorage();
-
-    rollupStore.config.vkTreeRoot = _genesisState.vkTreeRoot;
-    rollupStore.config.protocolContractsHash = _genesisState.protocolContractsHash;
 
     // The genesis archive root is decoded as an Fr off chain and propagates into the first header's lastArchiveRoot,
     // so it must be a valid field element.

--- a/l1-contracts/test/RollupWithPreheating.sol
+++ b/l1-contracts/test/RollupWithPreheating.sol
@@ -7,7 +7,8 @@ import {IERC20} from "@aztec/core/interfaces/IRollup.sol";
 import {IRollupCore} from "@aztec/core/interfaces/IRollup.sol";
 import {GSE} from "@aztec/governance/GSE.sol";
 import {IVerifier} from "@aztec/core/interfaces/IVerifier.sol";
-import {STFLib, RollupStore, RollupCore} from "@aztec/core/RollupCore.sol";
+import {STFLib, RollupCore} from "@aztec/core/RollupCore.sol";
+import {RollupStore} from "@aztec/core/interfaces/IRollup.sol";
 import {CompressedFeeHeader, FeeHeaderLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {
   CompressedTempCheckpointLogLib,

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -7,7 +7,7 @@ import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {RewardBooster, IBoosterCore, RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
-import {SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {SubmitEpochRootProofArgs, RollupConfig} from "@aztec/core/interfaces/IRollup.sol";
 import {STFLib, RollupStore} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
@@ -63,6 +63,8 @@ contract RewardLibWrapper {
 
   RewardBooster internal booster;
   Epoch internal currentEpoch;
+  IERC20 internal immutable FEE_ASSET;
+  IFeeJuicePortal internal immutable FEE_ASSET_PORTAL;
   FakeRewardDistributor public rewardDistributor;
   FakeFeePortal public feePortal;
 
@@ -83,9 +85,8 @@ contract RewardLibWrapper {
 
     RewardLib.initializeConfig(config);
 
-    RollupStore storage rollupStore = STFLib.getStorage();
-    rollupStore.config.feeAsset = _feeAsset;
-    rollupStore.config.feeAssetPortal = IFeeJuicePortal(address(feePortal));
+    FEE_ASSET = _feeAsset;
+    FEE_ASSET_PORTAL = IFeeJuicePortal(address(feePortal));
 
     TimeLib.initialize(
       block.timestamp,
@@ -129,11 +130,16 @@ contract RewardLibWrapper {
   }
 
   function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) external {
-    RewardLib.handleRewardsAndFees(_args, _endEpoch);
+    RewardLib.handleRewardsAndFees(_args, _endEpoch, _rollupConfig());
   }
 
   function getSequencerRewards(address _sequencer) external view returns (uint256) {
     return RewardLib.getSequencerRewards(_sequencer);
+  }
+
+  function _rollupConfig() internal view returns (RollupConfig memory config) {
+    config.feeAsset = FEE_ASSET;
+    config.feeAssetPortal = FEE_ASSET_PORTAL;
   }
 
   function getCollectiveProverRewardsForEpoch(Epoch _epoch) external view returns (uint256) {

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -137,6 +137,7 @@ contract RewardLibWrapper {
     return RewardLib.getSequencerRewards(_sequencer);
   }
 
+  // Only the fields handleRewardsAndFees reads are populated; the rest stay zero.
   function _rollupConfig() internal view returns (RollupConfig memory config) {
     config.feeAsset = FEE_ASSET;
     config.feeAssetPortal = FEE_ASSET_PORTAL;

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -81,7 +81,7 @@
     "lodash.omit": "^4.5.0",
     "tslib": "^2.5.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -105,7 +105,7 @@
     "axios": "^1.15.1",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/builder": "workspace:^",

--- a/yarn-project/blob-client/package.json
+++ b/yarn-project/blob-client/package.json
@@ -67,7 +67,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/bot/package.json
+++ b/yarn-project/bot/package.json
@@ -71,7 +71,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -105,7 +105,7 @@
     "typescript": "^5.3.3",
     "util": "^0.12.5",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "0x": "^5.7.0",

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -73,7 +73,7 @@
     "@aztec/standard-contracts": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -35,7 +35,7 @@
     "jest-mock-extended": "^4.0.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -58,7 +58,7 @@
     "lodash.pickby": "^4.5.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -362,12 +362,12 @@ describe('Rollup', () => {
   });
 
   describe('getVkTreeRoot and getProtocolContractsHash', () => {
-    it('reads vkTreeRoot from storage', async () => {
+    it('reads vkTreeRoot', async () => {
       const result = await rollup.getVkTreeRoot();
       expect(result).toEqual(vkTreeRoot);
     });
 
-    it('reads protocolContractsHash from storage', async () => {
+    it('reads protocolContractsHash', async () => {
       const result = await rollup.getProtocolContractsHash();
       expect(result).toEqual(protocolContractsHash);
     });

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -449,16 +449,12 @@ export class RollupContract {
 
   @memoize
   async getVkTreeRoot(): Promise<Fr> {
-    const slot = BigInt(RollupContract.stfStorageSlot) + 3n;
-    const value = await this.client.getStorageAt({ address: this.address, slot: `0x${slot.toString(16)}` });
-    return Fr.fromString(value ?? '0x0');
+    return Fr.fromString(await this.rollup.read.getVkTreeRoot());
   }
 
   @memoize
   async getProtocolContractsHash(): Promise<Fr> {
-    const slot = BigInt(RollupContract.stfStorageSlot) + 4n;
-    const value = await this.client.getStorageAt({ address: this.address, slot: `0x${slot.toString(16)}` });
-    return Fr.fromString(value ?? '0x0');
+    return Fr.fromString(await this.rollup.read.getProtocolContractsHash());
   }
 
   /**

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -167,7 +167,7 @@
     "pino-pretty": "^13.0.0",
     "sha3": "^2.1.4",
     "undici": "^5.28.5",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/node-keystore/package.json
+++ b/yarn-project/node-keystore/package.json
@@ -70,7 +70,7 @@
     "@ethersproject/wallet": "^5.7.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -87,7 +87,7 @@
     "lodash.chunk": "^4.2.0",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/noir-contracts.js": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -52,7 +52,7 @@
     "lodash.chunk": "^4.2.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -66,7 +66,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -110,7 +110,7 @@
     "pako": "^2.1.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/expect": "^30.0.0",

--- a/yarn-project/stdlib/src/tx/public_simulation_output.test.ts
+++ b/yarn-project/stdlib/src/tx/public_simulation_output.test.ts
@@ -1,11 +1,19 @@
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
-import { PublicSimulationOutput } from './public_simulation_output.js';
+import { NestedProcessReturnValues, PublicSimulationOutput } from './public_simulation_output.js';
 
 describe('PublicSimulationOutput', () => {
   it('serializes to JSON', async () => {
     const output = await PublicSimulationOutput.random();
     const json = jsonStringify(output);
     expect(PublicSimulationOutput.schema.parse(JSON.parse(json))).toEqual(output);
+  });
+});
+
+describe('NestedProcessReturnValues', () => {
+  it('serializes nested values to JSON', () => {
+    const values = NestedProcessReturnValues.random(3);
+    const json = jsonStringify(values);
+    expect(NestedProcessReturnValues.schema.parse(JSON.parse(json))).toEqual(values);
   });
 });

--- a/yarn-project/stdlib/src/tx/public_simulation_output.ts
+++ b/yarn-project/stdlib/src/tx/public_simulation_output.ts
@@ -35,12 +35,7 @@ export class NestedProcessReturnValues {
   }
 
   static get schema(): ZodFor<NestedProcessReturnValues> {
-    return z
-      .object({
-        values: NullishToUndefined(z.array(schemas.Fr)),
-        nested: z.array(z.lazy(() => NestedProcessReturnValues.schema)),
-      })
-      .transform(({ values, nested }) => new NestedProcessReturnValues(values, nested));
+    return nestedProcessReturnValuesSchema;
   }
 
   static fromPlainObject(obj: any): NestedProcessReturnValues {
@@ -61,6 +56,15 @@ export class NestedProcessReturnValues {
     );
   }
 }
+
+// Built once at module load so that the self-reference below resolves to a single schema instance. Rebuilding it per
+// access (as a getter body would) makes the recursion unbounded.
+const nestedProcessReturnValuesSchema: ZodFor<NestedProcessReturnValues> = z
+  .object({
+    values: NullishToUndefined(z.array(schemas.Fr)),
+    nested: z.array(z.lazy(() => nestedProcessReturnValuesSchema)),
+  })
+  .transform(({ values, nested }) => new NestedProcessReturnValues(values, nested));
 
 /**
  * Outputs of processing the public component of a transaction.

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -86,7 +86,7 @@
     "@aztec/stdlib": "workspace:^",
     "@aztec/world-state": "workspace:^",
     "msgpackr": "^1.11.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-ha-signer/package.json
+++ b/yarn-project/validator-ha-signer/package.json
@@ -83,7 +83,7 @@
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.11.3",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.14",

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -74,7 +74,7 @@
     "@aztec/wsdb": "0.1.0",
     "msgpackr": "^1.11.2",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -744,7 +744,7 @@ __metadata:
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -825,7 +825,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1041,7 +1041,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   bin:
     blob-client: ./dest/client/bin/index.js
   languageName: unknown
@@ -1096,7 +1096,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1347,7 +1347,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1367,7 +1367,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1391,7 +1391,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1420,7 +1420,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1480,7 +1480,7 @@ __metadata:
     typescript-eslint: "npm:^8.32.1"
     undici: "npm:^5.28.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1627,7 +1627,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1906,7 +1906,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2062,7 +2062,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2131,7 +2131,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2209,7 +2209,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
     vitest: "npm:^4.0.0"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2275,7 +2275,7 @@ __metadata:
     msgpackr: "npm:^1.11.2"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   bin:
     txe: ./dest/bin/index.js
   languageName: unknown
@@ -2344,7 +2344,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2419,7 +2419,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -22340,7 +22340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4":
+"zod@npm:~4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36


### PR DESCRIPTION
This is the bottom of the Fast Inbox stack: it targets `project/fast-inbox` directly and is independently mergeable — nothing in it depends on the inbox work above it.

## Context

Every field of `RollupConfig` — `vkTreeRoot`, `protocolContractsHash`, `version`, `feeAsset`, `feeAssetPortal`, `epochProofVerifier`, `inbox`, `outbox` — is written exactly once in the Rollup's constructor and has no setter anywhere in `src/`. They were nonetheless kept in storage, so every read paid a cold `SLOAD`. `propose` paid one, `submitEpochRootProof` paid six.

## Approach

Move all eight into immutables and drop `config` from `RollupStore`.

Libraries cannot read a contract's immutables, and the `*ExtLib` libraries here are `external` (delegatecalled), so they cannot either. The values are assembled into a memory `RollupConfig` by `RollupCore._getRollupConfig()` and threaded down as parameters: the full struct into the epoch-proof path, the `IInbox` into propose, and the fee asset into the reward claims. Propose needed its `IInbox` bundled with the existing `checkBlob` flag into a `ProposeConfig` struct — a seventh scalar parameter pushed `ProposeLib.propose` over the stack limit, and a memory struct costs one slot instead of two.

`config` was the last member of `RollupStore`, so `tips`, `archives` and `tempCheckpointLogs` keep slots 0–2 and every raw-slot consumer of `keccak256("aztec.stf.storage")` is unaffected — all of them use offsets ≤ +2. The two that used `+3`/`+4` were `RollupContract.getVkTreeRoot` and `getProtocolContractsHash` in the TS client, which now call the contract getters that `IRollup` has exposed since #22563.

The second commit is bytecode budget, not gas. Each immutable read inlines a 32-byte push, which grew `Rollup`'s runtime code to within 148 bytes of the EIP-170 limit. `Rollup.validateHeaderWithAttestations` was decoding seven parameters, building a `ValidateHeaderArgs` (which embeds a full `ProposedHeader`) in memory, resolving the mana min fee through two delegatecall hops, and re-encoding four arguments — all in the Rollup's own runtime code. Forwarding the parameters straight through and assembling the struct in `RollupOperationsExtLib` frees 629 bytes. The fee value is unchanged: `RewardExtLib.summedMinFee` and `.getManaMinFeeComponentsAt` are one-line forwarders to the `FeeLib` / `ProposeLib` functions the ExtLib now calls directly.

## Gas

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `propose` (no validators) | 199,366 | 197,433 | **−1,933** |
| `submitEpochRootProof` (no validators) | 991,032 | 980,225 | **−10,807** |
| `propose` (100 validators) | 327,774 | 325,847 | **−1,927** |
| `submitEpochRootProof` (100 validators) | 1,572,081 | 1,561,291 | **−10,790** |
| `aggregate3` (100 validators) | 376,665 | 374,738 | **−1,927** |

The config getters lose their cold `SLOAD` outright — `getInbox` 2,543 → 878, `getVersion` 1,447 → 852, `getOutbox` 2,521 → 856. A handful of unrelated views move by 22–44 gas as the Rollup's selector dispatch shifts. Deployment also drops eight `SSTORE`s.

`Rollup` runtime bytecode ends at 23,799 against the 24,576 limit — 777 bytes of margin, against 886 before this change.

Note on the regenerated `gas_report.json`: call counts on a few entries drop by 36 because the three tests that fail only under `FORGE_GAS_REPORT` (`testExtraBlobs`, `testRevertInvalidCoinbase`, `testRevertInvalidTimestamp` — all failing identically on the base commit) abort at a slightly different point. Per-call gas for those entries is unchanged.

## Node compatibility

Node binaries already in the field read `vkTreeRoot` and `protocolContractsHash` from raw slots `+3`/`+4`. Against a rollup deployed from this branch those slots are zero, so such a node's `waitForCompatibleRollup` reports a VK mismatch and sits in standby. #25313 lands the getter-based read on the v5 line so binaries cut from it work against a rollup deployed from either version; it does nothing for binaries already released, so this needs sequencing against any node rollout.
