### PR TITLE
fix(fast-inbox): insert the block's L1-to-L2 messages before executing its txs

### DIFF
--- a/yarn-project/end-to-end/src/single-node/cross-chain/streaming_inbox.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/streaming_inbox.test.ts
@@ -326,4 +326,66 @@ describe('single-node/cross-chain/streaming_inbox', () => {
       .send({ from: user1Address, wait: { dontThrowOnRevert: true } });
     expect(failedReceipt.executionResult).toBe(TxExecutionResult.REVERTED);
   });
+
+  // Test 5 (forced same-block consumption): a public tx consuming a message that the *same* block inserts must
+  // succeed. The block builder appends the block's messages to its fork before executing txs, matching the prover
+  // and the block-root circuit (which pins each tx's L1-to-L2 tree snapshot to the post-append root); if it did
+  // not, this tx would revert at proposal time and succeed at proving time, making the epoch unprovable. The node
+  // simulates public calls against the messages predicted for the next block, so a consume tx sent as soon as the
+  // message's bucket becomes lag-eligible passes simulation and lands in the pool before the inserting block is
+  // built. The send is timed to that instant and retried with fresh messages when a block slips in between.
+  it('consumes a message in the same block that inserts it', async () => {
+    const l1Account = t.ethAccount;
+    const minBucketAge = BigInt(t.constants.ethereumSlotDuration);
+    const maxAttempts = 5;
+    let sameBlockReceipt: { blockNumber: BlockNumber; msgHash: Fr; globalLeafIndex: bigint } | undefined;
+
+    for (let attempt = 0; attempt < maxAttempts && sameBlockReceipt === undefined; attempt++) {
+      const [secret, secretHash] = await generateClaimSecret();
+      const message = { recipient: testContract.address, content: Fr.random(), secretHash };
+      const { msgHash, globalLeafIndex, txReceipt: l1Receipt } = await sendMessageToL2(message);
+      const messageL1Ts = await getMessageL1Timestamp(l1Receipt.blockNumber!);
+      const eligibleAt = messageL1Ts + minBucketAge;
+      log.warn(`Attempt ${attempt}: sent message ${msgHash.toString()}, eligible at L1 timestamp ${eligibleAt}`);
+
+      // Do not drive L2 blocks while waiting: an extra block here only shifts the timing of the inserting block.
+      await retryUntil(
+        async () => BigInt(await t.cheatCodes.eth.lastBlockTimestamp()) >= eligibleAt,
+        `message bucket becomes eligible at ${eligibleAt}`,
+        Number(t.constants.slotDuration) * 3,
+        0.2,
+      );
+      const blockAtSend = await aztecNode.getBlockNumber();
+
+      const { receipt } = await testContract.methods
+        .consume_message_from_arbitrary_sender_public(message.content, secret, l1Account, globalLeafIndex.toBigInt())
+        .send({ from: user1Address, wait: { dontThrowOnRevert: true } });
+      const inserting = await findInsertingBlock(msgHash, BlockNumber(blockAtSend + 1));
+      const consumeBlock = BlockNumber(Number(receipt.blockNumber));
+      log.warn(`Consume tx for ${msgHash.toString()} landed in block ${consumeBlock}`, {
+        insertingBlock: inserting.blockNumber,
+        consumeBlock,
+        executionResult: receipt.executionResult,
+      });
+
+      if (consumeBlock !== inserting.blockNumber) {
+        // A block was built between eligibility and the tx's arrival; that is timing, not a bug.
+        log.warn(`Consume did not land in the inserting block; retrying with a fresh message`);
+        continue;
+      }
+
+      // Same block reached: the consume must have succeeded against the block's own messages.
+      expect(receipt.executionResult).toBe(TxExecutionResult.SUCCESS);
+      sameBlockReceipt = { blockNumber: consumeBlock, msgHash, globalLeafIndex: globalLeafIndex.toBigInt() };
+    }
+
+    if (sameBlockReceipt === undefined) {
+      throw new Error(`Could not produce a same-block consume in ${maxAttempts} attempts`);
+    }
+    const [resolvedIndex] = (await aztecNode.getL1ToL2MessageMembershipWitness(
+      sameBlockReceipt.blockNumber,
+      sameBlockReceipt.msgHash,
+    ))!;
+    expect(resolvedIndex).toBe(sameBlockReceipt.globalLeafIndex);
+  });
 });

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.bench.test.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.bench.test.ts
@@ -157,7 +157,7 @@ describe('LightweightCheckpointBuilder benchmarks', () => {
       const globalVariables = makeGlobalVariables(blockNumber, slotNumber);
       const txs = await timesAsync(numTxs, i => makeTx(globalVariables, 5000 + i));
 
-      const { timings } = await builder.addBlock(globalVariables, txs, [], { insertTxsEffects: true });
+      const { timings } = await builder.applyEffectsAndSealBlock(globalVariables, txs, []);
 
       const prefix = `addBlock/${label}/${numTxs} txs`;
       for (const [step, ms] of Object.entries(timings)) {

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
@@ -9,9 +9,9 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { EthAddress } from '@aztec/stdlib/block';
 import { GasFees } from '@aztec/stdlib/gas';
-import { accumulateCheckpointOutHashes } from '@aztec/stdlib/messaging';
+import { accumulateCheckpointOutHashes, appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
 import { mockProcessedTx } from '@aztec/stdlib/testing';
-import { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import type { CheckpointGlobalVariables, ProcessedTx } from '@aztec/stdlib/tx';
 import { GlobalVariables } from '@aztec/stdlib/tx';
 import type { GenesisData } from '@aztec/stdlib/world-state';
@@ -302,6 +302,42 @@ describe('LightweightCheckpointBuilder', () => {
       expect(checkpoint.blocks[1].number).toEqual(BlockNumber(2));
 
       await fork.close();
+    });
+
+    it('insertL1ToL2Messages: false reuses leaves already in the fork and produces the same block', async () => {
+      const checkpointNumber = CheckpointNumber(1);
+      const slotNumber = SlotNumber(15);
+      const constants = makeCheckpointConstants(slotNumber);
+      const messages = [new Fr(0xb00), new Fr(0xb01), new Fr(0xb02)];
+      const globalVariables = makeGlobalVariables(BlockNumber(1), slotNumber);
+
+      // Default path: addBlock appends the messages itself.
+      const fork1 = await worldState.fork();
+      const builder1 = LightweightCheckpointBuilder.startNewCheckpoint(checkpointNumber, constants, [], Fr.ZERO, fork1);
+      const { block: block1 } = await builder1.addBlock(globalVariables, [], messages, { insertTxsEffects: true });
+
+      // Caller path: the messages are appended before the block is added, and addBlock is told not to append them again.
+      const fork2 = await worldState.fork();
+      const builder2 = LightweightCheckpointBuilder.startNewCheckpoint(checkpointNumber, constants, [], Fr.ZERO, fork2);
+      await appendL1ToL2MessagesToTree(fork2, messages);
+      const { block: block2 } = await builder2.addBlock(globalVariables, [], messages, {
+        insertTxsEffects: true,
+        insertL1ToL2Messages: false,
+      });
+
+      expect(block2.header.equals(block1.header)).toBe(true);
+      expect(block1.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(messages.length);
+      expect((await fork1.getTreeInfo(MerkleTreeId.L1_TO_L2_MESSAGE_TREE)).size).toBe(BigInt(messages.length));
+      expect((await fork2.getTreeInfo(MerkleTreeId.L1_TO_L2_MESSAGE_TREE)).size).toBe(BigInt(messages.length));
+
+      // The messages are still accumulated into the checkpoint's message list when the append is skipped.
+      const checkpoint1 = await builder1.completeCheckpoint();
+      const checkpoint2 = await builder2.completeCheckpoint();
+      expect(checkpoint2.header.inboxRollingHash).toEqual(checkpoint1.header.inboxRollingHash);
+      expect(checkpoint1.header.inboxRollingHash).not.toEqual(Fr.ZERO);
+
+      await fork1.close();
+      await fork2.close();
     });
   });
 

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
@@ -112,7 +112,7 @@ describe('LightweightCheckpointBuilder', () => {
 
       // Build empty block
       const globalVariables = makeGlobalVariables(blockNumber, slotNumber);
-      const { block } = await checkpointBuilder.addBlock(globalVariables, [], [], { insertTxsEffects: true });
+      const { block } = await checkpointBuilder.applyEffectsAndSealBlock(globalVariables, [], []);
 
       expect(block.header.globalVariables.blockNumber).toEqual(blockNumber);
 
@@ -156,10 +156,8 @@ describe('LightweightCheckpointBuilder', () => {
       const msgs = [Fr.random(), Fr.random()];
       tx.txEffect.l2ToL1Msgs.push(...msgs);
 
-      // Build block with tx - insertTxsEffects will handle inserting side effects
-      const { block } = await checkpointBuilder.addBlock(globalVariables, [tx], [], {
-        insertTxsEffects: true,
-      });
+      // Build block with tx
+      const { block } = await checkpointBuilder.applyEffectsAndSealBlock(globalVariables, [tx], []);
 
       expect(block.header.globalVariables.blockNumber).toEqual(blockNumber);
       expect(block.body.txEffects.length).toBe(1);
@@ -202,10 +200,8 @@ describe('LightweightCheckpointBuilder', () => {
       const globalVariables = makeGlobalVariables(blockNumber, slotNumber);
       const txs = await timesAsync(3, i => makeProcessedTx(globalVariables, 1000 + i));
 
-      // Build block with txs - insertTxsEffects will handle inserting side effects
-      const { block } = await checkpointBuilder.addBlock(globalVariables, txs, [], {
-        insertTxsEffects: true,
-      });
+      // Build block with txs
+      const { block } = await checkpointBuilder.applyEffectsAndSealBlock(globalVariables, txs, []);
 
       expect(block.header.globalVariables.blockNumber).toEqual(blockNumber);
       expect(block.body.txEffects.length).toBe(3);
@@ -247,10 +243,8 @@ describe('LightweightCheckpointBuilder', () => {
         // Create txs for this block
         const txs = await timesAsync(txsPerBlock, j => makeProcessedTx(globalVariables, 2000 + i * 10 + j));
 
-        // Build block - insertTxsEffects will handle inserting side effects
-        const { block } = await checkpointBuilder.addBlock(globalVariables, txs, [], {
-          insertTxsEffects: true,
-        });
+        // Build block
+        const { block } = await checkpointBuilder.applyEffectsAndSealBlock(globalVariables, txs, []);
 
         expect(block.header.globalVariables.blockNumber).toEqual(blockNumber);
         expect(block.body.txEffects.length).toBe(txsPerBlock);
@@ -288,11 +282,11 @@ describe('LightweightCheckpointBuilder', () => {
 
       const globalVariables1 = makeGlobalVariables(BlockNumber(1), slotNumber);
       const txs1 = await timesAsync(2, i => makeProcessedTx(globalVariables1, 3000 + i));
-      await checkpointBuilder.addBlock(globalVariables1, txs1, [], { insertTxsEffects: true });
+      await checkpointBuilder.applyEffectsAndSealBlock(globalVariables1, txs1, []);
 
       const messages = [new Fr(0xb00), new Fr(0xb01)];
       const globalVariables2 = makeGlobalVariables(BlockNumber(2), slotNumber);
-      const { block } = await checkpointBuilder.addBlock(globalVariables2, [], messages, { insertTxsEffects: true });
+      const { block } = await checkpointBuilder.applyEffectsAndSealBlock(globalVariables2, [], messages);
 
       expect(block.body.txEffects.length).toBe(0);
       expect(block.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(messages.length);
@@ -304,26 +298,23 @@ describe('LightweightCheckpointBuilder', () => {
       await fork.close();
     });
 
-    it('insertL1ToL2Messages: false reuses leaves already in the fork and produces the same block', async () => {
+    it('sealBlock reuses leaves already in the fork and produces the same block as applyEffectsAndSealBlock', async () => {
       const checkpointNumber = CheckpointNumber(1);
       const slotNumber = SlotNumber(15);
       const constants = makeCheckpointConstants(slotNumber);
       const messages = [new Fr(0xb00), new Fr(0xb01), new Fr(0xb02)];
       const globalVariables = makeGlobalVariables(BlockNumber(1), slotNumber);
 
-      // Default path: addBlock appends the messages itself.
+      // applyEffectsAndSealBlock appends the messages itself.
       const fork1 = await worldState.fork();
       const builder1 = LightweightCheckpointBuilder.startNewCheckpoint(checkpointNumber, constants, [], Fr.ZERO, fork1);
-      const { block: block1 } = await builder1.addBlock(globalVariables, [], messages, { insertTxsEffects: true });
+      const { block: block1 } = await builder1.applyEffectsAndSealBlock(globalVariables, [], messages);
 
-      // Caller path: the messages are appended before the block is added, and addBlock is told not to append them again.
+      // sealBlock expects the caller to have appended the messages already.
       const fork2 = await worldState.fork();
       const builder2 = LightweightCheckpointBuilder.startNewCheckpoint(checkpointNumber, constants, [], Fr.ZERO, fork2);
       await appendL1ToL2MessagesToTree(fork2, messages);
-      const { block: block2 } = await builder2.addBlock(globalVariables, [], messages, {
-        insertTxsEffects: true,
-        insertL1ToL2Messages: false,
-      });
+      const { block: block2 } = await builder2.sealBlock(globalVariables, [], messages);
 
       expect(block2.header.equals(block1.header)).toBe(true);
       expect(block1.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(messages.length);
@@ -387,7 +378,7 @@ describe('LightweightCheckpointBuilder', () => {
       const wrongBlockNumber = BlockNumber(5);
       const globalVariables = makeGlobalVariables(wrongBlockNumber, slotNumber);
 
-      await expect(checkpointBuilder.addBlock(globalVariables, [], [], { insertTxsEffects: true })).rejects.toThrow(
+      await expect(checkpointBuilder.applyEffectsAndSealBlock(globalVariables, [], [])).rejects.toThrow(
         /Archive tree next leaf index mismatch/,
       );
 

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -167,13 +167,16 @@ export class LightweightCheckpointBuilder {
   /**
    * Adds a new block to the checkpoint. The tx effects must have already been inserted into the db if
    * this is called after tx processing, if that's not the case, then set `insertTxsEffects` to true.
+   * Likewise, the block's L1-to-L2 messages are appended to the tree here by default; a caller that already
+   * appended them before executing the block's txs (so the AVM reads the same post-append tree the prover and
+   * the block-root circuit use) sets `insertL1ToL2Messages` to false.
    * @param l1ToL2Messages - The message leaves this block consumes from the Inbox, in insertion order.
    */
   public async addBlock(
     globalVariables: GlobalVariables,
     txs: ProcessedTx[],
     l1ToL2Messages: Fr[],
-    opts: { insertTxsEffects?: boolean; expectedEndState?: StateReference } = {},
+    opts: { insertTxsEffects?: boolean; insertL1ToL2Messages?: boolean; expectedEndState?: StateReference } = {},
   ): Promise<{ block: L2Block; timings: Record<string, number> }> {
     const timings: Record<string, number> = {};
     const isFirstBlock = this.blocks.length === 0;
@@ -199,12 +202,14 @@ export class LightweightCheckpointBuilder {
       timings.insertSideEffects = msInsertSideEffects;
     }
 
-    // Streaming Inbox: insert this block's L1-to-L2 message bundle before reading the end state,
-    // so the block header's L1-to-L2 tree snapshot reflects it. Bundles are appended compactly (unpadded, at the
-    // tree's current next-available index). The logical messages are accumulated only once the block is fully built
-    // (below), so a mid-build failure does not pollute the checkpoint's rolling hash; the rolling hash is recomputed
-    // over them at checkpoint completion.
-    await appendL1ToL2MessagesToTree(this.db, l1ToL2Messages);
+    // Streaming Inbox: unless the caller appended them already, insert this block's L1-to-L2 messages before reading
+    // the end state, so the block header's L1-to-L2 tree snapshot reflects them. Messages are appended compactly
+    // (unpadded, at the tree's current next-available index). The logical messages are accumulated only once the block
+    // is fully built (below), so a mid-build failure does not pollute the checkpoint's rolling hash; the rolling hash
+    // is recomputed over them at checkpoint completion.
+    if (opts.insertL1ToL2Messages ?? true) {
+      await appendL1ToL2MessagesToTree(this.db, l1ToL2Messages);
+    }
 
     const [msGetEndState, endState] = await elapsed(() => this.db.getStateReference());
     timings.getEndState = msGetEndState;

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -165,18 +165,41 @@ export class LightweightCheckpointBuilder {
   }
 
   /**
-   * Adds a new block to the checkpoint. The tx effects must have already been inserted into the db if
-   * this is called after tx processing, if that's not the case, then set `insertTxsEffects` to true.
-   * Likewise, the block's L1-to-L2 messages are appended to the tree here by default; a caller that already
-   * appended them before executing the block's txs (so the AVM reads the same post-append tree the prover and
-   * the block-root circuit use) sets `insertL1ToL2Messages` to false.
+   * Seals a block whose state updates are already in the db: the caller has inserted the tx effects and appended the
+   * block's L1-to-L2 messages to the tree (so the AVM read the same post-append tree the prover and the block-root
+   * circuit use). Reads the end state, builds the header and body, and records the block in the checkpoint.
    * @param l1ToL2Messages - The message leaves this block consumes from the Inbox, in insertion order.
+   * @param opts.expectedEndState - If set, the db's end state must match it or the block is rejected.
    */
-  public async addBlock(
+  public sealBlock(
     globalVariables: GlobalVariables,
     txs: ProcessedTx[],
     l1ToL2Messages: Fr[],
-    opts: { insertTxsEffects?: boolean; insertL1ToL2Messages?: boolean; expectedEndState?: StateReference } = {},
+    opts: { expectedEndState?: StateReference } = {},
+  ): Promise<{ block: L2Block; timings: Record<string, number> }> {
+    return this.addBlock(globalVariables, txs, l1ToL2Messages, { ...opts, applyStateUpdates: false });
+  }
+
+  /**
+   * Inserts the txs' side effects into the db, appends the block's L1-to-L2 messages to the tree, and then seals the
+   * block as `sealBlock` does.
+   * @param l1ToL2Messages - The message leaves this block consumes from the Inbox, in insertion order.
+   * @param opts.expectedEndState - If set, the db's end state must match it or the block is rejected.
+   */
+  public applyEffectsAndSealBlock(
+    globalVariables: GlobalVariables,
+    txs: ProcessedTx[],
+    l1ToL2Messages: Fr[],
+    opts: { expectedEndState?: StateReference } = {},
+  ): Promise<{ block: L2Block; timings: Record<string, number> }> {
+    return this.addBlock(globalVariables, txs, l1ToL2Messages, { ...opts, applyStateUpdates: true });
+  }
+
+  private async addBlock(
+    globalVariables: GlobalVariables,
+    txs: ProcessedTx[],
+    l1ToL2Messages: Fr[],
+    opts: { applyStateUpdates: boolean; expectedEndState?: StateReference },
   ): Promise<{ block: L2Block; timings: Record<string, number> }> {
     const timings: Record<string, number> = {};
     const isFirstBlock = this.blocks.length === 0;
@@ -189,7 +212,7 @@ export class LightweightCheckpointBuilder {
 
     const lastArchive = this.lastArchives.at(-1)!;
 
-    if (opts.insertTxsEffects) {
+    if (opts.applyStateUpdates) {
       this.logger.debug(
         `Inserting side effects for ${txs.length} txs for block ${globalVariables.blockNumber} into db`,
         { txs: txs.map(tx => tx.hash.toString()) },
@@ -202,12 +225,12 @@ export class LightweightCheckpointBuilder {
       timings.insertSideEffects = msInsertSideEffects;
     }
 
-    // Streaming Inbox: unless the caller appended them already, insert this block's L1-to-L2 messages before reading
-    // the end state, so the block header's L1-to-L2 tree snapshot reflects them. Messages are appended compactly
-    // (unpadded, at the tree's current next-available index). The logical messages are accumulated only once the block
-    // is fully built (below), so a mid-build failure does not pollute the checkpoint's rolling hash; the rolling hash
-    // is recomputed over them at checkpoint completion.
-    if (opts.insertL1ToL2Messages ?? true) {
+    // Streaming Inbox: the block's L1-to-L2 messages must be in the tree before reading the end state, so the block
+    // header's L1-to-L2 tree snapshot reflects them. Messages are appended compactly (unpadded, at the tree's current
+    // next-available index). The logical messages are accumulated only once the block is fully built (below), so a
+    // mid-build failure does not pollute the checkpoint's rolling hash; the rolling hash is recomputed over them at
+    // checkpoint completion.
+    if (opts.applyStateUpdates) {
       await appendL1ToL2MessagesToTree(this.db, l1ToL2Messages);
     }
 

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -260,10 +260,12 @@ export class TestContext {
       const txs = blockTxs[i];
       const state = blockEndStates[i];
 
-      const { block } = await builder.addBlock(blockGlobalVariables[i], txs, i === 0 ? l1ToL2Messages : [], {
-        expectedEndState: state,
-        insertTxsEffects: true,
-      });
+      const { block } = await builder.applyEffectsAndSealBlock(
+        blockGlobalVariables[i],
+        txs,
+        i === 0 ? l1ToL2Messages : [],
+        { expectedEndState: state },
+      );
 
       const header = block.header;
       this.headers.set(block.number, header);
@@ -386,10 +388,12 @@ export class TestContext {
       const txs = blockTxs[i];
       const state = blockEndStates[i];
 
-      const { block } = await builder.addBlock(blockGlobalVariables[i], txs, l1ToL2MessagesPerBlock[i], {
-        expectedEndState: state,
-        insertTxsEffects: true,
-      });
+      const { block } = await builder.applyEffectsAndSealBlock(
+        blockGlobalVariables[i],
+        txs,
+        l1ToL2MessagesPerBlock[i],
+        { expectedEndState: state },
+      );
 
       const header = block.header;
       this.headers.set(block.number, header);

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -509,7 +509,7 @@ describe('L1Publisher integration', () => {
       tempFork,
     );
 
-    await builder.addBlock(globalVariables, txs, l1ToL2Messages, { insertTxsEffects: true });
+    await builder.applyEffectsAndSealBlock(globalVariables, txs, l1ToL2Messages);
     const checkpoint = await builder.completeCheckpoint();
 
     await tempFork.close();

--- a/yarn-project/validator-client/src/checkpoint_builder.test.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.test.ts
@@ -173,7 +173,7 @@ describe('CheckpointBuilder', () => {
 
     async function mockSuccessfulBlock() {
       const block = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block, timings: {} });
       processor.process.mockResolvedValue([[{ hash: TxHash.random() } as ProcessedTx], [], [], [], []]);
       return block;
     }
@@ -208,7 +208,7 @@ describe('CheckpointBuilder', () => {
       lightweightCheckpointBuilder.getBlockCount.mockReturnValue(0);
 
       const expectedBlock = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
 
       processor.process.mockResolvedValue([
         [{ hash: Fr.random() } as unknown as ProcessedTx],
@@ -223,12 +223,12 @@ describe('CheckpointBuilder', () => {
       expect(result.block).toBe(expectedBlock);
       expect(result.numTxs).toBe(1);
       expect(result.failedTxs).toEqual([]);
-      expect(lightweightCheckpointBuilder.addBlock).toHaveBeenCalled();
+      expect(lightweightCheckpointBuilder.sealBlock).toHaveBeenCalled();
     });
 
     it('allows building an empty block when minValidTxs is 0', async () => {
       const expectedBlock = await L2Block.random(blockNumber, { txsPerBlock: 0 });
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
 
       // No transactions processed
       processor.process.mockResolvedValue([
@@ -243,7 +243,7 @@ describe('CheckpointBuilder', () => {
 
       expect(result.block).toBe(expectedBlock);
       expect(result.numTxs).toBe(0);
-      expect(lightweightCheckpointBuilder.addBlock).toHaveBeenCalled();
+      expect(lightweightCheckpointBuilder.sealBlock).toHaveBeenCalled();
     });
 
     it('throws InsufficientValidTxsError when fewer txs than minValidTxs', async () => {
@@ -260,7 +260,7 @@ describe('CheckpointBuilder', () => {
         checkpointBuilder.buildBlock([], blockNumber, 1000n, validatorOpts({ minValidTxs: 1 })),
       ).rejects.toThrow(InsufficientValidTxsError);
 
-      expect(lightweightCheckpointBuilder.addBlock).not.toHaveBeenCalled();
+      expect(lightweightCheckpointBuilder.sealBlock).not.toHaveBeenCalled();
     });
 
     it('does not update state when some txs succeed but below minValidTxs', async () => {
@@ -282,19 +282,19 @@ describe('CheckpointBuilder', () => {
       expect(err).toBeInstanceOf(InsufficientValidTxsError);
       expect((err as InsufficientValidTxsError).processedCount).toBe(1);
       expect((err as InsufficientValidTxsError).minRequired).toBe(2);
-      expect(lightweightCheckpointBuilder.addBlock).not.toHaveBeenCalled();
+      expect(lightweightCheckpointBuilder.sealBlock).not.toHaveBeenCalled();
     });
 
     it('defaults to minValidTxs=0 when not specified, allowing empty blocks', async () => {
       const expectedBlock = await L2Block.random(blockNumber, { txsPerBlock: 0 });
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
 
       processor.process.mockResolvedValue([[], [], [], [], []]);
 
       const result = await checkpointBuilder.buildBlock([], blockNumber, 1000n, validatorOpts());
 
       expect(result.numTxs).toBe(0);
-      expect(lightweightCheckpointBuilder.addBlock).toHaveBeenCalled();
+      expect(lightweightCheckpointBuilder.sealBlock).toHaveBeenCalled();
     });
   });
 
@@ -580,7 +580,7 @@ describe('CheckpointBuilder', () => {
       ]);
 
       const expectedBlock = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
       processor.process.mockResolvedValue([[{ hash: Fr.random() } as unknown as ProcessedTx], [], [], [], []]);
 
       // Build block 2
@@ -598,7 +598,7 @@ describe('CheckpointBuilder', () => {
       setupBuilder({ rollupManaLimit });
 
       const expectedBlock = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
       processor.process.mockResolvedValue([[{ hash: Fr.random() } as unknown as ProcessedTx], [], [], [], []]);
 
       const capturedL2GasLimits: number[] = [];
@@ -631,7 +631,7 @@ describe('CheckpointBuilder', () => {
       setupBuilder({ rollupManaLimit });
 
       const expectedBlock = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
       processor.process.mockResolvedValue([[{ hash: Fr.random() } as unknown as ProcessedTx], [], [], [], []]);
 
       const capturedL2GasLimits: number[] = [];
@@ -669,7 +669,7 @@ describe('CheckpointBuilder', () => {
       setupBuilder({ rollupManaLimit });
 
       const expectedBlock = await L2Block.random(blockNumber);
-      lightweightCheckpointBuilder.addBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
+      lightweightCheckpointBuilder.sealBlock.mockResolvedValue({ block: expectedBlock, timings: {} });
       processor.process.mockResolvedValue([[{ hash: Fr.random() } as unknown as ProcessedTx], [], [], [], []]);
 
       // Explicit per-block limit (100k) is TIGHTER than redistribution.

--- a/yarn-project/validator-client/src/checkpoint_builder.test.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.test.ts
@@ -11,7 +11,7 @@ import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/bra
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { TestDateProvider } from '@aztec/foundation/timer';
-import type { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
+import { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
 import type { AvmSimulator, PublicContractsDB, PublicProcessor } from '@aztec/simulator/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, L2Block } from '@aztec/stdlib/block';
@@ -26,6 +26,7 @@ import {
   type PublicProcessorValidator,
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   type CheckpointGlobalVariables,
   type GlobalVariables,
@@ -34,8 +35,9 @@ import {
   TxHash,
 } from '@aztec/stdlib/tx';
 import type { TelemetryClient } from '@aztec/telemetry-client';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { CheckpointBuilder, FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
@@ -787,6 +789,102 @@ describe('CheckpointBuilder', () => {
 
       expect(capped.maxBlockGas!.daGas).toBeLessThan(largestDeployDaGas);
       expect(capped.maxBlobFields!).toBeLessThan(largestDeployBlobFields);
+    });
+  });
+
+  // These cases use a real world state fork and a real LightweightCheckpointBuilder, since the position of the
+  // block's L1-to-L2 messages relative to tx execution is invisible with a mocked fork.
+  describe('buildBlock with streaming L1-to-L2 messages (real world state)', () => {
+    let worldState: NativeWorldStateService;
+    let realFork: MerkleTreeWriteOperations;
+    let lightweight: LightweightCheckpointBuilder;
+    let builder: TestCheckpointBuilder;
+
+    const messages = [new Fr(0xb00), new Fr(0xb01), new Fr(0xb02)];
+    const firstBlockNumber = BlockNumber(1);
+
+    const getL1ToL2TreeSize = () => realFork.getTreeInfo(MerkleTreeId.L1_TO_L2_MESSAGE_TREE).then(info => info.size);
+
+    beforeEach(async () => {
+      worldState = await NativeWorldStateService.tmp();
+      realFork = await worldState.fork();
+      lightweight = LightweightCheckpointBuilder.startNewCheckpoint(checkpointNumber, constants, [], Fr.ZERO, realFork);
+      builder = new TestCheckpointBuilder(
+        lightweight,
+        realFork,
+        config,
+        contractDataSource,
+        dateProvider,
+        telemetryClient,
+        mock<AvmSimulator>(),
+      );
+    });
+
+    afterEach(async () => {
+      await realFork.close();
+      await worldState.close();
+    });
+
+    it("the block's messages are in the fork when the public processor runs", async () => {
+      let treeSizeDuringExecution: bigint | undefined;
+      let leafIndicesDuringExecution: (bigint | undefined)[] | undefined;
+      processor.process.mockImplementation(async () => {
+        treeSizeDuringExecution = await getL1ToL2TreeSize();
+        leafIndicesDuringExecution = await realFork.findLeafIndices(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, messages);
+        return [[], [], [], [], []];
+      });
+
+      const { block } = await builder.buildBlock([], firstBlockNumber, 1000n, {
+        ...validatorOpts(),
+        l1ToL2Messages: messages,
+      });
+
+      // The AVM must read the same post-append tree the prover and the block-root circuit use.
+      expect(treeSizeDuringExecution).toBe(3n);
+      expect(leafIndicesDuringExecution).toEqual([0n, 1n, 2n]);
+      expect(block.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(3);
+      // The messages are appended exactly once.
+      expect(await getL1ToL2TreeSize()).toBe(3n);
+    });
+
+    it('a failed block rolls its messages back', async () => {
+      processor.process.mockRejectedValue(new Error('processor failure'));
+
+      await expect(
+        builder.buildBlock([], firstBlockNumber, 1000n, { ...validatorOpts(), l1ToL2Messages: messages }),
+      ).rejects.toThrow('processor failure');
+
+      expect(await getL1ToL2TreeSize()).toBe(0n);
+      expect(lightweight.getBlocks()).toEqual([]);
+    });
+
+    it('a block below minValidTxs rolls its messages back', async () => {
+      processor.process.mockResolvedValue([[], [], [], [], []]);
+
+      await expect(
+        builder.buildBlock([], firstBlockNumber, 1000n, {
+          ...validatorOpts({ minValidTxs: 1 }),
+          l1ToL2Messages: messages,
+        }),
+      ).rejects.toThrow(InsufficientValidTxsError);
+
+      expect(await getL1ToL2TreeSize()).toBe(0n);
+      expect(lightweight.getBlocks()).toEqual([]);
+    });
+
+    it('an empty or absent message list leaves the tree untouched', async () => {
+      processor.process.mockResolvedValue([[], [], [], [], []]);
+
+      const { block: block1 } = await builder.buildBlock([], firstBlockNumber, 1000n, {
+        ...validatorOpts(),
+        l1ToL2Messages: [],
+      });
+      expect(block1.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(0);
+      expect(await getL1ToL2TreeSize()).toBe(0n);
+
+      const { block: block2 } = await builder.buildBlock([], BlockNumber(firstBlockNumber + 1), 1000n, validatorOpts());
+      expect(block2.header.state.l1ToL2MessageTree.nextAvailableLeafIndex).toBe(0);
+      expect(await getL1ToL2TreeSize()).toBe(0n);
     });
   });
 });

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -33,6 +33,7 @@ import {
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import { type DebugLogStore, NullDebugLogStore } from '@aztec/stdlib/logs';
+import { appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import { type CheckpointGlobalVariables, GlobalVariables, StateReference, Tx } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
@@ -118,6 +119,14 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     const forkCheckpoint = await ForkCheckpoint.new(this.fork);
 
     try {
+      // Insert this block's streaming L1-to-L2 message bundle before executing its txs. The prover node appends the
+      // bundle to its fork before re-executing, and the block-root circuit pins each tx's L1-to-L2 tree snapshot to
+      // the post-bundle root, so the AVM here must read the same tree or a tx consuming a message from this block's
+      // bundle would revert at proposal time and succeed at proving time. Appending inside the fork checkpoint means
+      // a failed block rolls the leaves back together with the tx effects.
+      const l1ToL2Messages = opts.l1ToL2Messages ?? [];
+      await appendL1ToL2MessagesToTree(this.fork, l1ToL2Messages);
+
       const [publicProcessorDuration, [processedTxs, failedTxs, usedTxs]] = await elapsed(() =>
         processor.process(pendingTxs, cappedOpts, validator),
       );
@@ -131,15 +140,12 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       // Commit the fork checkpoint
       await forkCheckpoint.commit();
 
-      // Add block to checkpoint, inserting this block's streaming L1-to-L2 message bundle (if any) into the fork.
-      const { block } = await this.checkpointBuilder.addBlock(
-        globalVariables,
-        processedTxs,
-        opts.l1ToL2Messages ?? [],
-        {
-          expectedEndState: opts.expectedEndState,
-        },
-      );
+      // Add block to checkpoint. The bundle is already in the fork; addBlock only accumulates it into the
+      // checkpoint's message list for the rolling hash.
+      const { block } = await this.checkpointBuilder.addBlock(globalVariables, processedTxs, l1ToL2Messages, {
+        expectedEndState: opts.expectedEndState,
+        insertL1ToL2Messages: false,
+      });
 
       this.contractsDB.commitCheckpoint();
 

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -119,11 +119,11 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     const forkCheckpoint = await ForkCheckpoint.new(this.fork);
 
     try {
-      // Insert this block's streaming L1-to-L2 message bundle before executing its txs. The prover node appends the
-      // bundle to its fork before re-executing, and the block-root circuit pins each tx's L1-to-L2 tree snapshot to
-      // the post-bundle root, so the AVM here must read the same tree or a tx consuming a message from this block's
-      // bundle would revert at proposal time and succeed at proving time. Appending inside the fork checkpoint means
-      // a failed block rolls the leaves back together with the tx effects.
+      // Insert this block's streaming L1-to-L2 messages before executing its txs. The prover node appends them to its
+      // fork before re-executing, and the block-root circuit pins each tx's L1-to-L2 tree snapshot to the post-append
+      // root, so the AVM here must read the same tree or a tx consuming a message this block inserts would revert at
+      // proposal time and succeed at proving time. Appending inside the fork checkpoint means a failed block rolls the
+      // leaves back together with the tx effects.
       const l1ToL2Messages = opts.l1ToL2Messages ?? [];
       await appendL1ToL2MessagesToTree(this.fork, l1ToL2Messages);
 
@@ -140,11 +140,8 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       // Commit the fork checkpoint
       await forkCheckpoint.commit();
 
-      // Add block to checkpoint. The bundle is already in the fork; addBlock only accumulates it into the
-      // checkpoint's message list for the rolling hash.
-      const { block } = await this.checkpointBuilder.addBlock(globalVariables, processedTxs, l1ToL2Messages, {
+      const { block } = await this.checkpointBuilder.sealBlock(globalVariables, processedTxs, l1ToL2Messages, {
         expectedEndState: opts.expectedEndState,
-        insertL1ToL2Messages: false,
       });
 
       this.contractsDB.commitCheckpoint();


### PR DESCRIPTION
Stacked on #25305

## The bug

`CheckpointBuilder.buildBlock` ran the public processor on a world-state fork that did not yet contain the block's own streaming L1-to-L2 messages; they were appended afterwards inside `LightweightCheckpointBuilder.addBlock`. The prover node appends them to its fork **before** re-executing the block (`checkpoint-prover.ts` `createFork`), and the block-root circuit pins each tx's `l1_to_l2_tree_snapshot` to the **post**-append root (`block_root_rollup_inputs_validator.nr`, `block_constant_data.nr`).

So a public tx that consumes a message inserted by its own block reverted at proposal time (the leaf was not there yet) and succeeded at proving time (the leaf was there). The tx effects differ, the prover throws `Block header mismatch` on an already-attested and published block, and the epoch cannot be proven and gets pruned. Proposer and validators both use `buildBlock`, so they agreed with each other and nothing caught it before the prover.

Fixes [A-1768](https://linear.app/aztec-labs/issue/A-1768/block-builder-runs-the-avm-before-inserting-the-blocks-l1-to-l2)

## Before and after

```mermaid
sequenceDiagram
    participant P as Proposer / validators<br/>(CheckpointBuilder.buildBlock)
    participant F as World-state fork
    participant V as Prover<br/>(checkpoint-prover.ts)

    rect rgb(255, 236, 236)
    note over P,V: Before
    P->>F: ForkCheckpoint.new
    P->>F: processor.process(txs) — L1-to-L2 tree has no messages yet
    F-->>P: consume tx REVERTED (leaf missing)
    P->>F: addBlock → append messages (too late)
    V->>F: append messages
    V->>F: re-execute txs — leaf present
    F-->>V: consume tx SUCCESS
    note over P,V: tx effects differ → "Block header mismatch" → epoch unprovable, pruned
    end

    rect rgb(232, 247, 236)
    note over P,V: After
    P->>F: ForkCheckpoint.new
    P->>F: append messages
    P->>F: processor.process(txs) — post-append tree
    F-->>P: consume tx SUCCESS
    P->>F: sealBlock (messages already in fork)
    V->>F: append messages, re-execute txs
    F-->>V: consume tx SUCCESS — headers match
    end
```

The circuits already pinned each tx's `l1_to_l2_tree_snapshot` to the post-append root, so only the proposer/validator side moves; the prover was already right. Appending inside the `ForkCheckpoint` means a failed block rolls the leaves back with the tx effects.

## The fix

- `CheckpointBuilder.buildBlock` now appends the block's L1-to-L2 messages to the fork right after `ForkCheckpoint.new` and before `processor.process`, so the AVM reads the same post-append tree the prover and the circuits use. Appending inside the fork checkpoint means a failed block (`InsufficientValidTxsError`, processor throw) rolls the leaves back together with the tx effects, so the retry in the next sub-slot does not double-insert.
- `LightweightCheckpointBuilder.addBlock` is split into two public methods over one private implementation: `sealBlock` (the caller already applied the block's tx effects and messages to the fork; used by `buildBlock`) and `applyEffectsAndSealBlock` (the builder inserts both, then seals; used by tests). The former `insertTxsEffects` flag and the message append were always toggled together, so a single `applyStateUpdates` switch replaces them. Either way the messages are accumulated into the checkpoint's message list, so `inboxRollingHash` is unchanged.

Block bodies, headers, leaf indices and the checkpoint `inboxRollingHash` are identical before and after; only the tree the AVM reads *during* execution changes. No circuit, L1, p2p, or serialization changes. The prover node, the orchestrator, and `node_public_calls_simulator.ts` were already correct and are untouched. Proposer and validators switch to the post-append view together, so there is no protocol-level version skew.

## Tests

Red/green, real world state (no mock call-order assertions):

- `validator-client/src/checkpoint_builder.test.ts`, new `buildBlock with streaming L1-to-L2 messages (real world state)`:
  - *the block's messages are in the fork when the public processor runs* — fails on the base branch with `Expected: 3n / Received: 0n` (the L1-to-L2 tree was empty while txs executed); passes with the fix. Also asserts the header's `nextAvailableLeafIndex` and that the tree holds the messages exactly once (guards against `sealBlock` re-appending).
  - *a failed block rolls its messages back* and *a block below minValidTxs rolls its messages back* — pin the "append inside the ForkCheckpoint" requirement.
  - *an empty or absent message list leaves the tree untouched*.
- `prover-client/src/light/lightweight_checkpoint_builder.test.ts`: *sealBlock reuses leaves already in the fork and produces the same block as applyEffectsAndSealBlock* — same header, same tree size and same `inboxRollingHash` as the default path.
- `end-to-end/.../streaming_inbox.test.ts`: new *consumes a message in the same block that inserts it* — times a public consume tx to the instant the message's bucket becomes lag-eligible (the node simulates against the messages predicted for the next block so it enters the pool), retries with a fresh message if a block slips in between, and asserts the consume `SUCCESS` when it lands in the inserting block. On the base branch that receipt is `REVERTED` (`Tried to consume nonexistent L1-to-L2 message`). Existing test 4 is kept as is.

Surrounding suites (`checkpoint_builder.test.ts`, `lightweight_checkpoint_builder.test.ts`, `proposal_handler.test.ts`, `checkpoint_proposal_job.test.ts`) pass.
