### PR TITLE
feat(fast-inbox): record the opening L1 block number and hash on each inbox bucket

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -272,12 +272,16 @@ describe('Archiver Sync', () => {
         msgCount: 3,
         totalMsgCount: 3n,
         timestamp: t1,
+        l1BlockNumber: 98n,
+        l1BlockHash: Buffer32.fromBigInt(98n),
       });
       expect(await archiver.getInboxBucket(3n)).toMatchObject({
         seq: 3n,
         msgCount: 3,
         totalMsgCount: 9n,
         timestamp: t3,
+        l1BlockNumber: 2511n,
+        l1BlockHash: Buffer32.fromBigInt(2511n),
       });
 
       // At-or-before lookups resolve the latest bucket not opened after the given timestamp.

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -14,6 +14,7 @@ import {
   makeInboxMessages,
   makeInboxMessagesWithFullBlocks,
   makeL1BlockHash,
+  makeL1BlockNumberForBucket,
   makePublishedCheckpoint,
   makeStateForBlock,
 } from '../test/mock_structs.js';
@@ -233,8 +234,9 @@ describe('MessageStore', () => {
       msgs.forEach((msg, i) => {
         msg.bucketSeq = spec[i].seq;
         msg.bucketTimestamp = spec[i].timestamp;
-        // A bucket lives entirely within one L1 block, so default each bucket to an L1 block of its own.
-        msg.l1BlockNumber = spec[i].l1BlockNumber ?? spec[i].seq;
+        // Buckets opened at the same L1 timestamp are rollover siblings within one L1 block, so derive the block
+        // from the timestamp rather than from the bucket sequence.
+        msg.l1BlockNumber = spec[i].l1BlockNumber ?? makeL1BlockNumberForBucket(spec[i].timestamp);
         msg.l1BlockHash = makeL1BlockHash(msg.l1BlockNumber);
       });
       return msgs;
@@ -274,8 +276,8 @@ describe('MessageStore', () => {
         timestamp: 100n,
         msgCount: 3,
         lastMessageIndex: msgs[2].index,
-        l1BlockNumber: 1n,
-        l1BlockHash: makeL1BlockHash(1n),
+        l1BlockNumber: msgs[0].l1BlockNumber,
+        l1BlockHash: msgs[0].l1BlockHash,
       });
       expect(await messageStore.getInboxBucket(2n)).toEqual({
         seq: 2n,
@@ -284,8 +286,8 @@ describe('MessageStore', () => {
         timestamp: 200n,
         msgCount: 2,
         lastMessageIndex: msgs[4].index,
-        l1BlockNumber: 2n,
-        l1BlockHash: makeL1BlockHash(2n),
+        l1BlockNumber: msgs[3].l1BlockNumber,
+        l1BlockHash: msgs[3].l1BlockHash,
       });
       expect(await messageStore.getInboxBucket(3n)).toEqual({
         seq: 3n,
@@ -294,8 +296,8 @@ describe('MessageStore', () => {
         timestamp: 300n,
         msgCount: 1,
         lastMessageIndex: msgs[5].index,
-        l1BlockNumber: 3n,
-        l1BlockHash: makeL1BlockHash(3n),
+        l1BlockNumber: msgs[5].l1BlockNumber,
+        l1BlockHash: msgs[5].l1BlockHash,
       });
       expect(await messageStore.getInboxBucket(4n)).toBeUndefined();
     });
@@ -345,8 +347,8 @@ describe('MessageStore', () => {
         timestamp: 100n,
         msgCount: 3,
         lastMessageIndex: replacement.index,
-        l1BlockNumber: 1n,
-        l1BlockHash: makeL1BlockHash(1n),
+        l1BlockNumber: msgs[0].l1BlockNumber,
+        l1BlockHash: msgs[0].l1BlockHash,
       });
       expect(await messageStore.getTotalL1ToL2MessageCount()).toEqual(3n);
     });
@@ -355,8 +357,8 @@ describe('MessageStore', () => {
       const msgs = makeBucketedMessages(threeBucketSpec).slice(0, 3);
       await messageStore.addL1ToL2MessageBuckets(msgs);
       expect(await messageStore.getInboxBucket(1n)).toMatchObject({
-        l1BlockNumber: 1n,
-        l1BlockHash: makeL1BlockHash(1n),
+        l1BlockNumber: msgs[0].l1BlockNumber,
+        l1BlockHash: msgs[0].l1BlockHash,
       });
 
       // The L1 block holding bucket 1 was reorged out and re-mined with the same messages under a different hash.
@@ -366,16 +368,41 @@ describe('MessageStore', () => {
 
       expect(await messageStore.getInboxBucket(1n)).toMatchObject({
         msgCount: 3,
-        l1BlockNumber: 1n,
+        l1BlockNumber: msgs[0].l1BlockNumber,
         l1BlockHash: makeL1BlockHash(99n),
       });
     });
 
-    it('rejects a bucket whose messages come from more than one L1 block', async () => {
-      const msgs = makeBucketedMessages(threeBucketSpec);
-      msgs[2].l1BlockNumber += 1n;
+    it('records the L1 block a bucket is re-delivered in without a rollback', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec).slice(0, 3);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
 
-      await expect(messageStore.addL1ToL2MessageBuckets(msgs)).rejects.toThrow(/Inbox bucket 1 spans L1 blocks 1 to 2/);
+      // The same messages are seen again under a different L1 block hash, and are reinserted in place.
+      const replayed = msgs.map(msg => ({ ...msg, l1BlockHash: makeL1BlockHash(99n) }));
+      await messageStore.addL1ToL2MessageBuckets(replayed);
+
+      expect(await messageStore.getInboxBucket(1n)).toMatchObject({
+        msgCount: 3,
+        totalMsgCount: 3n,
+        l1BlockNumber: msgs[0].l1BlockNumber,
+        l1BlockHash: makeL1BlockHash(99n),
+      });
+      expect(await messageStore.getTotalL1ToL2MessageCount()).toEqual(3n);
+    });
+
+    it('records the opening L1 block of a bucket spanning co-timestamped L1 blocks', async () => {
+      // Chains that allow consecutive blocks to share a timestamp (anvil with manual mining) can spread one
+      // bucket over several L1 blocks; the snapshot keeps the block the bucket was opened in.
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      msgs[2].l1BlockNumber = msgs[0].l1BlockNumber + 1n;
+      msgs[2].l1BlockHash = makeL1BlockHash(msgs[2].l1BlockNumber);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      expect(await messageStore.getInboxBucket(1n)).toMatchObject({
+        msgCount: 3,
+        l1BlockNumber: msgs[0].l1BlockNumber,
+        l1BlockHash: msgs[0].l1BlockHash,
+      });
     });
 
     it('rejects a message opening a bucket older than the newest stored one', async () => {
@@ -491,8 +518,8 @@ describe('MessageStore', () => {
         timestamp: 200n,
         msgCount: 1,
         lastMessageIndex: msgs[3].index,
-        l1BlockNumber: 2n,
-        l1BlockHash: makeL1BlockHash(2n),
+        l1BlockNumber: msgs[3].l1BlockNumber,
+        l1BlockHash: msgs[3].l1BlockHash,
       });
       expect(await messageStore.getInboxBucket(1n)).toMatchObject({ msgCount: 3, totalMsgCount: 3n });
 

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -13,6 +13,7 @@ import {
   makeInboxMessage,
   makeInboxMessages,
   makeInboxMessagesWithFullBlocks,
+  makeL1BlockHash,
   makePublishedCheckpoint,
   makeStateForBlock,
 } from '../test/mock_structs.js';
@@ -232,7 +233,9 @@ describe('MessageStore', () => {
       msgs.forEach((msg, i) => {
         msg.bucketSeq = spec[i].seq;
         msg.bucketTimestamp = spec[i].timestamp;
-        msg.l1BlockNumber = spec[i].l1BlockNumber ?? msg.l1BlockNumber;
+        // A bucket lives entirely within one L1 block, so default each bucket to an L1 block of its own.
+        msg.l1BlockNumber = spec[i].l1BlockNumber ?? spec[i].seq;
+        msg.l1BlockHash = makeL1BlockHash(msg.l1BlockNumber);
       });
       return msgs;
     };
@@ -271,6 +274,8 @@ describe('MessageStore', () => {
         timestamp: 100n,
         msgCount: 3,
         lastMessageIndex: msgs[2].index,
+        l1BlockNumber: 1n,
+        l1BlockHash: makeL1BlockHash(1n),
       });
       expect(await messageStore.getInboxBucket(2n)).toEqual({
         seq: 2n,
@@ -279,6 +284,8 @@ describe('MessageStore', () => {
         timestamp: 200n,
         msgCount: 2,
         lastMessageIndex: msgs[4].index,
+        l1BlockNumber: 2n,
+        l1BlockHash: makeL1BlockHash(2n),
       });
       expect(await messageStore.getInboxBucket(3n)).toEqual({
         seq: 3n,
@@ -287,6 +294,8 @@ describe('MessageStore', () => {
         timestamp: 300n,
         msgCount: 1,
         lastMessageIndex: msgs[5].index,
+        l1BlockNumber: 3n,
+        l1BlockHash: makeL1BlockHash(3n),
       });
       expect(await messageStore.getInboxBucket(4n)).toBeUndefined();
     });
@@ -336,8 +345,37 @@ describe('MessageStore', () => {
         timestamp: 100n,
         msgCount: 3,
         lastMessageIndex: replacement.index,
+        l1BlockNumber: 1n,
+        l1BlockHash: makeL1BlockHash(1n),
       });
       expect(await messageStore.getTotalL1ToL2MessageCount()).toEqual(3n);
+    });
+
+    it('records the L1 block a bucket is re-delivered in after a rollback', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec).slice(0, 3);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      expect(await messageStore.getInboxBucket(1n)).toMatchObject({
+        l1BlockNumber: 1n,
+        l1BlockHash: makeL1BlockHash(1n),
+      });
+
+      // The L1 block holding bucket 1 was reorged out and re-mined with the same messages under a different hash.
+      await messageStore.rollbackL1ToL2MessagesAfterL1Block(0n);
+      const replayed = msgs.map(msg => ({ ...msg, l1BlockHash: makeL1BlockHash(99n) }));
+      await messageStore.addL1ToL2MessageBuckets(replayed);
+
+      expect(await messageStore.getInboxBucket(1n)).toMatchObject({
+        msgCount: 3,
+        l1BlockNumber: 1n,
+        l1BlockHash: makeL1BlockHash(99n),
+      });
+    });
+
+    it('rejects a bucket whose messages come from more than one L1 block', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      msgs[2].l1BlockNumber += 1n;
+
+      await expect(messageStore.addL1ToL2MessageBuckets(msgs)).rejects.toThrow(/Inbox bucket 1 spans L1 blocks 1 to 2/);
     });
 
     it('rejects a message opening a bucket older than the newest stored one', async () => {
@@ -453,6 +491,8 @@ describe('MessageStore', () => {
         timestamp: 200n,
         msgCount: 1,
         lastMessageIndex: msgs[3].index,
+        l1BlockNumber: 2n,
+        l1BlockHash: makeL1BlockHash(2n),
       });
       expect(await messageStore.getInboxBucket(1n)).toMatchObject({ msgCount: 3, totalMsgCount: 3n });
 

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -21,6 +21,9 @@ import { type InboxMessage, deserializeInboxMessage, serializeInboxMessage } fro
  * Persisted snapshot of an Inbox rolling-hash bucket. Mirrors the fields the on-chain Inbox tracks per bucket, plus
  * the number and hash of the L1 block the bucket was opened in and the index span of its messages, so rollbacks,
  * range queries and canonicality checks can work off bucket records alone without scanning messages.
+ *
+ * The Inbox keys buckets by `block.timestamp`, so on a chain that allows consecutive blocks to share a timestamp
+ * (anvil with manual mining, for instance) a bucket may span several L1 blocks. Only the opening one is recorded.
  */
 type BucketSnapshot = {
   inboxRollingHash: Fr;
@@ -94,7 +97,8 @@ function groupMessagesByBucket(messages: InboxMessage[]): IncomingBucket[] {
 // The genesis sentinel bucket: sequence 0 with a zero rolling hash and no messages, mirroring the
 // on-chain Inbox's base case. The archiver never ingests a snapshot for it (no message is absorbed into sequence 0), so
 // it is synthesized on read. Consumers use its sequence number and zero total; its deploy-time timestamp is not tracked
-// here and is unused.
+// here and is unused. Its timestamp, L1 block number and L1 block hash are sentinels, not values read from L1:
+// consumers must short-circuit on sequence 0 rather than looking any of them up on chain.
 const GENESIS_INBOX_BUCKET: InboxBucket = {
   seq: 0n,
   inboxRollingHash: Fr.ZERO,
@@ -276,8 +280,7 @@ export class MessageStore {
   /**
    * Rejects a batch that delivers an Inbox bucket the store already holds without replaying it from its first message,
    * or that opens a bucket older than the newest one stored. Either would produce a snapshot that disagrees with the
-   * messages it covers, since each snapshot is derived from the batch's messages for that bucket alone. Also rejects a
-   * bucket whose messages span more than one L1 block, since the snapshot records a single opening L1 block for it.
+   * messages it covers, since each snapshot is derived from the batch's messages for that bucket alone.
    */
   private async assertIncomingBucketsAreComplete(incomingBuckets: IncomingBucket[]): Promise<void> {
     const newestStoredSeq = await this.getNewestBucketSeq();
@@ -306,37 +309,38 @@ export class MessageStore {
           bucket.messages[0],
         );
       }
-
-      const lastInBucket = bucket.messages.at(-1)!;
-      if (lastInBucket.l1BlockNumber !== bucket.messages[0].l1BlockNumber) {
-        throw new MessageStoreError(
-          `Inbox bucket ${bucket.seq} spans L1 blocks ${bucket.messages[0].l1BlockNumber} to ` +
-            `${lastInBucket.l1BlockNumber}`,
-          lastInBucket,
-        );
-      }
     }
   }
 
   /**
    * Writes one snapshot per bucket in the batch, each derived from the bucket's complete message set. Cumulative
    * totals thread forward from the bucket preceding the batch, so a bucket re-delivered with extra messages shifts
-   * the totals of the buckets after it within the same batch. Every message of a bucket comes from the same L1 block
-   * (checked when the batch is validated), so the opening L1 block is read off the bucket's last message.
+   * the totals of the buckets after it within the same batch. A bucket always arrives complete from its first message
+   * (checked when the batch is validated), so the opening L1 block is read off that first message; a bucket whose
+   * later messages come from a co-timestamped L1 block still records the block it was opened in.
    */
   private async writeIncomingBucketSnapshots(incomingBuckets: IncomingBucket[]): Promise<void> {
     let cumulativeTotal = await this.getTotalMsgCountBeforeBucket(incomingBuckets[0].seq);
     for (const { seq, messages } of incomingBuckets) {
+      const openingMessage = messages[0];
       const lastInBucket = messages.at(-1)!;
+      if (lastInBucket.l1BlockNumber !== openingMessage.l1BlockNumber) {
+        this.#log.warn(`Inbox bucket ${seq} spans more than one L1 block`, {
+          bucketSeq: seq,
+          bucketTimestamp: lastInBucket.bucketTimestamp,
+          firstL1BlockNumber: openingMessage.l1BlockNumber,
+          lastL1BlockNumber: lastInBucket.l1BlockNumber,
+        });
+      }
       cumulativeTotal += BigInt(messages.length);
       await this.writeBucketSnapshot(seq, {
         inboxRollingHash: lastInBucket.inboxRollingHash,
         totalMsgCount: cumulativeTotal,
         timestamp: lastInBucket.bucketTimestamp,
-        l1BlockNumber: lastInBucket.l1BlockNumber,
-        l1BlockHash: lastInBucket.l1BlockHash,
+        l1BlockNumber: openingMessage.l1BlockNumber,
+        l1BlockHash: openingMessage.l1BlockHash,
         msgCount: messages.length,
-        firstMessageIndex: messages[0].index,
+        firstMessageIndex: openingMessage.index,
         lastMessageIndex: lastInBucket.index,
       });
     }
@@ -611,8 +615,10 @@ export class MessageStore {
    * Removes every L1 to L2 message inserted after the given L1 block, so the message store matches the L1 Inbox state
    * as of that block. Used when rolling the archiver back to an earlier checkpoint, whose L1 block is passed here.
    *
-   * A bucket lives entirely within one L1 block, so the cut always falls on a bucket boundary and can be found from
-   * the bucket snapshots alone, without reading the messages being removed.
+   * The cut is found from the bucket snapshots alone, without reading the messages being removed: a bucket is kept
+   * whole when the block it was opened in survives. On a chain with strictly increasing block timestamps a bucket
+   * lives entirely within one L1 block, so that is exact; where consecutive blocks may share a timestamp, a bucket
+   * opened at or before the cut keeps the messages it absorbed in the co-timestamped blocks after it.
    */
   public async rollbackL1ToL2MessagesAfterL1Block(l1BlockNumber: bigint): Promise<void> {
     this.#log.debug(`Deleting L1 to L2 messages inserted after L1 block ${l1BlockNumber}`);

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -19,14 +19,15 @@ import { type InboxMessage, deserializeInboxMessage, serializeInboxMessage } fro
 
 /**
  * Persisted snapshot of an Inbox rolling-hash bucket. Mirrors the fields the on-chain Inbox tracks per bucket, plus
- * the L1 block the bucket was opened in and the index span of its messages, so rollbacks and range queries can work
- * off bucket records alone without scanning messages.
+ * the number and hash of the L1 block the bucket was opened in and the index span of its messages, so rollbacks,
+ * range queries and canonicality checks can work off bucket records alone without scanning messages.
  */
 type BucketSnapshot = {
   inboxRollingHash: Fr;
   totalMsgCount: bigint;
   timestamp: bigint;
   l1BlockNumber: bigint;
+  l1BlockHash: Buffer32;
   msgCount: number;
   firstMessageIndex: bigint;
   lastMessageIndex: bigint;
@@ -38,6 +39,7 @@ function serializeBucketSnapshot(snapshot: BucketSnapshot): Buffer {
     bigintToUInt64BE(snapshot.totalMsgCount),
     bigintToUInt64BE(snapshot.timestamp),
     bigintToUInt64BE(snapshot.l1BlockNumber),
+    snapshot.l1BlockHash,
     numToUInt32BE(snapshot.msgCount),
     bigintToUInt64BE(snapshot.firstMessageIndex),
     bigintToUInt64BE(snapshot.lastMessageIndex),
@@ -50,10 +52,20 @@ function deserializeBucketSnapshot(buffer: Buffer): BucketSnapshot {
   const totalMsgCount = reader.readUInt64();
   const timestamp = reader.readUInt64();
   const l1BlockNumber = reader.readUInt64();
+  const l1BlockHash = Buffer32.fromBuffer(reader.readBytes(Buffer32.SIZE));
   const msgCount = reader.readNumber();
   const firstMessageIndex = reader.readUInt64();
   const lastMessageIndex = reader.readUInt64();
-  return { inboxRollingHash, totalMsgCount, timestamp, l1BlockNumber, msgCount, firstMessageIndex, lastMessageIndex };
+  return {
+    inboxRollingHash,
+    totalMsgCount,
+    timestamp,
+    l1BlockNumber,
+    l1BlockHash,
+    msgCount,
+    firstMessageIndex,
+    lastMessageIndex,
+  };
 }
 
 /** The messages of a single Inbox bucket within an incoming batch, in insertion order. */
@@ -90,6 +102,8 @@ const GENESIS_INBOX_BUCKET: InboxBucket = {
   timestamp: 0n,
   msgCount: 0,
   lastMessageIndex: 0n,
+  l1BlockNumber: 0n,
+  l1BlockHash: Buffer32.ZERO,
 };
 
 export class MessageStoreError extends Error {
@@ -262,7 +276,8 @@ export class MessageStore {
   /**
    * Rejects a batch that delivers an Inbox bucket the store already holds without replaying it from its first message,
    * or that opens a bucket older than the newest one stored. Either would produce a snapshot that disagrees with the
-   * messages it covers, since each snapshot is derived from the batch's messages for that bucket alone.
+   * messages it covers, since each snapshot is derived from the batch's messages for that bucket alone. Also rejects a
+   * bucket whose messages span more than one L1 block, since the snapshot records a single opening L1 block for it.
    */
   private async assertIncomingBucketsAreComplete(incomingBuckets: IncomingBucket[]): Promise<void> {
     const newestStoredSeq = await this.getNewestBucketSeq();
@@ -291,13 +306,23 @@ export class MessageStore {
           bucket.messages[0],
         );
       }
+
+      const lastInBucket = bucket.messages.at(-1)!;
+      if (lastInBucket.l1BlockNumber !== bucket.messages[0].l1BlockNumber) {
+        throw new MessageStoreError(
+          `Inbox bucket ${bucket.seq} spans L1 blocks ${bucket.messages[0].l1BlockNumber} to ` +
+            `${lastInBucket.l1BlockNumber}`,
+          lastInBucket,
+        );
+      }
     }
   }
 
   /**
    * Writes one snapshot per bucket in the batch, each derived from the bucket's complete message set. Cumulative
    * totals thread forward from the bucket preceding the batch, so a bucket re-delivered with extra messages shifts
-   * the totals of the buckets after it within the same batch.
+   * the totals of the buckets after it within the same batch. Every message of a bucket comes from the same L1 block
+   * (checked when the batch is validated), so the opening L1 block is read off the bucket's last message.
    */
   private async writeIncomingBucketSnapshots(incomingBuckets: IncomingBucket[]): Promise<void> {
     let cumulativeTotal = await this.getTotalMsgCountBeforeBucket(incomingBuckets[0].seq);
@@ -309,6 +334,7 @@ export class MessageStore {
         totalMsgCount: cumulativeTotal,
         timestamp: lastInBucket.bucketTimestamp,
         l1BlockNumber: lastInBucket.l1BlockNumber,
+        l1BlockHash: lastInBucket.l1BlockHash,
         msgCount: messages.length,
         firstMessageIndex: messages[0].index,
         lastMessageIndex: lastInBucket.index,
@@ -568,6 +594,8 @@ export class MessageStore {
       timestamp: snapshot.timestamp,
       msgCount: snapshot.msgCount,
       lastMessageIndex: snapshot.lastMessageIndex,
+      l1BlockNumber: snapshot.l1BlockNumber,
+      l1BlockHash: snapshot.l1BlockHash,
     };
   }
 

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -1,3 +1,4 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
@@ -79,6 +80,8 @@ export class MockPrefilledArchiver extends MockArchiver {
         timestamp: 0n,
         msgCount: 0,
         lastMessageIndex: 0n,
+        l1BlockNumber: 0n,
+        l1BlockHash: Buffer32.ZERO,
       },
       [],
     );
@@ -99,6 +102,8 @@ export class MockPrefilledArchiver extends MockArchiver {
           timestamp: bucketSeq,
           msgCount: messages.length,
           lastMessageIndex: totalMsgCount - 1n,
+          l1BlockNumber: bucketSeq,
+          l1BlockHash: Buffer32.fromBigInt(bucketSeq),
         },
         messages,
       );

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -6,6 +6,7 @@ import type { InboxBucket, L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 
 import { MockL1ToL2MessageSource } from './mock_l1_to_l2_message_source.js';
 import { MockL2BlockSource } from './mock_l2_block_source.js';
+import { makeL1BlockHash, makeL1BlockNumberForBucket } from './mock_structs.js';
 
 /**
  * A mocked implementation of the archiver that implements L2BlockSource and L1ToL2MessageSource.
@@ -94,6 +95,7 @@ export class MockPrefilledArchiver extends MockArchiver {
       }
       bucketSeq += 1n;
       totalMsgCount += BigInt(messages.length);
+      const l1BlockNumber = makeL1BlockNumberForBucket(bucketSeq);
       this.setInboxBucket(
         {
           seq: bucketSeq,
@@ -102,8 +104,8 @@ export class MockPrefilledArchiver extends MockArchiver {
           timestamp: bucketSeq,
           msgCount: messages.length,
           lastMessageIndex: totalMsgCount - 1n,
-          l1BlockNumber: bucketSeq,
-          l1BlockHash: Buffer32.fromBigInt(bucketSeq),
+          l1BlockNumber,
+          l1BlockHash: makeL1BlockHash(l1BlockNumber),
         },
         messages,
       );

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -19,9 +19,24 @@ import { PartialStateReference, StateReference, TxEffect } from '@aztec/stdlib/t
 
 import type { InboxMessage } from '../structs/inbox_message.js';
 
-/** Deterministic, distinct L1 block hash for a block number, so tests can predict the hash a bucket records. */
+/**
+ * Deterministic, distinct L1 block hash for a block number, so tests can predict the hash a bucket records. The
+ * leading marker keeps it clearly distinguishable from a bare number-derived hash.
+ */
 export function makeL1BlockHash(l1BlockNumber: bigint): Buffer32 {
-  return Buffer32.fromBigInt(l1BlockNumber);
+  const buffer = Buffer.alloc(Buffer32.SIZE);
+  buffer.writeUInt16BE(0xb10c, 0);
+  buffer.writeBigUInt64BE(l1BlockNumber, Buffer32.SIZE - 8);
+  return Buffer32.fromBuffer(buffer);
+}
+
+/**
+ * Deterministic L1 block number for a bucket opened at the given L1 block timestamp. Buckets sharing a timestamp (a
+ * full bucket rolling over within one L1 block) land in the same L1 block, and the mapping is deliberately unrelated
+ * to the bucket sequence so that code confusing the two fails its tests.
+ */
+export function makeL1BlockNumberForBucket(bucketTimestamp: bigint): bigint {
+  return 1000n + 2n * bucketTimestamp;
 }
 
 export function makeInboxMessage(
@@ -35,8 +50,8 @@ export function makeInboxMessage(
   // Default each message to its own bucket, keyed monotonically off its global index.
   const { bucketSeq = index + 1n } = overrides;
   const { bucketTimestamp = index + 1n } = overrides;
-  // A bucket is opened and closed within a single L1 block, so default each bucket to an L1 block of its own.
-  const { l1BlockNumber = bucketSeq } = overrides;
+  // A bucket is opened by the first message of its L1 block timestamp, so derive the block from that timestamp.
+  const { l1BlockNumber = makeL1BlockNumberForBucket(bucketTimestamp) } = overrides;
   const { l1BlockHash = makeL1BlockHash(l1BlockNumber) } = overrides;
 
   return {
@@ -90,12 +105,13 @@ export function makeInboxMessagesWithFullBlocks(blockCount: number): InboxMessag
   return makeInboxMessages(MAX_L1_TO_L2_MSGS_PER_BLOCK * blockCount, {
     overrideFn: (msg, i) => {
       const bucketSeq = BigInt(Math.floor(i / MAX_L1_TO_L2_MSGS_PER_BLOCK)) + 1n;
+      const l1BlockNumber = makeL1BlockNumberForBucket(bucketSeq);
       return {
         ...msg,
         bucketSeq,
         bucketTimestamp: bucketSeq,
-        l1BlockNumber: bucketSeq,
-        l1BlockHash: makeL1BlockHash(bucketSeq),
+        l1BlockNumber,
+        l1BlockHash: makeL1BlockHash(l1BlockNumber),
       };
     },
   });

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -3,7 +3,6 @@ import { makeTuple } from '@aztec/foundation/array';
 import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { times, timesParallel } from '@aztec/foundation/collection';
-import { randomBigInt } from '@aztec/foundation/crypto/random';
 import type { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -20,12 +19,15 @@ import { PartialStateReference, StateReference, TxEffect } from '@aztec/stdlib/t
 
 import type { InboxMessage } from '../structs/inbox_message.js';
 
+/** Deterministic, distinct L1 block hash for a block number, so tests can predict the hash a bucket records. */
+export function makeL1BlockHash(l1BlockNumber: bigint): Buffer32 {
+  return Buffer32.fromBigInt(l1BlockNumber);
+}
+
 export function makeInboxMessage(
   previousInboxRollingHash = Fr.ZERO,
   overrides: Partial<InboxMessage> = {},
 ): InboxMessage {
-  const { l1BlockNumber = randomBigInt(100n) + 1n } = overrides;
-  const { l1BlockHash = Buffer32.random() } = overrides;
   const { leaf = Fr.random() } = overrides;
   // Compact global insertion index: defaults to the first slot.
   const { index = 0n } = overrides;
@@ -33,6 +35,9 @@ export function makeInboxMessage(
   // Default each message to its own bucket, keyed monotonically off its global index.
   const { bucketSeq = index + 1n } = overrides;
   const { bucketTimestamp = index + 1n } = overrides;
+  // A bucket is opened and closed within a single L1 block, so default each bucket to an L1 block of its own.
+  const { l1BlockNumber = bucketSeq } = overrides;
+  const { l1BlockHash = makeL1BlockHash(l1BlockNumber) } = overrides;
 
   return {
     index,
@@ -85,7 +90,13 @@ export function makeInboxMessagesWithFullBlocks(blockCount: number): InboxMessag
   return makeInboxMessages(MAX_L1_TO_L2_MSGS_PER_BLOCK * blockCount, {
     overrideFn: (msg, i) => {
       const bucketSeq = BigInt(Math.floor(i / MAX_L1_TO_L2_MSGS_PER_BLOCK)) + 1n;
-      return { ...msg, bucketSeq, bucketTimestamp: bucketSeq };
+      return {
+        ...msg,
+        bucketSeq,
+        bucketTimestamp: bucketSeq,
+        l1BlockNumber: bucketSeq,
+        l1BlockHash: makeL1BlockHash(bucketSeq),
+      };
     },
   });
 }

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
@@ -7,6 +7,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { unfreeze } from '@aztec/foundation/types';
@@ -126,6 +127,8 @@ describe('NodePublicCallsSimulator', () => {
       timestamp: 0n,
       msgCount: Number(totalMsgCount),
       lastMessageIndex: totalMsgCount === 0n ? 0n : totalMsgCount - 1n,
+      l1BlockNumber: seq,
+      l1BlockHash: Buffer32.fromBigInt(seq),
     });
     const bundle = [new Fr(0x1234), new Fr(0x5678)];
     l1ToL2MessageSource.getInboxBucketByTotalMsgCount.mockResolvedValue(makeBucket(0n, 0n));

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -294,6 +294,8 @@ describe('L1Publisher integration', () => {
         timestamp: 0n,
         msgCount: 0,
         lastMessageIndex: 0n,
+        l1BlockNumber: 0n,
+        l1BlockHash: Buffer32.ZERO,
       },
       [],
     );
@@ -603,6 +605,9 @@ describe('L1Publisher integration', () => {
         // Mirror the Inbox's new buckets (seq, timestamp, rolling hash, totals) and their leaves into messageSource,
         // so the selector, the world-state synchronizer, and L1 all read the same bucket state.
         const currentBucketSeq = await inbox.read.getCurrentBucketSeq();
+        // Every message above was sent within the last few L1 blocks, so the chain head stands in for the L1 block
+        // each new bucket was opened in; nothing under test reads it back.
+        const latestL1Block = await l1Client.getBlock();
         for (let seq = mirroredThroughSeq + 1n; seq <= currentBucketSeq; seq++) {
           const bucket = await inbox.read.getBucket([seq]);
           const bucketMessages = allSentMessages.slice(Number(mirroredThroughTotal), Number(bucket.totalMsgCount));
@@ -614,6 +619,8 @@ describe('L1Publisher integration', () => {
               timestamp: bucket.timestamp,
               msgCount: Number(bucket.msgCount),
               lastMessageIndex: bucket.totalMsgCount - 1n,
+              l1BlockNumber: latestL1Block.number,
+              l1BlockHash: Buffer32.fromString(latestL1Block.hash),
             },
             bucketMessages,
           );

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -24,7 +24,13 @@ import { EpochCache } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { type L1ContractsConfig, getL1ContractsConfigEnvVars } from '@aztec/ethereum/config';
-import { GovernanceProposerContract, RollupContract, SimulationOverridesBuilder } from '@aztec/ethereum/contracts';
+import {
+  GovernanceProposerContract,
+  InboxContract,
+  type MessageSentLog,
+  RollupContract,
+  SimulationOverridesBuilder,
+} from '@aztec/ethereum/contracts';
 import { type DeployAztecL1ContractsArgs, deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { TxUtilsState, createL1TxUtils } from '@aztec/ethereum/l1-tx-utils';
@@ -49,7 +55,7 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { hexToBuffer } from '@aztec/foundation/string';
 import { TestDateProvider } from '@aztec/foundation/timer';
-import { InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
+import { RollupAbi } from '@aztec/l1-artifacts';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractsList, protocolContractsHash } from '@aztec/protocol-contracts';
 import { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
@@ -88,7 +94,7 @@ import { NativeWorldStateService, ServerWorldStateSynchronizer, type WorldStateC
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
-import { type Address, encodeFunctionData, getAbiItem, getAddress, getContract, multicall3Abi } from 'viem';
+import { type Address, encodeFunctionData, getAbiItem, getAddress, multicall3Abi } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
@@ -574,11 +580,7 @@ describe('L1Publisher integration', () => {
       // then reuses the production `selectInboxBucketForBlock` (which mirrors `ProposeLib.validateInboxConsumption`) to
       // pick exactly the buckets it must consume, deriving the consumed bundle, the propose bucket hint, and the header
       // rolling hash from that one selection so header, world state, and L1 agree by construction.
-      const inbox = getContract({
-        address: getAddress(l1ContractAddresses.inboxAddress.toString()),
-        abi: InboxAbi,
-        client: l1Client,
-      });
+      const inbox = new InboxContract(l1Client, l1ContractAddresses.inboxAddress);
       // Every message sent to the Inbox, in insertion order, so each bucket's leaves can be mirrored into messageSource.
       const allSentMessages: Fr[] = [];
       let mirroredThroughSeq = 0n;
@@ -596,6 +598,9 @@ describe('L1Publisher integration', () => {
         // and causes a chain prune
         const l1ToL2Content = range(Math.min(16, MAX_L1_TO_L2_MSGS_PER_CHECKPOINT), 128 * i + 1 + 0x400).map(fr);
 
+        // Uncached: viem caches getBlockNumber for its polling interval, and a stale head here would leave the
+        // MessageSent query below short of the blocks the sends land in.
+        const l1BlockBeforeSending = await l1Client.getBlockNumber({ cacheTime: 0 });
         const sentThisCheckpoint: Fr[] = [];
         for (let j = 0; j < l1ToL2Content.length; j++) {
           sentThisCheckpoint.push(await sendToL2(l1ToL2Content[j], recipientAddress));
@@ -604,23 +609,33 @@ describe('L1Publisher integration', () => {
 
         // Mirror the Inbox's new buckets (seq, timestamp, rolling hash, totals) and their leaves into messageSource,
         // so the selector, the world-state synchronizer, and L1 all read the same bucket state.
-        const currentBucketSeq = await inbox.read.getCurrentBucketSeq();
-        // Every message above was sent within the last few L1 blocks, so the chain head stands in for the L1 block
-        // each new bucket was opened in; nothing under test reads it back.
-        const latestL1Block = await l1Client.getBlock();
+        const currentBucketSeq = await inbox.getCurrentBucketSeq();
+        // The MessageSent log of a bucket's first message names the L1 block the bucket was opened in, which is
+        // what the archiver records for it.
+        const openingLogs = new Map<bigint, MessageSentLog>();
+        const l1BlockAfterSending = await l1Client.getBlockNumber({ cacheTime: 0 });
+        for (const log of await inbox.getMessageSentEvents(l1BlockBeforeSending, l1BlockAfterSending)) {
+          if (!openingLogs.has(log.args.bucketSeq)) {
+            openingLogs.set(log.args.bucketSeq, log);
+          }
+        }
         for (let seq = mirroredThroughSeq + 1n; seq <= currentBucketSeq; seq++) {
-          const bucket = await inbox.read.getBucket([seq]);
+          const bucket = await inbox.getBucket(seq);
+          const openingLog = openingLogs.get(seq);
+          if (openingLog === undefined) {
+            throw new Error(`No MessageSent log found for inbox bucket ${seq}`);
+          }
           const bucketMessages = allSentMessages.slice(Number(mirroredThroughTotal), Number(bucket.totalMsgCount));
           messageSource.setInboxBucket(
             {
               seq,
-              inboxRollingHash: Fr.fromString(bucket.rollingHash),
+              inboxRollingHash: bucket.rollingHash,
               totalMsgCount: bucket.totalMsgCount,
               timestamp: bucket.timestamp,
               msgCount: Number(bucket.msgCount),
               lastMessageIndex: bucket.totalMsgCount - 1n,
-              l1BlockNumber: latestL1Block.number,
-              l1BlockHash: Buffer32.fromString(latestL1Block.hash),
+              l1BlockNumber: openingLog.l1BlockNumber,
+              l1BlockHash: openingLog.l1BlockHash,
             },
             bucketMessages,
           );

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -6,6 +6,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { timesAsync } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -258,6 +259,8 @@ describe('CheckpointProposalJob', () => {
       timestamp: 0n,
       msgCount: 0,
       lastMessageIndex: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
     });
 
     l2BlockSource = mock<L2BlockSource>();
@@ -1199,6 +1202,8 @@ describe('CheckpointProposalJob', () => {
         timestamp: 0n,
         msgCount: 2,
         lastMessageIndex,
+        l1BlockNumber: seq,
+        l1BlockHash: Buffer32.fromBigInt(seq),
       });
       l1ToL2MessageSource.getLatestInboxBucketAtOrBefore
         .mockResolvedValueOnce(makeBucket(2n, 2n, 1n))
@@ -1486,6 +1491,8 @@ describe('CheckpointProposalJob', () => {
         timestamp: 0n,
         msgCount: 2,
         lastMessageIndex: 4n,
+        l1BlockNumber: 2n,
+        l1BlockHash: Buffer32.fromBigInt(2n),
       };
       const bundle = Array.from({ length: 5 }, (_, i) => new Fr(i + 1));
       l1ToL2MessageSource.getLatestInboxBucketAtOrBefore.mockResolvedValue(bucket);
@@ -1526,6 +1533,8 @@ describe('CheckpointProposalJob', () => {
         timestamp: 0n,
         msgCount: 2,
         lastMessageIndex: 4n,
+        l1BlockNumber: 2n,
+        l1BlockHash: Buffer32.fromBigInt(2n),
       };
       const bundle = Array.from({ length: 5 }, (_, i) => new Fr(i + 1));
       l1ToL2MessageSource.getLatestInboxBucketAtOrBefore.mockResolvedValue(bucket);
@@ -1564,6 +1573,8 @@ describe('CheckpointProposalJob', () => {
         timestamp: 0n,
         msgCount: 2,
         lastMessageIndex: 4n,
+        l1BlockNumber: 2n,
+        l1BlockHash: Buffer32.fromBigInt(2n),
       };
       const bundle = Array.from({ length: 5 }, (_, i) => new Fr(i + 1));
       l1ToL2MessageSource.getLatestInboxBucketAtOrBefore.mockResolvedValue(bucket);
@@ -1607,6 +1618,8 @@ describe('CheckpointProposalJob', () => {
         timestamp: 0n,
         msgCount: Number(totalMsgCount - (i === 0 ? 0n : totals[i - 1])),
         lastMessageIndex: totalMsgCount - 1n,
+        l1BlockNumber: BigInt(i + 1),
+        l1BlockHash: Buffer32.fromBigInt(BigInt(i + 1)),
       }));
       l1ToL2MessageSource.getLatestInboxBucketAtOrBefore.mockResolvedValue(buckets[3]);
       l1ToL2MessageSource.getInboxBucket.mockImplementation(seq => Promise.resolve(buckets[Number(seq) - 1]));

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -1,5 +1,6 @@
 import { EpochCache, PROPOSER_PIPELINING_SLOT_OFFSET } from '@aztec/epoch-cache';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -462,6 +463,8 @@ describe('CheckpointProposalJob Timing Tests', () => {
       timestamp: 0n,
       msgCount: 0,
       lastMessageIndex: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
     });
 
     l2BlockSource = mock<L2BlockSource>();

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
@@ -1,3 +1,4 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type InboxBucket, MIN_BLOCKS_FOR_INBOX_CATCHUP, isInboxConsumptionSufficient } from '@aztec/stdlib/messaging';
 
@@ -30,6 +31,8 @@ function makeSource(specs: TestBucketSpec[]): {
       timestamp: spec.timestamp,
       msgCount: spec.msgCount,
       lastMessageIndex: total - 1n,
+      l1BlockNumber: spec.seq,
+      l1BlockHash: Buffer32.fromBigInt(spec.seq),
     });
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -7,6 +7,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { omit, times, timesParallel } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -372,6 +373,8 @@ describe('sequencer', () => {
       timestamp: 0n,
       msgCount: 0,
       lastMessageIndex: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
     });
 
     validatorClient = mock<ValidatorClient>();

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -1,4 +1,5 @@
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -218,7 +219,12 @@ describe('ArchiverApiSchema', () => {
 
   it('getInboxBucket', async () => {
     const result = await context.client.getInboxBucket(2n);
-    expect(result).toMatchObject({ seq: 2n, msgCount: 3 });
+    expect(result).toMatchObject({
+      seq: 2n,
+      msgCount: 3,
+      l1BlockNumber: 20n,
+      l1BlockHash: Buffer32.fromBigInt(20n),
+    });
   });
 
   it('getInboxBucketByTotalMsgCount', async () => {
@@ -604,6 +610,8 @@ class MockArchiver implements ArchiverApi {
       timestamp: 100n,
       msgCount: 3,
       lastMessageIndex: 2n,
+      l1BlockNumber: 20n,
+      l1BlockHash: Buffer32.fromBigInt(20n),
     });
   }
   getInboxBucket(seq: bigint): Promise<InboxBucket | undefined> {
@@ -615,6 +623,8 @@ class MockArchiver implements ArchiverApi {
       timestamp: 100n,
       msgCount: 3,
       lastMessageIndex: 2n,
+      l1BlockNumber: 20n,
+      l1BlockHash: Buffer32.fromBigInt(20n),
     });
   }
   getInboxBucketByTotalMsgCount(totalMsgCount: bigint): Promise<InboxBucket | undefined> {
@@ -626,6 +636,8 @@ class MockArchiver implements ArchiverApi {
       timestamp: 100n,
       msgCount: 3,
       lastMessageIndex: 2n,
+      l1BlockNumber: 20n,
+      l1BlockHash: Buffer32.fromBigInt(20n),
     });
   }
   getL1ToL2MessagesBetweenBuckets(fromExclusive: bigint, toInclusive: bigint): Promise<Fr[]> {

--- a/yarn-project/stdlib/src/messaging/inbox_bucket.test.ts
+++ b/yarn-project/stdlib/src/messaging/inbox_bucket.test.ts
@@ -1,8 +1,28 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { jsonParseWithSchema, jsonStringify } from '@aztec/foundation/json-rpc';
 
 import type { InboxBucket } from './inbox_bucket.js';
-import { InboxBucketRef } from './inbox_bucket.js';
+import { InboxBucketRef, InboxBucketSchema } from './inbox_bucket.js';
+
+const makeBucket = (overrides: Partial<InboxBucket> = {}): InboxBucket => ({
+  seq: 12n,
+  inboxRollingHash: new Fr(0xabcn),
+  totalMsgCount: 30n,
+  timestamp: 1_650_000_000n,
+  msgCount: 3,
+  lastMessageIndex: 29n,
+  l1BlockNumber: 4_200n,
+  l1BlockHash: Buffer32.fromBigInt(4_200n),
+  ...overrides,
+});
+
+describe('InboxBucket', () => {
+  it('round-trips through its zod schema', () => {
+    const bucket = makeBucket();
+    expect(jsonParseWithSchema(jsonStringify(bucket), InboxBucketSchema)).toEqual(bucket);
+  });
+});
 
 describe('InboxBucketRef', () => {
   it('serializes and deserializes round-trip', () => {
@@ -27,14 +47,7 @@ describe('InboxBucketRef', () => {
   });
 
   it('derives from a bucket snapshot', () => {
-    const bucket: InboxBucket = {
-      seq: 12n,
-      inboxRollingHash: new Fr(0xabcn),
-      totalMsgCount: 30n,
-      timestamp: 1_650_000_000n,
-      msgCount: 3,
-      lastMessageIndex: 29n,
-    };
+    const bucket = makeBucket();
     const ref = InboxBucketRef.fromBucket(bucket);
     expect(ref.bucketSeq).toBe(bucket.seq);
     expect(ref.bucketTimestamp).toBe(bucket.timestamp);

--- a/yarn-project/stdlib/src/messaging/inbox_bucket.ts
+++ b/yarn-project/stdlib/src/messaging/inbox_bucket.ts
@@ -1,3 +1,4 @@
+import type { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 import { BufferReader, bigintToUInt64BE, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -27,6 +28,13 @@ export type InboxBucket = {
   msgCount: number;
   /** Global leaf index of the last message absorbed into this bucket. */
   lastMessageIndex: bigint;
+  /** L1 block in which this bucket was opened. */
+  l1BlockNumber: bigint;
+  /**
+   * Hash of that L1 block as seen when the bucket was synced; lets callers test whether the bucket is still on the
+   * canonical chain.
+   */
+  l1BlockHash: Buffer32;
 };
 
 export const InboxBucketSchema = z.object({
@@ -36,6 +44,8 @@ export const InboxBucketSchema = z.object({
   timestamp: schemas.BigInt,
   msgCount: schemas.Integer,
   lastMessageIndex: schemas.BigInt,
+  l1BlockNumber: schemas.BigInt,
+  l1BlockHash: schemas.Buffer32,
 }) satisfies z.ZodType<InboxBucket>;
 
 /**

--- a/yarn-project/stdlib/src/messaging/inbox_bucket.ts
+++ b/yarn-project/stdlib/src/messaging/inbox_bucket.ts
@@ -28,11 +28,17 @@ export type InboxBucket = {
   msgCount: number;
   /** Global leaf index of the last message absorbed into this bucket. */
   lastMessageIndex: bigint;
-  /** L1 block in which this bucket was opened. */
+  /**
+   * L1 block in which this bucket was opened. Buckets are keyed by L1 block timestamp, so on a chain that allows
+   * consecutive blocks to share a timestamp (anvil with manual mining, for instance) a bucket may span several L1
+   * blocks and only the opening one is recorded. Production Ethereum timestamps are strictly increasing, so there a
+   * bucket never spans more than one block.
+   */
   l1BlockNumber: bigint;
   /**
    * Hash of that L1 block as seen when the bucket was synced; lets callers test whether the bucket is still on the
-   * canonical chain.
+   * canonical chain. Since only the opening block is recorded, a reorg that touches only a later co-timestamped block
+   * of the same bucket is not detectable from this hash.
    */
   l1BlockHash: Buffer32;
 };

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -4,6 +4,7 @@ import { INITIAL_L2_BLOCK_NUM, MAX_BLOCKS_PER_CHECKPOINT } from '@aztec/constant
 import type { EpochCache } from '@aztec/epoch-cache';
 import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TestDateProvider } from '@aztec/foundation/timer';
@@ -740,6 +741,8 @@ describe('ProposalHandler checkpoint validation', () => {
     timestamp: 0n,
     msgCount: 0,
     lastMessageIndex: 0n,
+    l1BlockNumber: 0n,
+    l1BlockHash: Buffer32.ZERO,
   };
 
   /**
@@ -966,6 +969,8 @@ describe('ProposalHandler checkpoint validation', () => {
       timestamp: 100n,
       msgCount: 2,
       lastMessageIndex: 1n,
+      l1BlockNumber: 10n,
+      l1BlockHash: Buffer32.fromBigInt(10n),
       ...overrides,
     });
 

--- a/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
@@ -1,3 +1,4 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { InboxBucket } from '@aztec/stdlib/messaging';
 import { InboxBucketRef } from '@aztec/stdlib/messaging';
@@ -33,6 +34,8 @@ class FakeInboxView implements StreamingInboxBucketSource {
       timestamp: 0n,
       msgCount: 0,
       lastMessageIndex: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
     });
   }
 
@@ -50,6 +53,8 @@ class FakeInboxView implements StreamingInboxBucketSource {
       timestamp: BigInt(timestamp),
       msgCount,
       lastMessageIndex: totalMsgCount - 1n,
+      l1BlockNumber: BigInt(seq),
+      l1BlockHash: Buffer32.fromBigInt(BigInt(seq)),
     };
     this.buckets.set(BigInt(seq), bucket);
     return bucket;

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -465,6 +465,8 @@ describe('ValidatorClient', () => {
       timestamp: 0n,
       msgCount: 0,
       lastMessageIndex: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
     };
     const genesisBucketRef = InboxBucketRef.fromBucket(genesisInboxBucket);
 


### PR DESCRIPTION
Stacked on #25342

Groundwork, no behaviour change. The archiver already knew which L1 block opened each Inbox bucket — every
`MessageSent` log carries the block number and hash — but only the number reached the persisted bucket snapshot,
and neither field reached the `InboxBucket` type the archiver serves to the sequencer and the validator.

`InboxBucket` now carries `l1BlockNumber` and `l1BlockHash` (schema included, so they survive the JSON-RPC hop
for out-of-process archivers), and `BucketSnapshot` persists the hash alongside the number. That is what lets the
next PR ask "is the L1 block that opened this bucket still canonical, and does it have a child?" for the
descendant-confirmed eligibility rule, and what lets the archiver in the message-only stack compare a stored
bucket against the live chain.

Two smaller things came with it:

- The snapshot records the block a bucket was *opened* in, taken from its first message. The Inbox keys buckets
  by `block.timestamp`, so on a chain where consecutive blocks can share a timestamp (anvil with manual mining)
  one bucket can span several L1 blocks; that is logged at `warn` and the opening block is kept. Production
  Ethereum timestamps are strictly increasing, so a bucket there never spans more than one block. The cost of
  recording only the opening block is that a reorg touching only a later co-timestamped block of the same bucket
  is invisible to the hash; both fields say so.
- The archiver's message test doubles now derive a bucket's L1 block from its L1 timestamp rather than from its
  sequence number, with a deterministic, distinct hash per block. Rollover siblings that share a timestamp share
  an L1 block, as on chain, and code that confused a bucket sequence with an L1 block number now fails its tests.

`InboxBucketRef`, the reference carried on block proposals, is deliberately unchanged: a validator reads the
bucket's L1 block from its own archiver and never from the proposer.

**Breaking store format.** The bucket snapshot gains a field with no versioning or migration, so an existing
archiver database will not deserialize. That is fine here — this line has never shipped, and dev databases
resync from L1.

Gates: full `yarn build`, `yarn format` and `yarn lint` on the touched packages. Tests: `archiver` 575/575,
`stdlib` `src/messaging` + `src/interfaces/archiver.test.ts` 118/118, `validator-client`, `sequencer-client`
(including the anvil-backed `l1_publisher.integration.test.ts`), `aztec-node`
`node_public_calls_simulator.test.ts`, `world-state` `integration.test.ts`. No e2e.

Fixes A-1878
