### PR TITLE
refactor(pxe): migrate RecipientTaggingStore to BaseStagingStore (backport of aztec-labs-eng/aztec-node#94)

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -492,6 +492,7 @@ async function createTestLogService(
 ) {
   const keyStore = new KeyStore(await openTmpStore('test'));
   const recipientTaggingStore = new RecipientTaggingStore(await openTmpStore('test'));
+  recipientTaggingStore.beginChangeSet('test');
   const taggingSecretSourcesStore = new TaggingSecretSourcesStore(await openTmpStore('test'));
   const addressStore = new AddressStore(await openTmpStore('test'));
   const aztecNode = mock<AztecNode>();

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -536,6 +536,8 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const recipientTaggingStore = new RecipientTaggingStore(kvStore);
 
       const changeSetId = 'fixture-change-set';
+      recipientTaggingStore.beginChangeSet(changeSetId);
+
       const secretA = new AppTaggingSecret(new Fr(2n), AztecAddress.fromBigIntUnsafe(3n));
       const secretB = new AppTaggingSecret(new Fr(5n), AztecAddress.fromBigIntUnsafe(7n));
       // A constrained secret keys under the `constrained:` prefix, so the snapshot pins both kinds side by side.

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
@@ -13,26 +13,27 @@ describe('RecipientTaggingStore', () => {
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
     secret1 = await randomAppTaggingSecret(AppTaggingSecretKind.UNCONSTRAINED);
     secret2 = await randomAppTaggingSecret(AppTaggingSecretKind.UNCONSTRAINED);
+
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    taggingStore.beginChangeSet('change-set-1');
   });
 
   describe('staged writes', () => {
     it('persists staged highest aged index to the store', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
 
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBeUndefined();
-
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
     });
 
     it('persists staged highest finalized index to the store', async () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 10, 'change-set-1');
 
-      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBeUndefined();
-
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBe(10);
     });
 
@@ -44,6 +45,7 @@ describe('RecipientTaggingStore', () => {
 
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
       expect(await taggingStore.getHighestAgedIndex(secret2, 'change-set-2')).toBe(8);
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBe(3);
@@ -54,35 +56,29 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
       await taggingStore.commitChangeSet('change-set-1');
 
-      // Updating again with a higher value in the same change set should work
-      // (if staged data wasn't cleared, it would still have the old value cached)
+      // Updating again with a higher value in a new change set should work
+      // (if staged data wasn't cleared on commit, the old value would still be cached)
+      taggingStore.beginChangeSet('change-set-2');
       await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(10);
       await taggingStore.commitChangeSet('change-set-2');
 
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(10);
-    });
-
-    it('does not affect other change sets when committing', async () => {
-      await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
-      await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
-
-      await taggingStore.commitChangeSet('change-set-2');
-
-      // change-set-1's staged value should still be intact
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(5);
+      taggingStore.beginChangeSet('change-set-3');
+      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-3')).toBe(10);
     });
 
     it('discards staged highest aged index without persisting', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
       taggingStore.discardChangeSet('change-set-1');
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBeUndefined();
+      taggingStore.beginChangeSet('change-set-2');
+      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBeUndefined();
     });
 
     it('discards staged highest finalized index without persisting', async () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 5, 'change-set-1');
       taggingStore.discardChangeSet('change-set-1');
-      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-1')).toBeUndefined();
+      taggingStore.beginChangeSet('change-set-2');
+      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBeUndefined();
     });
   });
 
@@ -102,6 +98,7 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestFinalizedIndex(constrained, 9, 'change-set-1');
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestFinalizedIndex(unconstrained, 'change-set-2')).toBe(4);
       expect(await taggingStore.getHighestFinalizedIndex(constrained, 'change-set-2')).toBe(9);
     });

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -1,7 +1,8 @@
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AppTaggingSecret } from '@aztec/stdlib/logs';
 
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 
 /**
  * Data provider of tagging data used when syncing the logs as a recipient. The sender counterpart of this class
@@ -11,129 +12,103 @@ import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
  * @dev Chain reorgs do not need to be handled here because both the finalized and aged indexes refer to finalized
  * blocks, which by definition cannot be affected by reorgs.
  */
-export class RecipientTaggingStore implements StagedStore {
-  storeName: string = 'recipient_tagging';
-
-  #store: AztecAsyncKVStore;
-
-  #highestAgedIndex: AztecAsyncMap<string, number>;
-  #highestFinalizedIndex: AztecAsyncMap<string, number>;
-
-  // changeSetId => secret => number
-  #highestAgedIndexForChangeSet: Map<ChangeSetId, Map<string, number>>;
-
-  // changeSetId => secret => number
-  #highestFinalizedIndexForChangeSet: Map<ChangeSetId, Map<string, number>>;
-
+export class RecipientTaggingStore extends BaseStagingStore<RecipientTaggingChangeSet, RecipientTaggingDb> {
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-
-    this.#highestAgedIndex = this.#store.openMap('highest_aged_index');
-    this.#highestFinalizedIndex = this.#store.openMap('highest_finalized_index');
-
-    this.#highestAgedIndexForChangeSet = new Map();
-    this.#highestFinalizedIndexForChangeSet = new Map();
+    super({
+      storeName: 'recipient_tagging',
+      store,
+      buildChangeSet: () => ({ highestAgedIndexes: new Map(), highestFinalizedIndexes: new Map() }),
+      buildDb: db => ({
+        highestAgedIndex: db.openMap('highest_aged_index'),
+        highestFinalizedIndex: db.openMap('highest_finalized_index'),
+      }),
+    });
   }
 
-  #getHighestAgedIndexForChangeSet(changeSetId: ChangeSetId): Map<string, number> {
-    let highestAgedIndexForChangeSet = this.#highestAgedIndexForChangeSet.get(changeSetId);
-    if (!highestAgedIndexForChangeSet) {
-      highestAgedIndexForChangeSet = new Map();
-      this.#highestAgedIndexForChangeSet.set(changeSetId, highestAgedIndexForChangeSet);
-    }
-    return highestAgedIndexForChangeSet;
-  }
-
-  async #readHighestAgedIndex(changeSetId: ChangeSetId, secret: string): Promise<number | undefined> {
+  async #readHighestAgedIndex(
+    changeSet: RecipientTaggingChangeSet,
+    db: ReadonlyDb<RecipientTaggingDb>,
+    secret: SecretStr,
+  ): Promise<Index | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const dbValue = await this.#highestAgedIndex.getAsync(secret);
-    const staged = this.#getHighestAgedIndexForChangeSet(changeSetId).get(secret);
-    return staged ?? dbValue;
+    const dbValue = await db.highestAgedIndex.getAsync(secret);
+    return changeSet.highestAgedIndexes.get(secret) ?? dbValue;
   }
 
-  #writeHighestAgedIndex(changeSetId: ChangeSetId, secret: string, index: number) {
-    this.#getHighestAgedIndexForChangeSet(changeSetId).set(secret, index);
-  }
-
-  #getHighestFinalizedIndexForChangeSet(changeSetId: ChangeSetId): Map<string, number> {
-    let stagedHighestFinalizedIndex = this.#highestFinalizedIndexForChangeSet.get(changeSetId);
-    if (!stagedHighestFinalizedIndex) {
-      stagedHighestFinalizedIndex = new Map();
-      this.#highestFinalizedIndexForChangeSet.set(changeSetId, stagedHighestFinalizedIndex);
-    }
-    return stagedHighestFinalizedIndex;
-  }
-
-  async #readHighestFinalizedIndex(changeSetId: ChangeSetId, secret: string): Promise<number | undefined> {
+  async #readHighestFinalizedIndex(
+    changeSet: RecipientTaggingChangeSet,
+    db: ReadonlyDb<RecipientTaggingDb>,
+    secret: SecretStr,
+  ): Promise<Index | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const dbValue = await this.#highestFinalizedIndex.getAsync(secret);
-    const staged = this.#getHighestFinalizedIndexForChangeSet(changeSetId).get(secret);
-    return staged ?? dbValue;
+    const dbValue = await db.highestFinalizedIndex.getAsync(secret);
+    return changeSet.highestFinalizedIndexes.get(secret) ?? dbValue;
   }
 
-  #writeHighestFinalizedIndex(changeSetId: ChangeSetId, secret: string, index: number) {
-    this.#getHighestFinalizedIndexForChangeSet(changeSetId).set(secret, index);
-  }
-
-  /**
-   * Writes all change set-specific in-memory data to persistent storage.
-   *
-   * @remark This method must run in a DB transaction context. It's designed to be called from
-   * {@link StagedWriteCoordinator.commit}.
-   */
-  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
-    const highestAgedIndexForChangeSet = this.#highestAgedIndexForChangeSet.get(changeSetId);
-    if (highestAgedIndexForChangeSet) {
-      for (const [secret, index] of highestAgedIndexForChangeSet.entries()) {
-        await this.#highestAgedIndex.set(secret, index);
-      }
+  protected async flushChangeSet(changeSet: RecipientTaggingChangeSet, db: RecipientTaggingDb): Promise<void> {
+    for (const [secret, index] of changeSet.highestAgedIndexes) {
+      await db.highestAgedIndex.set(secret, index);
     }
 
-    const highestFinalizedIndexForChangeSet = this.#highestFinalizedIndexForChangeSet.get(changeSetId);
-    if (highestFinalizedIndexForChangeSet) {
-      for (const [secret, index] of highestFinalizedIndexForChangeSet.entries()) {
-        await this.#highestFinalizedIndex.set(secret, index);
-      }
+    for (const [secret, index] of changeSet.highestFinalizedIndexes) {
+      await db.highestFinalizedIndex.set(secret, index);
     }
-
-    this.discardChangeSet(changeSetId);
   }
 
-  discardChangeSet(changeSetId: ChangeSetId): void {
-    this.#highestAgedIndexForChangeSet.delete(changeSetId);
-    this.#highestFinalizedIndexForChangeSet.delete(changeSetId);
+  /** No-op: both indexes refer to finalized blocks, which a prune cannot remove. */
+  protected applyRollback(): Promise<void> {
+    return Promise.resolve();
   }
 
-  getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<number | undefined> {
-    return this.#store.transactionAsync(() => this.#readHighestAgedIndex(changeSetId, secret.toString()));
+  getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
+    return this.withChangeSet(changeSetId, (changeSet, db) =>
+      this.#readHighestAgedIndex(changeSet, db, secret.toString()),
+    );
   }
 
-  updateHighestAgedIndex(secret: AppTaggingSecret, index: number, changeSetId: ChangeSetId): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      const currentIndex = await this.#readHighestAgedIndex(changeSetId, secret.toString());
+  updateHighestAgedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      const currentIndex = await this.#readHighestAgedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index <= currentIndex) {
         // Log sync should never set a lower highest aged index.
         throw new Error(`New highest aged index (${index}) must be higher than the current one (${currentIndex})`);
       }
-      this.#writeHighestAgedIndex(changeSetId, secret.toString(), index);
+      changeSet.highestAgedIndexes.set(secret.toString(), index);
     });
   }
 
-  getHighestFinalizedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<number | undefined> {
-    return this.#store.transactionAsync(() => this.#readHighestFinalizedIndex(changeSetId, secret.toString()));
+  getHighestFinalizedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
+    return this.withChangeSet(changeSetId, (changeSet, db) =>
+      this.#readHighestFinalizedIndex(changeSet, db, secret.toString()),
+    );
   }
 
-  updateHighestFinalizedIndex(secret: AppTaggingSecret, index: number, changeSetId: ChangeSetId): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      const currentIndex = await this.#readHighestFinalizedIndex(changeSetId, secret.toString());
+  updateHighestFinalizedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      const currentIndex = await this.#readHighestFinalizedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index < currentIndex) {
         // Log sync should never set a lower highest finalized index but it can happen that it would try to set the same
         // one because we are loading logs from highest aged index + 1 and not from the highest finalized index.
         throw new Error(`New highest finalized index (${index}) must be higher than the current one (${currentIndex})`);
       }
-      this.#writeHighestFinalizedIndex(changeSetId, secret.toString(), index);
+      changeSet.highestFinalizedIndexes.set(secret.toString(), index);
     });
   }
 }
+
+/// Alias types for kv map readability
+type SecretStr = string;
+type Index = number;
+
+/** A change set's staged data, created and discarded as a unit: both indexes, each keyed by tagging secret. */
+type RecipientTaggingChangeSet = {
+  highestAgedIndexes: Map<SecretStr, Index>;
+  highestFinalizedIndexes: Map<SecretStr, Index>;
+};
+
+type RecipientTaggingDb = {
+  highestAgedIndex: AztecAsyncMap<SecretStr, Index>;
+  highestFinalizedIndex: AztecAsyncMap<SecretStr, Index>;
+};

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
@@ -164,6 +164,7 @@ describeBench('syncTaggedPrivateLogs constrained-sync bench', () => {
 
     aztecNode.getPrivateLogsByTags.mockReset();
     const taggingStore = new RecipientTaggingStore(await openTmpStore('bench'));
+    taggingStore.beginChangeSet(CHANGE_SET_ID);
     const secrets = await Promise.all(Array.from({ length: secretCount }, () => randomAppTaggingSecret(kind)));
 
     // Seed the persisted finalized indexes to simulate a recipient that already synced prior finalized messages. The

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
@@ -104,6 +104,7 @@ describe('syncTaggedPrivateLogs', () => {
   beforeEach(async () => {
     aztecNode.getPrivateLogsByTags.mockReset();
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
+    taggingStore.beginChangeSet(CHANGE_SET_ID);
   });
 
   it('returns empty array when given no secrets', async () => {


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/94 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `1f14e9a69d10d12177032cc3fa5acddbeea2b751`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff 1f14e9a69d^..1f14e9a69d origin/nico/port-node-94-recipient-tagging-store^..origin/nico/port-node-94-recipient-tagging-store
   ```

   Expected: only the `(cherry picked from commit …)` trailer under the commit message and nothing else — no `-`/`+` lines under any file header. The patch applied without conflicts and was not edited.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#47 (base branch `nico/port-node-47-base-staging-store`); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 (aztec-node numbers).
