### PR TITLE
feat(fast-inbox): wait for the local archiver before rejecting a block proposal for an unsynced inbox bucket

### DIFF
--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -970,7 +970,7 @@ describe('ProposalHandler checkpoint validation', () => {
     });
 
     /** Genesis-parent streaming block proposal at slot 1, with the handler wired to reach the streaming checks. */
-    async function setupStreamingProposal(bucketRef: InboxBucketRef | undefined) {
+    async function setupStreamingProposal(bucketRef: InboxBucketRef | undefined, options: { nowMs?: number } = {}) {
       const proposal = ValidatedBlockProposal(
         await makeBlockProposal({
           blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
@@ -987,8 +987,8 @@ describe('ProposalHandler checkpoint validation', () => {
       const txProvider = mock<ITxProvider>();
       txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
 
-      // Well past the minimum bucket age (one 12s Ethereum slot) for a bucket opened at t=100.
-      dateProvider.setTime(1_000_000);
+      // Well past the minimum bucket age (one 12s Ethereum slot) for a bucket opened at t=100, unless overridden.
+      dateProvider.setTime(options.nowMs ?? 1_000_000);
 
       const blockHandler = new ProposalHandler(
         checkpointsBuilder,
@@ -1085,6 +1085,138 @@ describe('ProposalHandler checkpoint validation', () => {
         expect.anything(),
         expect.anything(),
       );
+    });
+
+    // A bucket the proposer already consumed is on L1 by construction, so a bucket this node cannot resolve is
+    // (usually) local archiver lag, not a divergence: the handler forces a sync and re-checks until the
+    // attestation deadline instead of dropping the attestation on the spot.
+    describe('bucket sync wait', () => {
+      // attestation_deadline(slot=1) = 1*24 + 24 - 8 = 40s. Waits run on a real timer against the remaining
+      // budget read off the fake clock, so holding it 2s short of the deadline keeps the tests short.
+      const DEADLINE_MS = 40_000;
+      const WAIT_BUDGET_MS = 2_000;
+      const BEFORE_DEADLINE_MS = DEADLINE_MS - WAIT_BUDGET_MS;
+      const PAST_DEADLINE_MS = DEADLINE_MS + 1_000;
+      const WAIT_INTERVAL_MS = 500;
+
+      /** A bucket old enough to be lag-eligible at {@link BEFORE_DEADLINE_MS}. */
+      const eligibleBucket = (overrides: Partial<InboxBucket> = {}) => bucket({ timestamp: 10n, ...overrides });
+
+      /** Wires the parent-bucket lookup and the bundle read for a proposal that consumes `eligibleBucket()`. */
+      function mockAcceptedSurroundings() {
+        l1ToL2MessageSource.getInboxBucketByTotalMsgCount.mockResolvedValue(
+          eligibleBucket({ seq: 0n, totalMsgCount: 0n, msgCount: 0 }),
+        );
+        l1ToL2MessageSource.getL1ToL2MessagesBetweenBuckets.mockResolvedValue([new Fr(1000), new Fr(1001)]);
+      }
+
+      it('attests once the referenced bucket shows up on a later archiver sync', async () => {
+        const ref = new InboxBucketRef(1n, 10n, new Fr(0xabc));
+        const { proposal, blockHandler } = await setupStreamingProposal(ref, { nowMs: BEFORE_DEADLINE_MS });
+        mockAcceptedSurroundings();
+        // Unknown on arrival, synced by the time the wait re-checks.
+        l1ToL2MessageSource.getInboxBucket.mockResolvedValueOnce(undefined).mockResolvedValue(eligibleBucket());
+        jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({ block: undefined } as any);
+
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+        expect(result.isValid).toBe(true);
+        expect(result.blockNumber).toEqual(BlockNumber(INITIAL_L2_BLOCK_NUM));
+      });
+
+      it('rejects with bucket_unknown when the bucket never syncs, no earlier than the deadline', async () => {
+        const ref = new InboxBucketRef(1n, 10n, new Fr(0xabc));
+        const { proposal, blockHandler, txProvider } = await setupStreamingProposal(ref, {
+          nowMs: BEFORE_DEADLINE_MS,
+        });
+        mockAcceptedSurroundings();
+        l1ToL2MessageSource.getInboxBucket.mockResolvedValue(undefined);
+
+        const startMs = Date.now();
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+        const elapsedMs = Date.now() - startMs;
+
+        expect(result).toEqual({
+          isValid: false,
+          blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+          reason: 'bucket_unknown',
+        });
+        // The wait runs out the remaining budget and gives up within one retry interval of the deadline.
+        expect(elapsedMs).toBeGreaterThanOrEqual(WAIT_BUDGET_MS - 100);
+        expect(elapsedMs).toBeLessThan(WAIT_BUDGET_MS + 2 * WAIT_INTERVAL_MS);
+        // Waiting never buys the proposer any network work: the rejection still happens before tx collection.
+        expect(txProvider.getTxsForBlockProposal).not.toHaveBeenCalled();
+      });
+
+      it('rejects immediately without syncing when the attestation deadline has already passed', async () => {
+        const ref = new InboxBucketRef(1n, 10n, new Fr(0xabc));
+        const { proposal, blockHandler } = await setupStreamingProposal(ref, { nowMs: PAST_DEADLINE_MS });
+        mockAcceptedSurroundings();
+        l1ToL2MessageSource.getInboxBucket.mockResolvedValue(undefined);
+
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+        expect(result).toEqual({
+          isValid: false,
+          blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+          reason: 'bucket_unknown',
+        });
+        // With no budget left there is nothing to wait for, so the archiver is not poked at all.
+        expect(blockSource.syncImmediate).not.toHaveBeenCalled();
+      });
+
+      it('rejects immediately without syncing when the proposal carries no bucket reference', async () => {
+        const { proposal, blockHandler } = await setupStreamingProposal(undefined, {
+          nowMs: BEFORE_DEADLINE_MS,
+        });
+
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+        expect(result).toEqual({
+          isValid: false,
+          blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+          reason: 'bucket_unknown',
+        });
+        expect(blockSource.syncImmediate).not.toHaveBeenCalled();
+      });
+
+      it('rejects a hash mismatch that survives one forced sync, without looping', async () => {
+        const ref = new InboxBucketRef(1n, 10n, new Fr(0xdead));
+        const { proposal, blockHandler } = await setupStreamingProposal(ref, { nowMs: BEFORE_DEADLINE_MS });
+        mockAcceptedSurroundings();
+        l1ToL2MessageSource.getInboxBucket.mockResolvedValue(eligibleBucket({ inboxRollingHash: new Fr(0xabc) }));
+
+        const startMs = Date.now();
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+        const elapsedMs = Date.now() - startMs;
+
+        expect(result).toEqual({
+          isValid: false,
+          blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+          reason: 'bucket_hash_mismatch',
+        });
+        // A persistent mismatch is a divergence from L1, not local lag: one sync, one re-check, no retry loop.
+        expect(blockSource.syncImmediate).toHaveBeenCalledTimes(1);
+        expect(elapsedMs).toBeLessThan(WAIT_INTERVAL_MS);
+      });
+
+      it('attests when the forced sync replaces our stale bucket with the proposed one', async () => {
+        // This validator held the orphaned side of an L1 reorg; the forced sync rolls it back and re-syncs.
+        const ref = new InboxBucketRef(1n, 10n, new Fr(0xabc));
+        const { proposal, blockHandler } = await setupStreamingProposal(ref, { nowMs: BEFORE_DEADLINE_MS });
+        mockAcceptedSurroundings();
+        l1ToL2MessageSource.getInboxBucket.mockResolvedValue(eligibleBucket({ inboxRollingHash: new Fr(0xbad) }));
+        blockSource.syncImmediate.mockImplementation(() => {
+          l1ToL2MessageSource.getInboxBucket.mockResolvedValue(eligibleBucket());
+          return Promise.resolve();
+        });
+        jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({ block: undefined } as any);
+
+        const result = await blockHandler.handleBlockProposal(proposal, {} as any, true);
+
+        expect(result.isValid).toBe(true);
+        expect(result.blockNumber).toEqual(BlockNumber(INITIAL_L2_BLOCK_NUM));
+      });
     });
   });
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -577,7 +577,7 @@ export class ProposalHandler {
     // Streaming Inbox: run the metadata checks before committing to any network work. They are point lookups
     // against our own Inbox view, so a proposal carrying a bucket reference that does not resolve locally is
     // rejected without a proposer being able to make us spend the validation window collecting its txs.
-    const streamingMetadata = await this.checkStreamingBlockMetadata(proposal, blockNumber, parentBlock);
+    const streamingMetadata = await this.awaitStreamingBlockMetadata(proposal, blockNumber, parentBlock, proposalInfo);
     if (!streamingMetadata.accepted) {
       this.log.warn(`Streaming Inbox block acceptance check failed, skipping processing`, {
         reason: streamingMetadata.reason,
@@ -729,6 +729,40 @@ export class ProposalHandler {
     }
   }
 
+  /**
+   * Re-runs `resolve` against this node's local view, forcing an archiver L1 sync before every attempt, until it
+   * yields a value or the slot's attestation deadline passes. Returns `undefined` when the deadline had already
+   * passed on entry (nothing is forced in that case) or when it passes while waiting; anything other than the
+   * timeout propagates. Callers own their own logging and whatever they fall back to on `undefined`, and check
+   * the deadline themselves when they need to tell "no budget on entry" apart from "timed out while waiting".
+   */
+  private async awaitLocalSync<T>(
+    slotNumber: SlotNumber,
+    what: string,
+    resolve: () => Promise<T | undefined>,
+  ): Promise<T | undefined> {
+    const deadline = this.getReexecutionDeadline(slotNumber);
+    if (deadline.getTime() - this.dateProvider.now() <= 0) {
+      return undefined;
+    }
+    try {
+      return await retryUntil(
+        async () => {
+          await this.blockSource.syncImmediate();
+          return await resolve();
+        },
+        what,
+        { deadline, dateProvider: this.dateProvider },
+        0.5,
+      );
+    } catch (err) {
+      if (err instanceof TimeoutError) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
   private async getParentBlock(proposal: BlockProposal): Promise<'genesis' | BlockData | undefined> {
     const parentArchive = proposal.blockHeader.lastArchive.root;
     const { genesisArchiveRoot } = await this.blockSource.getGenesisValues();
@@ -737,28 +771,23 @@ export class ProposalHandler {
       return 'genesis';
     }
 
-    const deadline = this.getReexecutionDeadline(proposal.slotNumber);
-    const timeoutDurationMs = deadline.getTime() - this.dateProvider.now();
-
     try {
-      return (
-        (await this.blockSource.getBlockData({ archive: parentArchive })) ??
-        (timeoutDurationMs <= 0
-          ? undefined
-          : await retryUntil(
-              () =>
-                this.blockSource.syncImmediate().then(() => this.blockSource.getBlockData({ archive: parentArchive })),
-              'force archiver sync',
-              { deadline, dateProvider: this.dateProvider },
-              0.5,
-            ))
-      );
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        this.log.debug(`Timed out getting parent block by archive root`, { parentArchive });
-      } else {
-        this.log.error('Error getting parent block by archive root', err, { parentArchive });
+      const parentBlock = await this.blockSource.getBlockData({ archive: parentArchive });
+      if (parentBlock !== undefined) {
+        return parentBlock;
       }
+      if (this.getReexecutionDeadline(proposal.slotNumber).getTime() - this.dateProvider.now() <= 0) {
+        return undefined;
+      }
+      const synced = await this.awaitLocalSync(proposal.slotNumber, 'force archiver sync', () =>
+        this.blockSource.getBlockData({ archive: parentArchive }),
+      );
+      if (synced === undefined) {
+        this.log.debug(`Timed out getting parent block by archive root`, { parentArchive });
+      }
+      return synced;
+    } catch (err) {
+      this.log.error('Error getting parent block by archive root', err, { parentArchive });
       return undefined;
     }
   }
@@ -784,8 +813,7 @@ export class ProposalHandler {
 
     // A different block already occupies this number: it may be a stale fork being pruned during a reorg, not a
     // genuine duplicate. Wait for the local prune rather than permanently rejecting the proposal.
-    const deadline = this.getReexecutionDeadline(slotNumber);
-    if (deadline.getTime() - this.dateProvider.now() <= 0) {
+    if (this.getReexecutionDeadline(slotNumber).getTime() - this.dateProvider.now() <= 0) {
       return existingBlock;
     }
 
@@ -795,29 +823,19 @@ export class ProposalHandler {
       proposalArchive: proposalArchive.toString(),
     });
 
-    try {
-      const { block } = await retryUntil(
-        async () => {
-          await this.blockSource.syncImmediate();
-          const block = await this.blockSource.getBlockData({ number: blockNumber });
-          // Resolve once the existing block is gone (pruned) or has been replaced by one matching the
-          // proposal — the same condition as the early return above. A matching block is returned so the
-          // caller still treats it as a genuine duplicate; an `undefined` (pruned) block lets the proposal
-          // be processed. Wrap in an object so the `undefined` case is still a truthy retry result.
-          return block === undefined || block.archive.root.equals(proposalArchive) ? { block } : undefined;
-        },
-        `prune of stale block ${blockNumber}`,
-        { deadline, dateProvider: this.dateProvider },
-        0.5,
-      );
-      return block;
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        this.log.warn(`Timed out waiting for stale block ${blockNumber} to be pruned`, { blockNumber });
-        return existingBlock;
-      }
-      throw err;
+    const pruned = await this.awaitLocalSync(slotNumber, `prune of stale block ${blockNumber}`, async () => {
+      const block = await this.blockSource.getBlockData({ number: blockNumber });
+      // Resolve once the existing block is gone (pruned) or has been replaced by one matching the
+      // proposal — the same condition as the early return above. A matching block is returned so the
+      // caller still treats it as a genuine duplicate; an `undefined` (pruned) block lets the proposal
+      // be processed. Wrap in an object so the `undefined` case is still a truthy retry result.
+      return block === undefined || block.archive.root.equals(proposalArchive) ? { block } : undefined;
+    });
+    if (pruned === undefined) {
+      this.log.warn(`Timed out waiting for stale block ${blockNumber} to be pruned`, { blockNumber });
+      return existingBlock;
     }
+    return pruned.block;
   }
 
   private computeCheckpointNumber(
@@ -970,6 +988,80 @@ export class ProposalHandler {
   }
 
   /**
+   * Runs the streaming-Inbox metadata checks, waiting out a local sync lag. A bucket the proposer consumed is at
+   * least one Ethereum slot old, so it is on L1 by the time the proposal arrives: a bucket this node cannot
+   * resolve is almost always its own archiver trailing L1, not a divergence. That case (and the equivalent one
+   * where the block before the checkpoint's first block has not synced) forces an archiver sync and re-checks
+   * every half second until it resolves or the attestation deadline passes, instead of dropping the attestation
+   * on the spot. A hash mismatch on a bucket we do know gets exactly one forced sync and one re-check, because
+   * this node may be the stale side of an L1 reorg and that sync performs the rollback; a mismatch that survives
+   * it will not resolve by waiting. Every other reason is a structural rejection and returns immediately.
+   *
+   * The wait is bounded by the same consensus deadline as the other sync waits here, so a proposer referencing a
+   * bucket that never appears can at most make validators poll their own archiver for the remainder of its own
+   * slot — which it could waste anyway by not proposing.
+   */
+  private async awaitStreamingBlockMetadata(
+    proposal: BlockProposal,
+    blockNumber: BlockNumber,
+    parentBlock: 'genesis' | BlockData,
+    proposalInfo: LogData,
+  ): Promise<StreamingBlockMetadataCheckResult> {
+    const first = await this.checkStreamingBlockMetadata(proposal, blockNumber, parentBlock);
+    const bucketRef = proposal.bucketRef;
+    if (first.accepted || bucketRef === undefined) {
+      return first;
+    }
+
+    const slotNumber = proposal.slotNumber;
+    const bucketSeq = bucketRef.bucketSeq;
+    const outOfBudget = this.getReexecutionDeadline(slotNumber).getTime() - this.dateProvider.now() <= 0;
+
+    if (first.reason === 'bucket_hash_mismatch') {
+      if (outOfBudget) {
+        return first;
+      }
+      await this.blockSource.syncImmediate();
+      const rechecked = await this.checkStreamingBlockMetadata(proposal, blockNumber, parentBlock);
+      if (!rechecked.accepted && rechecked.reason === 'bucket_hash_mismatch') {
+        this.log.warn(`Inbox bucket ${bucketSeq} still disagrees with the proposal after forcing an archiver sync`, {
+          reason: 'bucket_hash_mismatch_after_sync',
+          bucketSeq,
+          expected: bucketRef.inboxRollingHash.toString(),
+          actual: (await this.l1ToL2MessageSource.getInboxBucket(bucketSeq))?.inboxRollingHash.toString(),
+          ...proposalInfo,
+        });
+      }
+      return rechecked;
+    }
+
+    if (first.reason !== 'bucket_unknown') {
+      return first;
+    }
+
+    this.log.info(`Referenced Inbox bucket ${bucketSeq} not synced locally, awaiting archiver sync`, {
+      bucketSeq,
+      ...proposalInfo,
+    });
+    const timer = new Timer();
+    const resolved = await this.awaitLocalSync(slotNumber, `inbox bucket ${bucketSeq}`, async () => {
+      const result = await this.checkStreamingBlockMetadata(proposal, blockNumber, parentBlock);
+      return !result.accepted && result.reason === 'bucket_unknown' ? undefined : result;
+    });
+    if (resolved === undefined) {
+      this.log.warn(`Timed out waiting for Inbox bucket ${bucketSeq} to sync, rejecting proposal`, {
+        reason: 'bucket_sync_timeout',
+        slot: slotNumber,
+        bucketSeq,
+        waitedMs: timer.ms(),
+        ...proposalInfo,
+      });
+      return first;
+    }
+    return resolved;
+  }
+
+  /**
    * Runs the streaming-Inbox per-block metadata checks for a block proposal, returning the bucket range its message
    * bundle derives from or a rejection reason. The parent block's consumed total and the checkpoint's starting total
    * are derived from L1-to-L2 tree leaf counts; a parent whose count does not sit on a bucket boundary is rejected
@@ -988,7 +1080,8 @@ export class ProposalHandler {
     );
     if (checkpointStartTotalMsgCount === undefined) {
       // The block before the checkpoint's first block has not synced locally, so the per-checkpoint cap origin is
-      // unavailable: treat as an unknown local view. There is no bounded wait for the missing block yet.
+      // unavailable: treat as an unknown local view. Like an unknown bucket this is local lag rather than a
+      // divergence, and `awaitStreamingBlockMetadata` waits it out by re-running the whole check after a sync.
       return { accepted: false, reason: 'bucket_unknown' };
     }
     const nowSeconds = BigInt(Math.floor(this.dateProvider.now() / 1000));

--- a/yarn-project/validator-client/src/streaming_inbox_checks.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.ts
@@ -92,9 +92,11 @@ export type StreamingBlockCheckResult =
  * Mirrors the L1 acceptance conditions:
  *
  * 1. **Exists**: the referenced bucket resolves in this node's own Inbox view, and its consensus rolling hash matches
- *    the reference. An unknown bucket is an immediate reject here (there is no bounded wait yet); a hash
- *    mismatch means the wire reference disagrees with the local bucket. The reference is trusted only as a `bucketSeq`
- *    lookup hint — timestamp and message counts are read from the locally resolved bucket, never from the wire.
+ *    the reference. An unknown bucket is an immediate reject here; the caller decides whether it is worth waiting for
+ *    a local sync and re-running the checks (the validator's proposal handler does, bounded by the attestation
+ *    deadline). A hash mismatch means the wire reference disagrees with the local bucket. The reference is trusted
+ *    only as a `bucketSeq` lookup hint — timestamp and message counts are read from the locally resolved bucket,
+ *    never from the wire.
  * 2. **Moves forward**: the bucket's cumulative total is at least the parent block's, so consumption never rewinds.
  *    Equal totals mean the block consumes nothing (empty bundle).
  * 3. **Not too new**: the bucket is at least `minBucketAgeSeconds` old at validation time
@@ -107,7 +109,8 @@ export type StreamingBlockCheckResult =
  * Because this phase is cheap and needs nothing off the network, a caller can run it before committing to any
  * expensive work on a proposal — notably before collecting the proposal's transactions over P2P.
  *
- * The reject branch is a single function so a future bounded wait can wrap `bucket_unknown`.
+ * The reject branch is a single function so a caller can re-run the whole check after forcing a local sync, which
+ * is how the validator's proposal handler turns a `bucket_unknown` into a bounded wait.
  */
 export async function checkStreamingBlockProposalMetadata(
   input: StreamingBlockMetadataCheckInput,


### PR DESCRIPTION
Stacked on #25323.

## The race

A validator receiving a block proposal first runs the streaming-Inbox metadata checks, which look the proposal's bucket up in the validator's **own** archiver. If the archiver has not yet synced the L1 block that opened that bucket, the lookup returns `undefined` and the proposal was rejected on the spot with `bucket_unknown`.

That is a pure race, not a divergence. The proposer only consumes buckets at least one Ethereum slot old, so the bucket *is* on L1; the validator's archiver polls L1 on an interval, and a proposal arriving inside that window lost this validator's attestation. With buckets opening in nearly every L1 block under load this is a steady drip of lost attestations, not an edge case.

## What waits and what does not

- **`bucket_unknown` → bounded wait.** Force an archiver sync, re-run the *whole* metadata check, repeat every 0.5s until it resolves or the slot's attestation deadline (`target_slot_start + S − 2E`) passes — the same bound the handler's other sync waits use. On timeout the rejection keeps the `bucket_unknown` reason (no new reason string to teach the slashing/`invalid` classification maps) plus a `warn` carrying `reason: 'bucket_sync_timeout'` and `waitedMs`.
- **`bucket_hash_mismatch` → one forced sync and one re-check.** A known bucket seq with a different rolling hash means the two nodes saw different L1 blocks at that height, but it does not say *which* side is stale: after an L1 reorg the proposer may already be on the canonical replacement while this validator still holds the orphaned bucket. One forced sync performs the rollback and re-sync if we were the stale side. If the hashes still differ, our view is as good as L1's and the proposal is on the wrong fork — reject, with a `bucket_hash_mismatch_after_sync` warn. No loop: a persistent mismatch will not resolve by waiting.
- **Everything else rejects immediately** (`bucket_too_new`, `bucket_moves_backwards`, the caps, `parent_bucket_unresolved`, a proposal with no `bucketRef`, and any arrival after the deadline has already passed — in that last case the archiver is not poked at all).
- The wait re-runs `checkStreamingBlockMetadata` rather than just the bucket lookup, so it also covers the case where "the block before the checkpoint's first block has not synced" maps to `bucket_unknown` — the same kind of local lag — and guarantees the accepted result was computed against the synced view.

## Shared wait helper

The handler already had three near-identical `retryUntil(syncImmediate + lookup, { deadline, dateProvider }, 0.5)` blocks. Rather than adding a fourth, they now share a private `awaitLocalSync(slot, what, resolve)` that owns the deadline computation, the past-deadline short-circuit, the forced sync per attempt, and the `TimeoutError` → `undefined` conversion. Callers keep their own log level and their own timeout fallback value.

Migrated (behavior preserved exactly, `proposal_handler.test.ts` green with no test changes before any of the bucket work landed — 45/45):

- `getParentBlock` (parent block not yet synced). Keeps its own past-deadline check so the "timed out" debug log still fires only for real timeouts, not for an arrival with no budget left.
- `resolveExistingBlockAtNumber` (stale fork at this block number during a reorg). Already had the past-deadline guard ahead of its `warn`, so the mapping is exact.

Not migrated:

- The checkpoint proposal's last-block sync wait in `validateCheckpointProposal`. It has no past-deadline guard, and `retryUntil` runs `fn` once *before* checking the timeout — so today, when a proposal arrives past the deadline, it still performs one sync + lookup and accepts an already-synced block (there is a test pinning exactly that). The shared helper short-circuits to `undefined` in that case, which the new bucket wait needs, so migrating this site would flip that case to `last_block_not_found`. Left as is.

## DoS bound

Confirmed the p2p retention bound rather than assuming it. The attestation pool caps distinct payload hashes per position at `MAX_BLOCK_PROPOSALS_PER_POSITION = 2` per `(slot, indexWithinCheckpoint)`, and gossip validation rejects `indexWithinCheckpoint >= MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT` (= `MAX_BLOCKS_PER_CHECKPOINT` = 72) at ingress, after checking that the proposal is signed by the slot's expected proposer. So the worst case is ≤ 144 concurrently waiting handlers per slot, all from the elected proposer for that slot, each polling a `RunningPromise.trigger` that coalesces concurrent requests into a single sync run (one L1 head query when nothing changed). That is small, so the cheap `indexWithinCheckpoint` validation was **not** hoisted ahead of the wait and the handler's order is unchanged. The cost of a bucket that never appears is the proposer's own slot, which it could waste anyway by not proposing.

## Tests

Six new unit cases in `proposal_handler.test.ts` (`bucket sync wait`), all asserting on the result rather than on call counts, except where "did we poke the archiver at all" *is* the behavior. `retryUntil` converts the deadline to a duration once and then runs on a real timer, so the deadline cases hold the fake clock 2s short of the slot-1 attestation deadline (40s) and assert "within one interval after", never "exactly at"; the whole block runs in ~2.6s.

Red/green on case 1 and the mismatch cases, before the handler change:

```
✕ attests once the referenced bucket shows up on a later archiver sync
    expect(result.isValid).toBe(true) → Received: false   (rejected with bucket_unknown)
✕ rejects with bucket_unknown when the bucket never syncs, no earlier than the deadline
    expect(elapsedMs).toBeGreaterThanOrEqual(2000) → Received: 3   (no wait at all)
✓ rejects immediately without syncing when the attestation deadline has already passed
✓ rejects immediately without syncing when the proposal carries no bucket reference
✕ rejects a hash mismatch that survives one forced sync, without looping
✕ attests when the forced sync replaces our stale bucket with the proposed one
Tests: 4 failed, 2 passed
```

After:

```
Tests: 51 passed, 51 total   (proposal_handler.test.ts: 45 pre-existing + 6 new)
```

Full gate, all from `yarn-project`:

- `yarn build` — clean
- `yarn format validator-client`, `yarn lint validator-client` — clean
- `yarn workspace @aztec/validator-client test` — 274 passed, 3 skipped, 277 total (10 suites)

The existing `streaming_inbox_checks.test.ts` case "rejects promptly when the referenced bucket is unknown (no waiting)" is unchanged: the pure check is still immediate, the wait lives in the handler. Stale comments in `streaming_inbox_checks.ts` and `checkStreamingBlockMetadata` that said there was no bounded wait yet are updated.

No e2e was added: the behavior is a handler-local retry over an already-tested archiver API, and covering it end to end would need a test-only archiver pause hook (`Archiver.stop()` cannot stall `RunningPromise.trigger()`) plus a committee-member selection dance for minutes of wall clock per case.

