### PR TITLE
fix(pxe): per-change-set staging store that rejects dead change sets (backport of aztec-labs-eng/aztec-node#47)

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -17,7 +17,7 @@ import {
   makeL2CheckpointId,
 } from '@aztec/stdlib/block';
 import type { AztecNode, BlockResponse } from '@aztec/stdlib/interfaces/client';
-import { NoteDao } from '@aztec/stdlib/note';
+import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -27,6 +27,7 @@ import type { ContractSyncService } from '../contract/contract_sync_service.js';
 import { type CachingAztecNode, withCache } from '../node/caching_aztec_node.js';
 import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import { NoteStore } from '../storage/note_store/note_store.js';
+import { readNotes } from '../storage/note_store/test_utils.js';
 import type { Rollbackable } from '../storage/rollbackable.js';
 import { BlockSynchronizer } from './block_synchronizer.js';
 
@@ -290,8 +291,9 @@ describe('BlockSynchronizer', () => {
       const scope = await AztecAddress.random();
       const forkBlock = await L2Block.random(BlockNumber(3));
       const orphanedNote = await noteAt(contract, makeL2BlockId(BlockNumber(4), Fr.random().toString()));
+      noteStore.beginChangeSet('note-change-set');
       await noteStore.addNotes([orphanedNote], scope, 'note-change-set');
-      await noteStore.commitStaged('note-change-set');
+      await noteStore.commitChangeSet('note-change-set');
 
       await stagePruneTo(forkBlock, BlockNumber(5));
 
@@ -301,7 +303,12 @@ describe('BlockSynchronizer', () => {
 
       // Nothing from the failed attempt stuck: the orphaned note is back, the anchor still sits above the fork, and
       // the tips cursor never advanced onto the prune target.
-      expect(await noteStore.nullifiersOfNotesAtBlock(4)).toEqual([orphanedNote.siloedNullifier.toString()]);
+      const kept = await readNotes(noteStore, {
+        contractAddress: contract,
+        scopes: [scope],
+        status: NoteStatus.ACTIVE,
+      });
+      expect(kept.map(note => note.l2BlockNumber)).toEqual([4]);
       expect((await anchorBlockStore.getBlockHeader()).getBlockNumber()).toBe(5);
       expect((await tipsStore.getL2Tips()).proposed.number).toBe(0);
 
@@ -311,7 +318,12 @@ describe('BlockSynchronizer', () => {
 
       await synchronizer.handleBlockStreamEvent(prunedEvent(await blockId(forkBlock)));
 
-      expect(await noteStore.nullifiersOfNotesAtBlock(4)).toHaveLength(0);
+      const afterReplay = await readNotes(noteStore, {
+        contractAddress: contract,
+        scopes: [scope],
+        status: NoteStatus.ACTIVE,
+      });
+      expect(afterReplay).toEqual([]);
       expect((await anchorBlockStore.getBlockHeader()).getBlockNumber()).toBe(3);
       expect((await tipsStore.getL2Tips()).proposed.number).toBe(3);
     });
@@ -326,15 +338,21 @@ describe('BlockSynchronizer', () => {
       const forkBlock = await L2Block.random(BlockNumber(3));
       const noteAtFork = await noteAt(contract, await blockId(forkBlock));
       const orphanedNote = await noteAt(contract, makeL2BlockId(BlockNumber(4), Fr.random().toString()));
+      noteStore.beginChangeSet('note-change-set');
       await noteStore.addNotes([noteAtFork, orphanedNote], scope, 'note-change-set');
-      await noteStore.commitStaged('note-change-set');
+      await noteStore.commitChangeSet('note-change-set');
 
       await stagePruneTo(forkBlock, BlockNumber(5));
 
       await synchronizer.handleBlockStreamEvent(prunedEvent(await blockId(forkBlock)));
 
-      expect(await noteStore.nullifiersOfNotesAtBlock(4)).toHaveLength(0);
-      expect(await noteStore.nullifiersOfNotesAtBlock(3)).toEqual([noteAtFork.siloedNullifier.toString()]);
+      const remaining = await readNotes(noteStore, {
+        contractAddress: contract,
+        scopes: [scope],
+        status: NoteStatus.ACTIVE,
+      });
+      expect(remaining.map(note => note.l2BlockNumber)).toEqual([3]);
+      expect(remaining[0].siloedNullifier.equals(noteAtFork.siloedNullifier)).toBe(true);
     });
   });
 

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -91,7 +91,7 @@ describe('validateAndStoreEvents', () => {
     const map = overrides.validationTxDataMap ?? defaultValidationTxDataMap();
     await eventService.validateAndStoreEvents([request], recipient, map);
 
-    await privateEventStore.commitStaged('test');
+    await privateEventStore.commitChangeSet('test');
   }
 
   it('should throw when tx does not exist or has no effects', async () => {

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -40,6 +40,7 @@ describe('NoteService', () => {
     const store = await openTmpStore('test');
     keyStore = new KeyStore(store);
     noteStore = new NoteStore(store);
+    noteStore.beginChangeSet('test');
     aztecNode = mock<AztecNode>();
 
     contractAddress = await AztecAddress.random();
@@ -85,7 +86,8 @@ describe('NoteService', () => {
 
     // Verify that the changes persist after change set commit
     {
-      await noteStore.commitStaged('test');
+      await noteStore.commitChangeSet('test');
+      noteStore.beginChangeSet('fresh-change-set');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -121,7 +123,8 @@ describe('NoteService', () => {
 
     // Verify that the changes persist after change set commit
     {
-      await noteStore.commitStaged('test');
+      await noteStore.commitChangeSet('test');
+      noteStore.beginChangeSet('fresh-change-set');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -167,7 +170,8 @@ describe('NoteService', () => {
 
     // Verify that the changes persist after change set commit
     {
-      await noteStore.commitStaged('test');
+      await noteStore.commitChangeSet('test');
+      noteStore.beginChangeSet('fresh-change-set');
       const remainingNotes = await noteStore.getNotes(
         {
           contractAddress,
@@ -283,7 +287,8 @@ describe('NoteService', () => {
 
       // Verify note is still stored after committing the change set
       {
-        await noteStore.commitStaged('test');
+        await noteStore.commitChangeSet('test');
+        noteStore.beginChangeSet('fresh-change-set');
 
         const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'fresh-change-set');
 
@@ -393,7 +398,8 @@ describe('NoteService', () => {
 
       // Verify store behaves correctly pre and post commit
       await verifyNoteNullifiedInChangeSetContext('test');
-      await noteStore.commitStaged('test');
+      await noteStore.commitChangeSet('test');
+      noteStore.beginChangeSet('fresh-change-set');
       await verifyNoteNullifiedInChangeSetContext('fresh-change-set');
     });
 

--- a/yarn-project/pxe/src/operation_lifecycle.test.ts
+++ b/yarn-project/pxe/src/operation_lifecycle.test.ts
@@ -24,13 +24,12 @@ describe('runOperation', () => {
     discarded = [];
     const recordingStore: StagedStore = {
       storeName: 'recording_store',
-      commitStaged: id => {
+      commitChangeSet: id => {
         committed.push(id);
         return Promise.resolve();
       },
-      discardStaged: id => {
+      discardChangeSet: id => {
         discarded.push(id);
-        return Promise.resolve();
       },
     };
     coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [recordingStore] });

--- a/yarn-project/pxe/src/operation_lifecycle.ts
+++ b/yarn-project/pxe/src/operation_lifecycle.ts
@@ -52,7 +52,7 @@ export async function runOperation<T>(args: RunOperationArgs, fn: () => Promise<
   } catch (err) {
     log.verbose(`Aborting operation ${changeSetId}`, { changeSetId });
     await settleContributorsLoggingFailures(args);
-    await stagedWriteCoordinator.abort(changeSetId);
+    stagedWriteCoordinator.abort(changeSetId);
     notifyOperationEnd(args, 'discarded');
     throw err;
   }

--- a/yarn-project/pxe/src/operation_queue.test.ts
+++ b/yarn-project/pxe/src/operation_queue.test.ts
@@ -30,13 +30,12 @@ describe('OperationQueue', () => {
     discarded = [];
     const recordingStore: StagedStore = {
       storeName: 'recording_store',
-      commitStaged: id => {
+      commitChangeSet: id => {
         committed.push(id);
         return Promise.resolve();
       },
-      discardStaged: id => {
+      discardChangeSet: id => {
         discarded.push(id);
-        return Promise.resolve();
       },
     };
     coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [recordingStore] });

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -467,7 +467,7 @@ describe('PXE', () => {
       // Store a couple of events to exercise `getPrivateEvents`
       const event1 = await storeEvent();
       const event2 = await storeEvent();
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       const events = await pxe.getPrivateEvents(eventSelector, {
         contractAddress,
@@ -506,7 +506,7 @@ describe('PXE', () => {
         // Events in not-yet-synced blocks; stored only to verify they are filtered out.
         await Promise.all([storeEvent(lastKnownBlockNumber + 1), storeEvent(lastKnownBlockNumber + 1)]);
 
-        await privateEventStore.commitStaged('test');
+        await privateEventStore.commitChangeSet('test');
       });
 
       it('filters by txHash', async () => {

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -136,7 +136,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       capsuleStore.setCapsule(contractAddress, new Fr(5n), [new Fr(7n), new Fr(11n)], changeSetId, scope);
       capsuleStore.setCapsule(contractAddress, new Fr(13n), [new Fr(17n)], changeSetId, scope);
       capsuleStore.setCapsule(contractAddress, new Fr(19n), [], changeSetId, scope);
-      await kvStore.transactionAsync(() => capsuleStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => capsuleStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       capsules: await snapshotMap(kvStore.openMap<string, Buffer>('capsules')),
@@ -249,7 +249,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       // A collection with a non-retractable and a retractable fact.
       await factStore.recordFact(keyB, new Fr(1n), [new Fr(9n)], undefined, changeSetId);
       await factStore.recordFact(keyB, new Fr(2n), [], { blockNumber: 5, blockHash: new Fr(1n) }, changeSetId);
-      await kvStore.transactionAsync(() => factStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => factStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       facts: await snapshotMap(kvStore.openMap<string, Buffer>('facts')),
@@ -334,6 +334,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const noteStore = new NoteStore(kvStore);
 
       const changeSetId = 'fixture-change-set';
+      noteStore.beginChangeSet(changeSetId);
 
       // Two contracts so `note_nullifiers_by_contract` exhibits both a multi-value row (contractA → {n1, n2}) and a
       // single-value row (contractB → {n3}).
@@ -409,7 +410,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
         changeSetId,
       );
 
-      await kvStore.transactionAsync(() => noteStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => noteStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       notes: await snapshotMap(kvStore.openMap<string, Buffer>('notes')),
@@ -518,7 +519,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
         changeSetId,
       );
 
-      await kvStore.transactionAsync(() => privateEventStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => privateEventStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       private_event_logs: await snapshotMap(kvStore.openMap<string, Buffer>('private_event_logs')),
@@ -549,7 +550,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       await recipientTaggingStore.updateHighestFinalizedIndex(secretB, 17, changeSetId);
       await recipientTaggingStore.updateHighestFinalizedIndex(secretConstrained, 11, changeSetId);
       await recipientTaggingStore.updateHighestAgedIndex(secretConstrained, 13, changeSetId);
-      await kvStore.transactionAsync(() => recipientTaggingStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => recipientTaggingStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       highest_aged_index: await snapshotMap(kvStore.openMap<string, number>('highest_aged_index')),
@@ -663,7 +664,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
 
       await senderTaggingStore.finalizePendingIndexes([txHashA, txHashE], changeSetId);
 
-      await kvStore.transactionAsync(() => senderTaggingStore.commitStaged(changeSetId));
+      await kvStore.transactionAsync(() => senderTaggingStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({
       pending_indexes: await snapshotMap(kvStore.openMap<string, Buffer>('pending_indexes')),

--- a/yarn-project/pxe/src/storage/base_staging_store.test.ts
+++ b/yarn-project/pxe/src/storage/base_staging_store.test.ts
@@ -1,0 +1,284 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+
+import { tick } from '../test_utils.js';
+import { BaseStagingStore } from './base_staging_store.js';
+import type { ChangeSetId } from './staged_write_coordinator.js';
+
+describe('BaseStagingStore', () => {
+  let kv: AztecAsyncKVStore;
+  let store: TestStore;
+
+  beforeEach(async () => {
+    kv = await openTmpStore('base_staging_store_test');
+    store = new TestStore(kv);
+  });
+
+  describe('withChangeSet', () => {
+    it('accepts operations between beginChangeSet and the end of the change set', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      await expect(store.readStaged('key', 'cs1')).resolves.toBe(1);
+    });
+
+    it('rejects operations for a change set that was never opened', async () => {
+      let operationRan = false;
+      await expect(
+        store.op(() => {
+          operationRan = true;
+          return Promise.resolve();
+        }, 'never-opened'),
+      ).rejects.toThrow('Store "test": change set "never-opened" is not open');
+      expect(operationRan).toBe(false);
+    });
+
+    it('rejects operations for a change set that was committed', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      await store.commitChangeSet('cs1');
+      await expect(store.write('key', 2, 'cs1')).rejects.toThrow('Store "test": change set "cs1" is not open');
+      await expect(store.readStaged('key', 'cs1')).rejects.toThrow('Store "test": change set "cs1" is not open');
+    });
+
+    it('rejects operations for a change set that was discarded', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      store.discardChangeSet('cs1');
+      await expect(store.write('key', 2, 'cs1')).rejects.toThrow('Store "test": change set "cs1" is not open');
+    });
+
+    it('serializes operations of the same change set', async () => {
+      store.beginChangeSet('cs1');
+      const gate = promiseWithResolvers<void>();
+      const order: string[] = [];
+
+      const first = store.op(async () => {
+        order.push('first-start');
+        await gate.promise;
+        order.push('first-end');
+      }, 'cs1');
+      const second = store.op(() => {
+        order.push('second');
+        return Promise.resolve();
+      }, 'cs1');
+
+      await tick();
+      expect(order).toEqual(['first-start']);
+
+      gate.resolve();
+      await first;
+      await second;
+      expect(order).toEqual(['first-start', 'first-end', 'second']);
+    });
+
+    it('releases the lock when the operation throws', async () => {
+      store.beginChangeSet('cs1');
+      await expect(store.op(() => Promise.reject(new Error('boom')), 'cs1')).rejects.toThrow('boom');
+      await expect(store.op(() => Promise.resolve('ok'), 'cs1')).resolves.toBe('ok');
+    });
+
+    it('rejects an operation whose change set ended while it waited for the lock', async () => {
+      store.beginChangeSet('cs1');
+      const entered = promiseWithResolvers<void>();
+      const gate = promiseWithResolvers<void>();
+
+      const holding = store.op(() => {
+        entered.resolve();
+        return gate.promise;
+      }, 'cs1');
+      const queuedWrite = store.write('key', 1, 'cs1');
+
+      // Only end the change set once the first operation is inside its body, so it is the queued write that finds it
+      // closed.
+      await entered.promise;
+      store.discardChangeSet('cs1');
+      gate.resolve();
+
+      await holding;
+      await expect(queuedWrite).rejects.toThrow('Store "test": change set "cs1" is not open');
+    });
+
+    it('rejects an operation whose change set ended while it waited in the transaction queue', async () => {
+      store.beginChangeSet('cs1');
+      const gate = promiseWithResolvers<void>();
+
+      // Hold the kv store's writer queue so the write's transaction is in flight but not yet executed, then end the
+      // change set before releasing.
+      const holdTx = kv.transactionAsync(() => gate.promise);
+      const queuedWrite = store.write('key', 1, 'cs1');
+
+      store.discardChangeSet('cs1');
+      gate.resolve();
+      await holdTx;
+
+      await expect(queuedWrite).rejects.toThrow('Store "test": change set "cs1" is not open');
+
+      // The rejected write staged nothing: the change set is closed, so rollback runs and nothing reached the db.
+      await expect(store.rollbackToBlock(0)).resolves.not.toThrow();
+      await expect(store.committed('key')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('beginChangeSet', () => {
+    it('rejects opening a change set while another is open', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      expect(() => store.beginChangeSet('cs2')).toThrow(
+        'Store "test": cannot open change set "cs2" because change set "cs1" is already open',
+      );
+      await expect(store.readStaged('key', 'cs1')).resolves.toBe(1);
+    });
+
+    it('accepts a new change set once the previous one ended', async () => {
+      store.beginChangeSet('cs1');
+      await store.commitChangeSet('cs1');
+      expect(() => store.beginChangeSet('cs2')).not.toThrow();
+    });
+  });
+
+  describe('commitChangeSet', () => {
+    it('flushes staged data to the db', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      await store.commitChangeSet('cs1');
+      await expect(store.committed('key')).resolves.toBe(1);
+    });
+
+    it('rejects while an operation is in flight', async () => {
+      store.beginChangeSet('cs1');
+      const entered = promiseWithResolvers<void>();
+      const gate = promiseWithResolvers<void>();
+
+      const inFlight = store.op(async changeSet => {
+        entered.resolve();
+        await gate.promise;
+        changeSet.set('key', 1);
+      }, 'cs1');
+
+      await entered.promise;
+      await expect(store.commitChangeSet('cs1')).rejects.toThrow(
+        'Store "test": cannot commit change set "cs1" while 1 of its operations are in flight',
+      );
+
+      gate.resolve();
+      await inFlight;
+      await store.commitChangeSet('cs1');
+      await expect(store.committed('key')).resolves.toBe(1);
+    });
+
+    it('ends the change set even when nothing was staged', async () => {
+      store.beginChangeSet('cs1');
+      await store.commitChangeSet('cs1');
+      await expect(store.write('key', 1, 'cs1')).rejects.toThrow('Store "test": change set "cs1" is not open');
+    });
+
+    it('rejects a change set that was never opened', async () => {
+      await expect(store.commitChangeSet('never-opened')).rejects.toThrow(
+        'Store "test": change set "never-opened" is not open',
+      );
+    });
+  });
+
+  describe('discardChangeSet', () => {
+    it('leaves the open change set alone when discarding a different one', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+
+      store.discardChangeSet('never-opened');
+
+      await expect(store.readStaged('key', 'cs1')).resolves.toBe(1);
+    });
+
+    it('tolerates a repeated discard', () => {
+      store.beginChangeSet('cs1');
+      store.discardChangeSet('cs1');
+
+      expect(() => store.discardChangeSet('cs1')).not.toThrow();
+    });
+  });
+
+  describe('rollbackToBlock', () => {
+    it('rolls back when no change set is open', async () => {
+      await store.rollbackToBlock(7);
+      expect(store.rollbacks).toEqual([7]);
+    });
+
+    it('throws once a change set opens, even before it stages anything', async () => {
+      store.beginChangeSet('cs1');
+      await expect(store.rollbackToBlock(7)).rejects.toThrow(
+        'Store "test": cannot roll back while change set "cs1" is open',
+      );
+      expect(store.rollbacks).toEqual([]);
+    });
+
+    it('rolls back again once the change set is discarded', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      store.discardChangeSet('cs1');
+      await store.rollbackToBlock(7);
+      expect(store.rollbacks).toEqual([7]);
+    });
+
+    it('rolls back again once the change set is committed', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      await store.commitChangeSet('cs1');
+      await store.rollbackToBlock(7);
+      expect(store.rollbacks).toEqual([7]);
+    });
+  });
+});
+
+const VALUES_MAP = 'values';
+
+type TestDb = { values: AztecAsyncMap<string, number> };
+
+class TestStore extends BaseStagingStore<Map<string, number>, TestDb> {
+  /** Blocks passed to {@link applyRollback}, in order, so tests can tell a delegated rollback from a rejected one. */
+  readonly rollbacks: number[] = [];
+
+  /** Second handle on the same map, so assertions can read committed state without going through the store. */
+  readonly #committedValues: AztecAsyncMap<string, number>;
+
+  constructor(store: AztecAsyncKVStore) {
+    super({
+      storeName: 'test',
+      store,
+      buildChangeSet: () => new Map(),
+      buildDb: db => ({ values: db.openMap(VALUES_MAP) }),
+    });
+    this.#committedValues = store.openMap(VALUES_MAP);
+  }
+
+  protected async flushChangeSet(changeSet: Map<string, number>, db: TestDb): Promise<void> {
+    for (const [key, value] of changeSet) {
+      await db.values.set(key, value);
+    }
+  }
+
+  protected applyRollback(toBlock: number, _db: TestDb): Promise<void> {
+    this.rollbacks.push(toBlock);
+    return Promise.resolve();
+  }
+
+  write(key: string, value: number, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, changeSet => {
+      changeSet.set(key, value);
+      return Promise.resolve();
+    });
+  }
+
+  // Runs an arbitrary operation body under the change set's lock.
+  op<R>(fn: (changeSet: Map<string, number>) => Promise<R>, changeSetId: ChangeSetId): Promise<R> {
+    return this.withChangeSet(changeSetId, changeSet => fn(changeSet));
+  }
+
+  readStaged(key: string, changeSetId: ChangeSetId): Promise<number | undefined> {
+    return this.withChangeSet(changeSetId, changeSet => Promise.resolve(changeSet.get(key)));
+  }
+
+  committed(key: string): Promise<number | undefined> {
+    return this.#committedValues.getAsync(key);
+  }
+}

--- a/yarn-project/pxe/src/storage/base_staging_store.ts
+++ b/yarn-project/pxe/src/storage/base_staging_store.ts
@@ -1,0 +1,201 @@
+import { Semaphore } from '@aztec/foundation/queue';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+
+import type { Rollbackable } from './rollbackable.js';
+import type { ChangeSetId, StagedStore } from './staged_write_coordinator.js';
+
+/**
+ * Base class for stores that stage their writes per change set, flushing them on commit and dropping them on abort.
+ *
+ * A change set's staged data exists only between {@link beginChangeSet} and {@link commitChangeSet}/
+ * {@link discardChangeSet}. An operation arriving on behalf of a change set that already ended (e.g. one discarded on
+ * abort) finds no matching change set and throws, so it cannot stage new data for a dead one.
+ *
+ * The staged data and the store's kv handles live in this base class and are only reachable through
+ * {@link withChangeSet} (change set operations, with the DB read-only), {@link flushChangeSet} (the commit-time
+ * write-back) and {@link applyRollback} (the reorg truncation).
+ *
+ * The class is thread safe: an internal lock serializes the operations run through {@link withChangeSet}, so two of
+ * them issued concurrently (e.g. under `Promise.all`) never interleave across awaits. Subclasses can therefore read
+ * staged data and write it back without handling atomicity themselves.
+ *
+ * @typeParam TChangeSet - The in-memory buffer a change set accumulates its writes in, built empty by `buildChangeSet`
+ * on every {@link beginChangeSet} and dropped when the change set ends. A store keyed by id might stage
+ * `{ items: Map<string, Item> }`.
+ * @typeParam TDb - The store's kv handles, opened once at construction by `buildDb` and shared by every change set.
+ * That same store would open `{ items: AztecAsyncMap<string, Buffer>; itemsByBlockNumber: AztecAsyncMultiMap }`.
+ */
+export abstract class BaseStagingStore<TChangeSet, TDb> implements StagedStore, Rollbackable {
+  public readonly storeName: string;
+
+  readonly #store: AztecAsyncKVStore;
+  readonly #db: TDb;
+  readonly #buildChangeSet: () => TChangeSet;
+  readonly #lock = new Semaphore(1);
+
+  /** The change set currently open, if any. */
+  #current: OpenChangeSet<TChangeSet> | undefined;
+
+  protected constructor({
+    storeName,
+    store,
+    buildChangeSet,
+    buildDb,
+  }: {
+    /** Unique name identifying this store, used in error messages and for registration with StagedWriteCoordinator. */
+    storeName: string;
+    /** The backing kv store; the runners open their transactions on it. */
+    store: AztecAsyncKVStore;
+    /** Creates the empty staged data a change set starts with. */
+    buildChangeSet: () => TChangeSet;
+    /** Opens the store's kv handles. */
+    buildDb: (store: AztecAsyncKVStore) => TDb;
+  }) {
+    this.storeName = storeName;
+    this.#store = store;
+    this.#buildChangeSet = buildChangeSet;
+    this.#db = buildDb(store);
+  }
+
+  /**
+   * Opens the change set, so its operations are accepted until {@link commitChangeSet} or {@link discardChangeSet}.
+   *
+   * @throws If a change set is already open.
+   */
+  beginChangeSet(changeSetId: ChangeSetId): void {
+    if (this.#current !== undefined) {
+      throw new Error(
+        `Store "${this.storeName}": cannot open change set "${changeSetId}" because change set ` +
+          `"${this.#current.changeSetId}" is already open`,
+      );
+    }
+    this.#current = { changeSetId, changeSet: this.#buildChangeSet(), inFlight: 0 };
+  }
+
+  /**
+   * Commits the change set's staged data: flushes it via {@link flushChangeSet}, then closes the change set. Runs
+   * inside the transaction owned by the caller.
+   *
+   * Not meant to be overridden: subclasses implement {@link flushChangeSet}.
+   *
+   * @throws If the change set is not open, or still has operations in flight.
+   */
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
+    const current = this.#currentOrThrow(changeSetId);
+    if (current.inFlight > 0) {
+      throw new Error(
+        `Store "${this.storeName}": cannot commit change set "${changeSetId}" while ${current.inFlight} of its ` +
+          `operations are in flight`,
+      );
+    }
+    await this.flushChangeSet(current.changeSet, this.#db);
+    this.#closeChangeSet(changeSetId);
+  }
+
+  /** Closes the change set, discarding any staged data without committing. A no-op if it is not open. */
+  discardChangeSet(changeSetId: ChangeSetId): void {
+    this.#closeChangeSet(changeSetId);
+  }
+
+  /**
+   * Rolls the store back to `toBlock` via {@link applyRollback}.
+   *
+   * Must be called inside a transaction owned by the caller, since it opens none of its own.
+   *
+   * Not meant to be overridden: subclasses implement {@link applyRollback}.
+   *
+   * @throws If a change set is open, since its staged writes could later be committed anchored to deleted blocks.
+   */
+  async rollbackToBlock(toBlock: number): Promise<void> {
+    if (this.#current !== undefined) {
+      throw new Error(
+        `Store "${this.storeName}": cannot roll back while change set "${this.#current.changeSetId}" is open`,
+      );
+    }
+    await this.applyRollback(toBlock, this.#db);
+  }
+
+  /**
+   * Writes the change set's staged data to persistent storage. Runs inside the caller's transaction: it must not
+   * open a transaction of its own or call {@link withChangeSet}.
+   */
+  protected abstract flushChangeSet(changeSet: TChangeSet, db: TDb): Promise<void>;
+
+  /**
+   * Deletes the state originating from blocks strictly above `toBlock`. Runs inside the transaction owned by
+   * {@link rollbackToBlock}'s caller: it must not open a transaction of its own or call {@link withChangeSet}.
+   */
+  protected abstract applyRollback(toBlock: number, db: TDb): Promise<void>;
+
+  /**
+   * Runs a change set operation (read or write). Takes the store's lock, opens a transaction, and calls `fn` with the
+   * change set's staged data and a read-only view of the DB (writes are staged in memory until {@link flushChangeSet}
+   * runs on commit).
+   *
+   * The lock makes the store thread safe: two operations issued concurrently (e.g. under `Promise.all`) cannot
+   * interleave across awaits, so `fn` can read staged data and write it back without handling atomicity itself.
+   *
+   * @throws If the change set is not open.
+   */
+  protected async withChangeSet<R>(
+    changeSetId: ChangeSetId,
+    fn: (changeSet: TChangeSet, db: ReadonlyDb<TDb>) => Promise<R>,
+  ): Promise<R> {
+    const entered = this.#currentOrThrow(changeSetId);
+    entered.inFlight++;
+    try {
+      await this.#lock.acquire();
+      try {
+        return await this.#store.transactionAsync(() => {
+          // Re-resolve after the wait: the change set may have been discarded while this operation queued on the lock.
+          const current = this.#currentOrThrow(changeSetId);
+          return fn(current.changeSet, this.#db);
+        });
+      } finally {
+        this.#lock.release();
+      }
+    } finally {
+      // Count down on the change set this operation entered, which may no longer be the open one.
+      entered.inFlight--;
+    }
+  }
+
+  #currentOrThrow(changeSetId: ChangeSetId): OpenChangeSet<TChangeSet> {
+    if (this.#current?.changeSetId !== changeSetId) {
+      throw new Error(`Store "${this.storeName}": change set "${changeSetId}" is not open`);
+    }
+    return this.#current;
+  }
+
+  #closeChangeSet(changeSetId: ChangeSetId): void {
+    if (this.#current?.changeSetId === changeSetId) {
+      this.#current = undefined;
+    }
+  }
+}
+
+/**
+ * View of a store's kv handles restricted to the kv interfaces' read methods. Change set operations receive this view:
+ * while a change set is open the DB is read-only, since all writes are staged in memory until
+ * {@link BaseStagingStore.flushChangeSet} runs on commit.
+ */
+export type ReadonlyDb<T> = {
+  readonly [K in keyof T]: Pick<T[K], Extract<keyof T[K], ReadMethod>>;
+};
+
+/** The kv read surface staging stores use: what {@link ReadonlyDb} exposes while a change set is open. */
+type ReadMethod =
+  | 'getAsync'
+  | 'hasAsync'
+  | 'entriesAsync'
+  | 'valuesAsync'
+  | 'keysAsync'
+  | 'sizeAsync'
+  | 'getValuesAsync'
+  | 'getValueCountAsync';
+
+/**
+ * The change set in progress: its id, its staged data (created empty when it opens), and how many of its operations
+ * are still running.
+ */
+type OpenChangeSet<T> = { changeSetId: ChangeSetId; changeSet: T; inFlight: number };

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
@@ -389,7 +389,7 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -407,7 +407,7 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -425,7 +425,7 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
 
         // Append a single element
@@ -438,7 +438,7 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -456,14 +456,14 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
 
         // We just move the entire thing one slot.
         await capsuleStore.copyCapsule(contract, new Fr(0), new Fr(1), NUMBER_OF_ITEMS, 'test', scope);
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -481,13 +481,13 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
 
         await capsuleStore.readCapsuleArray(contract, new Fr(0), 'test', scope);
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -505,13 +505,13 @@ describe('capsule data provider', () => {
         );
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
 
         await capsuleStore.setCapsuleArray(contract, new Fr(0), [], 'test', scope);
 
         await store.transactionAsync(async () => {
-          await capsuleStore.commitStaged('test');
+          await capsuleStore.commitChangeSet('test');
         });
       },
       TEST_TIMEOUT_MS,
@@ -531,11 +531,11 @@ describe('capsule data provider', () => {
 
       // After this commit, 'change-set-1' should logically be reset
       // Any read of contract-slot after this should see committedValues1
-      await capsuleStore.commitStaged('change-set-1');
+      await capsuleStore.commitChangeSet('change-set-1');
 
       // Any read of contract-slot should see committedValues2
       capsuleStore.setCapsule(contract, slot, committedValues2, 'change-set-2', scope);
-      await capsuleStore.commitStaged('change-set-2');
+      await capsuleStore.commitChangeSet('change-set-2');
 
       // If we failed to properly dispose 'change-set-1's staged writes on commit, Instead of reading committedValues2
       // (as we should), we would end up reading committedValues1 (which would be wrong)
@@ -552,7 +552,7 @@ describe('capsule data provider', () => {
 
       // First set a committed capsule (using a different change set that we commit)
       capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitStaged(commitChangeSetId);
+      await capsuleStore.commitChangeSet(commitChangeSetId);
 
       // Then set a staged capsule (not committed)
       capsuleStore.setCapsule(contract, slot, stagedValues, stagedWrites1, scope);
@@ -573,7 +573,7 @@ describe('capsule data provider', () => {
 
       // First set a committed capsule
       capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitStaged(commitChangeSetId);
+      await capsuleStore.commitChangeSet(commitChangeSetId);
 
       // Delete in change set (not committed)
       capsuleStore.deleteCapsule(contract, slot, stagedWrites1, scope);
@@ -592,16 +592,16 @@ describe('capsule data provider', () => {
       const deleteChangeSetId: ChangeSetId = 'delete-change-set';
 
       capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitStaged(commitChangeSetId);
+      await capsuleStore.commitChangeSet(commitChangeSetId);
       capsuleStore.deleteCapsule(contract, slot, deleteChangeSetId, scope);
 
-      await capsuleStore.commitStaged(deleteChangeSetId);
+      await capsuleStore.commitChangeSet(deleteChangeSetId);
 
       // Now any change set should see this null (deleted)
       expect(await capsuleStore.getCapsule(contract, slot, 'any-change-set-sees-this', scope)).toBeNull();
     });
 
-    it('discardStaged removes staged data without affecting main', async () => {
+    it('discardChangeSet removes staged data without affecting main', async () => {
       const slot = Fr.random();
       const committedValues = [Fr.random()];
       const stagedValues = [Fr.random()];
@@ -609,10 +609,10 @@ describe('capsule data provider', () => {
       const stagedChangeSetId: ChangeSetId = 'staged';
 
       capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitStaged(commitChangeSetId);
+      await capsuleStore.commitChangeSet(commitChangeSetId);
       capsuleStore.setCapsule(contract, slot, stagedValues, stagedChangeSetId, scope);
 
-      await capsuleStore.discardStaged(stagedChangeSetId);
+      capsuleStore.discardChangeSet(stagedChangeSetId);
 
       // Should still get committed capsule
       expect(await capsuleStore.getCapsule(contract, slot, 'any-change-set', scope)).toEqual(committedValues);

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -97,7 +97,7 @@ export class CapsuleStore implements StagedStore {
    * here (and using one would deadlock on IndexedDB).
    * @param changeSetId - The changeSetId identifying which staged data to commit
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
     const stagedCapsules = this.#getStagedCapsules(changeSetId);
 
     for (const [key, value] of stagedCapsules) {
@@ -117,9 +117,8 @@ export class CapsuleStore implements StagedStore {
   /**
    * Discards staged data without committing.
    */
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
+  discardChangeSet(changeSetId: ChangeSetId): void {
     this.#stagedCapsules.delete(changeSetId);
-    return Promise.resolve();
   }
 
   /**

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.test.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.test.ts
@@ -69,7 +69,7 @@ describe('FactStore', () => {
     it('records facts and reads a collection back after commit (implicit collection creation)', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeB, [], { blockNumber: 5, blockHash: Fr.random() }, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET))!;
       expect(hexSet(facts.map(f => f.factTypeId))).toEqual(hexSet([factTypeA, factTypeB]));
@@ -82,7 +82,7 @@ describe('FactStore', () => {
     it('lists collections via getFactCollectionsByType', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const collections = await store.getFactCollectionsByType(typeKey, CHANGE_SET);
       expect(hexSet(collectionIdsOf(collections))).toEqual(hexSet([collectionId1, collectionId2]));
@@ -91,7 +91,7 @@ describe('FactStore', () => {
     it('getFactCollectionsByType returns each collection complete with its facts', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeB, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const collections = await store.getFactCollectionsByType(typeKey, CHANGE_SET);
       expect(collections).toHaveLength(1);
@@ -104,7 +104,7 @@ describe('FactStore', () => {
       const payload = Fr.random();
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
     });
@@ -125,7 +125,7 @@ describe('FactStore', () => {
         { blockNumber: 10, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET))!;
       expect(facts).toHaveLength(2);
@@ -135,11 +135,11 @@ describe('FactStore', () => {
     it('re-recording an identical fact across change sets is a no-op', async () => {
       const payload = Fr.random();
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const CHANGE_SET_2 = 'rerecord-change-set';
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET_2);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET_2));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
     });
@@ -148,7 +148,7 @@ describe('FactStore', () => {
   describe('scope isolation', () => {
     it('a collection recorded under one scope is a different collection under another scope', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeDefined();
       expect(await store.getFactCollection(collectionKey1ScopeB, CHANGE_SET)).toBeUndefined();
@@ -160,7 +160,7 @@ describe('FactStore', () => {
       const origin = { blockNumber: 5, blockHash: Fr.random() };
       await store.recordFact(collectionKey1, factTypeA, [payload], origin, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeB, [payload], origin, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeA,
@@ -173,7 +173,7 @@ describe('FactStore', () => {
     it('getFactCollectionsByType only returns collections for the queried scope', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET))).toEqual([collectionId1]);
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKeyScopeB, CHANGE_SET))).toEqual([collectionId1]);
@@ -197,7 +197,7 @@ describe('FactStore', () => {
       const payloads = Array.from({ length: 4 }, () => Fr.random());
       await store.recordFact(collectionKey1, factTypeA, [payloads[0]], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeA, [payloads[1]], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const CHANGE_SET_2 = 'staged-change-set';
       await store.recordFact(collectionKey1, factTypeA, [payloads[2]], undefined, CHANGE_SET_2);
@@ -212,11 +212,11 @@ describe('FactStore', () => {
     it('deletes the collection and leaves neighbouring collections untouched', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const DEL = 'delete-change-set';
       await store.deleteFactCollection(collectionKey1, DEL);
-      await kv.transactionAsync(() => store.commitStaged(DEL));
+      await kv.transactionAsync(() => store.commitChangeSet(DEL));
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET))).toEqual([collectionId2]);
@@ -225,11 +225,11 @@ describe('FactStore', () => {
     it('only deletes the queried scope: the same (contract,type,id) under another scope survives', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeB, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const DEL = 'delete-change-set';
       await store.deleteFactCollection(collectionKey1, DEL);
-      await kv.transactionAsync(() => store.commitStaged(DEL));
+      await kv.transactionAsync(() => store.commitChangeSet(DEL));
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
       expect((await store.getFactCollection(collectionKey1ScopeB, CHANGE_SET))!.facts.map(f => f.factTypeId)).toEqual([
@@ -239,18 +239,18 @@ describe('FactStore', () => {
 
     it('is a no-op for a collection that does not exist', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const DEL = 'delete-change-set';
       await store.deleteFactCollection(collectionKey2, DEL);
-      await kv.transactionAsync(() => store.commitStaged(DEL));
+      await kv.transactionAsync(() => store.commitChangeSet(DEL));
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
     });
 
     it('hides a collection from its own change set after a staged delete, even over committed facts', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const DEL = 'delete-change-set';
       await store.deleteFactCollection(collectionKey1, DEL);
@@ -262,7 +262,7 @@ describe('FactStore', () => {
 
     it('a staged delete-then-record re-creates the collection within the same change set', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const CHANGE_SET_2 = 'recreate-change-set';
       await store.deleteFactCollection(collectionKey1, CHANGE_SET_2);
@@ -271,7 +271,7 @@ describe('FactStore', () => {
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET_2))!;
       expect(facts.map(f => f.factTypeId)).toEqual([factTypeB]);
 
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET_2));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
       expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeB,
       ]);
@@ -283,7 +283,7 @@ describe('FactStore', () => {
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
 
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
       expect(await store.getFactCollection(collectionKey1, 'reader')).toBeUndefined();
     });
   });
@@ -300,7 +300,7 @@ describe('FactStore', () => {
         { blockNumber: 6, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       await kv.transactionAsync(() => store.rollbackToBlock(5));
 
@@ -316,7 +316,7 @@ describe('FactStore', () => {
         { blockNumber: 6, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       await kv.transactionAsync(() => store.rollbackToBlock(5));
 
@@ -340,13 +340,13 @@ describe('FactStore', () => {
         { blockNumber: 10, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       await kv.transactionAsync(() => store.rollbackToBlock(7));
       expect(
         (await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts.map(f => f.originBlock?.blockNumber),
       ).toEqual([5]);
-      await store.discardStaged(CHANGE_SET);
+      store.discardChangeSet(CHANGE_SET);
 
       await kv.transactionAsync(() => store.rollbackToBlock(4));
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
@@ -357,7 +357,7 @@ describe('FactStore', () => {
       await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).rejects.toThrow(
         'PXE fact store rollback is not allowed while staged writes are pending',
       );
-      await store.discardStaged('uncommitted-change-set');
+      store.discardChangeSet('uncommitted-change-set');
       await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).resolves.not.toThrow();
     });
 
@@ -366,7 +366,7 @@ describe('FactStore', () => {
       await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).rejects.toThrow(
         'PXE fact store rollback is not allowed while staged writes are pending',
       );
-      await store.discardStaged('reader-change-set');
+      store.discardChangeSet('reader-change-set');
       await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).resolves.not.toThrow();
     });
   });
@@ -400,7 +400,7 @@ describe('FactStore', () => {
         undefined,
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect(await store.getFactCollectionsByType(typeKey, CHANGE_SET)).toHaveLength(1);
       expect(
@@ -424,7 +424,7 @@ describe('FactStore', () => {
       await store.recordFact(collectionKey1, factTypeA, [payloads[0]], undefined, CHANGE_SET);
       const CHANGE_SET_2 = 'second-change-set';
       await store.recordFact(collectionKey1, factTypeA, [payloads[1]], undefined, CHANGE_SET_2);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.payload[0])).toEqual([
         payloads[0],
@@ -433,23 +433,23 @@ describe('FactStore', () => {
         hexSet((await store.getFactCollection(collectionKey1, CHANGE_SET_2))!.facts.map(f => f.payload[0])),
       ).toEqual(hexSet(payloads));
 
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET_2));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
       expect(hexSet((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.payload[0]))).toEqual(
         hexSet(payloads),
       );
     });
 
-    it('discardStaged drops staged writes without touching committed state', async () => {
+    it('discardChangeSet drops staged writes without touching committed state', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
 
       const CHANGE_SET_2 = 'discarded-change-set';
       await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET_2);
       await store.recordFact(collectionKey1, factTypeB, [Fr.random()], undefined, CHANGE_SET_2);
-      await store.discardStaged(CHANGE_SET_2);
+      store.discardChangeSet(CHANGE_SET_2);
 
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET_2))).toEqual([collectionId1]);
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET_2));
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
       expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts).toHaveLength(1);
       expect(await store.getFactCollection(collectionKey2, 'reader')).toBeUndefined();
     });
@@ -460,8 +460,8 @@ describe('FactStore', () => {
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET_2);
 
-      await kv.transactionAsync(() => store.commitStaged(CHANGE_SET));
-      await expect(kv.transactionAsync(() => store.commitStaged(CHANGE_SET_2))).resolves.not.toThrow();
+      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await expect(kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2))).resolves.not.toThrow();
 
       expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts).toHaveLength(1);
     });

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.ts
@@ -164,7 +164,7 @@ export class FactStore implements StagedStore, Rollbackable {
    * DO NOT call `#withChangeSetLock` here: awaiting the lock creates a microtask boundary that causes IndexedDB to
    * auto-commit the outer transaction.
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
     for (const op of this.#stagedOpsFor(changeSetId)) {
       switch (op.kind) {
         case 'recordFact':
@@ -183,9 +183,8 @@ export class FactStore implements StagedStore, Rollbackable {
   }
 
   /** Discards all staged operations for the given change set without persisting them. */
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
+  discardChangeSet(changeSetId: ChangeSetId): void {
     this.#clearChangeSetData(changeSetId);
-    return Promise.resolve();
   }
 
   /**

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -7,6 +7,7 @@ import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 
 import type { ChangeSetId } from '../staged_write_coordinator.js';
 import { NoteStore } from './note_store.js';
+import { readNotes } from './test_utils.js';
 
 // -----------------------------------------------------------------------------
 // Shared constants for deterministic fixtures
@@ -42,6 +43,7 @@ describe('NoteStore', () => {
   async function setupNoteStoreWithNotes(storeName: string) {
     const store = await openTmpStore(storeName);
     const noteStore = new NoteStore(store);
+    noteStore.beginChangeSet('before-each-test-change-set');
 
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
@@ -61,7 +63,10 @@ describe('NoteStore', () => {
 
     await noteStore.addNotes([note1, note2], SCOPE_1, 'before-each-test-change-set');
     await noteStore.addNotes([note3], SCOPE_2, 'before-each-test-change-set');
-    await noteStore.commitStaged('before-each-test-change-set');
+    await noteStore.commitChangeSet('before-each-test-change-set');
+
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    noteStore.beginChangeSet('test');
 
     return { store, noteStore, note1, note2, note3 };
   }
@@ -81,17 +86,21 @@ describe('NoteStore', () => {
   }
 
   /**
-   * Runs the same function sequentially in the given list of changeSetId's.
-   * Handy to assert that state is consistent pre and post commit.
+   * Runs the same function sequentially in the given list of changeSetId's, committing each change set after its run.
+   * The first change set must already be open. Each subsequent one is opened fresh. Handy to assert that state is
+   * consistent pre and post commit.
    */
   async function verifyAndCommitForEachChangeSet(
     changeSetIds: ChangeSetId[],
     noteStore: NoteStore,
     fn: (changeSetId: ChangeSetId) => Promise<void>,
   ) {
-    for (const changeSetId of changeSetIds) {
+    for (const [i, changeSetId] of changeSetIds.entries()) {
+      if (i > 0) {
+        noteStore.beginChangeSet(changeSetId);
+      }
       await fn(changeSetId);
-      await noteStore.commitStaged(changeSetId);
+      await noteStore.commitChangeSet(changeSetId);
     }
   }
 
@@ -100,6 +109,7 @@ describe('NoteStore', () => {
     it('creates a NoteStore on an empty store and confirms getNotes returns an empty array', async () => {
       const store = await openTmpStore('note_store_fresh_store');
       const noteStore = new NoteStore(store);
+      noteStore.beginChangeSet('pre-commit');
 
       await verifyAndCommitForEachChangeSet(
         ['pre-commit', 'post-commit'],
@@ -123,14 +133,16 @@ describe('NoteStore', () => {
       // First note store populates the persistent store; second reopens it to verify persistence
       {
         const noteStore1 = new NoteStore(store);
+        noteStore1.beginChangeSet('first-store');
 
         const noteA = await mkNote({ contractAddress: CONTRACT_A, siloedNullifier: SILOED_NULLIFIER_1 });
         const noteB = await mkNote({ contractAddress: CONTRACT_B, siloedNullifier: SILOED_NULLIFIER_2 });
         await noteStore1.addNotes([noteA, noteB], FAKE_ADDRESS, 'first-store');
-        await noteStore1.commitStaged('first-store');
+        await noteStore1.commitChangeSet('first-store');
       }
 
       const noteStore2 = new NoteStore(store);
+      noteStore2.beginChangeSet('second-store');
 
       await verifyAndCommitForEachChangeSet(
         ['second-store', 'fresh-change-set'],
@@ -522,7 +534,8 @@ describe('NoteStore', () => {
     // run concurrently in a Promise.all context without risking unnecessarily defensive checks failing.
     it('applying nullifier a second time is a no-op and returns no transitioned notes', async () => {
       await noteStore.applyNullifiers([mkNullifier(note1)], 'test');
-      await noteStore.commitStaged('test');
+      await noteStore.commitChangeSet('test');
+      noteStore.beginChangeSet('test');
 
       // Second application is idempotent: the emission is already recorded, so no note transitions to nullified. The
       // result is empty (only notes that flip active -> nullified in this call are returned) and visibility is
@@ -554,15 +567,15 @@ describe('NoteStore', () => {
       });
 
       // Add note to stage without committing
-      await noteStore.addNotes([freshNote], SCOPE_1, 'fresh-change-set');
+      await noteStore.addNotes([freshNote], SCOPE_1, 'test');
 
       // Immediately nullify it in the same change set (simulating validateAndStoreNote when nullifier exists on chain)
       const nullifiers = [mkNullifier(freshNote)];
-      await expect(noteStore.applyNullifiers(nullifiers, 'fresh-change-set')).resolves.toEqual([freshNote]);
+      await expect(noteStore.applyNullifiers(nullifiers, 'test')).resolves.toEqual([freshNote]);
 
       // Verify note is now in nullified state
       await verifyAndCommitForEachChangeSet(
-        ['fresh-change-set', 'after-change-set-commit'],
+        ['test', 'after-change-set-commit'],
         noteStore,
         async (changeSetId: ChangeSetId) => {
           const activeNotes = await noteStore.getNotes(
@@ -591,7 +604,11 @@ describe('NoteStore', () => {
         ),
       );
 
-      // Simulate concurrent validateAndStoreNote calls where each note is added and immediately nullified
+      // Simulate concurrent validateAndStoreNote calls where each note is added and immediately nullified. Only one
+      // change set can be open at a time, so the setup one is closed first; discarding it throws nothing away, since
+      // setup already committed.
+      noteStore.discardChangeSet('test');
+      noteStore.beginChangeSet('concurrent-change-set');
       const concurrentStoreNoteCalls = notes.map(async note => {
         await noteStore.addNotes([note], SCOPE_1, 'concurrent-change-set');
         const nullifiers = [mkNullifier(note)];
@@ -630,6 +647,8 @@ describe('NoteStore', () => {
 
       // note1 is from setup and committed (i.e.: it's persisted) We should be able to nullify it in a new change set
       const nullifiers = [mkNullifier(note1)];
+      noteStore.discardChangeSet('test');
+      noteStore.beginChangeSet('new-change-set');
       await expect(noteStore.applyNullifiers(nullifiers, 'new-change-set')).resolves.toEqual([note1]);
 
       // Verify the note is in nullified state
@@ -663,15 +682,15 @@ describe('NoteStore', () => {
       });
 
       // First attempt to store: add and nullify the note
-      await noteStore.addNotes([duplicateNote], SCOPE_1, 'duplicate-change-set');
-      await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-change-set');
+      await noteStore.addNotes([duplicateNote], SCOPE_1, 'test');
+      await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'test');
 
       // Second attempt to store (duplicate): try to add the same note again - should not throw
       // This simulates what happens in concurrent validateAndStoreNote calls when the same note is processed twice
-      await noteStore.addNotes([duplicateNote], SCOPE_2, 'duplicate-change-set');
+      await noteStore.addNotes([duplicateNote], SCOPE_2, 'test');
       const notesAfterSecondAttempt = await noteStore.getNotes(
         { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE, scopes: [SCOPE_1, SCOPE_2] },
-        'duplicate-change-set',
+        'test',
       );
 
       // Check that the second attempt at calling validateAndStoreNote didn't accidentally overwrite the first one
@@ -680,12 +699,12 @@ describe('NoteStore', () => {
 
       // The second applyNullifiers is a no-op: the emission is already staged, so nothing transitions to nullified and
       // visibility is unchanged.
-      const secondApply = await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-change-set');
+      const secondApply = await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'test');
       expect(secondApply).toEqual([]);
 
       // Verify the note is nullified and has both scopes
       await verifyAndCommitForEachChangeSet(
-        ['duplicate-change-set', 'after-change-set-commit'],
+        ['test', 'after-change-set-commit'],
         noteStore,
         async (changeSetId: ChangeSetId) => {
           const allNotes = await noteStore.getNotes(
@@ -707,6 +726,7 @@ describe('NoteStore', () => {
     beforeEach(async () => {
       store = await openTmpStore('note_store_visibility');
       noteStore = new NoteStore(store);
+      noteStore.beginChangeSet(CHANGE_SET);
     });
 
     afterEach(async () => {
@@ -716,7 +736,8 @@ describe('NoteStore', () => {
     it('shows a note as soon as it is committed', async () => {
       const note = await mkNote({ l2BlockNumber: BlockNumber(10) });
       await noteStore.addNotes([note], SCOPE_1, CHANGE_SET);
-      await noteStore.commitStaged(CHANGE_SET);
+      await noteStore.commitChangeSet(CHANGE_SET);
+      noteStore.beginChangeSet('read-change-set');
 
       const found = await noteStore.getNotes(activeFilter, 'read-change-set');
       expect(found).toHaveLength(1);
@@ -731,7 +752,8 @@ describe('NoteStore', () => {
         [{ data: note.siloedNullifier, l2BlockNumber: BlockNumber(11), l2BlockHash: BlockHash.random() }],
         CHANGE_SET,
       );
-      await noteStore.commitStaged(CHANGE_SET);
+      await noteStore.commitChangeSet(CHANGE_SET);
+      noteStore.beginChangeSet('read-change-set');
 
       expect(await noteStore.getNotes(activeFilter, 'read-change-set')).toHaveLength(0);
       expect(
@@ -743,10 +765,14 @@ describe('NoteStore', () => {
       const note = await mkNote({ l2BlockNumber: BlockNumber(10) });
       await noteStore.addNotes([note], SCOPE_1, CHANGE_SET);
       expect(await noteStore.getNotes(activeFilter, CHANGE_SET)).toHaveLength(1);
+
+      // The staged note was never committed: once the change set ends, the next one does not see it.
+      noteStore.discardChangeSet(CHANGE_SET);
+      noteStore.beginChangeSet('other-change-set');
       expect(await noteStore.getNotes(activeFilter, 'other-change-set')).toHaveLength(0);
     });
 
-    it('discardStaged drops staged notes and nullifications', async () => {
+    it('discardChangeSet drops staged notes and nullifications', async () => {
       const note = await mkNote({ l2BlockNumber: BlockNumber(10) });
 
       await noteStore.addNotes([note], SCOPE_1, CHANGE_SET);
@@ -755,45 +781,14 @@ describe('NoteStore', () => {
         CHANGE_SET,
       );
 
-      await noteStore.discardStaged(CHANGE_SET);
+      noteStore.discardChangeSet(CHANGE_SET);
+      noteStore.beginChangeSet('fresh-change-set');
 
       // A fresh change set sees nothing committed — both the note and the nullification were discarded.
       expect(await noteStore.getNotes(activeFilter, 'fresh-change-set')).toHaveLength(0);
       expect(
         await noteStore.getNotes({ ...activeFilter, status: NoteStatus.ACTIVE_OR_NULLIFIED }, 'fresh-change-set'),
       ).toHaveLength(0);
-    });
-  });
-
-  describe('nullifiersOfNotesAtBlock', () => {
-    let store: AztecLMDBStoreV2;
-    let noteStore: NoteStore;
-    const CHANGE_SET = 'note-store-test-change-set';
-
-    beforeEach(async () => {
-      store = await openTmpStore('note_store_block_index');
-      noteStore = new NoteStore(store);
-    });
-
-    afterEach(async () => {
-      await store.close();
-    });
-
-    it('indexes note nullifiers by creation block number', async () => {
-      const note = await mkNote({ l2BlockNumber: BlockNumber(9) });
-      await noteStore.addNotes([note], SCOPE_1, CHANGE_SET);
-      await noteStore.commitStaged(CHANGE_SET);
-      const nullifiers = await noteStore.nullifiersOfNotesAtBlock(9);
-      expect(nullifiers).toEqual([note.siloedNullifier.toString()]);
-    });
-
-    it('indexes multiple notes created at the same block', async () => {
-      const a = await mkNote({ l2BlockNumber: BlockNumber(9) });
-      const b = await mkNote({ l2BlockNumber: BlockNumber(9) });
-      await noteStore.addNotes([a, b], SCOPE_1, CHANGE_SET);
-      await noteStore.commitStaged(CHANGE_SET);
-      const nullifiers = await noteStore.nullifiersOfNotesAtBlock(9);
-      expect(new Set(nullifiers)).toEqual(new Set([a.siloedNullifier.toString(), b.siloedNullifier.toString()]));
     });
   });
 });
@@ -812,6 +807,7 @@ describe('NoteStore.rollbackToBlock', () => {
   beforeEach(async () => {
     kv = await openTmpStore('note-store-reorg-test');
     store = new NoteStore(kv);
+    store.beginChangeSet(CHANGE_SET);
   });
 
   it('deletes notes and nullifier emissions above the target block, leaving lower blocks intact', async () => {
@@ -834,18 +830,15 @@ describe('NoteStore.rollbackToBlock', () => {
       [{ data: noteB.siloedNullifier, l2BlockNumber: BlockNumber(11), l2BlockHash: nullBlockHash }],
       CHANGE_SET,
     );
-    await store.commitStaged(CHANGE_SET);
+    await store.commitChangeSet(CHANGE_SET);
 
     await kv.transactionAsync(() => store.rollbackToBlock(9));
 
-    // Only note A survives.
-    expect(await store.nullifiersOfNotesAtBlock(9)).toEqual([noteA.siloedNullifier.toString()]);
-    expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
-    expect(await store.nullifiersOfNotesAtBlock(11)).toHaveLength(0);
-
-    const found = await store.getNotes(activeFilter, 'read-change-set');
-    expect(found).toHaveLength(1);
-    expect(found[0].siloedNullifier.equals(noteA.siloedNullifier)).toBe(true);
+    // Only note A survives, and it reads back active: B is gone rather than nullified.
+    const remaining = await notesInStore(NoteStatus.ACTIVE_OR_NULLIFIED);
+    expect(remaining.map(note => note.l2BlockNumber)).toEqual([9]);
+    expect(remaining[0].siloedNullifier.equals(noteA.siloedNullifier)).toBe(true);
+    expect(await notesInStore(NoteStatus.ACTIVE)).toHaveLength(1);
   });
 
   it('sweeps every block above the target, including non-contiguous ones', async () => {
@@ -862,13 +855,11 @@ describe('NoteStore.rollbackToBlock', () => {
       l2BlockHash: FIXED_BLOCK_HASH,
     });
     await store.addNotes([noteLow, noteHigh], scope, CHANGE_SET);
-    await store.commitStaged(CHANGE_SET);
+    await store.commitChangeSet(CHANGE_SET);
 
     await kv.transactionAsync(() => store.rollbackToBlock(9));
 
-    expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
-    expect(await store.nullifiersOfNotesAtBlock(50)).toHaveLength(0);
-    expect(await store.getNotes(activeFilter, 'read-change-set')).toHaveLength(0);
+    expect(await notesInStore(NoteStatus.ACTIVE_OR_NULLIFIED)).toHaveLength(0);
   });
 
   it('restores notes that were nullified after the rollback block', async () => {
@@ -885,17 +876,19 @@ describe('NoteStore.rollbackToBlock', () => {
       [{ data: noteB.siloedNullifier, l2BlockNumber: BlockNumber(20), l2BlockHash: nullBlockHash }],
       CHANGE_SET,
     );
-    await store.commitStaged(CHANGE_SET);
+    await store.commitChangeSet(CHANGE_SET);
 
     await kv.transactionAsync(() => store.rollbackToBlock(16));
 
-    // The creation row at block 10 is untouched.
-    expect(await store.nullifiersOfNotesAtBlock(10)).toEqual([noteB.siloedNullifier.toString()]);
-
-    // The note should read back ACTIVE again (nullification row gone).
-    const found = await store.getNotes(activeFilter, 'read-change-set');
+    // The note reads back ACTIVE again (nullification row gone).
+    const found = await notesInStore(NoteStatus.ACTIVE);
     expect(found).toHaveLength(1);
     expect(found[0].siloedNullifier.equals(noteB.siloedNullifier)).toBe(true);
+
+    // Its creation at block 10 came through the sweep intact: rolling back below that block deletes the note, which
+    // only happens while the store still indexes it there.
+    await kv.transactionAsync(() => store.rollbackToBlock(9));
+    expect(await notesInStore(NoteStatus.ACTIVE_OR_NULLIFIED)).toHaveLength(0);
   });
 
   it('is idempotent — re-running an already-applied rollback is a no-op', async () => {
@@ -905,31 +898,24 @@ describe('NoteStore.rollbackToBlock', () => {
       l2BlockHash: FIXED_BLOCK_HASH,
     });
     await store.addNotes([noteB], scope, CHANGE_SET);
-    await store.commitStaged(CHANGE_SET);
+    await store.commitChangeSet(CHANGE_SET);
 
     await kv.transactionAsync(() => store.rollbackToBlock(9));
-    expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
+    expect(await notesInStore(NoteStatus.ACTIVE_OR_NULLIFIED)).toHaveLength(0);
 
     // Second run hits the missing-row guard: no throw, state unchanged.
     await kv.transactionAsync(() => store.rollbackToBlock(9));
-    expect(await store.nullifiersOfNotesAtBlock(10)).toHaveLength(0);
+    expect(await notesInStore(NoteStatus.ACTIVE_OR_NULLIFIED)).toHaveLength(0);
   });
 
-  it('throws when rollback is called while staged writes are pending', async () => {
-    // Stage a note under a change set but never commit it, so the store still holds in-flight staged data. Rolling back
-    // now could later let the change set commit notes anchored to blocks the rollback just deleted.
-    const staged = await NoteDao.random({
-      contractAddress: contract,
-      l2BlockNumber: BlockNumber(10),
-      l2BlockHash: FIXED_BLOCK_HASH,
-    });
-    await store.addNotes([staged], scope, 'uncommitted-change-set');
-
+  it('throws when rollback is called while a change set is open', async () => {
+    // The change set opened in beforeEach has not ended, so it may still stage notes derived from pre-rollback reads
+    // and commit them anchored to blocks the rollback just deleted.
     await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).rejects.toThrow(
-      'PXE note store rollback is not allowed while staged writes are pending',
+      `Store "note": cannot roll back while change set "${CHANGE_SET}" is open`,
     );
 
-    await store.discardStaged('uncommitted-change-set');
+    store.discardChangeSet(CHANGE_SET);
 
     await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).resolves.not.toThrow();
   });
@@ -937,4 +923,9 @@ describe('NoteStore.rollbackToBlock', () => {
   afterEach(async () => {
     await kv.close();
   });
+
+  /** Every note the store holds for the test's contract and scope, at the given status. */
+  function notesInStore(status: NoteStatus): Promise<NoteDao[]> {
+    return readNotes(store, { ...activeFilter, status });
+  }
 });

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
 import { allToCompletion } from '@aztec/foundation/promise';
-import { Semaphore } from '@aztec/foundation/queue';
 import type { Fr } from '@aztec/foundation/schemas';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -8,15 +7,9 @@ import type { DataInBlock } from '@aztec/stdlib/block';
 import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 
 import type { NotesFilter } from '../../notes_filter.js';
-import type { Rollbackable } from '../rollbackable.js';
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 import { StoredNote } from './stored_note.js';
-
-/// Alias types for kv map readability
-type SiloedNullifier = string;
-type AddressStr = string;
-type BlockNum = number;
-type StoredNoteBuffer = Buffer;
 
 /**
  * NoteStore manages the storage and retrieval of notes using an append-only model.
@@ -28,59 +21,22 @@ type StoredNoteBuffer = Buffer;
  * Reorgs are handled by delete-on-prune: the `chain-pruned` event triggers deletion of every note and nullifier
  * originating on a reorg'd block.
  */
-export class NoteStore implements StagedStore, Rollbackable {
-  readonly storeName: string = 'note';
-
-  logger = createLogger('note_store');
-
-  #store: AztecAsyncKVStore;
-
-  // Note that we use the siloedNullifier as the note id in this store as it's guaranteed to be unique.
-
-  // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
-  // #nullifiersByContractAddress to find relevant note nullifiers that can be used to read into this map instead.
-  //
-  // nullifier => StoredNote (serialized)
-  #notes: AztecAsyncMap<SiloedNullifier, StoredNoteBuffer>;
-
-  // Indexes which notes (via their nullifiers) belong to a contract. Used in `getNotes` to reduce the amount of notes
-  // checked.
-  //
-  // contract address => nullifier
-  #notesByContractAddress: AztecAsyncMultiMap<AddressStr, SiloedNullifier>;
-
-  // block number => nullifier
-  #notesByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
-
-  // Records, for each nullified note, the block number where its nullifier was emitted.
-  // nullifier => emission block number
-  #nullifierEmissions: AztecAsyncMap<SiloedNullifier, BlockNum>;
-
-  // Index of emitted nullifiers by block height, used for performance reasons upon reorgs.
-  // nullification block number => nullifier
-  #nullifierEmissionsByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
-
-  // In-memory changes performed during a not-yet committed change set. When `commit` is called with said change set's
-  // id, these changes are persisted in the DB maps specified above and cleared. changeSetId => nullifier => StoredNote
-  #notesForChangeSet: Map<ChangeSetId, Map<SiloedNullifier, StoredNote>>;
-
-  // Staged nullifier emissions per change set. changeSetId => nullifier => emission block number
-  #nullifierEmissionsForChangeSet: Map<ChangeSetId, Map<SiloedNullifier, BlockNum>>;
-
-  // Per-change-set locks to prevent multiple concurrent writes from affecting each other. changeSetId => lock
-  #changeSetLocks: Map<ChangeSetId, Semaphore>;
+export class NoteStore extends BaseStagingStore<NoteStoreChangeSet, NoteStoreDb> {
+  readonly #logger = createLogger('note_store');
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-    this.#notes = store.openMap('notes');
-    this.#notesByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
-    this.#notesByBlockNumber = store.openMultiMap('note_nullifiers_by_block');
-    this.#nullifierEmissions = store.openMap('note_nullifications_by_nullifier');
-    this.#nullifierEmissionsByBlockNumber = store.openMultiMap('note_nullifications_by_block');
-
-    this.#changeSetLocks = new Map();
-    this.#notesForChangeSet = new Map();
-    this.#nullifierEmissionsForChangeSet = new Map();
+    super({
+      storeName: 'note',
+      store,
+      buildChangeSet: () => ({ notes: new Map(), nullifierEmissions: new Map() }),
+      buildDb: db => ({
+        notes: db.openMap('notes'),
+        notesByContractAddress: db.openMultiMap('note_nullifiers_by_contract'),
+        notesByBlockNumber: db.openMultiMap('note_nullifiers_by_block'),
+        nullifierEmissions: db.openMap('note_nullifications_by_nullifier'),
+        nullifierEmissionsByBlockNumber: db.openMultiMap('note_nullifications_by_block'),
+      }),
+    });
   }
 
   /**
@@ -94,30 +50,28 @@ export class NoteStore implements StagedStore, Rollbackable {
    * @param changeSetId - The change set to stage writes under
    */
   public addNotes(notes: NoteDao[], scope: AztecAddress, changeSetId: ChangeSetId): Promise<void[]> {
-    return this.#withChangeSetLock(changeSetId, () =>
-      this.#store.transactionAsync(() =>
-        allToCompletion(
-          notes.map(async note => {
-            const noteForChangeSet =
-              (await this.#readNote(note.siloedNullifier.toString(), changeSetId)) ?? new StoredNote(note, new Set());
-            noteForChangeSet.addScope(scope.toString());
-            this.#writeNote(noteForChangeSet, changeSetId);
-          }),
-        ),
+    return this.withChangeSet(changeSetId, (changeSet, db) =>
+      allToCompletion(
+        notes.map(async note => {
+          const noteForChangeSet =
+            (await this.#readNote(changeSet, db, note.siloedNullifier.toString())) ?? new StoredNote(note, new Set());
+          noteForChangeSet.addScope(scope.toString());
+          changeSet.notes.set(note.siloedNullifier.toString(), noteForChangeSet);
+        }),
       ),
     );
   }
 
-  async #readNote(nullifier: string, changeSetId: ChangeSetId): Promise<StoredNote | undefined> {
+  async #readNote(
+    changeSet: NoteStoreChangeSet,
+    db: ReadonlyDb<NoteStoreDb>,
+    nullifier: string,
+  ): Promise<StoredNote | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const noteBuffer = await this.#notes.getAsync(nullifier);
-    const noteForChangeSet = this.#getNotesForChangeSet(changeSetId).get(nullifier);
+    const noteBuffer = await db.notes.getAsync(nullifier);
+    const noteForChangeSet = changeSet.notes.get(nullifier);
     return noteForChangeSet ?? (noteBuffer ? StoredNote.fromBuffer(noteBuffer) : undefined);
-  }
-
-  #writeNote(note: StoredNote, changeSetId: ChangeSetId) {
-    this.#getNotesForChangeSet(changeSetId).set(note.noteDao.siloedNullifier.toString(), note);
   }
 
   /**
@@ -125,16 +79,15 @@ export class NoteStore implements StagedStore, Rollbackable {
    * committed state, the nullifier emission counterpart to {@link #readNote}. Returns the emission block number if the
    * nullifier has been emitted (committed or currently staged), or `undefined` if it has not.
    */
-  async #readNullifierEmission(nullifier: string, changeSetId: ChangeSetId): Promise<number | undefined> {
+  async #readNullifierEmission(
+    changeSet: NoteStoreChangeSet,
+    db: ReadonlyDb<NoteStoreDb>,
+    nullifier: string,
+  ): Promise<number | undefined> {
     // Always issue the DB read to keep the IndexedDB transaction alive (see #readNote); the staged emission still takes
     // precedence if present.
-    const committed = await this.#nullifierEmissions.getAsync(nullifier);
-    const staged = this.#getNullifierEmissionsForChangeSet(changeSetId).get(nullifier);
-    return staged ?? committed;
-  }
-
-  #writeNullifierEmission(nullifier: string, blockNumber: BlockNum, changeSetId: ChangeSetId): void {
-    this.#getNullifierEmissionsForChangeSet(changeSetId).set(nullifier, blockNumber);
+    const committed = await db.nullifierEmissions.getAsync(nullifier);
+    return changeSet.nullifierEmissions.get(nullifier) ?? committed;
   }
 
   /**
@@ -150,11 +103,11 @@ export class NoteStore implements StagedStore, Rollbackable {
    * @returns Filtered and deduplicated notes (a note might be present in multiple scopes, but returned at most once)
    */
   getNotes(filter: NotesFilter, changeSetId: ChangeSetId): Promise<NoteDao[]> {
-    if (filter.scopes.length === 0) {
-      return Promise.resolve([]);
-    }
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      if (filter.scopes.length === 0) {
+        return [];
+      }
 
-    return this.#store.transactionAsync(async () => {
       const targetStatus = filter.status ?? NoteStatus.ACTIVE;
 
       // Collect note-read and nullifier-emission-read promises together in one map so all DB reads are in-flight
@@ -166,21 +119,21 @@ export class NoteStore implements StagedStore, Rollbackable {
       >();
 
       // Committed notes indexed by contract address
-      for await (const nullifier of this.#notesByContractAddress.getValuesAsync(filter.contractAddress.toString())) {
+      for await (const nullifier of db.notesByContractAddress.getValuesAsync(filter.contractAddress.toString())) {
         candidates.set(nullifier, {
-          notePromise: this.#readNote(nullifier, changeSetId),
-          nullificationPromise: this.#readNullifierEmission(nullifier, changeSetId),
+          notePromise: this.#readNote(changeSet, db, nullifier),
+          nullificationPromise: this.#readNullifierEmission(changeSet, db, nullifier),
         });
       }
 
       // Staged notes from the current change set (not yet committed to the DB index)
-      for (const storedNote of this.#getNotesForChangeSet(changeSetId).values()) {
+      for (const storedNote of changeSet.notes.values()) {
         if (storedNote.noteDao.contractAddress.equals(filter.contractAddress)) {
           const nullifier = storedNote.noteDao.siloedNullifier.toString();
           if (!candidates.has(nullifier)) {
             candidates.set(nullifier, {
               notePromise: Promise.resolve(storedNote),
-              nullificationPromise: this.#readNullifierEmission(nullifier, changeSetId),
+              nullificationPromise: this.#readNullifierEmission(changeSet, db, nullifier),
             });
           }
         }
@@ -274,157 +227,77 @@ export class NoteStore implements StagedStore, Rollbackable {
       return Promise.reject(new Error('applyNullifiers: nullifiers cannot have been emitted at block 0'));
     }
 
-    return this.#withChangeSetLock(changeSetId, () =>
-      this.#store.transactionAsync(async () => {
-        // Kick off the note read and the existing-emission read together during the synchronous map so all are in
-        // flight before the first await, which keeps the IndexedDB transaction alive.
-        const resolved = await allToCompletion(
-          siloedNullifiers.map(async nullifier => {
-            const key = nullifier.data.toString();
-            const [storedNote, existingEmission] = await allToCompletion([
-              this.#readNote(key, changeSetId),
-              this.#readNullifierEmission(key, changeSetId),
-            ]);
-            if (!storedNote) {
-              throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB: ${key}`);
-            }
-            return { nullifier, storedNote, alreadyEmitted: existingEmission !== undefined };
-          }),
-        );
-
-        // Await-free tail: record an emission only for notes not already nullified, and return exactly those that
-        // transition active -> nullified in this call.
-        const affected: NoteDao[] = [];
-        for (const { nullifier, storedNote, alreadyEmitted } of resolved) {
-          if (alreadyEmitted) {
-            continue;
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      // Kick off the note read and the existing-emission read together during the synchronous map so all are in
+      // flight before the first await, which keeps the IndexedDB transaction alive.
+      const resolved = await allToCompletion(
+        siloedNullifiers.map(async nullifier => {
+          const key = nullifier.data.toString();
+          const [storedNote, existingEmission] = await allToCompletion([
+            this.#readNote(changeSet, db, key),
+            this.#readNullifierEmission(changeSet, db, key),
+          ]);
+          if (!storedNote) {
+            throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB: ${key}`);
           }
-          this.#writeNullifierEmission(nullifier.data.toString(), nullifier.l2BlockNumber, changeSetId);
-          affected.push(storedNote.noteDao);
+          return { nullifier, storedNote, alreadyEmitted: existingEmission !== undefined };
+        }),
+      );
+
+      // Await-free tail: record an emission only for notes not already nullified, and return exactly those that
+      // transition active -> nullified in this call.
+      const affected: NoteDao[] = [];
+      for (const { nullifier, storedNote, alreadyEmitted } of resolved) {
+        if (alreadyEmitted) {
+          continue;
         }
+        changeSet.nullifierEmissions.set(nullifier.data.toString(), nullifier.l2BlockNumber);
+        affected.push(storedNote.noteDao);
+      }
 
-        return affected;
-      }),
-    );
+      return affected;
+    });
+  }
+
+  protected async flushChangeSet(changeSet: NoteStoreChangeSet, db: NoteStoreDb): Promise<void> {
+    for (const [nullifier, storedNote] of changeSet.notes) {
+      await db.notes.set(nullifier, storedNote.toBuffer());
+      await db.notesByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
+      await db.notesByBlockNumber.set(storedNote.noteDao.l2BlockNumber, nullifier);
+    }
+
+    for (const [nullifier, blockNumber] of changeSet.nullifierEmissions) {
+      await db.nullifierEmissions.set(nullifier, blockNumber);
+      await db.nullifierEmissionsByBlockNumber.set(blockNumber, nullifier);
+    }
   }
 
   /**
-   * Commits in-memory staged data to persistent storage.
-   *
-   * Called by StagedWriteCoordinator when an operation completes successfully.
-   *
-   * Note: StagedWriteCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync
-   * here (and using one would throw on IndexedDB as it does not support nested txs).
-   *
-   * @param changeSetId - The changeSetId identifying which staged data to commit
+   * Deletes every note and nullifier emission originating on a block strictly above `toBlock`, as if nothing past that
+   * block height ever happened, retracting notes and nullifiers on a reorg.
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
-    for (const [nullifier, storedNote] of this.#getNotesForChangeSet(changeSetId)) {
-      await this.#notes.set(nullifier, storedNote.toBuffer());
-      await this.#notesByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
-      await this.#notesByBlockNumber.set(storedNote.noteDao.l2BlockNumber, nullifier);
-    }
-
-    for (const [nullifier, blockNumber] of this.#getNullifierEmissionsForChangeSet(changeSetId)) {
-      await this.#nullifierEmissions.set(nullifier, blockNumber);
-      await this.#nullifierEmissionsByBlockNumber.set(blockNumber, nullifier);
-    }
-
-    this.#clearChangeSetData(changeSetId);
-  }
-
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
-    this.#clearChangeSetData(changeSetId);
-    return Promise.resolve();
-  }
-
-  #clearChangeSetData(changeSetId: ChangeSetId) {
-    this.#notesForChangeSet.delete(changeSetId);
-    this.#nullifierEmissionsForChangeSet.delete(changeSetId);
-    this.#changeSetLocks.delete(changeSetId);
-  }
-
-  /**
-   * Functions run withChangeSetLock are forced to wait for each other, i.e. if they share a `changeSetId`, they run
-   * serially instead of concurrently. This is needed because staged data is stored in memory, and concurrent async
-   * operations (e.g., allToCompletion in `validateAndStoreNote`) could otherwise interleave and corrupt state.
-   */
-  async #withChangeSetLock<T>(changeSetId: ChangeSetId, fn: () => Promise<T>): Promise<T> {
-    let lock = this.#changeSetLocks.get(changeSetId);
-    if (!lock) {
-      lock = new Semaphore(1);
-      this.#changeSetLocks.set(changeSetId, lock);
-    }
-    await lock.acquire();
-    try {
-      return await fn();
-    } finally {
-      lock.release();
-    }
-  }
-
-  #getNotesForChangeSet(changeSetId: ChangeSetId): Map<string, StoredNote> {
-    let notesForChangeSet = this.#notesForChangeSet.get(changeSetId);
-    if (!notesForChangeSet) {
-      notesForChangeSet = new Map();
-      this.#notesForChangeSet.set(changeSetId, notesForChangeSet);
-    }
-    return notesForChangeSet;
-  }
-
-  #getNullifierEmissionsForChangeSet(changeSetId: ChangeSetId): Map<string, BlockNum> {
-    let nullificationsForChangeSet = this.#nullifierEmissionsForChangeSet.get(changeSetId);
-    if (!nullificationsForChangeSet) {
-      nullificationsForChangeSet = new Map();
-      this.#nullifierEmissionsForChangeSet.set(changeSetId, nullificationsForChangeSet);
-    }
-    return nullificationsForChangeSet;
-  }
-
-  /** Returns the nullifiers (note ids) of all notes created at the given block number. Used by delete-on-prune. */
-  public async nullifiersOfNotesAtBlock(blockNumber: number): Promise<string[]> {
-    const nullifiers: string[] = [];
-    for await (const nullifier of this.#notesByBlockNumber.getValuesAsync(blockNumber)) {
-      nullifiers.push(nullifier);
-    }
-    return nullifiers;
-  }
-
-  /**
-   * Rolls the store back to `toBlock`: deletes every note and nullifier emission originating on a block strictly above
-   * it, as if nothing past that block height ever happened. Used to retract notes and nullifiers on a reorg.
-   *
-   * Must be called inside a transaction owned by the caller (it issues no `transactionAsync` of its own, because the
-   * reorg path wraps it together with other store operations, and IndexedDB has no nested transaction support).
-   *
-   * Throws if any change set has uncommitted staged writes, since rolling back mid-change-set could later re-introduce
-   * notes or nullifier emissions anchored to deleted blocks.
-   */
-  public async rollbackToBlock(toBlock: number): Promise<void> {
-    if (this.#notesForChangeSet.size > 0 || this.#nullifierEmissionsForChangeSet.size > 0) {
-      throw new Error('PXE note store rollback is not allowed while staged writes are pending');
-    }
+  protected async applyRollback(toBlock: number, db: NoteStoreDb): Promise<void> {
     // Snapshot the orphaned (block, nullifier) pairs before mutating so we never delete from the cursor we are
     // iterating. Scanning from `toBlock + 1` upward covers everything above the rollback target without needing to know
     // the chain tip. Each nullifier's rows are independent (nullifiers are globally unique), so the deletes run
     // concurrently. Keeping requests in flight also prevents the IndexedDB transaction from auto-committing mid-way.
     const orphanedNotes: { block: number; siloedNullifier: string }[] = [];
 
-    for await (const [block, siloedNullifier] of this.#notesByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
+    for await (const [block, siloedNullifier] of db.notesByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
       orphanedNotes.push({ block, siloedNullifier });
     }
 
     let removedNotes = 0;
     await allToCompletion(
       orphanedNotes.map(async ({ block, siloedNullifier }) => {
-        const buf = await this.#notes.getAsync(siloedNullifier);
+        const buf = await db.notes.getAsync(siloedNullifier);
         if (!buf) {
           throw new Error(`Note not found for siloedNullifier ${siloedNullifier}`);
         }
         const stored = StoredNote.fromBuffer(buf);
-        await this.#notes.delete(siloedNullifier);
-        await this.#notesByContractAddress.deleteValue(stored.noteDao.contractAddress.toString(), siloedNullifier);
-        await this.#notesByBlockNumber.deleteValue(block, siloedNullifier);
+        await db.notes.delete(siloedNullifier);
+        await db.notesByContractAddress.deleteValue(stored.noteDao.contractAddress.toString(), siloedNullifier);
+        await db.notesByBlockNumber.deleteValue(block, siloedNullifier);
         removedNotes++;
       }),
     );
@@ -432,7 +305,7 @@ export class NoteStore implements StagedStore, Rollbackable {
     // Same procedure, with nullifier emissions
     const orphanedEmissions: { block: number; siloedNullifier: string }[] = [];
 
-    for await (const [block, siloedNullifier] of this.#nullifierEmissionsByBlockNumber.entriesAsync({
+    for await (const [block, siloedNullifier] of db.nullifierEmissionsByBlockNumber.entriesAsync({
       start: toBlock + 1,
     })) {
       orphanedEmissions.push({ block, siloedNullifier });
@@ -440,15 +313,55 @@ export class NoteStore implements StagedStore, Rollbackable {
 
     await allToCompletion(
       orphanedEmissions.map(async ({ block, siloedNullifier }) => {
-        await this.#nullifierEmissions.delete(siloedNullifier);
-        await this.#nullifierEmissionsByBlockNumber.deleteValue(block, siloedNullifier);
+        await db.nullifierEmissions.delete(siloedNullifier);
+        await db.nullifierEmissionsByBlockNumber.deleteValue(block, siloedNullifier);
       }),
     );
 
-    this.logger.verbose('rolled back notes and nullifier emissions', {
+    this.#logger.verbose('rolled back notes and nullifier emissions', {
       removedNotes,
       removedNullifierEmissions: orphanedEmissions.length,
       toBlock,
     });
   }
 }
+
+/// Alias types for kv map readability
+type SiloedNullifier = string;
+type AddressStr = string;
+type BlockNum = number;
+type StoredNoteBuffer = Buffer;
+
+/**
+ * A change set's staged data, created and discarded as a unit: notes plus nullifier emissions, both keyed by nullifier.
+ */
+type NoteStoreChangeSet = {
+  notes: Map<SiloedNullifier, StoredNote>;
+  nullifierEmissions: Map<SiloedNullifier, BlockNum>;
+};
+
+// Note that we use the siloedNullifier as the note id in this store as it's guaranteed to be unique.
+type NoteStoreDb = {
+  // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
+  // notesByContractAddress to find relevant note nullifiers that can be used to read into this map instead.
+  //
+  // nullifier => StoredNote (serialized)
+  notes: AztecAsyncMap<SiloedNullifier, StoredNoteBuffer>;
+
+  // Indexes which notes (via their nullifiers) belong to a contract. Used in `getNotes` to reduce the amount of notes
+  // checked.
+  //
+  // contract address => nullifier
+  notesByContractAddress: AztecAsyncMultiMap<AddressStr, SiloedNullifier>;
+
+  // block number => nullifier
+  notesByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
+
+  // Records, for each nullified note, the block number where its nullifier was emitted.
+  // nullifier => emission block number
+  nullifierEmissions: AztecAsyncMap<SiloedNullifier, BlockNum>;
+
+  // Index of emitted nullifiers by block height, used for performance reasons upon reorgs.
+  // nullification block number => nullifier
+  nullifierEmissionsByBlockNumber: AztecAsyncMultiMap<BlockNum, SiloedNullifier>;
+};

--- a/yarn-project/pxe/src/storage/note_store/test_utils.ts
+++ b/yarn-project/pxe/src/storage/note_store/test_utils.ts
@@ -1,0 +1,16 @@
+import type { NoteDao } from '@aztec/stdlib/note';
+
+import type { NotesFilter } from '../../notes_filter.js';
+import type { NoteStore } from './note_store.js';
+
+/**
+ * Reads notes in a change set opened and closed around the read. A test that reads and then rolls back needs this: the
+ * store rejects a rollback while a change set is open.
+ */
+export async function readNotes(store: NoteStore, filter: NotesFilter): Promise<NoteDao[]> {
+  const changeSetId = 'read-change-set';
+  store.beginChangeSet(changeSetId);
+  const notes = await store.getNotes(filter, changeSetId);
+  store.discardChangeSet(changeSetId);
+  return notes;
+}

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -74,7 +74,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
     }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -115,7 +115,7 @@ describe('PrivateEventStore', () => {
       metadata,
       'test',
     );
-    await privateEventStore.commitStaged('test');
+    await privateEventStore.commitChangeSet('test');
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -163,7 +163,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
     }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -232,7 +232,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
     }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -281,7 +281,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
     }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -319,7 +319,7 @@ describe('PrivateEventStore', () => {
       'test',
     );
 
-    await privateEventStore.commitStaged('test');
+    await privateEventStore.commitChangeSet('test');
 
     const filter = { contractAddress, fromBlock: l2BlockNumber, toBlock: l2BlockNumber + 1 };
 
@@ -413,7 +413,7 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitStaged('test');
+        await privateEventStore.commitChangeSet('test');
       }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -481,7 +481,7 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitStaged('test');
+        await privateEventStore.commitChangeSet('test');
       }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -550,7 +550,7 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitStaged('test');
+        await privateEventStore.commitChangeSet('test');
       }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -593,7 +593,7 @@ describe('PrivateEventStore', () => {
 
       await storeEventAt(eventAt9, 9, BLOCK_HASH_9);
       await storeEventAt(eventAt10, 10, BLOCK_HASH_10);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
 
@@ -620,7 +620,7 @@ describe('PrivateEventStore', () => {
       await storeEventAt(eventAt9, 9, BLOCK_HASH_9);
       await storeEventAt(eventAt10, 10, BLOCK_HASH_10);
       await storeEventAt(eventAt12, 12, BLOCK_HASH_12);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
 
@@ -636,7 +636,7 @@ describe('PrivateEventStore', () => {
 
       await storeEventAt(eventAt9, 9, BLOCK_HASH_9);
       await storeEventAt(eventAt10, 10, BLOCK_HASH_10);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
       // Re-running over the already-truncated tail must not throw and must not change anything.
@@ -660,21 +660,21 @@ describe('PrivateEventStore', () => {
         });
 
       await storeEventAt(commitment, 10, BLOCK_HASH_10);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
       expect(await readBack()).toHaveLength(0);
 
       // Re-add the same commitment, as happens when the tx is re-included after the reorg.
       await storeEventAt(commitment, 10, BLOCK_HASH_10);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
       expect(await readBack()).toHaveLength(1);
     });
 
     it('handles rollback with no events to remove', async () => {
       const eventAt10 = Fr.random();
       await storeEventAt(eventAt10, 10, BLOCK_HASH_10);
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       // Rolling back to a block above every stored event removes nothing.
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(20));
@@ -705,7 +705,7 @@ describe('PrivateEventStore', () => {
         'PXE private event store rollback is not allowed while staged writes are pending',
       );
 
-      await privateEventStore.discardStaged('uncommitted-change-set');
+      privateEventStore.discardChangeSet('uncommitted-change-set');
 
       await expect(kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(0))).resolves.not.toThrow();
     });
@@ -729,7 +729,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       const ids = await privateEventStore.eventIdsAtBlock(l2BlockNumber);
       expect(ids).toContain(siloedEventCommitment.toString());
@@ -770,7 +770,7 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitStaged('test');
+      await privateEventStore.commitChangeSet('test');
 
       const ids = await privateEventStore.eventIdsAtBlock(l2BlockNumber);
       expect(new Set(ids)).toEqual(new Set([siloedEventCommitment.toString(), siloedEventCommitment2.toString()]));
@@ -802,7 +802,7 @@ describe('PrivateEventStore', () => {
         },
         commitChangeSetId,
       );
-      await privateEventStore.commitStaged(commitChangeSetId);
+      await privateEventStore.commitChangeSet(commitChangeSetId);
 
       // Store staged event (not committed)
       const stagedMsgContent = getRandomMsgContent();
@@ -856,7 +856,7 @@ describe('PrivateEventStore', () => {
         stagedChangeSetId,
       );
 
-      await privateEventStore.commitStaged(stagedChangeSetId);
+      await privateEventStore.commitChangeSet(stagedChangeSetId);
 
       // Now should see the event with a fresh changeSetId
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -869,7 +869,7 @@ describe('PrivateEventStore', () => {
       expect(events[0].packedEvent).toEqual(stagedMsgContent);
     });
 
-    it('discardStaged removes staged events without affecting main', async () => {
+    it('discardChangeSet removes staged events without affecting main', async () => {
       const commitChangeSetId: ChangeSetId = 'commit-change-set';
       const stagedChangeSetId: ChangeSetId = 'staged';
       const committedEventRandomness = Fr.random();
@@ -892,7 +892,7 @@ describe('PrivateEventStore', () => {
         },
         commitChangeSetId,
       );
-      await privateEventStore.commitStaged(commitChangeSetId);
+      await privateEventStore.commitChangeSet(commitChangeSetId);
 
       // Store staged event (not committed)
       const stagedMsgContent = getRandomMsgContent();
@@ -914,7 +914,7 @@ describe('PrivateEventStore', () => {
       );
 
       // Discard change set
-      await privateEventStore.discardStaged(stagedChangeSetId);
+      privateEventStore.discardChangeSet(stagedChangeSetId);
 
       // Should only see committed event
       const events = await privateEventStore.getPrivateEvents(eventSelector, {

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -283,7 +283,7 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
    *
    * @param changeSetId - The changeSetId identifying which staged data to commit
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
     // Note: Don't use #withChangeSetLock here - commit runs within StagedWriteCoordinator's transactionAsync,
     // and awaiting the lock would create a microtask boundary with no pending DB request,
     // causing IndexedDB to auto-commit the transaction.
@@ -304,9 +304,8 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
   /**
    * Discards in-memory staged data without persisting it.
    */
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
+  discardChangeSet(changeSetId: ChangeSetId): void {
     this.#clearChangeSetData(changeSetId);
-    return Promise.resolve();
   }
 
   /**

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
@@ -26,6 +26,26 @@ describe('StagedWriteCoordinator', () => {
       coordinator.begin();
       expect(() => coordinator.begin()).toThrow(/already active/);
     });
+
+    it('notifies its stores of the change set it opened', async () => {
+      const opened: ChangeSetId[] = [];
+      const mockStore: StagedStore = {
+        storeName: 'mock_store',
+        beginChangeSet: changeSetId => opened.push(changeSetId),
+        commitChangeSet: () => Promise.resolve(),
+        discardChangeSet: () => {},
+      };
+
+      coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
+
+      const first = coordinator.begin();
+      expect(opened).toEqual([first]);
+      await coordinator.commit(first);
+
+      const second = coordinator.begin();
+      expect(opened).toEqual([first, second]);
+      coordinator.abort(second);
+    });
   });
 
   describe('commit', () => {
@@ -50,7 +70,7 @@ describe('StagedWriteCoordinator', () => {
       await expect(coordinator.commit('deadbeef')).rejects.toThrow(/no matching change set/);
     });
 
-    it('calls commitStaged on its stores within a single kv transaction', async () => {
+    it('calls commitChangeSet on its stores within a single kv transaction', async () => {
       const realTransactionAsync = store.transactionAsync.bind(store);
       let inTransaction = false;
       jest.spyOn(store, 'transactionAsync').mockImplementation(async callback => {
@@ -65,11 +85,11 @@ describe('StagedWriteCoordinator', () => {
       const committed: { changeSetId: ChangeSetId; inTransaction: boolean }[] = [];
       const mockStore: StagedStore = {
         storeName: 'mock_store',
-        commitStaged: changeSetId => {
+        commitChangeSet: changeSetId => {
           committed.push({ changeSetId, inTransaction });
           return Promise.resolve();
         },
-        discardStaged: () => Promise.resolve(),
+        discardChangeSet: () => {},
       };
 
       coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
@@ -83,57 +103,57 @@ describe('StagedWriteCoordinator', () => {
   });
 
   describe('abort', () => {
-    it('clears change set marker on abort', async () => {
+    it('clears change set marker on abort', () => {
       const changeSetId = coordinator.begin();
 
-      await coordinator.abort(changeSetId);
+      coordinator.abort(changeSetId);
 
       expect(() => coordinator.begin()).not.toThrow();
     });
 
-    it('throws if no matching change set active', async () => {
+    it('throws if no matching change set active', () => {
       const changeSetId = coordinator.begin();
-      await coordinator.abort(changeSetId);
+      coordinator.abort(changeSetId);
 
-      await expect(coordinator.abort(changeSetId)).rejects.toThrow(/no matching change set/);
+      expect(() => coordinator.abort(changeSetId)).toThrow(/no matching change set/);
     });
 
-    it('throws if no change set was ever opened', async () => {
-      await expect(coordinator.abort('deadbeef')).rejects.toThrow(/no matching change set/);
+    it('throws if no change set was ever opened', () => {
+      expect(() => coordinator.abort('deadbeef')).toThrow(/no matching change set/);
     });
 
-    it('throws if the change set id does not match the open one', async () => {
+    it('throws if the change set id does not match the open one', () => {
       coordinator.begin();
-      await expect(coordinator.abort('deadbeef')).rejects.toThrow(/no matching change set/);
+      expect(() => coordinator.abort('deadbeef')).toThrow(/no matching change set/);
     });
 
-    it('calls discardStaged on all its stores', async () => {
+    it('calls discardChangeSet on all its stores', () => {
       const commitMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
-      const discardStagedMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const discardChangeSetMock = jest.fn<() => void>();
       const mockStore: StagedStore = {
         storeName: 'mock_store',
-        commitStaged: commitMock,
-        discardStaged: discardStagedMock,
+        commitChangeSet: commitMock,
+        discardChangeSet: discardChangeSetMock,
       };
 
       coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
 
       const changeSetId = coordinator.begin();
 
-      await coordinator.abort(changeSetId);
+      coordinator.abort(changeSetId);
 
-      expect(discardStagedMock).toHaveBeenCalledWith(changeSetId);
+      expect(discardChangeSetMock).toHaveBeenCalledWith(changeSetId);
     });
   });
 
   describe('construction', () => {
     it('throws on stores with duplicate names', () => {
       const commitMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
-      const discardStagedMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const discardChangeSetMock = jest.fn<() => void>();
       const mockStore: StagedStore = {
         storeName: 'mock_store',
-        commitStaged: commitMock,
-        discardStaged: discardStagedMock,
+        commitChangeSet: commitMock,
+        discardChangeSet: discardChangeSetMock,
       };
 
       expect(() => new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore, mockStore] })).toThrow(

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.ts
@@ -14,12 +14,22 @@ export type ChangeSetId = string;
  * Every read and write on such a store takes a change set ID. Writes are held under that ID; a read sees the database
  * plus whatever its own change set has staged, never another's.
  *
- * {@link StagedWriteCoordinator} ends a change set by calling {@link commitStaged}, which promotes its staged writes
- * to the database, or {@link discardStaged}, which throws them away.
+ * {@link StagedWriteCoordinator} ends a change set by calling {@link commitChangeSet}, which promotes its staged writes
+ * to the database, or {@link discardChangeSet}, which throws them away.
  */
 export interface StagedStore {
   /** Unique name identifying this store (used for tracking staged stores from StagedWriteCoordinator) */
   readonly storeName: string;
+
+  /**
+   * Notifies the store that a change set has been opened.
+   *
+   * TODO: make it required once every staged store extends `BaseStagingStore`. It is optional only while
+   * they migrate to per-change-set staging.
+   *
+   * @param changeSetId - The change set identifier
+   */
+  beginChangeSet?(changeSetId: ChangeSetId): void;
 
   /**
    * Commits staged data to persistent storage. Will be called within a db transaction for atomicity, alongside the
@@ -27,14 +37,14 @@ export interface StagedStore {
    *
    * @param changeSetId - The change set identifier
    */
-  commitStaged(changeSetId: ChangeSetId): Promise<void>;
+  commitChangeSet(changeSetId: ChangeSetId): Promise<void>;
 
   /**
    * Discards staged data without committing. Called on abort.
    *
    * @param changeSetId - The change set identifier
    */
-  discardStaged(changeSetId: ChangeSetId): Promise<void>;
+  discardChangeSet(changeSetId: ChangeSetId): void;
 }
 
 /**
@@ -90,6 +100,10 @@ export class StagedWriteCoordinator {
     const changeSetId = randomBytes(8).toString('hex');
     this.#currentChangeSetId = changeSetId;
 
+    for (const store of this.#stagedStores.values()) {
+      store.beginChangeSet?.(changeSetId);
+    }
+
     this.#log.debug(`Opened change set ${changeSetId}`, { changeSetId });
     return changeSetId;
   }
@@ -110,10 +124,9 @@ export class StagedWriteCoordinator {
     this.#log.debug(`Committing change set ${changeSetId}`, { changeSetId });
 
     // Commit all stores atomically in a single transaction.
-    // Each store's commit is a no-op if it has no staged data (but that's up to each store to handle).
     await this.#kvStore.transactionAsync(async () => {
       for (const store of this.#stagedStores.values()) {
-        await store.commitStaged(changeSetId);
+        await store.commitChangeSet(changeSetId);
       }
     });
 
@@ -126,7 +139,7 @@ export class StagedWriteCoordinator {
    *
    * @param changeSetId - The change set ID returned from begin
    */
-  async abort(changeSetId: ChangeSetId): Promise<void> {
+  abort(changeSetId: ChangeSetId): void {
     if (this.#currentChangeSetId !== changeSetId) {
       throw new Error(
         `Cannot abort change set ${changeSetId}: no matching change set active. ` +
@@ -137,7 +150,7 @@ export class StagedWriteCoordinator {
     this.#log.debug(`Aborting change set ${changeSetId}`, { changeSetId });
 
     for (const store of this.#stagedStores.values()) {
-      await store.discardStaged(changeSetId);
+      store.discardChangeSet(changeSetId);
     }
 
     this.#currentChangeSetId = undefined;

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
@@ -21,7 +21,7 @@ describe('RecipientTaggingStore', () => {
 
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBeUndefined();
 
-      await taggingStore.commitStaged('change-set-1');
+      await taggingStore.commitChangeSet('change-set-1');
 
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
     });
@@ -31,7 +31,7 @@ describe('RecipientTaggingStore', () => {
 
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBeUndefined();
 
-      await taggingStore.commitStaged('change-set-1');
+      await taggingStore.commitChangeSet('change-set-1');
 
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBe(10);
     });
@@ -42,7 +42,7 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 3, 'change-set-1');
       await taggingStore.updateHighestFinalizedIndex(secret2, 6, 'change-set-1');
 
-      await taggingStore.commitStaged('change-set-1');
+      await taggingStore.commitChangeSet('change-set-1');
 
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
       expect(await taggingStore.getHighestAgedIndex(secret2, 'change-set-2')).toBe(8);
@@ -52,13 +52,13 @@ describe('RecipientTaggingStore', () => {
 
     it('clears staged data after commit', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
-      await taggingStore.commitStaged('change-set-1');
+      await taggingStore.commitChangeSet('change-set-1');
 
       // Updating again with a higher value in the same change set should work
       // (if staged data wasn't cleared, it would still have the old value cached)
       await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(10);
-      await taggingStore.commitStaged('change-set-2');
+      await taggingStore.commitChangeSet('change-set-2');
 
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(10);
     });
@@ -67,7 +67,7 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
       await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
 
-      await taggingStore.commitStaged('change-set-2');
+      await taggingStore.commitChangeSet('change-set-2');
 
       // change-set-1's staged value should still be intact
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(5);
@@ -75,13 +75,13 @@ describe('RecipientTaggingStore', () => {
 
     it('discards staged highest aged index without persisting', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
-      await taggingStore.discardStaged('change-set-1');
+      taggingStore.discardChangeSet('change-set-1');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBeUndefined();
     });
 
     it('discards staged highest finalized index without persisting', async () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 5, 'change-set-1');
-      await taggingStore.discardStaged('change-set-1');
+      taggingStore.discardChangeSet('change-set-1');
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-1')).toBeUndefined();
     });
   });
@@ -100,7 +100,7 @@ describe('RecipientTaggingStore', () => {
 
       await taggingStore.updateHighestFinalizedIndex(unconstrained, 4, 'change-set-1');
       await taggingStore.updateHighestFinalizedIndex(constrained, 9, 'change-set-1');
-      await taggingStore.commitStaged('change-set-1');
+      await taggingStore.commitChangeSet('change-set-1');
 
       expect(await taggingStore.getHighestFinalizedIndex(unconstrained, 'change-set-2')).toBe(4);
       expect(await taggingStore.getHighestFinalizedIndex(constrained, 'change-set-2')).toBe(9);

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -83,7 +83,7 @@ export class RecipientTaggingStore implements StagedStore {
    * @remark This method must run in a DB transaction context. It's designed to be called from
    * {@link StagedWriteCoordinator.commit}.
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
     const highestAgedIndexForChangeSet = this.#highestAgedIndexForChangeSet.get(changeSetId);
     if (highestAgedIndexForChangeSet) {
       for (const [secret, index] of highestAgedIndexForChangeSet.entries()) {
@@ -98,13 +98,12 @@ export class RecipientTaggingStore implements StagedStore {
       }
     }
 
-    return this.discardStaged(changeSetId);
+    this.discardChangeSet(changeSetId);
   }
 
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
+  discardChangeSet(changeSetId: ChangeSetId): void {
     this.#highestAgedIndexForChangeSet.delete(changeSetId);
     this.#highestFinalizedIndexForChangeSet.delete(changeSetId);
-    return Promise.resolve();
   }
 
   getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<number | undefined> {

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
@@ -771,7 +771,7 @@ describe('SenderTaggingStore', () => {
       {
         const commitChangeSetId: ChangeSetId = 'commit-change-set';
         await taggingStore.storePendingIndexes([range(secret1, 3)], committedTxHash, commitChangeSetId);
-        await taggingStore.commitStaged(commitChangeSetId);
+        await taggingStore.commitChangeSet(commitChangeSetId);
       }
 
       const stagedTxHash = TxHash.random();
@@ -796,7 +796,7 @@ describe('SenderTaggingStore', () => {
         const commitChangeSetId: ChangeSetId = 'commit-change-set';
         await taggingStore.storePendingIndexes([range(secret1, 3)], txHash1, commitChangeSetId);
         await taggingStore.finalizePendingIndexes([txHash1], commitChangeSetId);
-        await taggingStore.commitStaged(commitChangeSetId);
+        await taggingStore.commitChangeSet(commitChangeSetId);
       }
 
       const txHash2 = TxHash.random();
@@ -813,7 +813,7 @@ describe('SenderTaggingStore', () => {
       expect(await taggingStore.getLastFinalizedIndex(secret1, stagedChangeSetId)).toBe(7);
     });
 
-    it('discardStaged removes staged data without affecting persistent storage', async () => {
+    it('discardChangeSet removes staged data without affecting persistent storage', async () => {
       {
         const txHash1 = TxHash.random();
         const txHash2 = TxHash.random();
@@ -821,7 +821,7 @@ describe('SenderTaggingStore', () => {
         await taggingStore.storePendingIndexes([range(secret1, 2)], txHash1, commitChangeSetId);
         await taggingStore.storePendingIndexes([range(secret1, 3)], txHash2, commitChangeSetId);
         await taggingStore.finalizePendingIndexes([txHash1], commitChangeSetId);
-        await taggingStore.commitStaged(commitChangeSetId);
+        await taggingStore.commitChangeSet(commitChangeSetId);
       }
 
       const stagedChangeSetId: ChangeSetId = 'staged';
@@ -829,7 +829,7 @@ describe('SenderTaggingStore', () => {
         const txHash3 = TxHash.random();
         await taggingStore.storePendingIndexes([range(secret1, 7)], txHash3, stagedChangeSetId);
         await taggingStore.finalizePendingIndexes([txHash3], stagedChangeSetId);
-        await taggingStore.discardStaged(stagedChangeSetId);
+        taggingStore.discardChangeSet(stagedChangeSetId);
       }
 
       // Should still get the committed finalized index

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -104,7 +104,7 @@ export class SenderTaggingStore implements StagedStore {
    * @remark This method must run in a DB transaction context. It's designed to be called from
    * {@link StagedWriteCoordinator.commit}.
    */
-  async commitStaged(changeSetId: ChangeSetId): Promise<void> {
+  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
     const pendingIndexesForChangeSet = this.#pendingIndexesForChangeSet.get(changeSetId);
     if (pendingIndexesForChangeSet) {
       for (const [secret, pendingIndexes] of pendingIndexesForChangeSet.entries()) {
@@ -123,13 +123,12 @@ export class SenderTaggingStore implements StagedStore {
       }
     }
 
-    return this.discardStaged(changeSetId);
+    this.discardChangeSet(changeSetId);
   }
 
-  discardStaged(changeSetId: ChangeSetId): Promise<void> {
+  discardChangeSet(changeSetId: ChangeSetId): void {
     this.#pendingIndexesForChangeSet.delete(changeSetId);
     this.#lastFinalizedIndexesForChangeSet.delete(changeSetId);
-    return Promise.resolve();
   }
 
   /**


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/47 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `e9d1410eba861752ef4a9ebf7e54768917e589e1`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff e9d1410eba^..e9d1410eba origin/nico/port-node-47-base-staging-store^..origin/nico/port-node-47-base-staging-store
   ```

   Expected: only the `(cherry picked from commit …)` trailer under the commit message and nothing else — no `-`/`+` lines under any file header. The patch applied without conflicts and was not edited.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#40 (base branch `nico/port-node-40-rollbackable`); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 (aztec-node numbers).
