### PR TITLE
fix(labs): record the labs submodule in barretenberg/sol/foundry.lock and keep both locks in step with bumps

### DIFF
--- a/barretenberg/sol/foundry.lock
+++ b/barretenberg/sol/foundry.lock
@@ -11,6 +11,9 @@
   "../../l1-contracts/lib/openzeppelin-contracts": {
     "rev": "448efeea6640bbbc09373f03fbc9c88e280147ba"
   },
+  "../../labs": {
+    "rev": "1f14e9a69d10d12177032cc3fa5acddbeea2b751"
+  },
   "../../noir/noir-repo": {
     "rev": "1fce7cac1b6b116b6af98875580b5122eb9fe051"
   },

--- a/labs-patches/bootstrap.sh
+++ b/labs-patches/bootstrap.sh
@@ -234,6 +234,18 @@ function check {
   echo "labs patches apply cleanly to $base."
 }
 
+# forge records every submodule of the repository in each foundry.lock, including labs/, and
+# rewrites a rev that does not match the gitlink (dirtying a rebuild pattern under CI=1). Keep
+# the locks in step with the pin. Forge serialises the file without a trailing newline.
+function sync_foundry_locks {
+  local new=$1 f
+  for f in $(git -C "$fnd_root" ls-files -- '*foundry.lock'); do
+    grep -q '"\.\./\(\.\./\)\?labs"' "$fnd_root/$f" || continue
+    perl -0pi -e 's#("\.\./(?:\.\./)?labs": \{\s*"rev": ")[0-9a-f]{40}(")#${1}'"$new"'$2#' "$fnd_root/$f"
+    git -C "$fnd_root" add -- "$f"
+  done
+}
+
 function bump {
   local ref=${1:-}
   [ -n "$ref" ] || die "usage: bump <upstream ref>"
@@ -248,6 +260,7 @@ function bump {
   local new; new=$(git_labs rev-parse FETCH_HEAD)
   local old; old=$(base_sha)
   git -C "$fnd_root" update-index --cacheinfo "160000,$new,labs"
+  sync_foundry_locks "$new"
   echo "labs gitlink: $old -> $new"
   apply
 }

--- a/labs-patches/tests/lifecycle_test
+++ b/labs-patches/tests/lifecycle_test
@@ -93,7 +93,9 @@ git -C "$fnd" update-index --cacheinfo "160000,$v2,labs"
 git -C "$fnd" restore --staged labs
 ok "check_staged guard"
 
-# 5. same-pin bump is a no-op re-apply; forward bump moves the gitlink and re-applies
+# 5. same-pin bump is a no-op re-apply; forward bump moves the gitlink, re-applies, and keeps
+#    the foundry.lock entries forge records for the submodule in step with the pin
+printf '{\n  "../labs": {\n    "rev": "%s"\n  }\n}' "$v1" > "$fnd/foundry.lock"; g -C "$fnd" add foundry.lock; g -C "$fnd" commit -q -m "foundry.lock"
 "$lp" bump "$v1" >/dev/null || fail "bump: same pin"
 [ "$(git -C "$fnd" rev-parse :labs)" = "$v1" ] || fail "bump same pin: gitlink"
 "$lp" bump "$v2" >/dev/null || fail "bump: forward"
@@ -102,6 +104,8 @@ git -C "$fnd/labs" merge-base --is-ancestor "$v2" HEAD || fail "bump forward: se
 [ "$(git -C "$fnd/labs" rev-list --count "$v2..HEAD")" = 3 ] || { git -C "$fnd/labs" log --oneline "$v2..HEAD" >&2; git -C "$fnd/labs" log --oneline -6 >&2; fail "bump forward: three patches applied"; }
 grep -q "a=2" "$fnd/labs/config" && grep -q "y" "$fnd/labs/src" && [ -f "$fnd/labs/extra" ] || fail "bump forward: content"
 "$lp" apply | grep -q "already applied" || fail "bump forward: applied state recorded"
+grep -q "\"rev\": \"$v2\"" "$fnd/foundry.lock" || fail "bump: foundry.lock rev not moved to the new pin"
+[ "$(tail -c1 "$fnd/foundry.lock" | xxd -p)" = 7d ] || fail "bump: foundry.lock trailing newline"
 ok "same-pin and forward bump"
 g -C "$fnd" commit -q -m "bump to v2"
 


### PR DESCRIPTION
forge records every git submodule of the repository in each `foundry.lock` and rewrites a rev that does not match the gitlink; under `CI=1` that is "changes to rebuild patterns". `l1-contracts/foundry.lock` has had a `../labs` entry since #25306; `barretenberg/sol/foundry.lock` never got one, so `bb-sol-tests` fails whenever it really runs — the private release run on aztec-packages-private#714 hit it; public runs had been served from the test cache.

- Adds `"../../labs"` at the current pin (`1f14e9a6`) to `barretenberg/sol/foundry.lock` (no trailing newline, as forge writes it).
- `labs-patches/bootstrap.sh bump` now rewrites the labs rev in every tracked `foundry.lock` that records it and stages them, so a pin move cannot leave a lock behind (#25333 updated the l1-contracts one by hand). Lifecycle test covers it.