### PR TITLE
refactor(pxe): separate the operation queue from staged-write jobs (backport of aztec-labs-eng/aztec-node#20)

### DIFF
--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -2,13 +2,12 @@ import type { FunctionCall } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { NoteDao } from '@aztec/stdlib/note';
-import type { ContractOverrides } from '@aztec/stdlib/tx';
+import type { BlockHeader, ContractOverrides } from '@aztec/stdlib/tx';
 
-import type { BlockSynchronizer } from '../block_synchronizer/block_synchronizer.js';
 import type { ContractSyncService } from '../contract/contract_sync_service.js';
 import type { ContractFunctionSimulator } from '../contract_function_simulator/contract_function_simulator.js';
 import type { NotesFilter } from '../notes_filter.js';
-import type { AnchorBlockStore } from '../storage/index.js';
+import type { SyncedJobContext } from '../pxe.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
 /**
@@ -16,36 +15,36 @@ import type { NoteStore } from '../storage/note_store/note_store.js';
  * No backwards compatibility or API stability should be expected. Use at your own risk.
  */
 export class PXEDebugUtils {
-  #putJobInQueue!: <T>(job: (jobId: string) => Promise<T>) => Promise<T>;
+  #syncedJob!: <T>(job: (ctx: SyncedJobContext) => Promise<T>) => Promise<T>;
   #getSimulatorForTx!: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator;
   #executeUtility!: (
     contractFunctionSimulator: ContractFunctionSimulator,
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
     scopes: AztecAddress[],
+    anchorBlockHeader: BlockHeader,
     jobId: string,
   ) => Promise<any>;
 
   constructor(
     private contractSyncService: ContractSyncService,
     private noteStore: NoteStore,
-    private blockStateSynchronizer: BlockSynchronizer,
-    private anchorBlockStore: AnchorBlockStore,
   ) {}
 
   /** Not injected through constructor since they're are co-dependant */
   public setPXEHelpers(
-    putJobInQueue: <T>(job: (jobId: string) => Promise<T>) => Promise<T>,
+    syncedJob: <T>(job: (ctx: SyncedJobContext) => Promise<T>) => Promise<T>,
     getSimulatorForTx: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator,
     executeUtility: (
       contractFunctionSimulator: ContractFunctionSimulator,
       call: FunctionCall,
       authWitnesses: AuthWitness[] | undefined,
       scopes: AztecAddress[],
+      anchorBlockHeader: BlockHeader,
       jobId: string,
     ) => Promise<any>,
   ) {
-    this.#putJobInQueue = putJobInQueue;
+    this.#syncedJob = syncedJob;
     this.#getSimulatorForTx = getSimulatorForTx;
     this.#executeUtility = executeUtility;
   }
@@ -62,18 +61,21 @@ export class PXEDebugUtils {
    * @returns The requested notes.
    */
   public getNotes(filter: NotesFilter): Promise<NoteDao[]> {
-    return this.#putJobInQueue(async (jobId: string) => {
-      await this.blockStateSynchronizer.sync();
-
-      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-
+    return this.#syncedJob(async ({ jobId, anchorBlockHeader }) => {
       const contractFunctionSimulator = this.#getSimulatorForTx();
 
       await this.contractSyncService.ensureContractSynced({
         contract: filter.contractAddress,
         functionToInvokeAfterSync: null,
         utilityExecutor: async (privateSyncCall, execScopes) =>
-          await this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          await this.#executeUtility(
+            contractFunctionSimulator,
+            privateSyncCall,
+            [],
+            execScopes,
+            anchorBlockHeader,
+            jobId,
+          ),
         anchorBlockHeader,
         jobId,
         scopes: filter.scopes,

--- a/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
+++ b/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
@@ -46,9 +46,9 @@ export interface StagedStore {
  * 3. On commit, staging is promoted to main storage
  * 4. On abort, staged data is discarded
  *
- * Note: PXE should only rely on a single JobCoordinator instance, so it can eventually
- * orchestrate concurrent jobs. Right now it doesn't make a difference because we're
- * using a job queue with concurrency=1.
+ * Note: jobs must be serialized — beginJob throws if one is already in progress. We still key staging by job ID
+ * because aborting a job doesn't cancel its in-flight async work: a late write from an aborted job lands under its
+ * old job ID and is never promoted, instead of leaking into the next job's staging.
  */
 export class JobCoordinator {
   private readonly log: Logger;

--- a/yarn-project/pxe/src/node/benchmarked_node.test.ts
+++ b/yarn-project/pxe/src/node/benchmarked_node.test.ts
@@ -26,7 +26,7 @@ describe('withRecording', () => {
     await node.getPublicStorageAt(read.blockHash, read.contractAddress, read.storageSlot);
     await node.getPublicStorageAt(read.blockHash, read.contractAddress, read.storageSlot);
 
-    const { perMethod, roundTrips } = recording.stop();
+    const { perMethod, roundTrips } = recording.stats();
     expect(roundTrips.roundTrips).toBe(2);
     expect(roundTrips.roundTripMethods).toEqual([['getPublicStorageAt'], ['getPublicStorageAt']]);
     expect(perMethod.getPublicStorageAt!.times).toHaveLength(2);
@@ -41,7 +41,7 @@ describe('withRecording', () => {
       node.getBlockNumber(),
     ]);
 
-    const { roundTrips } = recording.stop();
+    const { roundTrips } = recording.stats();
     expect(roundTrips.roundTrips).toBe(1);
     expect(roundTrips.roundTripMethods).toEqual([['getPublicStorageAt', 'getBlockNumber']]);
   });
@@ -54,8 +54,8 @@ describe('withRecording', () => {
     const secondHalf = node.startRecording();
     await node.getPublicStorageAt(read.blockHash, read.contractAddress, read.storageSlot);
 
-    expect(secondHalf.stop().roundTrips.roundTrips).toBe(1);
-    expect(wholeRun.stop().roundTrips.roundTrips).toBe(2);
+    expect(secondHalf.stats().roundTrips.roundTrips).toBe(1);
+    expect(wholeRun.stats().roundTrips.roundTrips).toBe(2);
   });
 
   it('records nothing once stopped', async () => {
@@ -65,7 +65,7 @@ describe('withRecording', () => {
     recording.stop();
     await node.getPublicStorageAt(read.blockHash, read.contractAddress, read.storageSlot);
 
-    const { perMethod, roundTrips } = recording.stop();
+    const { perMethod, roundTrips } = recording.stats();
     expect(perMethod).toEqual({});
     expect(roundTrips.roundTrips).toBe(0);
   });

--- a/yarn-project/pxe/src/node/benchmarked_node.ts
+++ b/yarn-project/pxe/src/node/benchmarked_node.ts
@@ -18,8 +18,10 @@ import type { NodeStats } from '@aztec/stdlib/tx';
  * limits in web browsers which is not a problem when debugging in node.js).
  */
 export interface Recording {
-  /** Closes the recording and returns what it saw. Reads served after this are not recorded. */
-  stop(): NodeStats;
+  /** A snapshot of the reads seen so far. Safe to call while the recording is still open. */
+  stats(): NodeStats;
+  /** Closes the recording. Reads served after this are not recorded. Idempotent. */
+  stop(): void;
 }
 
 /** An {@link AztecNode} wrapper that can report the reads it serves. */
@@ -54,10 +56,9 @@ export function withRecording(node: AztecNode): BenchmarkedAztecNode {
           };
           open.add(stats);
           return {
-            stop: () => {
-              open.delete(stats);
-              return stats;
-            },
+            // Cloned so a snapshot embedded in an operation's results is not mutated by reads served later.
+            stats: () => structuredClone(stats),
+            stop: () => open.delete(stats),
           };
         };
       }

--- a/yarn-project/pxe/src/node/caching_aztec_node.test.ts
+++ b/yarn-project/pxe/src/node/caching_aztec_node.test.ts
@@ -567,7 +567,7 @@ describe('withCache', () => {
       await cachedNode.getPublicStorageAt(blockHash, contractAddress, storageSlot);
       await cachedNode.getPublicStorageAt(blockHash, contractAddress, storageSlot);
 
-      expect(callCounts(recording.stop())).toEqual({ getPublicStorageAt: 1 });
+      expect(callCounts(recording.stats())).toEqual({ getPublicStorageAt: 1 });
     });
 
     it('records a batched leaf read only when it fetches a missing leaf', async () => {
@@ -581,7 +581,7 @@ describe('withCache', () => {
       await cachedNode.findLeavesIndexes(blockHash, MerkleTreeId.NULLIFIER_TREE, [leafA]);
       await cachedNode.findLeavesIndexes(blockHash, MerkleTreeId.NULLIFIER_TREE, [leafA, leafB]);
 
-      expect(callCounts(recording.stop())).toEqual({ findLeavesIndexes: 2 });
+      expect(callCounts(recording.stats())).toEqual({ findLeavesIndexes: 2 });
     });
 
     it('does not count a batch the cache serves in full as a round trip', async () => {
@@ -592,7 +592,7 @@ describe('withCache', () => {
       await cachedNode.getPublicStorageAt(blockHash, contractAddress, storageSlot);
       await cachedNode.getPublicStorageAt(blockHash, contractAddress, storageSlot);
 
-      const { roundTrips } = recording.stop();
+      const { roundTrips } = recording.stats();
       expect(roundTrips.roundTrips).toBe(1);
       expect(roundTrips.roundTripMethods).toEqual([['getPublicStorageAt']]);
     });
@@ -609,7 +609,7 @@ describe('withCache', () => {
         cachedNode.getBlockNumber(),
       ]);
 
-      const { roundTrips } = recording.stop();
+      const { roundTrips } = recording.stats();
       expect(roundTrips.roundTrips).toBe(2);
       // The second batch waited on `getBlockNumber` alone: its storage read was served without reaching the node.
       expect(roundTrips.roundTripMethods).toEqual([['getPublicStorageAt'], ['getBlockNumber']]);

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -74,6 +74,7 @@ import { PrivateEventFilterValidator } from './events/private_event_filter_valid
 import type { ExecutionHooks } from './hooks/index.js';
 import { JobCoordinator } from './job_coordinator/job_coordinator.js';
 import { TxResolverService } from './messages/tx_resolver_service.js';
+import type { Recording } from './node/benchmarked_node.js';
 import { type CachingAztecNode, withCache } from './node/caching_aztec_node.js';
 import {
   PrivateKernelExecutionProver,
@@ -257,7 +258,7 @@ export class PXE {
     private protocolContractsProvider: ProtocolContractsProvider,
     private preloadedContractsProvider: PreloadedContractsProvider,
     private log: Logger,
-    private jobQueue: SerialQueue,
+    private queue: SerialQueue,
     private jobCoordinator: JobCoordinator,
     public debug: PXEDebugUtils,
     private hooks: ExecutionHooks | undefined,
@@ -355,9 +356,9 @@ export class PXE {
       contractSyncService,
     ]);
 
-    const debugUtils = new PXEDebugUtils(contractSyncService, noteStore, synchronizer, anchorBlockStore);
+    const debugUtils = new PXEDebugUtils(contractSyncService, noteStore);
 
-    const jobQueue = new SerialQueue();
+    const queue = new SerialQueue();
 
     const pxe = new PXE(
       readCachedNode,
@@ -386,19 +387,19 @@ export class PXE {
       protocolContractsProvider,
       preloadedContractsProvider,
       log,
-      jobQueue,
+      queue,
       jobCoordinator,
       debugUtils,
       hooks,
     );
 
     debugUtils.setPXEHelpers(
-      pxe.#putInJobQueue.bind(pxe),
+      fn => pxe.#syncedJob(fn, { forceSync: true }),
       pxe.#getSimulatorForTx.bind(pxe),
       pxe.#executeUtility.bind(pxe),
     );
 
-    pxe.jobQueue.start();
+    pxe.queue.start();
 
     await allToCompletion([pxe.#registerProtocolContracts(), pxe.#registerPreloadedContracts()]);
     log.info(`Started PXE connected to chain ${info.l1ChainId} version ${info.rollupVersion}`);
@@ -469,33 +470,60 @@ export class PXE {
   }
 
   /**
-   * Enqueues a job for execution once no other jobs are running. Returns a promise that will resolve once the job is
-   * complete.
+   * Enqueues an operation for execution once no other operations are running. Returns a promise that will resolve
+   * once the operation is complete.
    *
    * Useful for tasks that cannot run concurrently, such as contract function simulation.
    */
-  #putInJobQueue<T>(fn: (jobId: string) => Promise<T>): Promise<T> {
+  #enqueue<T>(fn: () => Promise<T>): Promise<T> {
     // TODO(#12636): relax the conditions under which we forbid concurrency.
-    if (this.jobQueue.length() != 0) {
+    if (this.queue.length() != 0) {
       this.log.warn(
-        `PXE is already processing ${this.jobQueue.length()} jobs, concurrent execution is not supported. Will run once those are complete.`,
+        `PXE is already processing ${this.queue.length()} operations, concurrent execution is not supported. Will run once those are complete.`,
       );
     }
 
-    return this.jobQueue.put(async () => {
-      const jobId = this.jobCoordinator.beginJob();
-      this.log.verbose(`Beginning job ${jobId}`);
+    return this.queue.put(fn);
+  }
 
+  /**
+   * Enqueues a job (`fn`) that runs after a sync with the node (skipped when the `autoSync` config flag is disabled,
+   * unless `forceSync` is set). If the job run is successful, then all staged writes are committed. If the job
+   * rejects, then all staged writes are discarded.
+   */
+  #syncedJob<T>(
+    fn: (ctx: SyncedJobContext) => Promise<T>,
+    { errorContext, forceSync = false }: { errorContext?: () => string[]; forceSync?: boolean } = {},
+  ): Promise<T> {
+    return this.#enqueue(async () => {
+      const totalTimer = new Timer();
+      const recording = this.node.startRecording();
       try {
-        const result = await fn(jobId);
-        this.log.verbose(`Committing job ${jobId}`);
+        const syncTimer = new Timer();
+        if (forceSync || this.autoSync) {
+          await this.blockStateSynchronizer.sync();
+        }
+        const syncTime = syncTimer.ms();
 
-        await this.jobCoordinator.commitJob(jobId);
-        return result;
-      } catch (err) {
-        this.log.verbose(`Aborting job ${jobId}`);
-        await this.jobCoordinator.abortJob(jobId);
-        throw err;
+        const jobId = this.jobCoordinator.beginJob();
+        this.log.verbose(`Beginning job ${jobId}`, { syncMs: syncTime });
+
+        try {
+          const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+          const result = await fn({ jobId, syncTime, anchorBlockHeader, recording, totalMs: () => totalTimer.ms() });
+          this.log.verbose(`Committing job ${jobId}`);
+
+          await this.jobCoordinator.commitJob(jobId);
+          return result;
+        } catch (err) {
+          this.log.verbose(`Aborting job ${jobId}`);
+          await this.jobCoordinator.abortJob(jobId);
+          throw err;
+        }
+      } catch (err: any) {
+        throw errorContext ? this.#contextualizeError(err, ...errorContext()) : err;
+      } finally {
+        recording.stop();
       }
     });
   }
@@ -554,7 +582,7 @@ export class PXE {
         contract: contractAddress,
         functionToInvokeAfterSync: functionSelector,
         utilityExecutor: (privateSyncCall, execScopes) =>
-          this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, anchorBlockHeader, jobId),
         anchorBlockHeader,
         jobId,
         scopes,
@@ -584,6 +612,7 @@ export class PXE {
    * @param authWitnesses - Authentication witnesses required for the function call.
    * @param scopes - Optional array of account addresses whose notes can be accessed in this call. Defaults to all
    * accounts if not specified.
+   * @param anchorBlockHeader - The anchor block header established by the enclosing job.
    * @param jobId - The job ID for staged writes.
    * @returns The execution result containing the outputs of the utility function.
    */
@@ -592,10 +621,10 @@ export class PXE {
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
     scopes: AztecAddress[],
+    anchorBlockHeader: BlockHeader,
     jobId: string,
   ) {
     try {
-      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
       const { result, offchainEffects } = await contractFunctionSimulator.runUtility(
         call,
         authWitnesses ?? [],
@@ -606,7 +635,6 @@ export class PXE {
       return { result, offchainEffects };
     } catch (err) {
       if (err instanceof SimulationError) {
-        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
         await enrichSimulationError(err, this.contractStore, this.contractClassService, anchorBlockHeader, this.log);
       }
       throw err;
@@ -682,26 +710,15 @@ export class PXE {
     return await kernelTraceProver.proveWithKernels(txExecutionRequest.toTxRequest(), privateExecutionResult, config);
   }
 
-  /**
-   * Syncs with the node only when `autoSync` is enabled.
-   * When `autoSync` is disabled, callers (typically a wallet) are
-   * responsible for invoking `pxe.sync()` at the right granularity.
-   */
-  async #maybeSync(): Promise<void> {
-    if (this.autoSync) {
-      await this.blockStateSynchronizer.sync();
-    }
-  }
-
   // Public API
 
   /**
    * Triggers a sync of PXE state with the node, regardless of the `autoSync` config flag. Use this to
    * batch syncs across composite flows when `autoSync` is disabled (e.g. one sync per simulate+send
-   * instead of one per inner PXE call). Serialized through the job queue.
+   * instead of one per inner PXE call). Serialized through the queue.
    */
   public sync(): Promise<void> {
-    return this.#putInJobQueue(() => this.blockStateSynchronizer.sync());
+    return this.#enqueue(() => this.blockStateSynchronizer.sync());
   }
 
   /**
@@ -709,7 +726,7 @@ export class PXE {
    * @returns The synced block header
    */
   public getSyncedBlockHeader(): Promise<BlockHeader> {
-    return this.#putInJobQueue(() => {
+    return this.#enqueue(() => {
       return this.anchorBlockStore.getBlockHeader();
     });
   }
@@ -812,7 +829,7 @@ export class PXE {
 
     if (wasAdded) {
       // Queued to avoid wiping while a job is in flight.
-      await this.#putInJobQueue(() => Promise.resolve(this.contractSyncService.wipe()));
+      await this.#enqueue(() => Promise.resolve(this.contractSyncService.wipe()));
     }
   }
 
@@ -989,8 +1006,8 @@ export class PXE {
    * @returns The address of the registered instance.
    */
   public registerContract(instance: ContractInstancePreimage): Promise<AztecAddress> {
-    // Run inside the job queue so we can't race a concurrent simulation while writing the instance to the store.
-    return this.#putInJobQueue(async () => {
+    // Run inside the queue so we can't race a concurrent simulation while writing the instance to the store.
+    return this.#enqueue(async () => {
       const address = await computeContractAddressFromInstance(instance);
       await this.contractStore.addContractInstance({ ...instance, address });
       this.log.info(`Added contract at ${address}`, { address });
@@ -1020,14 +1037,8 @@ export class PXE {
     let privateExecutionResult: PrivateExecutionResult;
     // We disable proving concurrently mostly out of caution, since it accesses some of our stores. Proving is so
     // computationally demanding that it'd be rare for someone to try to do it concurrently regardless.
-    return this.#putInJobQueue(async jobId => {
-      const totalTimer = new Timer();
-      const recording = this.node.startRecording();
-      try {
-        const syncTimer = new Timer();
-        await this.#maybeSync();
-        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-        const syncTime = syncTimer.ms();
+    return this.#syncedJob(
+      async ({ jobId, syncTime, anchorBlockHeader, recording, totalMs }) => {
         const contractFunctionSimulator = this.#getSimulatorForTx();
         privateExecutionResult = await this.#executePrivate({
           contractFunctionSimulator,
@@ -1049,7 +1060,7 @@ export class PXE {
           profileMode: 'none',
         });
 
-        const totalTime = totalTimer.ms();
+        const totalTime = totalMs();
 
         const perFunction = executionSteps.map(({ functionName, timings: { witgen, oracles } }) => ({
           functionName,
@@ -1070,7 +1081,7 @@ export class PXE {
 
         const txProvingResult = new TxProvingResult(privateExecutionResult, publicInputs, chonkProof!, {
           timings,
-          nodeRPCCalls: recording.stop(),
+          nodeRPCCalls: recording.stats(),
         });
 
         // We keep track of which tagging indices we've used in this tx so that we don't repeat them in future txs
@@ -1089,13 +1100,9 @@ export class PXE {
         );
 
         return txProvingResult;
-      } catch (err: any) {
-        throw this.#contextualizeError(err, inspect(txRequest), inspect(privateExecutionResult));
-      } finally {
-        // Idempotent cleanup for the error and early-exit paths. The success path already stopped the recording.
-        recording.stop();
-      }
-    });
+      },
+      { errorContext: () => [inspect(txRequest), inspect(privateExecutionResult)] },
+    );
   }
 
   /**
@@ -1109,10 +1116,8 @@ export class PXE {
     { profileMode, skipProofGeneration = true, scopes, senderForTags }: ProfileTxOpts,
   ): Promise<TxProfileResult> {
     // We disable concurrent profiles for consistency with simulateTx.
-    return this.#putInJobQueue(async jobId => {
-      const totalTimer = new Timer();
-      const recording = this.node.startRecording();
-      try {
+    return this.#syncedJob(
+      async ({ jobId, syncTime, anchorBlockHeader, recording, totalMs }) => {
         const txInfo = {
           origin: txRequest.origin,
           functionSelector: txRequest.functionSelector,
@@ -1125,10 +1130,6 @@ export class PXE {
           `Profiling transaction execution request to ${txRequest.functionSelector} at ${txRequest.origin}`,
           txInfo,
         );
-        const syncTimer = new Timer();
-        await this.#maybeSync();
-        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-        const syncTime = syncTimer.ms();
 
         const contractFunctionSimulator = this.#getSimulatorForTx();
         const privateExecutionResult = await this.#executePrivate({
@@ -1152,7 +1153,7 @@ export class PXE {
           },
         );
 
-        const totalTime = totalTimer.ms();
+        const totalTime = totalMs();
 
         const perFunction = executionSteps.map(({ functionName, timings: { witgen, oracles } }) => {
           return {
@@ -1177,14 +1178,10 @@ export class PXE {
             total - ((syncTime ?? 0) + (proving ?? 0) + perFunction.reduce((acc, { time }) => acc + time, 0)),
         };
 
-        return new TxProfileResult(executionSteps, { timings, nodeRPCCalls: recording.stop() });
-      } catch (err: any) {
-        throw this.#contextualizeError(err, inspect(txRequest), `profileMode=${profileMode}`);
-      } finally {
-        // Idempotent cleanup for the error and early-exit paths. The success path already stopped the recording.
-        recording.stop();
-      }
-    });
+        return new TxProfileResult(executionSteps, { timings, nodeRPCCalls: recording.stats() });
+      },
+      { errorContext: () => [inspect(txRequest), `profileMode=${profileMode}`] },
+    );
   }
 
   /**
@@ -1220,10 +1217,8 @@ export class PXE {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
     // delete the same read value, or reading values that another simulation is currently modifying).
-    return this.#putInJobQueue(async jobId => {
-      const recording = this.node.startRecording();
-      try {
-        const totalTimer = new Timer();
+    return this.#syncedJob(
+      async ({ jobId, syncTime, anchorBlockHeader, recording, totalMs }) => {
         const txInfo = {
           origin: txRequest.origin,
           functionSelector: txRequest.functionSelector,
@@ -1236,10 +1231,6 @@ export class PXE {
           `Simulating transaction execution request to ${txRequest.functionSelector} at ${txRequest.origin}`,
           txInfo,
         );
-        const syncTimer = new Timer();
-        await this.#maybeSync();
-        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-        const syncTime = syncTimer.ms();
 
         if (overrides?.contracts && Object.keys(overrides.contracts).length > 0 && !skipKernels) {
           throw new Error(
@@ -1308,7 +1299,7 @@ export class PXE {
 
         const txHash = simulatedTx.getTxHash();
 
-        const totalTime = totalTimer.ms();
+        const totalTime = totalMs();
 
         const perFunction = executionSteps.map(({ functionName, timings: { witgen, oracles } }) => ({
           functionName,
@@ -1344,21 +1335,18 @@ export class PXE {
 
         return TxSimulationResult.fromPrivateSimulationResultAndPublicOutput(privateSimulationResult, publicOutput, {
           timings,
-          nodeRPCCalls: recording.stop(),
+          nodeRPCCalls: recording.stats(),
         });
-      } catch (err: any) {
-        throw this.#contextualizeError(
-          err,
+      },
+      {
+        errorContext: () => [
           inspect(txRequest),
           `simulatePublic=${simulatePublic}`,
           `skipTxValidation=${skipTxValidation}`,
           `scopes=${scopes.map(s => s.toString()).join(', ')}`,
-        );
-      } finally {
-        // Idempotent cleanup for the error and early-exit paths. The success path already stopped the recording.
-        recording.stop();
-      }
-    });
+        ],
+      },
+    );
   }
 
   /**
@@ -1372,22 +1360,16 @@ export class PXE {
     // We disable concurrent executions since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
     // delete the same read value, or reading values that another execution is currently modifying).
-    return this.#putInJobQueue(async jobId => {
-      const recording = this.node.startRecording();
-      try {
-        const totalTimer = new Timer();
-        const syncTimer = new Timer();
-        await this.#maybeSync();
-        const syncTime = syncTimer.ms();
+    return this.#syncedJob(
+      async ({ jobId, syncTime, anchorBlockHeader, recording, totalMs }) => {
         const functionTimer = new Timer();
         const contractFunctionSimulator = this.#getSimulatorForTx();
 
-        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
         await this.contractSyncService.ensureContractSynced({
           contract: call.to,
           functionToInvokeAfterSync: call.selector,
           utilityExecutor: (privateSyncCall, execScopes) =>
-            this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+            this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, anchorBlockHeader, jobId),
           anchorBlockHeader,
           jobId,
           scopes,
@@ -1399,11 +1381,12 @@ export class PXE {
           call,
           authwits ?? [],
           scopes,
+          anchorBlockHeader,
           jobId,
         );
         const functionTime = functionTimer.ms();
 
-        const totalTime = totalTimer.ms();
+        const totalTime = totalMs();
 
         const perFunction = [{ functionName: call.name, time: functionTime }];
 
@@ -1418,21 +1401,20 @@ export class PXE {
           result: executionResult,
           offchainEffects,
           anchorBlockTimestamp: anchorBlockHeader.globalVariables.timestamp,
-          stats: { timings, nodeRPCCalls: recording.stop() },
+          stats: { timings, nodeRPCCalls: recording.stats() },
         };
-      } catch (err: any) {
-        const { to, name, args } = call;
-        const stringifiedArgs = args.map(arg => arg.toString()).join(', ');
-        throw this.#contextualizeError(
-          err,
-          `executeUtility ${to}:${name}(${stringifiedArgs})`,
-          `scopes=${scopes.map(s => s.toString()).join(', ')}`,
-        );
-      } finally {
-        // Idempotent cleanup for the error and early-exit paths. The success path already stopped the recording.
-        recording.stop();
-      }
-    });
+      },
+      {
+        errorContext: () => {
+          const { to, name, args } = call;
+          const stringifiedArgs = args.map(arg => arg.toString()).join(', ');
+          return [
+            `executeUtility ${to}:${name}(${stringifiedArgs})`,
+            `scopes=${scopes.map(s => s.toString()).join(', ')}`,
+          ];
+        },
+      },
+    );
   }
 
   /**
@@ -1454,10 +1436,7 @@ export class PXE {
   ): Promise<PackedPrivateEvent[]> {
     let anchorBlockNumber: BlockNumber;
 
-    await this.#putInJobQueue(async jobId => {
-      await this.#maybeSync();
-
-      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+    await this.#syncedJob(async ({ jobId, anchorBlockHeader }) => {
       anchorBlockNumber = anchorBlockHeader.getBlockNumber();
 
       const contractFunctionSimulator = this.#getSimulatorForTx();
@@ -1466,7 +1445,14 @@ export class PXE {
         contract: filter.contractAddress,
         functionToInvokeAfterSync: null,
         utilityExecutor: async (privateSyncCall, execScopes) =>
-          await this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          await this.#executeUtility(
+            contractFunctionSimulator,
+            privateSyncCall,
+            [],
+            execScopes,
+            anchorBlockHeader,
+            jobId,
+          ),
         anchorBlockHeader,
         jobId,
         scopes: filter.scopes,
@@ -1485,11 +1471,23 @@ export class PXE {
   }
 
   /**
-   * Stops the PXE's job queue and closes the backing store.
+   * Stops the PXE's queue and closes the backing store.
    */
   public async stop(): Promise<void> {
-    await this.jobQueue.end();
+    await this.queue.end();
     await this.blockStateSynchronizer.stop();
     await this.db.close();
   }
 }
+
+/** What a synced job receives: its id, the anchor its sync established, and the operation's instrumentation. */
+export type SyncedJobContext = {
+  jobId: string;
+  /** Duration of the sync, for timing stats. */
+  syncTime: number;
+  anchorBlockHeader: BlockHeader;
+  /** Open recording of the node RPC calls made so far in this job; `stats()` snapshots them for reporting. */
+  recording: Recording;
+  /** The operation's duration so far, including the sync. */
+  totalMs: () => number;
+};

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
@@ -210,7 +210,7 @@ describeBench('syncTaggedPrivateLogs constrained-sync bench', () => {
 
     // Round-trips and blocking time from the same instrumentation the app benches use. `syncTaggedPrivateLogs` only
     // ever calls `getPrivateLogsByTags`, so every round-trip is that method.
-    const { roundTrips } = recording.stop();
+    const { roundTrips } = recording.stats();
     const rpcRoundTrips = roundTrips.roundTrips;
     const rpcBlockingTimeMs = roundTrips.totalBlockingTime;
 


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/20 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `10ab86541ef48443f2e1d53d2882acbf619278a1`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff 10ab86541e^..10ab86541e origin/nico/port-node-20-operation-queue^..origin/nico/port-node-20-operation-queue
   ```

   Expected: only the `(cherry picked from commit …)` trailer under the commit message and nothing else — no `-`/`+` lines under any file header. The patch applied without conflicts and was not edited.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.

## Stack

First PR of the stack, targets `merge-train/fairies-v5` directly. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 (aztec-node numbers).

