### PR TITLE
fix(wallets): make WalletDB.deleteAccount atomic

### DIFF
--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -1,4 +1,5 @@
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
@@ -6,10 +7,11 @@ import { WalletDB } from './wallet_db.js';
 import type { AccountType } from './wallet_db.js';
 
 describe('WalletDB', () => {
+  let store: AztecAsyncKVStore;
   let db: WalletDB;
 
   beforeEach(async () => {
-    const store = await openTmpStore('wallet-db-test');
+    store = await openTmpStore('wallet-db-test');
     db = new WalletDB(store, () => {});
   });
 
@@ -146,6 +148,20 @@ describe('WalletDB', () => {
       expect(accounts[0].alias).toEqual('bob');
       expect(accounts[0].item.toString()).toEqual(addr2.toString());
     });
+
+    it('deletes every alias pointing at the account', async () => {
+      const address = await AztecAddress.random();
+      const data = makeAccountData('schnorr', 'alice');
+      await db.storeAccount(address, data);
+      await db.storeAccount(address, { ...data, alias: 'alice-again' });
+
+      await db.deleteAccount(address);
+
+      expect(await db.listAccounts()).toHaveLength(0);
+      const aliases = store.openMap<string, Buffer>('aliases');
+      expect(await aliases.getAsync('accounts:alice')).toBeUndefined();
+      expect(await aliases.getAsync('accounts:alice-again')).toBeUndefined();
+    });
   });
 
   describe('storeSender / listSenders', () => {
@@ -179,6 +195,80 @@ describe('WalletDB', () => {
       expect(senders).toHaveLength(1);
       expect(accounts[0].alias).toEqual('alice');
       expect(senders[0].alias).toEqual('exchange');
+    });
+  });
+
+  describe('atomicity', () => {
+    /** Wraps a store so map writes whose key matches `shouldCrash` fail, simulating a crash mid-operation. */
+    function crashingStore(store: AztecAsyncKVStore, shouldCrash: (key: string) => boolean): AztecAsyncKVStore {
+      const wrapMap = (map: AztecAsyncMap<string, Buffer>): AztecAsyncMap<string, Buffer> =>
+        new Proxy(map, {
+          get(target, prop) {
+            if (prop === 'set' || prop === 'delete') {
+              const write = (target[prop] as (key: string, value?: Buffer) => Promise<void>).bind(target);
+              return (key: string, value?: Buffer) =>
+                shouldCrash(key) ? Promise.reject(new Error('simulated write failure')) : write(key, value);
+            }
+            const member = Reflect.get(target, prop);
+            return typeof member === 'function' ? member.bind(target) : member;
+          },
+        });
+      return new Proxy(store, {
+        get(target, prop) {
+          if (prop === 'openMap') {
+            return (name: string) => wrapMap(target.openMap(name));
+          }
+          const member = Reflect.get(target, prop);
+          return typeof member === 'function' ? member.bind(target) : member;
+        },
+      });
+    }
+
+    it('persists no partial account data when a write fails midway through storeAccount', async () => {
+      const store = await openTmpStore('wallet-db-atomicity-test');
+      const failingDb = new WalletDB(
+        crashingStore(store, key => key.startsWith('signingKey:')),
+        () => {},
+      );
+      const address = await AztecAddress.random();
+
+      await expect(failingDb.storeAccount(address, makeAccountData('schnorr', 'alice'))).rejects.toThrow(
+        'simulated write failure',
+      );
+
+      // Inspect the same underlying store with a fresh WalletDB: no trace of the account may remain
+      const dbAfterCrash = new WalletDB(store, () => {});
+      await expect(dbAfterCrash.retrieveAccount(address)).rejects.toThrow('does not exist');
+      expect(await dbAfterCrash.listAccounts()).toEqual([]);
+      expect(await store.openMap<string, Buffer>('aliases').getAsync('accounts:alice')).toBeUndefined();
+    });
+
+    it('deletes no account data when a write fails midway through deleteAccount', async () => {
+      const store = await openTmpStore('wallet-db-atomicity-test');
+      const seedDb = new WalletDB(store, () => {});
+      const address = await AztecAddress.random();
+      const data = makeAccountData('schnorr', 'alice');
+      await seedDb.storeAccount(address, data);
+
+      // Fail the alias delete, which happens after all the account entry deletes
+      const failingDb = new WalletDB(
+        crashingStore(store, key => key.startsWith('accounts:')),
+        () => {},
+      );
+      await expect(failingDb.deleteAccount(address)).rejects.toThrow('simulated write failure');
+
+      // Inspect the same underlying store with a fresh WalletDB: the account must be fully intact
+      const dbAfterCrash = new WalletDB(store, () => {});
+      const retrieved = await dbAfterCrash.retrieveAccount(address);
+      expect(retrieved.secretKey).toEqual(data.secretKey);
+      expect(retrieved.salt).toEqual(data.salt);
+      expect(retrieved.type).toEqual('schnorr');
+      expect(retrieved.signingKey).toEqual(data.signingKey.toBuffer());
+
+      const accounts = await dbAfterCrash.listAccounts();
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].alias).toEqual('alice');
+      expect(accounts[0].item.toString()).toEqual(address.toString());
     });
   });
 

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -43,16 +43,18 @@ export class WalletDB {
     },
     log: LogFn = this.userLog,
   ) {
-    if (alias) {
-      await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
-    }
-    await this.accounts.set(accountKey('type', address), Buffer.from(type));
-    await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
-    await this.accounts.set(accountKey('salt', address), salt.toBuffer());
-    await this.accounts.set(
-      accountKey('signingKey', address),
-      'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
-    );
+    await this.store.transactionAsync(async () => {
+      if (alias) {
+        await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
+      }
+      await this.accounts.set(accountKey('type', address), Buffer.from(type));
+      await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
+      await this.accounts.set(accountKey('salt', address), salt.toBuffer());
+      await this.accounts.set(
+        accountKey('signingKey', address),
+        'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
+      );
+    });
     log(`Account stored in database${alias ? ` with alias ${alias}` : ''}`);
   }
 
@@ -119,19 +121,27 @@ export class WalletDB {
     return addresses;
   }
 
+  /**
+   * Deletes an account's stored data and every alias pointing at it atomically. Deletion is local to this store;
+   * any state the PXE holds for the account is unaffected.
+   */
   async deleteAccount(address: AztecAddress) {
-    await Promise.all([
-      this.accounts.delete(accountKey('sk', address)),
-      this.accounts.delete(accountKey('salt', address)),
-      this.accounts.delete(accountKey('type', address)),
-      this.accounts.delete(accountKey('signingKey', address)),
-    ]);
-    // Clean up alias if one exists
-    const aliasesByAddress = await this.#readAccountAliases();
-    const alias = aliasesByAddress.get(address.toString());
-    if (alias) {
-      await this.aliases.delete(`accounts:${alias}`);
-    }
+    await this.store.transactionAsync(async () => {
+      await Promise.all([
+        this.accounts.delete(accountKey('sk', address)),
+        this.accounts.delete(accountKey('salt', address)),
+        this.accounts.delete(accountKey('type', address)),
+        this.accounts.delete(accountKey('signingKey', address)),
+      ]);
+
+      const aliasKeys: string[] = [];
+      for await (const [key, item] of this.aliases.entriesAsync({ start: 'accounts:', end: 'accounts:\uffff' })) {
+        if (item.toString() === address.toString()) {
+          aliasKeys.push(key);
+        }
+      }
+      await Promise.all(aliasKeys.map(key => this.aliases.delete(key)));
+    });
   }
 
   async close() {


### PR DESCRIPTION
Reimplementation of https://github.com/AztecProtocol/aztec-packages/pull/25219, along with its predecessor #25216 (which did not exist in v5).