### PR TITLE
chore(labs-patches): upstream command and a tooling reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,15 +56,24 @@ Follow Conventional Commits: `fix:`, `feat:`, `chore:`, `refactor:`, `docs:`, `t
 </commits_and_prs>
 
 <git_staging>
-When staging files, prefer `git add -u` or name specific files rather than `git add -A` or `git add .`. The aggregate flags will pick up unrelated untracked working directories (e.g. personal scratch projects at the repo root) and quietly stage them. `git add -u` and `git commit -a` also stage the `labs` gitlink whenever the patch series is applied (`git status` shows ` M labs`); unstage it with `git restore --staged labs` (see `<labs_submodule_patches>`). Subagents must always name specific files in `git add` — never `-u`, `-A`, or `.` — because they lack the main conversation's context for judging which changes belong to the current task.
-</git_staging>
+When staging files, prefer `git add -u` or name specific files rather than `git add -A` or `git add .`. The aggregate flags will pick up unrelated untracked working directories (e.g. personal scratch projects at the repo root) and quietly stage them. `git add -u` and `git commit -a` also stage the `labs` gitlink whenever the patch series is applied (`git status` shows ` M labs`); unstage it with `git restore --staged labs` (see `<labs_submodule_patches>
+`labs/` (the aztec-node submodule) carries the foundation's patch series from `labs-patches/*.patch`, applied with `git am` by `labs-patches/bootstrap.sh apply` (run by the root bootstrap, the git hooks and `make labs-patched`), so `labs/` HEAD normally sits ahead of the recorded gitlink. Never `git add labs` by hand — that records a patch commit that does not exist upstream; move the pin with `labs-patches/bootstrap.sh bump <ref>`. To change a patch, commit inside `labs/` on top of the applied series and run `labs-patches/bootstrap.sh export`, then commit the regenerated `.patch` files. To send a patch to aztec-node, `labs-patches/bootstrap.sh upstream <n>` prepares the branch and prints the push/PR commands. See `labs-patches/README.md`.
 
-<lockfile_discipline>
-Never bulk-update lockfiles (`Cargo.lock`, `yarn.lock`). Use targeted updates only: `cargo update --precise <version> --package <name>` for Rust, and `yarn up <package>@<version>` in the relevant workspace for TypeScript. Bulk updates drag in unrelated transitive changes that make review impossible and frequently break reproducibility.
-</lockfile_discipline>
+The tooling, all in `labs-patches/bootstrap.sh` (foundation-owned; only the `.patch` contents ever go upstream):
 
-<labs_submodule_patches>
-`labs/` (the aztec-node submodule) carries the foundation's patch series from `labs-patches/*.patch`, applied with `git am` by `labs-patches/bootstrap.sh apply` (run by the root bootstrap, the git hooks and `make labs-patched`), so `labs/` HEAD normally sits ahead of the recorded gitlink. Never `git add labs` by hand — that records a patch commit that does not exist upstream; move the pin with `labs-patches/bootstrap.sh bump <ref>`. To change a patch, commit inside `labs/` on top of the applied series and run `labs-patches/bootstrap.sh export`, then commit the regenerated `.patch` files. See `labs-patches/README.md`.
+| Command | What it does |
+|---|---|
+| `apply` | Checks out the gitlink (`update = none` submodule) and `git am`s the series with a fixed committer identity, so the applied SHAs are identical everywhere. Idempotent; refuses to drop `labs/` commits that are not in the series (`LABS_PATCHES_FORCE=1` overrides); stashes uncommitted edits. |
+| `export` | Regenerates `*.patch` from the commits above the gitlink, skipping marker commits. Run it after committing inside `labs/`. |
+| `check` | Applies the committed series to the gitlink in a temporary worktree; CI runs it. |
+| `bump <ref>` | Fetches an aztec-node ref, stages the new gitlink and re-applies; refuses on unexported work. |
+| `upstream <n> [branch]` | Creates `fnd/<patch-slug>` in `labs/`'s repository with only patch `n` applied under your own identity, and prints the push and `gh pr create` commands. |
+| `status` | Base, checkout, series, whether it is applied, and unexported commits. |
+| `commit-use-local` | Commits the build's manifest rewrite as the marker commit (`labs-patches: use-local rewrite (never exported)`), staging only `package.json`/`yarn.lock`/`Nargo.toml`/`fnd-hashes`. Called by the build, not by hand. |
+| `check_staged` | The `pre-commit` hook: rejects a staged gitlink that is a series or marker commit. |
+| `test`, `test_cmds` | Run / list the tooling's tests: `tests/lifecycle_test` (a sandbox fixture exercising every command) and `check`; `make labs-patches-tests` runs them in CI. |
+
+State lives in `.git/modules/labs/labs-patches.state` (stamp of base + series, applied commits); the series is recognised by `git patch-id`, so a lost state file is re-derived from content. `post-merge`/`post-checkout` hooks re-run `apply` only when the gitlink or the series changed.
 </labs_submodule_patches>
 
 <standard_contract_repin>

--- a/labs-patches/README.md
+++ b/labs-patches/README.md
@@ -29,4 +29,16 @@ fetches the ref, stages the new gitlink and re-applies the series. If a patch no
 
 `bootstrap.sh check` verifies the series applies to the gitlink in a temporary worktree without touching `labs/`. CI runs it, together with `tests/lifecycle_test` (the tooling exercised end to end against a sandbox fixture: apply, export, marker commits, bumps, the guards), through `make labs-patches-tests`; `bootstrap.sh test` runs both locally.
 
+## Upstreaming a patch
+
 The series is a queue of things to upstream: every patch here is carried through every bump, so open the aztec-node PR early and let the patch drop out when it lands.
+
+```
+./labs-patches/bootstrap.sh upstream 3            # or a .patch path; optional branch name as 2nd arg
+git -C labs push origin fnd/<patch-slug>
+gh pr create --repo aztec-labs-eng/aztec-node --head fnd/<patch-slug> --base main --fill
+```
+
+`upstream` creates the branch in `labs/`'s repository at the recorded base with only that patch applied, under your own git identity (the series itself is applied with a fixed one). It pushes nothing; the two commands it prints do. When the PR is merged, `bump` past it and the patch disappears from the next `export`.
+
+Everything else in this directory (`bootstrap.sh`, the tests, `test_cmd_skip`) is the foundation's own tooling and never goes upstream.

--- a/labs-patches/bootstrap.sh
+++ b/labs-patches/bootstrap.sh
@@ -29,6 +29,9 @@ labs=$fnd_root/labs
 MARKER_SUBJECT="labs-patches: use-local rewrite (never exported)"
 # Fixed committer identity and author dates keep the applied SHAs identical on every machine,
 # and mark every commit this script makes so check_staged can tell them from upstream ones.
+# The caller's own identity is kept for commits meant to leave this clone (upstream).
+caller_committer_name=${GIT_COMMITTER_NAME:-}
+caller_committer_email=${GIT_COMMITTER_EMAIL:-}
 export GIT_COMMITTER_NAME=labs-patches
 export GIT_COMMITTER_EMAIL=labs-patches@localhost
 git_labs() { git -C "$labs" -c commit.gpgsign=false "$@"; }
@@ -299,6 +302,44 @@ function check_staged {
   fi
 }
 
+# Prepares one patch as an aztec-node branch: a branch in labs/'s repository at the recorded
+# base with just that patch applied under your own git identity, ready to push and open as the
+# upstream PR. Nothing is pushed; the commands to do so are printed. Once the PR lands and the
+# pin is bumped past it, the patch drops out of the next export on its own.
+function upstream {
+  local sel=${1:-} branch=${2:-}
+  [ -n "$sel" ] || die "usage: upstream <patch number or file> [branch]"
+  initialized || die "labs/ is not checked out; run apply first"
+  local p
+  if [ -f "$sel" ]; then p=$sel; else
+    p=$(patches | grep "/0*${sel#0}-[^/]*\.patch\$" | head -1)
+    [ -n "$p" ] || die "no patch matching '$sel' in $patch_dir"
+  fi
+  local slug; slug=$(basename "$p" .patch | sed 's/^[0-9]*-//')
+  branch=${branch:-fnd/$slug}
+  if git_labs show-ref -q --verify "refs/heads/$branch"; then
+    die "branch $branch already exists in labs/; pick another name or delete it"
+  fi
+  local base; base=$(base_sha)
+  git_labs worktree prune
+  local tmp; tmp=$(mktemp -d)
+  trap "rm -rf '$tmp'; git -C '$labs' worktree prune" EXIT
+  git_labs worktree add -q -b "$branch" "$tmp" "$base"
+  local ident=()
+  if [ -n "$caller_committer_name" ]; then
+    ident=("GIT_COMMITTER_NAME=$caller_committer_name" "GIT_COMMITTER_EMAIL=$caller_committer_email")
+  fi
+  if ! env -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL ${ident[@]+"${ident[@]}"} \
+      git -C "$tmp" -c commit.gpgsign=false am -q --3way "$p"; then
+    git -C "$tmp" am --abort || true
+    git_labs branch -q -D "$branch"
+    die "$(basename "$p") does not apply to $base"
+  fi
+  echo "Prepared $branch in labs/ ($(git -C "$tmp" rev-parse --short HEAD) on $base): $(basename "$p")"
+  echo "  git -C labs push origin $branch"
+  echo "  gh pr create --repo aztec-labs-eng/aztec-node --head $branch --base main --fill"
+}
+
 function status {
   local base; base=$(base_sha)
   echo "base:    $base"
@@ -337,6 +378,7 @@ case "${1:-apply}" in
   commit-use-local) commit_use_local ;;
   check_staged) check_staged ;;
   status) status ;;
+  upstream) upstream "${2:-}" "${3:-}" ;;
   test_cmds) test_cmds ;;
   test) "$patch_dir/tests/lifecycle_test" && check ;;
   *) die "unknown command: $1" ;;

--- a/labs-patches/tests/lifecycle_test
+++ b/labs-patches/tests/lifecycle_test
@@ -164,7 +164,18 @@ n=$(cd "$fnd" && labs-patches/bootstrap.sh test_cmds | grep -c '^[0-9a-f]\{16\} 
 [ "$n" = 2 ] || fail "test_cmds from root: $n commands"
 ok "test_cmds from any cwd"
 
-# 11. check verifies without touching labs/
+# 11. upstream prepares one patch as a branch at the recorded base, under the caller's identity
+base=$(git -C "$fnd" rev-parse HEAD:labs)
+out=$("$lp" upstream 1 fnd/one) && grep -q "Prepared fnd/one" <<<"$out" || fail "upstream: output"
+[ "$(git -C "$fnd/labs" rev-list --count "$base..fnd/one")" = 1 ] || fail "upstream: one commit above the base"
+[ "$(git -C "$fnd/labs" show fnd/one:config)" = "a=2" ] || fail "upstream: patch content"
+[ "$(git -C "$fnd/labs" log -1 --format=%cn fnd/one)" = "test" ] || fail "upstream: committer identity"
+expect_fail "$lp" upstream 1 fnd/one || fail "upstream: existing branch accepted"
+"$lp" upstream "$fnd/labs-patches"/0002-*.patch >/dev/null || fail "upstream: by path"
+git -C "$fnd/labs" show-ref -q --verify refs/heads/fnd/patch-two-extra || fail "upstream: default branch name"
+ok "upstream branch"
+
+# 12. check verifies without touching labs/
 before=$(git -C "$fnd/labs" rev-parse HEAD)
 "$lp" check >/dev/null || fail "check"
 [ "$(git -C "$fnd/labs" rev-parse HEAD)" = "$before" ] || fail "check moved labs/"


### PR DESCRIPTION
Review follow-ups for #25306, as a separate PR into `ad/labs-submodule`.

- `labs-patches/bootstrap.sh upstream <n> [branch]`: prepares patch *n* as an aztec-node branch (`fnd/<patch-slug>` in `labs/`'s repository, at the recorded base, applied under your own git identity rather than the tooling's fixed one) and prints the `git push` / `gh pr create` commands. Nothing is pushed by the tool. Covered by a new lifecycle case (13 checks).
- CLAUDE.md `<labs_submodule_patches>`: a table of every command the tooling has, what state it keeps and which hooks call it.
- README: "Upstreaming a patch" section; states that everything in `labs-patches/` other than the `.patch` contents is foundation-only and never goes upstream.