### PR TITLE
chore: fix malformed LOG_LEVEL bash permission rule

### DIFF
--- a/yarn-project/.claude/settings.json
+++ b/yarn-project/.claude/settings.json
@@ -17,7 +17,10 @@
     "allow": [
       "Bash(yarn:*)",
       "Bash(forge:*)",
-      "Bash(env LOG_LEVEL=* yarn *)",
+      "Bash(env LOG_LEVEL=verbose yarn *)",
+      "Bash(env LOG_LEVEL=debug yarn *)",
+      "Bash(env LOG_LEVEL=trace yarn *)",
+      "Bash(env LOG_LEVEL=info yarn *)",
       "Bash(./bootstrap.sh:*)",
       "Bash(git status:*)",
       "Bash(git diff:*)",


### PR DESCRIPTION
`Bash(env LOG_LEVEL=* yarn *)` in `yarn-project/.claude/settings.json` puts a wildcard before the rest of the command, so Claude Code prints a warning about it on every startup.

It is not only cosmetic: the wildcard also matches anything inserted at that position, so `env LOG_LEVEL=x LD_PRELOAD=/tmp/evil.so yarn build` was pre-approved without a prompt. Replaced with one exact rule per log level (`verbose`, `debug`, `trace`, `info`), which clears the warning and closes the injection point. Bare `yarn ...` is still covered by the existing `Bash(yarn:*)`; the quoted compound forms in `CLAUDE.md` prompt as before.