### PR TITLE
fix(fast-inbox): tolerate configured clock disparity in the validator's inbox bucket-age check

### DIFF
--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -969,8 +969,15 @@ describe('ProposalHandler checkpoint validation', () => {
       ...overrides,
     });
 
+    // A bucket opened at t=100 is exactly one second too young at this wall clock, given the 4s Ethereum slot the
+    // mocked L1 constants carry: `now - ethereumSlotDuration` is 99, one short of the bucket's timestamp.
+    const ONE_SECOND_TOO_NEW_MS = 103_000;
+
     /** Genesis-parent streaming block proposal at slot 1, with the handler wired to reach the streaming checks. */
-    async function setupStreamingProposal(bucketRef: InboxBucketRef | undefined) {
+    async function setupStreamingProposal(
+      bucketRef: InboxBucketRef | undefined,
+      options: { nowMs?: number; maxGossipClockDisparityMs?: number } = {},
+    ) {
       const proposal = ValidatedBlockProposal(
         await makeBlockProposal({
           blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
@@ -987,8 +994,8 @@ describe('ProposalHandler checkpoint validation', () => {
       const txProvider = mock<ITxProvider>();
       txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
 
-      // Well past the minimum bucket age (one 12s Ethereum slot) for a bucket opened at t=100.
-      dateProvider.setTime(1_000_000);
+      // Well past the minimum bucket age (one Ethereum slot) for a bucket opened at t=100, unless overridden.
+      dateProvider.setTime(options.nowMs ?? 1_000_000);
 
       const blockHandler = new ProposalHandler(
         checkpointsBuilder,
@@ -998,7 +1005,7 @@ describe('ProposalHandler checkpoint validation', () => {
         txProvider,
         epochCache,
         consensusTimetable,
-        config,
+        { ...config, maxGossipClockDisparityMs: options.maxGossipClockDisparityMs },
         mock<BlobClientInterface>(),
         new CheckpointReexecutionTracker(),
         metrics,
@@ -1085,6 +1092,48 @@ describe('ProposalHandler checkpoint validation', () => {
         expect.anything(),
         expect.anything(),
       );
+    });
+
+    // The proposer selects buckets against its own clock; a validator lagging it by less than the configured gossip
+    // clock disparity must not reject the selection as too new.
+    it('accepts a bucket one second too new by its own clock when a clock disparity is configured', async () => {
+      const ref = new InboxBucketRef(1n, 100n, new Fr(0xabc));
+      const { proposal, blockHandler } = await setupStreamingProposal(ref, {
+        nowMs: ONE_SECOND_TOO_NEW_MS,
+        maxGossipClockDisparityMs: 500,
+      });
+      l1ToL2MessageSource.getInboxBucket.mockResolvedValue(bucket());
+      l1ToL2MessageSource.getInboxBucketByTotalMsgCount.mockResolvedValue(
+        bucket({ seq: 0n, totalMsgCount: 0n, msgCount: 0 }),
+      );
+      l1ToL2MessageSource.getL1ToL2MessagesBetweenBuckets.mockResolvedValue([
+        { timestamp: 100n, leaves: [new Fr(1000), new Fr(1001)] },
+      ]);
+      jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({ block: undefined } as any);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects the same bucket when no clock disparity is configured', async () => {
+      const ref = new InboxBucketRef(1n, 100n, new Fr(0xabc));
+      const { proposal, blockHandler } = await setupStreamingProposal(ref, {
+        nowMs: ONE_SECOND_TOO_NEW_MS,
+        maxGossipClockDisparityMs: 0,
+      });
+      l1ToL2MessageSource.getInboxBucket.mockResolvedValue(bucket());
+      l1ToL2MessageSource.getInboxBucketByTotalMsgCount.mockResolvedValue(
+        bucket({ seq: 0n, totalMsgCount: 0n, msgCount: 0 }),
+      );
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+      expect(result).toEqual({
+        isValid: false,
+        blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+        reason: 'bucket_too_new',
+      });
     });
   });
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -1001,6 +1001,7 @@ export class ProposalHandler {
       checkpointStartTotalMsgCount,
       nowSeconds,
       minBucketAgeSeconds: this.epochCache.getL1Constants().ethereumSlotDuration,
+      clockDisparityMs: this.config.maxGossipClockDisparityMs ?? 0,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,
       perCheckpointCap: MAX_L1_TO_L2_MSGS_PER_CHECKPOINT,
     });

--- a/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
@@ -193,6 +193,64 @@ describe('checkStreamingBlockProposal', () => {
       const result = await checkStreamingBlockProposal(baseInput({ messageSource: view, bucketRef: refFor(bucket) }));
       expect(result).toEqual({ accepted: false, reason: 'bucket_too_new' });
     });
+
+    it('accepts a bucket one second too new when the tolerated clock disparity covers it', async () => {
+      const view = new FakeInboxView();
+      const bucket = view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 1);
+      const result = await checkStreamingBlockProposal(
+        baseInput({ messageSource: view, bucketRef: refFor(bucket), clockDisparityMs: 500 }),
+      );
+      expect(result.accepted).toBe(true);
+    });
+
+    it('rejects a bucket two seconds too new for a sub-second tolerance', async () => {
+      const view = new FakeInboxView();
+      const bucket = view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 2);
+      const result = await checkStreamingBlockProposal(
+        baseInput({ messageSource: view, bucketRef: refFor(bucket), clockDisparityMs: 500 }),
+      );
+      expect(result).toEqual({ accepted: false, reason: 'bucket_too_new' });
+    });
+
+    it('rounds a non-multiple tolerance up to whole seconds', async () => {
+      const view = new FakeInboxView();
+      const accepted = await checkStreamingBlockProposal(
+        baseInput({
+          messageSource: view,
+          bucketRef: refFor(view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 2)),
+          clockDisparityMs: 1500,
+        }),
+      );
+      expect(accepted.accepted).toBe(true);
+
+      const rejectedView = new FakeInboxView();
+      const rejected = await checkStreamingBlockProposal(
+        baseInput({
+          messageSource: rejectedView,
+          bucketRef: refFor(rejectedView.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 3)),
+          clockDisparityMs: 1500,
+        }),
+      );
+      expect(rejected).toEqual({ accepted: false, reason: 'bucket_too_new' });
+    });
+
+    it('rejects a bucket opened right now regardless of the tolerance', async () => {
+      const view = new FakeInboxView();
+      const bucket = view.addBucket(1, 2, Number(NOW));
+      const result = await checkStreamingBlockProposal(
+        baseInput({ messageSource: view, bucketRef: refFor(bucket), clockDisparityMs: 500 }),
+      );
+      expect(result).toEqual({ accepted: false, reason: 'bucket_too_new' });
+    });
+
+    it('applies no tolerance when the clock disparity is zero', async () => {
+      const view = new FakeInboxView();
+      const bucket = view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 1);
+      const result = await checkStreamingBlockProposal(
+        baseInput({ messageSource: view, bucketRef: refFor(bucket), clockDisparityMs: 0 }),
+      );
+      expect(result).toEqual({ accepted: false, reason: 'bucket_too_new' });
+    });
   });
 
   describe('check 4: caps', () => {

--- a/yarn-project/validator-client/src/streaming_inbox_checks.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.ts
@@ -47,6 +47,13 @@ export type StreamingBlockMetadataCheckInput = {
    * the archiver records each bucket's `l1BlockNumber`.
    */
   minBucketAgeSeconds: number;
+  /**
+   * Tolerated clock disparity between this node and the proposer, in milliseconds. Check 3 accepts a bucket that would
+   * be old enough under any clock up to this much ahead of ours, so a validator whose clock lags the proposer's does
+   * not reject a bucket the proposer legitimately selected. Rounded up to whole seconds because bucket timestamps are
+   * L1 block timestamps. Defaults to 0 (no tolerance).
+   */
+  clockDisparityMs?: number;
   /** Maximum number of messages this block may consume (`MAX_L1_TO_L2_MSGS_PER_BLOCK`). */
   perBlockCap: number;
   /** Maximum number of messages the checkpoint may consume in total (`MAX_L1_TO_L2_MSGS_PER_CHECKPOINT`). */
@@ -104,7 +111,9 @@ export type StreamingBlockCheckResult =
  *    Equal totals mean the block consumes nothing (empty bundle).
  * 3. **Not too new**: the bucket is at least `minBucketAgeSeconds` old at validation time
  *    (`timestamp <= now - minBucketAgeSeconds`, inclusive — a bucket exactly that old is eligible, matching L1's
- *    strict `>` "too new" test).
+ *    strict `>` "too new" test), widened by `clockDisparityMs` in the permissive direction only. The proposer selects
+ *    against its own clock with no such tolerance, so widening here only covers the case where this node's clock lags
+ *    the proposer's; it never lets an honest proposer's selection get younger.
  * 4. **Caps**: the per-block message count and the running per-checkpoint total fit their respective caps.
  * 5. **Parent boundary**: the parent block's cumulative total sits on a bucket boundary, so the consumed range is
  *    well defined.
@@ -124,6 +133,7 @@ export async function checkStreamingBlockProposalMetadata(
     checkpointStartTotalMsgCount,
     nowSeconds,
     minBucketAgeSeconds,
+    clockDisparityMs,
     perBlockCap,
     perCheckpointCap,
   } = input;
@@ -147,8 +157,10 @@ export async function checkStreamingBlockProposalMetadata(
     return { accepted: false, reason: 'bucket_moves_backwards' };
   }
 
-  // Check 3: the bucket is at least `minBucketAgeSeconds` old at validation time.
-  if (bucket.timestamp > nowSeconds - BigInt(minBucketAgeSeconds)) {
+  // Check 3: the bucket is at least `minBucketAgeSeconds` old at validation time, allowing for a clock up to
+  // `clockDisparityMs` ahead of ours.
+  const toleranceSeconds = BigInt(Math.ceil((clockDisparityMs ?? 0) / 1000));
+  if (bucket.timestamp > nowSeconds + toleranceSeconds - BigInt(minBucketAgeSeconds)) {
     return { accepted: false, reason: 'bucket_too_new' };
   }
 


### PR DESCRIPTION
## Problem

Blocks may only consume Inbox buckets at least one Ethereum slot old, so a shallow L1 reorg cannot pull messages out from under an L2 block. L1 does not enforce this; both sides evaluate it against their own wall clock:

- proposer: eligible iff `bucket.timestamp <= now_p - ethereumSlotDuration`
- validator (`streaming_inbox_checks.ts`, check 3): eligible iff `bucket.timestamp <= now_v - ethereumSlotDuration`

The two clocks differ. A validator whose clock is *ahead* of the proposer's is harmless (it is strictly more permissive). A validator whose clock is *behind* the proposer's can reject a bucket the proposer legitimately selected, with reason `bucket_too_new`.

The blast radius is small: L1 has no age rule in `ProposeLib.validateInboxConsumption`, so the checkpoint lands regardless; the bucket's real settlement risk is covered by the rolling-hash check. It costs one attestation from one validator. It is also unlikely — the validator checks after block build plus gossip, so its clock has to lag the proposer's by more than that whole delay. It is a liveness edge, not a safety issue, but it is free to remove.

## The fix

Widen the validator's check 3 by the clock-disparity tolerance the node already configures for proposal gossip, in the permissive direction only:

- before: `bucket.timestamp > now_v - E` -> `bucket_too_new`
- after: `bucket.timestamp > now_v + tolerance - E` -> `bucket_too_new`, with `tolerance = ceil(maxGossipClockDisparityMs / 1000)` (500ms default, so 1s)

Equivalently, a validator accepts a bucket if any clock within the tolerated disparity of its own would have made it eligible. The tolerance is rounded up to whole seconds because bucket timestamps are L1 block timestamps and the check works in seconds; the floor-to-seconds on both sides is itself a ~1s skew source that the round-up absorbs.

`maxGossipClockDisparityMs` is reused rather than adding a new knob: it is already the node's single definition of tolerated clock skew, and it is already mirrored onto `ValidatorClientFullConfig`. Two knobs for one physical quantity would drift.

The tolerance is passed into `checkStreamingBlockProposalMetadata` as an explicit `clockDisparityMs` input defaulting to `0`, rather than pre-adjusting `nowSeconds` in the caller, so `nowSeconds` keeps meaning "the wall clock" and the check stays unit-testable in isolation.

## Why the proposer side stays strict

The proposer keeps selecting against its own clock with no tolerance (`inbox_bucket_selector.ts` is untouched). Only the validator-behind-proposer direction can fail, and widening the validator's reject threshold covers it. A symmetric tolerance on the proposer would let an honest proposer select buckets that are genuinely younger than the reorg-safety margin, which only makes every validator's job harder. Nothing in the sequencer changes.

## Runtime-config finding

The value already reaches the validator config; no mapping was needed. `AztecNodeConfig` includes `P2PConfig`, whose `maxGossipClockDisparityMs` mapping carries a default of 500ms, and `aztec-node/src/factory.ts` passes that flat config object straight into `createValidatorClient`, which hands it whole to `ValidatorClient.new` and on to the `ProposalHandler` with no picking or narrowing. `ValidatorClientFullConfig` already declares the key (mirrored from `P2PConfig` to avoid a circular dependency). So `validator-client/src/config.ts` and the stdlib validator config are untouched.

## Red/green

The failing case was written first against the base branch (`streaming_inbox_checks.test.ts`, check 3): a bucket at `NOW - E + 1` with `clockDisparityMs: 500`.

Before:

```
    check 3: bucket is at least one Ethereum slot old
      ✓ accepts a bucket exactly at the minimum age (inclusive boundary)
      ✓ rejects a bucket one second too new
      ✕ accepts a bucket one second too new when the tolerated clock disparity covers it
      ✓ rejects a bucket two seconds too new for a sub-second tolerance
      ✕ rounds a non-multiple tolerance up to whole seconds
      ✓ rejects a bucket opened right now regardless of the tolerance
      ✓ applies no tolerance when the clock disparity is zero

Tests:       2 failed, 19 passed, 21 total
```

After: `Tests: 21 passed, 21 total`.

Coverage added:

- `clockDisparityMs: 500` accepts `NOW - E + 1` and still rejects `NOW - E + 2` (the `ceil` to 1s).
- `clockDisparityMs: 1500` accepts `NOW - E + 2` and rejects `NOW - E + 3` (round-up on a non-multiple).
- A bucket opened at `NOW` is still rejected under the tolerance.
- `clockDisparityMs: 0`, and the two pre-existing tests that omit it entirely, preserve today's behavior exactly.
- `proposal_handler.test.ts`: a proposal referencing a bucket exactly one second too young by the validator's clock is attested when the config carries `maxGossipClockDisparityMs: 500` and rejected with `bucket_too_new` when it is `0`, asserted on the handler's outcome rather than on a spy.

## Checks

- `yarn build`, `yarn format validator-client`, `yarn lint validator-client`: clean
- `yarn workspace @aztec/validator-client test`: 277 passed, 3 skipped, 10 suites
- `yarn workspace @aztec/sequencer-client test src/sequencer/inbox_bucket_selector.test.ts`: 12 passed (unchanged, sanity)
- `yarn workspace @aztec/end-to-end test:e2e src/single-node/cross-chain/streaming_inbox.test.ts`: 5 passed (513s)