### PR TITLE
feat(fast-inbox): consume inbox buckets once their L1 block has a canonical descendant

### DIFF
--- a/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
@@ -441,7 +441,7 @@ Extract the message leaf index:
 
 #include_code get_claim_leaf_index /docs/examples/ts/aave_bridge/index.ts typescript
 
-On the local network, L2 blocks are only produced when transactions are submitted. An L1-to-L2 message can only be consumed once an L2 block includes it, and the sequencer waits until the L1 block carrying the message has been followed by another L1 block before including it. This utility deploys two dummy contracts (with random salts for unique addresses) to force block production. On devnet or testnet, blocks are produced continuously and this step is unnecessary:
+On the local network, L2 blocks are only produced when transactions are submitted. An L1-to-L2 message can only be consumed once an L2 block includes it, and the local sandbox includes it as soon as it sees it. This utility deploys two dummy contracts (with random salts for unique addresses) to force block production. On devnet or testnet, blocks are produced continuously and this step is unnecessary, but there the sequencer first waits for the L1 block carrying the message to gain a child, which takes one more L1 block (around 12 to 14 seconds):
 
 #include_code mine_blocks /docs/examples/ts/aave_bridge/index.ts typescript
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
@@ -441,7 +441,7 @@ Extract the message leaf index:
 
 #include_code get_claim_leaf_index /docs/examples/ts/aave_bridge/index.ts typescript
 
-On the local network, L2 blocks are only produced when transactions are submitted. An L1-to-L2 message can only be consumed once an L2 block includes it, and the network waits until the message is at least 12 seconds old before including it. This utility deploys two dummy contracts (with random salts for unique addresses) to force block production. On devnet or testnet, blocks are produced continuously and this step is unnecessary:
+On the local network, L2 blocks are only produced when transactions are submitted. An L1-to-L2 message can only be consumed once an L2 block includes it, and the sequencer waits until the L1 block carrying the message has been followed by another L1 block before including it. This utility deploys two dummy contracts (with random salts for unique addresses) to force block production. On devnet or testnet, blocks are produced continuously and this step is unnecessary:
 
 #include_code mine_blocks /docs/examples/ts/aave_bridge/index.ts typescript
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -443,7 +443,7 @@ Use viem to extract this information:
 
 #include_code get_message_leaf_index /docs/examples/ts/token_bridge/index.ts typescript
 
-This extracts the logs from the deposit and retrieves the leaf index. You can now claim it on L2. However, a message can only be claimed once an L2 block includes it, and the sequencer waits until the L1 block carrying the message has been followed by another L1 block before including it, so expect 15 to 30 seconds of latency. If you called `claim` on the L2 contract immediately, it would return "no message available".
+This extracts the logs from the deposit and retrieves the leaf index. You can now claim it on L2. However, a message can only be claimed once an L2 block includes it. On a live network the sequencer first waits for the L1 block carrying the message to gain a child, which takes one more L1 block (around 12 to 14 seconds), so expect 15 to 30 seconds of latency; the local sandbox consumes the message as soon as it sees it. If you called `claim` on the L2 contract immediately, it would return "no message available".
 
 On a local network blocks are only produced when transactions are submitted, so add a utility function that forces a couple of blocks (it deploys a contract with a random salt):
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -443,7 +443,7 @@ Use viem to extract this information:
 
 #include_code get_message_leaf_index /docs/examples/ts/token_bridge/index.ts typescript
 
-This extracts the logs from the deposit and retrieves the leaf index. You can now claim it on L2. However, a message can only be claimed once an L2 block includes it, and the network waits until the message is at least 12 seconds old before including it, so expect 12 to 30 seconds of latency. If you called `claim` on the L2 contract immediately, it would return "no message available".
+This extracts the logs from the deposit and retrieves the leaf index. You can now claim it on L2. However, a message can only be claimed once an L2 block includes it, and the sequencer waits until the L1 block carrying the message has been followed by another L1 block before including it, so expect 15 to 30 seconds of latency. If you called `claim` on the L2 contract immediately, it would return "no message available".
 
 On a local network blocks are only produced when transactions are submitted, so add a utility function that forces a couple of blocks (it deploys a contract with a random salt):
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/uniswap_swap.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/uniswap_swap.md
@@ -309,7 +309,7 @@ Bridge WETH from L1 to L2:
 When depositing from L1 to L2, we use a secret/secret-hash pattern: generate a random secret on the client, send only the hash to L1 (in the deposit transaction), then later reveal the secret on L2 to claim the tokens. This prevents **front-running attacks**: a malicious sequencer (the node that orders and processes L2 transactions) cannot observe the L1 deposit and claim the tokens themselves because they don't know the secret. Only someone who knows the preimage can claim.
 :::
 
-Before claiming, we need to mine a couple of L2 blocks. An L1-to-L2 message is not available the moment it is sent -- the sequencer waits until the L1 block carrying it has been followed by another L1 block before including it in an L2 block, which usually takes around 15 seconds, and it becomes consumable as soon as that block lands. We use a helper that deploys throwaway contracts to force these blocks:
+Before claiming, we need to mine a couple of L2 blocks. An L1-to-L2 message is not available the moment it is sent -- it becomes consumable only once an L2 block includes it. The local sandbox includes it as soon as it sees it; on a live network the sequencer first waits for the L1 block carrying it to gain a child, which takes one more L1 block (around 12 to 14 seconds). We use a helper that deploys throwaway contracts to force these blocks:
 
 #include_code mine_blocks /docs/examples/ts/example_swap/index.ts typescript
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/uniswap_swap.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/uniswap_swap.md
@@ -309,7 +309,7 @@ Bridge WETH from L1 to L2:
 When depositing from L1 to L2, we use a secret/secret-hash pattern: generate a random secret on the client, send only the hash to L1 (in the deposit transaction), then later reveal the secret on L2 to claim the tokens. This prevents **front-running attacks**: a malicious sequencer (the node that orders and processes L2 transactions) cannot observe the L1 deposit and claim the tokens themselves because they don't know the secret. Only someone who knows the preimage can claim.
 :::
 
-Before claiming, we need to mine a couple of L2 blocks. An L1-to-L2 message is not available the moment it is sent -- the rollup only includes it in an L2 block once it is at least 12 seconds old, and it becomes consumable as soon as that block lands. We use a helper that deploys throwaway contracts to force these blocks:
+Before claiming, we need to mine a couple of L2 blocks. An L1-to-L2 message is not available the moment it is sent -- the sequencer waits until the L1 block carrying it has been followed by another L1 block before including it in an L2 block, which usually takes around 15 seconds, and it becomes consumable as soon as that block lands. We use a helper that deploys throwaway contracts to force these blocks:
 
 #include_code mine_blocks /docs/examples/ts/example_swap/index.ts typescript
 

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
@@ -117,7 +117,7 @@ describe('NodePublicCallsSimulator', () => {
 
   /**
    * Mocks the Inbox so the next-block prediction selects a two-message bundle: the fork's message total (0)
-   * resolves to bucket 0, and bucket 1 is lag-eligible and holds both messages.
+   * resolves to bucket 0, and bucket 1 holds both messages.
    */
   const mockInboxSelection = () => {
     const makeBucket = (seq: bigint, totalMsgCount: bigint): InboxBucket => ({

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
@@ -11,6 +11,7 @@ import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { unfreeze } from '@aztec/foundation/types';
+import type { L1BlockReader } from '@aztec/sequencer-client';
 import { type AvmSimulator, PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
@@ -119,12 +120,12 @@ describe('NodePublicCallsSimulator', () => {
    * Mocks the Inbox so the next-block prediction selects a two-message bundle: the fork's message total (0)
    * resolves to bucket 0, and bucket 1 holds both messages.
    */
-  const mockInboxSelection = () => {
+  const mockInboxSelection = (timestamp = 0n) => {
     const makeBucket = (seq: bigint, totalMsgCount: bigint): InboxBucket => ({
       seq,
       inboxRollingHash: Fr.ZERO,
       totalMsgCount,
-      timestamp: 0n,
+      timestamp,
       msgCount: Number(totalMsgCount),
       lastMessageIndex: totalMsgCount === 0n ? 0n : totalMsgCount - 1n,
       l1BlockNumber: seq,
@@ -280,6 +281,102 @@ describe('NodePublicCallsSimulator', () => {
       await expect(simulator.simulate(tx)).resolves.toBeDefined();
 
       expect(merkleTreeFork.appendLeaves).not.toHaveBeenCalled();
+    });
+
+    describe('with an L1 client, mirroring the proposer eligibility rule', () => {
+      const ETHEREUM_SLOT_DURATION = 12;
+      // The simulator reads wall-clock time, so bucket timestamps are placed relative to it.
+      const nowSeconds = () => BigInt(Math.floor(Date.now() / 1000));
+
+      /** An L1 view in which the bucket's opening block already has a canonical child. */
+      const makeL1Client = (): L1BlockReader & { reads: bigint[] } => {
+        const reads: bigint[] = [];
+        return {
+          reads,
+          getBlock({ blockNumber }) {
+            reads.push(blockNumber);
+            return Promise.resolve({
+              hash: Buffer32.fromBigInt(blockNumber).toString(),
+              parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString(),
+            });
+          },
+        };
+      };
+
+      const makeSimulator = (opts: { l1Client?: L1BlockReader; useAutomineSequencer?: boolean }) =>
+        new NodePublicCallsSimulator({
+          blockSource,
+          worldStateSynchronizer,
+          l1ToL2MessageSource,
+          contractDataSource,
+          globalVariableBuilder,
+          rollupContract,
+          epochCache,
+          avmSimulator,
+          signatureContext: { chainId: CHAIN_ID.toNumber(), rollupAddress: ROLLUP_ADDRESS },
+          l1Client: opts.l1Client,
+          config: {
+            rpcSimulatePublicMaxGasLimit: 1e11,
+            rpcSimulatePublicMaxDebugLogMemoryReads: 100,
+            useAutomineSequencer: opts.useAutomineSequencer,
+          },
+        });
+
+      beforeEach(() => {
+        epochCache.getL1Constants.mockReturnValue({
+          ...EmptyL1RollupConstants,
+          ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        });
+        setupMidCheckpoint();
+        blockSource.getBlockData.mockImplementation((query: BlockQuery) =>
+          Promise.resolve('number' in query ? makeBlockData(query.number, SlotNumber(42)) : undefined),
+        );
+        mockNextL1Slot(SlotNumber(100));
+      });
+
+      it('predicts nothing from a bucket the proposer would still be waiting on', async () => {
+        const tx = await lowGasTx();
+        // Opened this very second: no L1 block can have built on it yet, so no proposer will consume it.
+        mockInboxSelection(nowSeconds());
+        const l1Client = makeL1Client();
+
+        await expect(makeSimulator({ l1Client }).simulate(tx)).resolves.toBeDefined();
+
+        expect(merkleTreeFork.appendLeaves).not.toHaveBeenCalled();
+        expect(l1Client.reads).toEqual([]);
+      });
+
+      it('predicts the bundle once the bucket opening block has a canonical child', async () => {
+        const tx = await lowGasTx();
+        const bundle = mockInboxSelection(nowSeconds() - BigInt(ETHEREUM_SLOT_DURATION));
+        const l1Client = makeL1Client();
+
+        await makeSimulator({ l1Client }).simulate(tx);
+
+        expect(merkleTreeFork.appendLeaves).toHaveBeenCalledWith(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, bundle);
+        // Bucket 1 was opened by L1 block 1, so its child is block 2.
+        expect(l1Client.reads).toEqual([2n]);
+      });
+
+      it('never waits for a confirmation under automine, which mines on demand', async () => {
+        const tx = await lowGasTx();
+        const bundle = mockInboxSelection(nowSeconds());
+        const l1Client = makeL1Client();
+
+        await makeSimulator({ l1Client, useAutomineSequencer: true }).simulate(tx);
+
+        expect(merkleTreeFork.appendLeaves).toHaveBeenCalledWith(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, bundle);
+        expect(l1Client.reads).toEqual([]);
+      });
+
+      it('predicts against every synced bucket when the node has no L1 client', async () => {
+        const tx = await lowGasTx();
+        const bundle = mockInboxSelection(nowSeconds());
+
+        await makeSimulator({}).simulate(tx);
+
+        expect(merkleTreeFork.appendLeaves).toHaveBeenCalledWith(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, bundle);
+      });
     });
 
     it('fails with a retryable error when the latest proposed header is missing, without double-inserting messages', async () => {

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
@@ -285,6 +285,7 @@ export class NodePublicCallsSimulator {
         // Every synced bucket counts: this is a best-effort prediction of what the next proposer will consume, and
         // the node does not read L1 to track which buckets the proposer considers confirmed.
         isEligible: immediateEligibility,
+        ethereumSlotDuration: l1Constants.ethereumSlotDuration,
         parent: { seq: parentBucket.seq, totalMsgCount: parentBucket.totalMsgCount },
         checkpointStartTotalMsgCount,
         perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
@@ -12,7 +12,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { BadRequestError } from '@aztec/foundation/json-rpc';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
-import { type InboxBucketSource, selectInboxBucketForBlock } from '@aztec/sequencer-client';
+import { type InboxBucketSource, immediateEligibility, selectInboxBucketForBlock } from '@aztec/sequencer-client';
 import { type AvmSimulator, PublicContractsDB, PublicProcessorFactory } from '@aztec/simulator/server';
 import { CollectionLimitsConfig, PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -241,9 +241,9 @@ export class NodePublicCallsSimulator {
   /**
    * Appends the L1-to-L2 message bundle the next block would consume to the simulation fork, so a transaction
    * consuming a message that has reached the Inbox but no block yet simulates against the state it will run in.
-   * Runs the same bucket selection the sequencer runs (lag eligibility plus the per-block and per-checkpoint caps),
-   * treating the next block as non-final: the censorship cutoff only widens consumption on a checkpoint's last
-   * block, and the node cannot know whether the next block is it.
+   * Runs the same bucket selection the sequencer runs (the per-block and per-checkpoint caps), treating the next
+   * block as non-final: the censorship cutoff only widens consumption on a checkpoint's last block, and the node
+   * cannot know whether the next block is it.
    *
    * Best-effort. Any failure — Inbox buckets not synced yet, a torn archiver snapshot — leaves the fork at the tip
    * state, which is what the transaction sees if the next block consumes nothing.
@@ -282,7 +282,9 @@ export class NodePublicCallsSimulator {
       const selection = await selectInboxBucketForBlock({
         messageSource: this.l1ToL2MessageSource,
         now: BigInt(Math.floor(this.dateProvider.now() / 1000)),
-        minBucketAgeSeconds: BigInt(l1Constants.ethereumSlotDuration),
+        // Every synced bucket counts: this is a best-effort prediction of what the next proposer will consume, and
+        // the node does not read L1 to track which buckets the proposer considers confirmed.
+        isEligible: immediateEligibility,
         parent: { seq: parentBucket.seq, totalMsgCount: parentBucket.totalMsgCount },
         checkpointStartTotalMsgCount,
         perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
@@ -12,7 +12,14 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { BadRequestError } from '@aztec/foundation/json-rpc';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
-import { type InboxBucketSource, immediateEligibility, selectInboxBucketForBlock } from '@aztec/sequencer-client';
+import {
+  InboxBucketConfirmationTracker,
+  type InboxBucketEligibility,
+  type InboxBucketSource,
+  type L1BlockReader,
+  immediateEligibility,
+  selectInboxBucketForBlock,
+} from '@aztec/sequencer-client';
 import { type AvmSimulator, PublicContractsDB, PublicProcessorFactory } from '@aztec/simulator/server';
 import { CollectionLimitsConfig, PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -43,6 +50,11 @@ export interface NodePublicCallsSimulatorConfig {
   rpcSimulatePublicMaxGasLimit: number;
   /** Maximum number of debug-log memory reads collected during simulation. */
   rpcSimulatePublicMaxDebugLogMemoryReads: number;
+  /**
+   * Whether this node runs the automine sequencer. Automine consumes Inbox buckets the moment it sees them, so the
+   * next-block prediction must not wait for an L1 confirmation the local chain will never produce on its own.
+   */
+  useAutomineSequencer?: boolean;
 }
 
 /** Dependencies required to build a {@link NodePublicCallsSimulator}. */
@@ -62,6 +74,11 @@ export interface NodePublicCallsSimulatorDeps {
   rollupContract?: RollupContract;
   epochCache: EpochCacheInterface;
   signatureContext: CoordinationSignatureContext;
+  /**
+   * L1 client used to tell which Inbox buckets a proposer would consider confirmed. Optional: without one the
+   * prediction assumes every synced bucket is consumable, which is what automine and TXE nodes do anyway.
+   */
+  l1Client?: L1BlockReader;
   config: NodePublicCallsSimulatorConfig;
   /**
    * AVM execution backend the public processor drives to run public calls. Optional because unit/TXE nodes
@@ -101,7 +118,13 @@ export class NodePublicCallsSimulator {
   private readonly rollupContract: RollupContract | undefined;
   private readonly epochCache: EpochCacheInterface;
   private readonly signatureContext: CoordinationSignatureContext;
+  private readonly l1Client: L1BlockReader | undefined;
   private readonly config: NodePublicCallsSimulatorConfig;
+  /**
+   * Shared by every simulation on this node. Its confirmations are permanent facts about L1, so a node-lifetime
+   * cache is correct and keeps the RPC cost of the prediction near zero; its rejections expire every second.
+   */
+  private inboxBucketConfirmations: InboxBucketConfirmationTracker | undefined;
   private readonly avmSimulator?: AvmSimulator;
   private readonly telemetry: TelemetryClient;
   private readonly log: Logger;
@@ -116,6 +139,7 @@ export class NodePublicCallsSimulator {
     this.rollupContract = deps.rollupContract;
     this.epochCache = deps.epochCache;
     this.signatureContext = deps.signatureContext;
+    this.l1Client = deps.l1Client;
     this.config = deps.config;
     this.avmSimulator = deps.avmSimulator;
     this.telemetry = deps.telemetry ?? getTelemetryClient();
@@ -282,9 +306,7 @@ export class NodePublicCallsSimulator {
       const selection = await selectInboxBucketForBlock({
         messageSource: this.l1ToL2MessageSource,
         now: BigInt(Math.floor(this.dateProvider.now() / 1000)),
-        // Every synced bucket counts: this is a best-effort prediction of what the next proposer will consume, and
-        // the node does not read L1 to track which buckets the proposer considers confirmed.
-        isEligible: immediateEligibility,
+        isEligible: this.getInboxBucketEligibility(l1Constants.ethereumSlotDuration),
         ethereumSlotDuration: l1Constants.ethereumSlotDuration,
         parent: { seq: parentBucket.seq, totalMsgCount: parentBucket.totalMsgCount },
         checkpointStartTotalMsgCount,
@@ -305,6 +327,24 @@ export class NodePublicCallsSimulator {
     } catch (err) {
       this.log.verbose(`Could not predict the next block's L1-to-L2 messages, simulating against the tip: ${err}`);
     }
+  }
+
+  /**
+   * The eligibility rule the next proposer is expected to apply. It has to match the sequencer's: a transaction
+   * simulated against a bundle no proposer will consume yet enters the pool and then fails when the block that
+   * includes it consumes less. Automine, and any node without an L1 client, never waits, so those predict against
+   * every synced bucket instead.
+   */
+  private getInboxBucketEligibility(ethereumSlotDuration: number): InboxBucketEligibility {
+    if (this.config.useAutomineSequencer || this.l1Client === undefined) {
+      return immediateEligibility;
+    }
+    this.inboxBucketConfirmations ??= new InboxBucketConfirmationTracker({
+      l1Client: this.l1Client,
+      ethereumSlotDuration,
+      log: this.log.createChild('inbox-bucket-confirmation'),
+    });
+    return this.inboxBucketConfirmations.isEligible;
   }
 
   /** Cumulative Inbox message total consumed as of `blockNumber`, i.e. its L1-to-L2 message tree leaf count. */

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -29,6 +29,7 @@ import { type P2P, createTxValidatorForAcceptingTxsOverRPC, getDefaultAllowedSet
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import type { ProverNode } from '@aztec/prover-node';
 import { SequencerClient } from '@aztec/sequencer-client';
+import type { L1BlockReader } from '@aztec/sequencer-client';
 import { AutomineSequencer } from '@aztec/sequencer-client/automine';
 import type { AvmSimulator } from '@aztec/simulator/server';
 import type { SlasherClientInterface } from '@aztec/slasher';
@@ -151,6 +152,11 @@ export interface AztecNodeServiceDeps {
   keyStoreManager?: KeystoreManager;
   debugLogStore?: DebugLogStore;
   automineSequencer?: AutomineSequencer;
+  /**
+   * L1 client the public-calls simulator reads blocks from, to predict which Inbox buckets the next proposer will
+   * consider confirmed. Absent in unit/TXE nodes, which fall back to predicting against every synced bucket.
+   */
+  l1Client?: L1BlockReader;
   // AVM execution backend for public simulation. Wired in production (factory.ts); absent in unit/TXE nodes
   // that don't drive public execution, hence optional and asserted at the simulation call site. Owned by the
   // node (disposed on stop), so it must be disposable — a spawned process pool + CDB IPC server.
@@ -248,6 +254,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
       rollupContract: this.rollupContract,
       epochCache: this.epochCache,
       signatureContext: { chainId: this.l1ChainId, rollupAddress: this.config.rollupAddress },
+      l1Client: deps.l1Client,
       config: this.config,
       avmSimulator: this.avmSimulator,
       telemetry: this.telemetry,

--- a/yarn-project/aztec-node/src/factory.ts
+++ b/yarn-project/aztec-node/src/factory.ts
@@ -664,6 +664,7 @@ export async function createAztecNodeService(
       debugLogStore,
       automineSequencer,
       avmSimulator,
+      l1Client: publicClient,
     });
 
     return node;

--- a/yarn-project/end-to-end/src/single-node/cross-chain/streaming_inbox.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/streaming_inbox.test.ts
@@ -22,8 +22,8 @@ jest.setTimeout(600_000);
 // entered at the first block of the *next* checkpoint, mid-checkpoint inclusion, message-only blocks, and
 // per-block streaming latency had no observable surface. Runs the production
 // pipelining sequencer via CrossChainMessagingTest with a widened slot (36s / 6s blocks -> up to ~4 blocks
-// per checkpoint) so a message can become lag-eligible partway through a checkpoint and land in a non-first
-// block. minTxsPerBlock=0 lets a checkpoint carry a zero-tx block whose only content is a streaming bundle.
+// per checkpoint) so a message's bucket can become eligible partway through a checkpoint and land in a
+// non-first block. minTxsPerBlock=0 lets a checkpoint carry a zero-tx block whose only content is a streaming bundle.
 //
 // Grounded on l1_to_l2.test.ts (send/wait helpers, TestContract arbitrary-sender consume) and
 // cross_chain_public_message.test.ts (same-block public consume). All cases share one node stood up once.
@@ -46,9 +46,9 @@ describe('single-node/cross-chain/streaming_inbox', () => {
     t = new CrossChainMessagingTest(
       'streaming_inbox',
       // A 36s slot with 6s blocks yields up to ~4 blocks per checkpoint (the pipelining timing model gives
-      // maxBlocks = floor((36 - 0.5 - (0.5 + D)) / D) = 4 for D=6), which is what lets a message aged past
-      // the minimum bucket age land in a non-first block of the same checkpoint. minTxsPerBlock=0 permits a
-      // zero-tx message-only block (the FI-05 relaxation).
+      // maxBlocks = floor((36 - 0.5 - (0.5 + D)) / D) = 4 for D=6), which is what lets a message whose bucket
+      // is confirmed mid-checkpoint land in a non-first block of the same checkpoint. minTxsPerBlock=0 permits
+      // a zero-tx message-only block (the FI-05 relaxation).
       { ...PIPELINING_SETUP_OPTS, aztecSlotDuration: 36, blockDurationMs: 6000, minTxsPerBlock: 0 },
       { aztecProofSubmissionEpochs: 2, aztecEpochDuration: 4 },
       { syncChainTip: 'checkpointed' },
@@ -133,7 +133,7 @@ describe('single-node/cross-chain/streaming_inbox', () => {
   // Test 1 (mid-checkpoint inclusion): a message sent mid-checkpoint becomes available in a *later* block of
   // the same checkpoint (indexWithinCheckpoint > 0), which the legacy first-block-of-next-checkpoint flow
   // could never produce. Feeds a steady tx stream so checkpoints fill to multiple blocks, times the send so
-  // the message ages past the minimum bucket age partway through a checkpoint's build, then locates the inserting
+  // the message's bucket becomes eligible partway through a checkpoint's build, then locates the inserting
   // block. Retries with fresh messages so a message that happens to age exactly at a checkpoint boundary (and
   // lands at index 0) does not fail the run.
   it('includes a message in a non-first block of a checkpoint (mid-checkpoint streaming)', async () => {
@@ -203,10 +203,9 @@ describe('single-node/cross-chain/streaming_inbox', () => {
   // Test 2 (latency bound): the delay between a message's L1 inclusion and the L2 block that makes it
   // available stays within the streaming bound. Asserted in slot-denominated terms (L1/L2 timestamps, not
   // wall-clock): the including block's timestamp minus the message's L1 timestamp must be at most
-  // ethereumSlotDuration + 2 * slotDuration (the minimum bucket age + a full slot straddle + one slot of CI
-  // slack). No lower bound
-  // is asserted (eligibility is already enforced by L1 and the validator). The wall-clock latency is logged
-  // for information only.
+  // ethereumSlotDuration + 2 * slotDuration (the descendant-confirmation wait + a full slot straddle + one slot
+  // of CI slack). No lower bound is asserted: when a bucket becomes consumable is the proposer's own policy. The
+  // wall-clock latency is logged for information only.
   it('makes a message available within the streaming latency bound', async () => {
     const { slotDuration } = t.constants;
     const maxDelaySeconds = BigInt(t.constants.ethereumSlotDuration) + 2n * BigInt(slotDuration);
@@ -332,11 +331,10 @@ describe('single-node/cross-chain/streaming_inbox', () => {
   // and the block-root circuit (which pins each tx's L1-to-L2 tree snapshot to the post-append root); if it did
   // not, this tx would revert at proposal time and succeed at proving time, making the epoch unprovable. The node
   // simulates public calls against the messages predicted for the next block, so a consume tx sent as soon as the
-  // message's bucket becomes lag-eligible passes simulation and lands in the pool before the inserting block is
+  // message's bucket becomes eligible passes simulation and lands in the pool before the inserting block is
   // built. The send is timed to that instant and retried with fresh messages when a block slips in between.
   it('consumes a message in the same block that inserts it', async () => {
     const l1Account = t.ethAccount;
-    const minBucketAge = BigInt(t.constants.ethereumSlotDuration);
     const maxAttempts = 5;
     let sameBlockReceipt: { blockNumber: BlockNumber; msgHash: Fr; globalLeafIndex: bigint } | undefined;
 
@@ -345,13 +343,18 @@ describe('single-node/cross-chain/streaming_inbox', () => {
       const message = { recipient: testContract.address, content: Fr.random(), secretHash };
       const { msgHash, globalLeafIndex, txReceipt: l1Receipt } = await sendMessageToL2(message);
       const messageL1Ts = await getMessageL1Timestamp(l1Receipt.blockNumber!);
-      const eligibleAt = messageL1Ts + minBucketAge;
-      log.warn(`Attempt ${attempt}: sent message ${msgHash.toString()}, eligible at L1 timestamp ${eligibleAt}`);
+      const messageL1Block = l1Receipt.blockNumber!;
+      // The proposer consumes a bucket once its opening L1 block has a canonical descendant, falling back to
+      // "two Ethereum slots have elapsed and the block is still canonical" when the next L1 slot is missed.
+      const fallbackAt = messageL1Ts + 2n * BigInt(t.constants.ethereumSlotDuration);
+      log.warn(`Attempt ${attempt}: sent message ${msgHash.toString()} in L1 block ${messageL1Block}`);
 
       // Do not drive L2 blocks while waiting: an extra block here only shifts the timing of the inserting block.
       await retryUntil(
-        async () => BigInt(await t.cheatCodes.eth.lastBlockTimestamp()) >= eligibleAt,
-        `message bucket becomes eligible at ${eligibleAt}`,
+        async () =>
+          (await t.harnessL1Client.getBlockNumber()) > messageL1Block ||
+          BigInt(await t.cheatCodes.eth.lastBlockTimestamp()) >= fallbackAt,
+        `message bucket gains an L1 descendant (or reaches ${fallbackAt})`,
         Number(t.constants.slotDuration) * 3,
         0.2,
       );

--- a/yarn-project/sequencer-client/src/index.ts
+++ b/yarn-project/sequencer-client/src/index.ts
@@ -6,7 +6,12 @@ export { Sequencer, SequencerState, type SequencerEvents } from './sequencer/ind
 // Used by the node to simulate public parts of transactions. Should these be moved to a shared library?
 // ISSUE(#9832)
 export * from './global_variable_builder/index.js';
-export { type InboxBucketEligibility, immediateEligibility } from './sequencer/inbox_bucket_eligibility.js';
+export {
+  InboxBucketConfirmationTracker,
+  type InboxBucketEligibility,
+  type L1BlockReader,
+  immediateEligibility,
+} from './sequencer/inbox_bucket_eligibility.js';
 export {
   type ConsumedBucketCursor,
   type InboxBucketSelection,

--- a/yarn-project/sequencer-client/src/index.ts
+++ b/yarn-project/sequencer-client/src/index.ts
@@ -6,6 +6,7 @@ export { Sequencer, SequencerState, type SequencerEvents } from './sequencer/ind
 // Used by the node to simulate public parts of transactions. Should these be moved to a shared library?
 // ISSUE(#9832)
 export * from './global_variable_builder/index.js';
+export { type InboxBucketEligibility, immediateEligibility } from './sequencer/inbox_bucket_eligibility.js';
 export {
   type ConsumedBucketCursor,
   type InboxBucketSelection,

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -677,6 +677,7 @@ describe('L1Publisher integration', () => {
           // message set stays pinned to the slot it belongs to.
           now: cutoffTimestamp,
           isEligible: immediateEligibility,
+          ethereumSlotDuration: config.ethereumSlotDuration,
           parent,
           checkpointStartTotalMsgCount: parent.totalMsgCount,
           perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -99,6 +99,7 @@ import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
 import { type SequencerClientConfig, getConfigEnvVars } from '../config.js';
+import { immediateEligibility } from '../sequencer/inbox_bucket_eligibility.js';
 import { selectInboxBucketForBlock } from '../sequencer/inbox_bucket_selector.js';
 import { sendL1ToL2Message } from './l1_to_l2_messaging.js';
 import { SequencerPublisherMetrics } from './sequencer-publisher-metrics.js';
@@ -671,8 +672,11 @@ describe('L1Publisher integration', () => {
         const cutoffTimestamp = previousSlotStart - BigInt(config.ethereumSlotDuration);
         const selection = await selectInboxBucketForBlock({
           messageSource,
-          now: previousSlotStart,
-          minBucketAgeSeconds: BigInt(config.ethereumSlotDuration),
+          // Anvil mines on demand, so a bucket's opening L1 block gains a descendant only when the next transaction
+          // is sent; the harness consumes every bucket it has, anchored at the cutoff so each block's expected
+          // message set stays pinned to the slot it belongs to.
+          now: cutoffTimestamp,
+          isEligible: immediateEligibility,
           parent,
           checkpointStartTotalMsgCount: parent.totalMsgCount,
           perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -487,6 +487,7 @@ export class AutomineSequencer {
       messageSource: this.deps.l1ToL2MessageSource,
       now: BigInt(Math.floor(this.deps.dateProvider.now() / 1000)),
       isEligible: immediateEligibility,
+      ethereumSlotDuration: this.deps.l1Constants.ethereumSlotDuration,
       parent: { seq: parentBucket.seq, totalMsgCount: parentBucket.totalMsgCount },
       checkpointStartTotalMsgCount: parentTotalMsgCount,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -38,6 +38,7 @@ import type { GlobalVariableBuilder } from '../../global_variable_builder/global
 import type { SequencerPublisherFactory } from '../../publisher/sequencer-publisher-factory.js';
 import type { SequencerPublisher } from '../../publisher/sequencer-publisher.js';
 import type { SequencerConfig } from '../config.js';
+import { immediateEligibility } from '../inbox_bucket_eligibility.js';
 import { selectInboxBucketForBlock } from '../inbox_bucket_selector.js';
 
 /**
@@ -471,8 +472,10 @@ export class AutomineSequencer {
     await using fork = await this.deps.worldState.fork(syncedToBlockNumber, { closeDelayMs: 0 });
 
     // Streaming Inbox: automine builds a single-block checkpoint, so its one block is the
-    // checkpoint's final block; select its bundle from the newest lag-eligible bucket with the last-block censorship
-    // floor. The parent total is the fork's L1-to-L2 leaf count (compact indexing), which resolves the parent bucket.
+    // checkpoint's final block; select its bundle from the newest synced bucket with the last-block censorship floor.
+    // Automine never waits for L1 confirmations: anvil mines on demand, so a bucket's opening block gains a
+    // descendant only when the next transaction is sent, which may be long after the block that consumes it.
+    // The parent total is the fork's L1-to-L2 leaf count (compact indexing), which resolves the parent bucket.
     const parentInfo = await fork.getTreeInfo(MerkleTreeId.L1_TO_L2_MESSAGE_TREE);
     const parentTotalMsgCount = parentInfo.size;
     const parentBucket = await this.deps.l1ToL2MessageSource.getInboxBucketByTotalMsgCount(parentTotalMsgCount);
@@ -483,7 +486,7 @@ export class AutomineSequencer {
     const selection = await selectInboxBucketForBlock({
       messageSource: this.deps.l1ToL2MessageSource,
       now: BigInt(Math.floor(this.deps.dateProvider.now() / 1000)),
-      minBucketAgeSeconds: BigInt(this.deps.l1Constants.ethereumSlotDuration),
+      isEligible: immediateEligibility,
       parent: { seq: parentBucket.seq, totalMsgCount: parentBucket.totalMsgCount },
       checkpointStartTotalMsgCount: parentTotalMsgCount,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -76,8 +76,18 @@ import {
 import { CheckpointProposalJob } from './checkpoint_proposal_job.js';
 import type { CheckpointProposalJobMetricsRecorder } from './checkpoint_proposal_job_metrics.js';
 import type { SequencerEvents } from './events.js';
+import type { L1BlockReader } from './inbox_bucket_eligibility.js';
 import type { SequencerMetrics } from './metrics.js';
 import { RequestsTracker } from './requests_tracker.js';
+
+/**
+ * L1 view in which every bucket's opening block already has a canonical child, so the job's confirmation tracker
+ * admits every bucket the archiver mock returns.
+ */
+const confirmingL1Client = {
+  getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
+    Promise.resolve({ parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString() }),
+} as unknown as L1BlockReader;
 
 describe('CheckpointProposalJob', () => {
   let publisher: MockProxy<SequencerPublisher>;
@@ -818,6 +828,7 @@ describe('CheckpointProposalJob', () => {
       p2p,
       worldState,
       l1ToL2MessageSource,
+      confirmingL1Client,
       l2BlockSource,
       checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
       blockSink,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -84,10 +84,13 @@ import { RequestsTracker } from './requests_tracker.js';
  * L1 view in which every bucket's opening block already has a canonical child, so the job's confirmation tracker
  * admits every bucket the archiver mock returns.
  */
-const confirmingL1Client = {
-  getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
-    Promise.resolve({ parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString() }),
-} as unknown as L1BlockReader;
+const confirmingL1Client: L1BlockReader = {
+  getBlock: ({ blockNumber }) =>
+    Promise.resolve({
+      hash: Buffer32.fromBigInt(blockNumber).toString(),
+      parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString(),
+    }),
+};
 
 describe('CheckpointProposalJob', () => {
   let publisher: MockProxy<SequencerPublisher>;

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -195,10 +195,13 @@ class TimingTestCheckpointProposalJob extends CheckpointProposalJob {
  * L1 view in which every bucket's opening block already has a canonical child, so the job's confirmation tracker
  * admits every bucket the archiver mock returns.
  */
-const confirmingL1Client = {
-  getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
-    Promise.resolve({ parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString() }),
-} as unknown as L1BlockReader;
+const confirmingL1Client: L1BlockReader = {
+  getBlock: ({ blockNumber }) =>
+    Promise.resolve({
+      hash: Buffer32.fromBigInt(blockNumber).toString(),
+      parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString(),
+    }),
+};
 
 describe('CheckpointProposalJob Timing Tests', () => {
   // Realistic production-like timing configuration

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -50,6 +50,7 @@ import {
 import { CheckpointProposalJob } from './checkpoint_proposal_job.js';
 import type { CheckpointProposalJobMetricsRecorder } from './checkpoint_proposal_job_metrics.js';
 import type { SequencerEvents } from './events.js';
+import type { L1BlockReader } from './inbox_bucket_eligibility.js';
 import type { SequencerMetrics } from './metrics.js';
 import { RequestsTracker } from './requests_tracker.js';
 import { SequencerState } from './utils.js';
@@ -189,6 +190,15 @@ class TimingTestCheckpointProposalJob extends CheckpointProposalJob {
     this.blockBuildTimes.push({ blockNumber, startTime, endTime });
   }
 }
+
+/**
+ * L1 view in which every bucket's opening block already has a canonical child, so the job's confirmation tracker
+ * admits every bucket the archiver mock returns.
+ */
+const confirmingL1Client = {
+  getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
+    Promise.resolve({ parentHash: Buffer32.fromBigInt(blockNumber - 1n).toString() }),
+} as unknown as L1BlockReader;
 
 describe('CheckpointProposalJob Timing Tests', () => {
   // Realistic production-like timing configuration
@@ -332,6 +342,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       p2p,
       worldState,
       l1ToL2MessageSource,
+      confirmingL1Client,
       l2BlockSource,
       checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
       blockSink,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -84,6 +84,7 @@ import type { CheckpointProposalJobMetricsRecorder } from './checkpoint_proposal
 import { CheckpointVoter } from './checkpoint_voter.js';
 import { SequencerInterruptedError } from './errors.js';
 import type { SequencerEvents } from './events.js';
+import { InboxBucketConfirmationTracker, type L1BlockReader } from './inbox_bucket_eligibility.js';
 import {
   type ConsumedBucketCursor,
   type InboxBucketSelection,
@@ -148,6 +149,12 @@ export class CheckpointProposalJob implements Traceable {
   private interrupted = false;
 
   /**
+   * Tracks which Inbox buckets have gained a canonical L1 descendant. One per job, so its confirmation cache lives
+   * exactly as long as the slot whose blocks consult it.
+   */
+  private readonly inboxBucketConfirmations: InboxBucketConfirmationTracker;
+
+  /**
    * Chain state overrides built once per slot in proposeCheckpoint after the checkpoint is
    * complete. Carries the pending parent override (archive + slot + fee header) for pipelining,
    * or the invalidation pending override when rolling back. Consumed by
@@ -175,6 +182,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly p2pClient: P2P,
     private readonly worldState: WorldStateSynchronizer,
     private readonly l1ToL2MessageSource: L1ToL2MessageSource,
+    private readonly l1Client: L1BlockReader,
     private readonly l2BlockSource: L2BlockSource,
     private readonly checkpointsBuilder: FullNodeCheckpointsBuilder,
     private readonly blockSink: L2BlockSink & ProposedCheckpointSink,
@@ -203,6 +211,11 @@ export class CheckpointProposalJob implements Traceable {
     this.checkpointEventLog = createLogger('sequencer:checkpoint-events', {
       ...bindings,
       instanceId: `slot-${this.getBuildSlot()}`,
+    });
+    this.inboxBucketConfirmations = new InboxBucketConfirmationTracker({
+      l1Client: this.l1Client,
+      ethereumSlotDuration: this.l1Constants.ethereumSlotDuration,
+      log: this.log,
     });
   }
 
@@ -1207,7 +1220,7 @@ export class CheckpointProposalJob implements Traceable {
     return selectInboxBucketForBlock({
       messageSource: this.l1ToL2MessageSource,
       now: BigInt(Math.floor(nowSeconds)),
-      minBucketAgeSeconds: BigInt(this.l1Constants.ethereumSlotDuration),
+      isEligible: this.inboxBucketConfirmations.isEligible,
       parent: state.parent,
       checkpointStartTotalMsgCount: state.checkpointStartTotalMsgCount,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1221,6 +1221,7 @@ export class CheckpointProposalJob implements Traceable {
       messageSource: this.l1ToL2MessageSource,
       now: BigInt(Math.floor(nowSeconds)),
       isEligible: this.inboxBucketConfirmations.isEligible,
+      ethereumSlotDuration: this.l1Constants.ethereumSlotDuration,
       parent: state.parent,
       checkpointStartTotalMsgCount: state.checkpointStartTotalMsgCount,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
@@ -8,6 +8,7 @@ import { BlockNotFoundError } from 'viem';
 import {
   InboxBucketConfirmationTracker,
   type L1BlockReader,
+  type L1BlockRef,
   immediateEligibility,
 } from './inbox_bucket_eligibility.js';
 
@@ -16,7 +17,7 @@ const OPENED_AT = 1_000n;
 const BLOCK_NUMBER = 500n;
 
 /** An L1 block as far as the tracker is concerned: only its hash and parent hash are read. */
-type FakeL1Block = { number: bigint; hash: string; parentHash: string };
+type FakeL1Block = L1BlockRef & { number: bigint };
 
 const hashOf = (blockNumber: bigint) => Buffer32.fromBigInt(blockNumber).toString();
 
@@ -38,13 +39,14 @@ function makeBucket(overrides: Partial<InboxBucket> = {}): InboxBucket {
 function makeL1Client(blocks: FakeL1Block[]): L1BlockReader & { calls: bigint[] } {
   const byNumber = new Map(blocks.map(block => [block.number, block]));
   const calls: bigint[] = [];
-  const getBlock = (args?: { blockNumber?: bigint }) => {
-    const blockNumber = args!.blockNumber!;
-    calls.push(blockNumber);
-    const block = byNumber.get(blockNumber);
-    return block === undefined ? Promise.reject(new BlockNotFoundError({ blockNumber })) : Promise.resolve(block);
+  return {
+    calls,
+    getBlock({ blockNumber }) {
+      calls.push(blockNumber);
+      const block = byNumber.get(blockNumber);
+      return block === undefined ? Promise.reject(new BlockNotFoundError({ blockNumber })) : Promise.resolve(block);
+    },
   };
-  return { getBlock, calls } as unknown as L1BlockReader & { calls: bigint[] };
 }
 
 /** A canonical child of the bucket's opening block. */
@@ -159,12 +161,12 @@ describe('InboxBucketConfirmationTracker', () => {
 
   it('leaves a bucket ineligible when the L1 read fails outright, without retrying in the same second', async () => {
     const calls: bigint[] = [];
-    const l1Client = {
-      getBlock: ({ blockNumber }: { blockNumber: bigint }) => {
+    const l1Client: L1BlockReader = {
+      getBlock({ blockNumber }) {
         calls.push(blockNumber);
         return Promise.reject(new Error('connection reset'));
       },
-    } as unknown as L1BlockReader;
+    };
     const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: ETHEREUM_SLOT_DURATION });
 
     await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
@@ -177,7 +179,7 @@ describe('InboxBucketConfirmationTracker', () => {
   });
 
   it('leaves a bucket ineligible when the L1 read does not answer in time', async () => {
-    const l1Client = { getBlock: () => new Promise(() => {}) } as unknown as L1BlockReader;
+    const l1Client: L1BlockReader = { getBlock: () => new Promise<L1BlockRef>(() => {}) };
     const tracker = new InboxBucketConfirmationTracker({
       l1Client,
       ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
@@ -109,13 +109,13 @@ describe('InboxBucketConfirmationTracker', () => {
     expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
   });
 
-  it('reads L1 once per sub-slot, reusing the rejection within the same one', async () => {
+  it('reads L1 once per second, reusing the rejection within the same one', async () => {
     const { tracker, l1Client } = makeTracker([]);
     await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
     await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
     expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
 
-    // A later sub-slot re-checks, still before the missed-slot fallback opens.
+    // A later second re-checks, still before the missed-slot fallback opens.
     await expect(tracker.isEligible(makeBucket(), OPENED_AT + 17n)).resolves.toBe(false);
     expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER + 1n]);
   });
@@ -157,11 +157,32 @@ describe('InboxBucketConfirmationTracker', () => {
     expect(l1Client.calls).toEqual([]);
   });
 
-  it('leaves a bucket ineligible when the L1 read fails outright', async () => {
+  it('leaves a bucket ineligible when the L1 read fails outright, without retrying in the same second', async () => {
+    const calls: bigint[] = [];
     const l1Client = {
-      getBlock: () => Promise.reject(new Error('connection reset')),
+      getBlock: ({ blockNumber }: { blockNumber: bigint }) => {
+        calls.push(blockNumber);
+        return Promise.reject(new Error('connection reset'));
+      },
     } as unknown as L1BlockReader;
     const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: ETHEREUM_SLOT_DURATION });
+
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+    expect(calls).toEqual([BLOCK_NUMBER + 1n]);
+
+    // The failure is not sticky: the next second tries again.
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 15n)).resolves.toBe(false);
+    expect(calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER + 1n]);
+  });
+
+  it('leaves a bucket ineligible when the L1 read does not answer in time', async () => {
+    const l1Client = { getBlock: () => new Promise(() => {}) } as unknown as L1BlockReader;
+    const tracker = new InboxBucketConfirmationTracker({
+      l1Client,
+      ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+      l1ReadTimeoutMs: 20,
+    });
     await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
   });
 });

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.test.ts
@@ -1,0 +1,167 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { InboxBucket } from '@aztec/stdlib/messaging';
+
+import { describe, expect, it } from '@jest/globals';
+import { BlockNotFoundError } from 'viem';
+
+import {
+  InboxBucketConfirmationTracker,
+  type L1BlockReader,
+  immediateEligibility,
+} from './inbox_bucket_eligibility.js';
+
+const ETHEREUM_SLOT_DURATION = 12;
+const OPENED_AT = 1_000n;
+const BLOCK_NUMBER = 500n;
+
+/** An L1 block as far as the tracker is concerned: only its hash and parent hash are read. */
+type FakeL1Block = { number: bigint; hash: string; parentHash: string };
+
+const hashOf = (blockNumber: bigint) => Buffer32.fromBigInt(blockNumber).toString();
+
+function makeBucket(overrides: Partial<InboxBucket> = {}): InboxBucket {
+  return {
+    seq: 3n,
+    inboxRollingHash: new Fr(7),
+    totalMsgCount: 5n,
+    timestamp: OPENED_AT,
+    msgCount: 2,
+    lastMessageIndex: 4n,
+    l1BlockNumber: BLOCK_NUMBER,
+    l1BlockHash: Buffer32.fromString(hashOf(BLOCK_NUMBER)),
+    ...overrides,
+  };
+}
+
+/** An L1 client serving a fixed set of blocks by number, counting the reads the tracker makes. */
+function makeL1Client(blocks: FakeL1Block[]): L1BlockReader & { calls: bigint[] } {
+  const byNumber = new Map(blocks.map(block => [block.number, block]));
+  const calls: bigint[] = [];
+  const getBlock = (args?: { blockNumber?: bigint }) => {
+    const blockNumber = args!.blockNumber!;
+    calls.push(blockNumber);
+    const block = byNumber.get(blockNumber);
+    return block === undefined ? Promise.reject(new BlockNotFoundError({ blockNumber })) : Promise.resolve(block);
+  };
+  return { getBlock, calls } as unknown as L1BlockReader & { calls: bigint[] };
+}
+
+/** A canonical child of the bucket's opening block. */
+const canonicalChild: FakeL1Block = {
+  number: BLOCK_NUMBER + 1n,
+  hash: hashOf(BLOCK_NUMBER + 1n),
+  parentHash: hashOf(BLOCK_NUMBER),
+};
+
+/** The opening block itself, still canonical. */
+const canonicalSelf: FakeL1Block = {
+  number: BLOCK_NUMBER,
+  hash: hashOf(BLOCK_NUMBER),
+  parentHash: hashOf(BLOCK_NUMBER - 1n),
+};
+
+function makeTracker(blocks: FakeL1Block[], clockToleranceSeconds = 0) {
+  const l1Client = makeL1Client(blocks);
+  const tracker = new InboxBucketConfirmationTracker({
+    l1Client,
+    ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+    clockToleranceSeconds,
+  });
+  return { tracker, l1Client };
+}
+
+describe('immediateEligibility', () => {
+  it('accepts any bucket at any time', async () => {
+    await expect(immediateEligibility(makeBucket(), 0n)).resolves.toBe(true);
+  });
+});
+
+describe('InboxBucketConfirmationTracker', () => {
+  it('does not read L1 before the next Ethereum slot has started', async () => {
+    const { tracker, l1Client } = makeTracker([canonicalChild]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 11n)).resolves.toBe(false);
+    expect(l1Client.calls).toEqual([]);
+  });
+
+  it('confirms a bucket whose opening block has a canonical child', async () => {
+    const { tracker, l1Client } = makeTracker([canonicalChild]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 12n)).resolves.toBe(true);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
+  });
+
+  it('caches a confirmation for the tracker lifetime', async () => {
+    const { tracker, l1Client } = makeTracker([canonicalChild]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 12n)).resolves.toBe(true);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 15n)).resolves.toBe(true);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
+  });
+
+  it('rejects a bucket whose opening block was replaced, seen through the child parent hash', async () => {
+    const orphaningChild: FakeL1Block = {
+      number: BLOCK_NUMBER + 1n,
+      hash: hashOf(BLOCK_NUMBER + 1n),
+      // Built on the replacement of the bucket's block, not on the bucket's block itself.
+      parentHash: hashOf(999n),
+    };
+    const { tracker, l1Client } = makeTracker([orphaningChild]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
+  });
+
+  it('reads L1 once per sub-slot, reusing the rejection within the same one', async () => {
+    const { tracker, l1Client } = makeTracker([]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n]);
+
+    // A later sub-slot re-checks, still before the missed-slot fallback opens.
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 17n)).resolves.toBe(false);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER + 1n]);
+  });
+
+  it('falls back to the opening block itself once the next Ethereum slot has fully elapsed', async () => {
+    const { tracker, l1Client } = makeTracker([canonicalSelf]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 24n)).resolves.toBe(true);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER]);
+  });
+
+  it('rejects when the fallback finds a different block at the same height', async () => {
+    const replacement: FakeL1Block = {
+      number: BLOCK_NUMBER,
+      hash: hashOf(999n),
+      parentHash: hashOf(BLOCK_NUMBER - 1n),
+    };
+    const { tracker, l1Client } = makeTracker([replacement]);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 24n)).resolves.toBe(false);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER]);
+  });
+
+  it('applies the clock tolerance in the permissive direction', async () => {
+    const { tracker, l1Client } = makeTracker([canonicalSelf], 2);
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 22n)).resolves.toBe(true);
+    expect(l1Client.calls).toEqual([BLOCK_NUMBER + 1n, BLOCK_NUMBER]);
+  });
+
+  it('treats the genesis sentinel bucket as eligible without reading L1', async () => {
+    const { tracker, l1Client } = makeTracker([]);
+    const genesis = makeBucket({
+      seq: 0n,
+      totalMsgCount: 0n,
+      msgCount: 0,
+      timestamp: 0n,
+      l1BlockNumber: 0n,
+      l1BlockHash: Buffer32.ZERO,
+    });
+    await expect(tracker.isEligible(genesis, 0n)).resolves.toBe(true);
+    expect(l1Client.calls).toEqual([]);
+  });
+
+  it('leaves a bucket ineligible when the L1 read fails outright', async () => {
+    const l1Client = {
+      getBlock: () => Promise.reject(new Error('connection reset')),
+    } as unknown as L1BlockReader;
+    const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: ETHEREUM_SLOT_DURATION });
+    await expect(tracker.isEligible(makeBucket(), OPENED_AT + 14n)).resolves.toBe(false);
+  });
+});

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
@@ -1,4 +1,3 @@
-import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { executeTimeout } from '@aztec/foundation/timer';
 import type { InboxBucket } from '@aztec/stdlib/messaging';
@@ -16,8 +15,18 @@ export type InboxBucketEligibility = (bucket: InboxBucket, nowSeconds: bigint) =
 /** Consumes every bucket the archiver has, with no L1 confirmation wait. Used by automine, which never waits. */
 export const immediateEligibility: InboxBucketEligibility = () => Promise.resolve(true);
 
-/** The single L1 read the confirmation tracker performs: a block by number. */
-export type L1BlockReader = Pick<ViemPublicClient, 'getBlock'>;
+/** What the confirmation tracker reads off an L1 block: its own identity and its parent link. */
+export type L1BlockRef = { hash: string | null; parentHash: string };
+
+/**
+ * The single L1 read the confirmation tracker performs: a block by number. Narrower than viem's `getBlock` on
+ * purpose, so tests and any other caller can supply a plain object instead of a whole public client; a viem public
+ * client satisfies it as-is.
+ */
+export interface L1BlockReader {
+  /** Fetches an L1 block header by number; rejects with viem's `BlockNotFoundError` when the block does not exist. */
+  getBlock(args: { blockNumber: bigint; includeTransactions?: false }): Promise<L1BlockRef>;
+}
 
 /** Dependencies of an {@link InboxBucketConfirmationTracker}. */
 export type InboxBucketConfirmationTrackerDeps = {

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
@@ -1,0 +1,169 @@
+import type { ViemPublicClient } from '@aztec/ethereum/types';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { InboxBucket } from '@aztec/stdlib/messaging';
+
+import { BlockNotFoundError } from 'viem';
+
+/**
+ * Whether a proposer may consume an Inbox bucket in the sub-slot anchored at `nowSeconds`. Eligibility is proposer
+ * policy, not a consensus rule: L1 accepts any bucket at or below the censorship cutoff, and validators only check
+ * what L1 checks. A proposer that consumes an Inbox bucket whose L1 block is later reorged out builds a checkpoint
+ * its own archiver will disown, so it delays consumption until the opening block looks settled.
+ */
+export type InboxBucketEligibility = (bucket: InboxBucket, nowSeconds: bigint) => Promise<boolean>;
+
+/** Consumes every bucket the archiver has, with no L1 confirmation wait. Used by automine, which never waits. */
+export const immediateEligibility: InboxBucketEligibility = () => Promise.resolve(true);
+
+/** The single L1 read the confirmation tracker performs: a block by number. */
+export type L1BlockReader = Pick<ViemPublicClient, 'getBlock'>;
+
+/** Dependencies of an {@link InboxBucketConfirmationTracker}. */
+export type InboxBucketConfirmationTrackerDeps = {
+  /** L1 client used to look up the bucket's opening block and its child. */
+  l1Client: L1BlockReader;
+  /** Configured Ethereum slot duration in seconds; the unit the confirmation deadlines are expressed in. */
+  ethereumSlotDuration: number;
+  /** Wall-clock tolerance in seconds, applied in the permissive direction only. Defaults to 0. */
+  clockToleranceSeconds?: number;
+  log?: Logger;
+};
+
+/**
+ * Decides when an Inbox bucket's opening L1 block is safe from the common one-block reorg, using only EL block reads.
+ *
+ * A bucket opened in L1 block `N` (number `h`, hash `H`, timestamp `T`) is eligible once either
+ *
+ * - block `h + 1` is visible and its `parentHash` is `H` — `N` then survives even if that child is itself reorged,
+ *   since the replacement builds on the same parent; or
+ * - slot `S + 1` has fully elapsed (`now >= T + 2E`) and block `h` still hashes to `H`, which covers a missed slot
+ *   `S + 1`. Past that point the honest fork-choice reorg mechanism can no longer displace `N`, as it only ever
+ *   reorgs the head's immediate successor slot.
+ *
+ * A child with a different parent, or a block `h` with a different hash, means `N` is already orphaned: the bucket is
+ * permanently ineligible under this tracker, and the archiver will roll it back shortly.
+ *
+ * Age in seconds is deliberately not the rule. A replacement block lands at roughly `T + 13..15`, which is *after*
+ * the `T + 12` tick an age-of-one-Ethereum-slot rule would have released the bucket at, so that rule buys no safety
+ * at all; and with a missed slot a bucket can be a full Ethereum slot old while still sitting in the latest L1 block.
+ * Waiting for evidence of a descendant is both cheaper (usually ~`T + 14`) and actually sound.
+ *
+ * One tracker is meant to live for one proposal job (one slot). It is frugal with RPCs: it performs no call before a
+ * child could exist, caches confirmations for its lifetime, caches rejections for the sub-slot they were computed in,
+ * and decides each branch from a single response — behind a load-balanced RPC two calls may see different heads, so
+ * no branch ever compares two responses.
+ */
+export class InboxBucketConfirmationTracker {
+  private readonly l1Client: L1BlockReader;
+  private readonly ethereumSlotDuration: bigint;
+  private readonly clockToleranceSeconds: bigint;
+  private readonly log: Logger;
+
+  /** Buckets whose opening block has a confirmed descendant. Confirmed never becomes unconfirmed. */
+  private readonly confirmed = new Set<string>();
+
+  /** Buckets known to be ineligible, keyed to the sub-slot clock the answer was computed at. */
+  private readonly rejectedAt = new Map<string, bigint>();
+
+  constructor(deps: InboxBucketConfirmationTrackerDeps) {
+    this.l1Client = deps.l1Client;
+    this.ethereumSlotDuration = BigInt(deps.ethereumSlotDuration);
+    this.clockToleranceSeconds = BigInt(deps.clockToleranceSeconds ?? 0);
+    this.log = deps.log ?? createLogger('sequencer:inbox-bucket-confirmation');
+  }
+
+  /**
+   * Eligibility function for the Inbox bucket selector, bound to this tracker's caches. An L1 read that fails leaves
+   * the bucket ineligible for now rather than aborting the block: a bucket at or below the censorship cutoff is
+   * consumed by the checkpoint's last block regardless of eligibility, so a flaky L1 endpoint costs latency, not
+   * liveness.
+   */
+  public readonly isEligible: InboxBucketEligibility = async (bucket, nowSeconds) => {
+    try {
+      return await this.check(bucket, nowSeconds);
+    } catch (err) {
+      this.log.warn(`Failed to check L1 confirmation for Inbox bucket ${bucket.seq}: ${err}`, {
+        bucketSeq: bucket.seq,
+        l1BlockNumber: bucket.l1BlockNumber,
+      });
+      return false;
+    }
+  };
+
+  private async check(bucket: InboxBucket, nowSeconds: bigint): Promise<boolean> {
+    // The genesis sentinel holds no messages and was never opened by an L1 block, so there is nothing to confirm.
+    if (bucket.seq === 0n) {
+      return true;
+    }
+
+    const key = `${bucket.seq}:${bucket.l1BlockHash.toString()}`;
+    if (this.confirmed.has(key)) {
+      return true;
+    }
+    if (this.rejectedAt.get(key) === nowSeconds) {
+      return false;
+    }
+
+    const openedAt = bucket.timestamp;
+    const permissiveNow = nowSeconds + this.clockToleranceSeconds;
+
+    // Slot S+1 has not started, so no child can exist yet and block h cannot have settled either.
+    if (permissiveNow < openedAt + this.ethereumSlotDuration) {
+      return this.reject(key, nowSeconds);
+    }
+
+    const child = await this.getBlockByNumber(bucket.l1BlockNumber + 1n);
+    if (child !== undefined) {
+      if (this.hashMatches(child.parentHash, bucket)) {
+        this.confirmed.add(key);
+        return true;
+      }
+      this.log.debug(`Inbox bucket ${bucket.seq} sits on an orphaned L1 block`, {
+        reason: 'bucket_l1_block_orphaned',
+        bucketSeq: bucket.seq,
+        l1BlockNumber: bucket.l1BlockNumber,
+        expectedParent: bucket.l1BlockHash.toString(),
+        actualParent: child.parentHash,
+      });
+      return this.reject(key, nowSeconds);
+    }
+
+    // No child: slot S+1 was missed. Once it has fully elapsed, block h being canonical is enough.
+    if (permissiveNow >= openedAt + 2n * this.ethereumSlotDuration) {
+      const current = await this.getBlockByNumber(bucket.l1BlockNumber);
+      if (current !== undefined && this.hashMatches(current.hash, bucket)) {
+        this.confirmed.add(key);
+        return true;
+      }
+      this.log.debug(`Inbox bucket ${bucket.seq} is no longer on the canonical L1 chain`, {
+        reason: 'bucket_l1_block_orphaned',
+        bucketSeq: bucket.seq,
+        l1BlockNumber: bucket.l1BlockNumber,
+        expectedHash: bucket.l1BlockHash.toString(),
+        actualHash: current?.hash,
+      });
+    }
+
+    return this.reject(key, nowSeconds);
+  }
+
+  private reject(key: string, nowSeconds: bigint): false {
+    this.rejectedAt.set(key, nowSeconds);
+    return false;
+  }
+
+  private hashMatches(hash: string | null, bucket: InboxBucket): boolean {
+    return hash !== null && hash.toLowerCase() === bucket.l1BlockHash.toString().toLowerCase();
+  }
+
+  private async getBlockByNumber(blockNumber: bigint) {
+    try {
+      return await this.l1Client.getBlock({ blockNumber, includeTransactions: false });
+    } catch (err) {
+      if (err instanceof BlockNotFoundError) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
@@ -1,5 +1,6 @@
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { executeTimeout } from '@aztec/foundation/timer';
 import type { InboxBucket } from '@aztec/stdlib/messaging';
 
 import { BlockNotFoundError } from 'viem';
@@ -26,8 +27,17 @@ export type InboxBucketConfirmationTrackerDeps = {
   ethereumSlotDuration: number;
   /** Wall-clock tolerance in seconds, applied in the permissive direction only. Defaults to 0. */
   clockToleranceSeconds?: number;
+  /**
+   * How long a single L1 block read may take before the bucket is treated as unconfirmed for now.
+   * Defaults to {@link DEFAULT_L1_READ_TIMEOUT_MS}. These reads sit on the block-building path, where the viem
+   * default (10s plus retries) would eat the sub-slot.
+   */
+  l1ReadTimeoutMs?: number;
   log?: Logger;
 };
+
+/** Default cap on a single confirmation read, well under a sub-slot. */
+const DEFAULT_L1_READ_TIMEOUT_MS = 2_000;
 
 /**
  * Decides when an Inbox bucket's opening L1 block is safe from the common one-block reorg, using only EL block reads.
@@ -49,14 +59,16 @@ export type InboxBucketConfirmationTrackerDeps = {
  * Waiting for evidence of a descendant is both cheaper (usually ~`T + 14`) and actually sound.
  *
  * One tracker is meant to live for one proposal job (one slot). It is frugal with RPCs: it performs no call before a
- * child could exist, caches confirmations for its lifetime, caches rejections for the sub-slot they were computed in,
- * and decides each branch from a single response — behind a load-balanced RPC two calls may see different heads, so
- * no branch ever compares two responses.
+ * child could exist, caches confirmations for its lifetime, caches rejections for the second they were computed in,
+ * answers every bucket a given L1 block opened from one read, and decides each branch from a single response —
+ * behind a load-balanced RPC two calls may see different heads, so no branch ever compares two responses. Every read
+ * is time-boxed: an L1 endpoint that hangs must not cost the proposer its sub-slot.
  */
 export class InboxBucketConfirmationTracker {
   private readonly l1Client: L1BlockReader;
   private readonly ethereumSlotDuration: bigint;
   private readonly clockToleranceSeconds: bigint;
+  private readonly l1ReadTimeoutMs: number;
   private readonly log: Logger;
 
   /**
@@ -65,13 +77,17 @@ export class InboxBucketConfirmationTracker {
    */
   private readonly confirmed = new Set<string>();
 
-  /** Opening L1 blocks known to be unconfirmed, keyed to the sub-slot clock the answer was computed at. */
+  /**
+   * Opening L1 blocks known to be unconfirmed, keyed to the `nowSeconds` the answer was computed at: a repeat call
+   * within the same second reuses it, a later one re-reads L1.
+   */
   private readonly rejectedAt = new Map<string, bigint>();
 
   constructor(deps: InboxBucketConfirmationTrackerDeps) {
     this.l1Client = deps.l1Client;
     this.ethereumSlotDuration = BigInt(deps.ethereumSlotDuration);
     this.clockToleranceSeconds = BigInt(deps.clockToleranceSeconds ?? 0);
+    this.l1ReadTimeoutMs = deps.l1ReadTimeoutMs ?? DEFAULT_L1_READ_TIMEOUT_MS;
     this.log = deps.log ?? createLogger('sequencer:inbox-bucket-confirmation');
   }
 
@@ -82,24 +98,26 @@ export class InboxBucketConfirmationTracker {
    * liveness.
    */
   public readonly isEligible: InboxBucketEligibility = async (bucket, nowSeconds) => {
-    try {
-      return await this.check(bucket, nowSeconds);
-    } catch (err) {
-      this.log.warn(`Failed to check L1 confirmation for Inbox bucket ${bucket.seq}: ${err}`, {
-        bucketSeq: bucket.seq,
-        l1BlockNumber: bucket.l1BlockNumber,
-      });
-      return false;
-    }
-  };
-
-  private async check(bucket: InboxBucket, nowSeconds: bigint): Promise<boolean> {
     // The genesis sentinel holds no messages and was never opened by an L1 block, so there is nothing to confirm.
     if (bucket.seq === 0n) {
       return true;
     }
 
     const key = `${bucket.l1BlockNumber}:${bucket.l1BlockHash.toString()}`;
+    try {
+      return await this.check(bucket, key, nowSeconds);
+    } catch (err) {
+      // A read that times out or fails leaves the block neither confirmed nor orphaned; it is pending, and the
+      // rejection is cached so a flaky endpoint costs one read per second rather than one per bucket.
+      this.log.debug(`Could not read L1 to confirm Inbox bucket ${bucket.seq}, treating it as pending: ${err}`, {
+        bucketSeq: bucket.seq,
+        l1BlockNumber: bucket.l1BlockNumber,
+      });
+      return this.reject(key, nowSeconds);
+    }
+  };
+
+  private async check(bucket: InboxBucket, key: string, nowSeconds: bigint): Promise<boolean> {
     if (this.confirmed.has(key)) {
       return true;
     }
@@ -161,7 +179,11 @@ export class InboxBucketConfirmationTracker {
 
   private async getBlockByNumber(blockNumber: bigint) {
     try {
-      return await this.l1Client.getBlock({ blockNumber, includeTransactions: false });
+      return await executeTimeout(
+        () => this.l1Client.getBlock({ blockNumber, includeTransactions: false }),
+        this.l1ReadTimeoutMs,
+        `L1 getBlock(${blockNumber})`,
+      );
     } catch (err) {
       if (err instanceof BlockNotFoundError) {
         return undefined;

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
@@ -59,10 +59,13 @@ export class InboxBucketConfirmationTracker {
   private readonly clockToleranceSeconds: bigint;
   private readonly log: Logger;
 
-  /** Buckets whose opening block has a confirmed descendant. Confirmed never becomes unconfirmed. */
+  /**
+   * Opening L1 blocks known to have a canonical descendant. Confirmed never becomes unconfirmed. Keyed by block
+   * identity rather than by bucket, so the many buckets a busy L1 block opens all resolve from one read.
+   */
   private readonly confirmed = new Set<string>();
 
-  /** Buckets known to be ineligible, keyed to the sub-slot clock the answer was computed at. */
+  /** Opening L1 blocks known to be unconfirmed, keyed to the sub-slot clock the answer was computed at. */
   private readonly rejectedAt = new Map<string, bigint>();
 
   constructor(deps: InboxBucketConfirmationTrackerDeps) {
@@ -96,7 +99,7 @@ export class InboxBucketConfirmationTracker {
       return true;
     }
 
-    const key = `${bucket.seq}:${bucket.l1BlockHash.toString()}`;
+    const key = `${bucket.l1BlockNumber}:${bucket.l1BlockHash.toString()}`;
     if (this.confirmed.has(key)) {
       return true;
     }

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_eligibility.ts
@@ -50,14 +50,17 @@ const DEFAULT_L1_READ_TIMEOUT_MS = 2_000;
 
 /**
  * Decides when an Inbox bucket's opening L1 block is safe from the common one-block reorg, using only EL block reads.
+ * A bucket becomes eligible once a child block is observed on top of the block carrying it, or the following L1 slot
+ * was missed and that block is still canonical after it.
  *
- * A bucket opened in L1 block `N` (number `h`, hash `H`, timestamp `T`) is eligible once either
+ * Concretely, a bucket opened in L1 block `N` (number `h`, hash `H`, timestamp `T`) is eligible once either
  *
  * - block `h + 1` is visible and its `parentHash` is `H` — `N` then survives even if that child is itself reorged,
  *   since the replacement builds on the same parent; or
  * - slot `S + 1` has fully elapsed (`now >= T + 2E`) and block `h` still hashes to `H`, which covers a missed slot
- *   `S + 1`. Past that point the honest fork-choice reorg mechanism can no longer displace `N`, as it only ever
- *   reorgs the head's immediate successor slot.
+ *   `S + 1`. Once `S + 1` has passed with no child, the attestations slot `S`'s committee already cast for `N` keep
+ *   it canonical under honest fork choice, and proposer boost only ever weights the current slot's proposal, so it
+ *   cannot lift a competitor from a past slot above it.
  *
  * A child with a different parent, or a block `h` with a different hash, means `N` is already orphaned: the bucket is
  * permanently ineligible under this tracker, and the archiver will roll it back shortly.
@@ -65,7 +68,7 @@ const DEFAULT_L1_READ_TIMEOUT_MS = 2_000;
  * Age in seconds is deliberately not the rule. A replacement block lands at roughly `T + 13..15`, which is *after*
  * the `T + 12` tick an age-of-one-Ethereum-slot rule would have released the bucket at, so that rule buys no safety
  * at all; and with a missed slot a bucket can be a full Ethereum slot old while still sitting in the latest L1 block.
- * Waiting for evidence of a descendant is both cheaper (usually ~`T + 14`) and actually sound.
+ * Waiting for evidence of a descendant is cheaper too (usually ~`T + 14`).
  *
  * One tracker is meant to live for one proposal job (one slot). It is frugal with RPCs: it performs no call before a
  * child could exist, caches confirmations for its lifetime, caches rejections for the second they were computed in,

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
@@ -2,6 +2,14 @@ import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type InboxBucket, MIN_BLOCKS_FOR_INBOX_CATCHUP, isInboxConsumptionSufficient } from '@aztec/stdlib/messaging';
 
+import { BlockNotFoundError } from 'viem';
+
+import {
+  InboxBucketConfirmationTracker,
+  type InboxBucketEligibility,
+  type L1BlockReader,
+  immediateEligibility,
+} from './inbox_bucket_eligibility.js';
 import { type InboxBucketSource, selectInboxBucketForBlock } from './inbox_bucket_selector.js';
 
 /** A test bucket: its cumulative totals and leaves are derived from a running message count. */
@@ -66,15 +74,32 @@ function makeSource(specs: TestBucketSpec[]): {
 const GENESIS_PARENT = { seq: 0n, totalMsgCount: 0n };
 
 // Pinned cross-layer values shared with the L1 Foundry harness: genesisTime=100000, slotDuration=36,
-// ethereumSlotDuration=12 (which is also the minimum bucket age).
+// ethereumSlotDuration=12.
 const GENESIS_TIME = 100000n;
 const SLOT_DURATION = 36n;
-const MIN_AGE = 12n;
-const cutoffForSlot = (slot: bigint) => GENESIS_TIME + (slot - 1n) * SLOT_DURATION - MIN_AGE;
+const ETHEREUM_SLOT_DURATION = 12n;
+const cutoffForSlot = (slot: bigint) => GENESIS_TIME + (slot - 1n) * SLOT_DURATION - ETHEREUM_SLOT_DURATION;
+
+/**
+ * Stands in for the descendant-confirmed rule without an L1 client: a bucket is eligible once one Ethereum slot has
+ * passed since it was opened, which is when its child block would be visible.
+ */
+const eligibleAfterOneEthereumSlot: InboxBucketEligibility = (bucket, now) =>
+  Promise.resolve(bucket.timestamp + ETHEREUM_SLOT_DURATION <= now);
+
+/** Records which buckets the eligibility rule was asked about, for the walk-bound assertions. */
+function trackingEligibility(inner: InboxBucketEligibility): InboxBucketEligibility & { asked: bigint[] } {
+  const asked: bigint[] = [];
+  const fn = async (bucket: InboxBucket, now: bigint) => {
+    asked.push(bucket.seq);
+    return await inner(bucket, now);
+  };
+  return Object.assign(fn, { asked });
+}
 
 describe('selectInboxBucketForBlock', () => {
   const baseInput = {
-    minBucketAgeSeconds: MIN_AGE,
+    isEligible: eligibleAfterOneEthereumSlot,
     checkpointStartTotalMsgCount: 0n,
     perBlockCap: 1024,
     perCheckpointCap: 1024,
@@ -93,17 +118,17 @@ describe('selectInboxBucketForBlock', () => {
     expect(result.consume).toBe(false);
   });
 
-  it('picks the newest lag-eligible bucket and derives its bundle from genesis', async () => {
+  it('picks the newest eligible bucket and derives its bundle from genesis', async () => {
     const { source } = makeSource([
       { seq: 1n, timestamp: 100n, msgCount: 3 },
       { seq: 2n, timestamp: 200n, msgCount: 2 },
       { seq: 3n, timestamp: 300n, msgCount: 4 },
     ]);
-    // now - lag = 250 -> newest bucket at-or-before 250 is seq 2.
+    // At now=262 buckets 1 and 2 are confirmed but bucket 3 (opened at 300) is still in the future.
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 250n + MIN_AGE,
+      now: 250n + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
     });
     expect(result).toMatchObject({ consume: true });
@@ -113,25 +138,77 @@ describe('selectInboxBucketForBlock', () => {
     }
   });
 
-  it('treats a bucket exactly one Ethereum slot old as eligible (inclusive lag boundary)', async () => {
-    const { source } = makeSource([{ seq: 1n, timestamp: 500n, msgCount: 1 }]);
-    // Bucket age exactly == the minimum: timestamp == now - minBucketAgeSeconds.
+  it('skips an unconfirmed newest bucket and consumes through the newest confirmed one', async () => {
+    const { source } = makeSource([
+      { seq: 1n, timestamp: 100n, msgCount: 3 },
+      { seq: 2n, timestamp: 200n, msgCount: 2 },
+      { seq: 3n, timestamp: 300n, msgCount: 4 },
+    ]);
+    const isEligible = trackingEligibility(bucket => Promise.resolve(bucket.seq <= 2n));
     const result = await selectInboxBucketForBlock({
       ...baseInput,
+      isEligible,
       messageSource: source,
-      now: 500n + MIN_AGE,
+      now: 1_000n,
       parent: GENESIS_PARENT,
     });
-    expect(result.consume).toBe(true);
+    expect(result).toMatchObject({ consume: true });
+    if (result.consume) {
+      expect(result.bucket.seq).toBe(2n);
+      expect(result.bundle).toHaveLength(5);
+    }
+    // The walk starts at the archiver's head bucket and stops at the first eligible one.
+    expect(isEligible.asked).toEqual([3n, 2n]);
+  });
 
-    // One second younger than the minimum-age boundary: not yet eligible.
-    const tooYoung = await selectInboxBucketForBlock({
+  it('consumes nothing when no bucket past the parent is eligible', async () => {
+    const { source } = makeSource([
+      { seq: 1n, timestamp: 100n, msgCount: 3 },
+      { seq: 2n, timestamp: 200n, msgCount: 2 },
+    ]);
+    const result = await selectInboxBucketForBlock({
       ...baseInput,
+      isEligible: () => Promise.resolve(false),
       messageSource: source,
-      now: 500n + MIN_AGE - 1n,
+      now: 1_000n,
       parent: GENESIS_PARENT,
     });
-    expect(tooYoung.consume).toBe(false);
+    expect(result.consume).toBe(false);
+  });
+
+  it('stops the eligibility walk after a bounded number of buckets', async () => {
+    const { source } = makeSource(
+      Array.from({ length: 12 }, (_, i) => ({ seq: BigInt(i + 1), timestamp: BigInt((i + 1) * 10), msgCount: 1 })),
+    );
+    // Only the oldest bucket is eligible, which is well past the walk bound from the head.
+    const isEligible = trackingEligibility(bucket => Promise.resolve(bucket.seq === 1n));
+    const result = await selectInboxBucketForBlock({
+      ...baseInput,
+      isEligible,
+      messageSource: source,
+      now: 1_000n,
+      parent: GENESIS_PARENT,
+    });
+    expect(result.consume).toBe(false);
+    expect(isEligible.asked).toEqual([12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n]);
+  });
+
+  it('consumes every bucket the archiver has under immediate eligibility', async () => {
+    const { source } = makeSource([
+      { seq: 1n, timestamp: 100n, msgCount: 3 },
+      { seq: 2n, timestamp: 999n, msgCount: 2 },
+    ]);
+    const result = await selectInboxBucketForBlock({
+      ...baseInput,
+      isEligible: immediateEligibility,
+      messageSource: source,
+      now: 1_000n,
+      parent: GENESIS_PARENT,
+    });
+    expect(result).toMatchObject({ consume: true });
+    if (result.consume) {
+      expect(result.bucket.seq).toBe(2n);
+    }
   });
 
   it('walks back to the newest bucket that fits the per-block cap', async () => {
@@ -144,7 +221,7 @@ describe('selectInboxBucketForBlock', () => {
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 300n + MIN_AGE,
+      now: 300n + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
       perBlockCap: 400,
     });
@@ -165,7 +242,7 @@ describe('selectInboxBucketForBlock', () => {
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 200n + MIN_AGE,
+      now: 200n + ETHEREUM_SLOT_DURATION,
       parent: { seq: 1n, totalMsgCount: buckets.get(1n)!.totalMsgCount },
       checkpointStartTotalMsgCount: 0n,
       perCheckpointCap: 1000,
@@ -178,11 +255,11 @@ describe('selectInboxBucketForBlock', () => {
       { seq: 1n, timestamp: 100n, msgCount: 2 },
       { seq: 2n, timestamp: 260n, msgCount: 3 },
     ]);
-    // Block 1 at now-lag=150: only bucket 1 eligible.
+    // Block 1 at now=162: only bucket 1 is confirmed.
     const first = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 150n + MIN_AGE,
+      now: 150n + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
     });
     expect(first).toMatchObject({ consume: true });
@@ -191,11 +268,11 @@ describe('selectInboxBucketForBlock', () => {
     }
     expect(first.bucket.seq).toBe(1n);
 
-    // Block 2, later sub-slot (now-lag=300): bucket 2 has now aged in; parent is block 1's bucket.
+    // Block 2, later sub-slot (now=312): bucket 2 is now confirmed too; parent is block 1's bucket.
     const second = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 300n + MIN_AGE,
+      now: 300n + ETHEREUM_SLOT_DURATION,
       parent: { seq: first.bucket.seq, totalMsgCount: first.bucket.totalMsgCount },
       checkpointStartTotalMsgCount: 0n,
     });
@@ -208,14 +285,14 @@ describe('selectInboxBucketForBlock', () => {
   });
 
   it('applies the cutoff as a consumption floor on the last block', async () => {
-    // Bucket sits at the cutoff for slot 10 but is younger than now-lag, so a non-last block skips it.
+    // Bucket sits at the cutoff for slot 10 but is not yet confirmed, so a non-last block skips it.
     const cutoff = cutoffForSlot(10n);
     const { source } = makeSource([{ seq: 1n, timestamp: cutoff, msgCount: 5 }]);
 
     const nonLast = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: cutoff + MIN_AGE - 1n, // bucket is one second too young for lag eligibility
+      now: cutoff + ETHEREUM_SLOT_DURATION - 1n, // bucket's opening block has no descendant yet
       parent: GENESIS_PARENT,
       isLastBlock: false,
       cutoffTimestamp: cutoff,
@@ -225,7 +302,7 @@ describe('selectInboxBucketForBlock', () => {
     const last = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: cutoff + MIN_AGE - 1n,
+      now: cutoff + ETHEREUM_SLOT_DURATION - 1n,
       parent: GENESIS_PARENT,
       isLastBlock: true,
       cutoffTimestamp: cutoff,
@@ -245,7 +322,7 @@ describe('selectInboxBucketForBlock', () => {
     const mustConsume = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: atCutoff.source,
-      now: cutoff, // before lag would make it eligible, forcing reliance on the cutoff floor
+      now: cutoff, // before eligibility would admit it, forcing reliance on the cutoff floor
       parent: GENESIS_PARENT,
       isLastBlock: true,
       cutoffTimestamp: cutoff,
@@ -276,7 +353,7 @@ describe('selectInboxBucketForBlock', () => {
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: cutoff + MIN_AGE,
+      now: cutoff + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
       perBlockCap: 256,
       perCheckpointCap: 1024,
@@ -302,7 +379,7 @@ describe('selectInboxBucketForBlock', () => {
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: cutoff + MIN_AGE,
+      now: cutoff + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
       perBlockCap: 256,
       perCheckpointCap: 1024,
@@ -338,7 +415,7 @@ describe('selectInboxBucketForBlock', () => {
         ...baseInput,
         ...caps,
         messageSource: source,
-        now: cutoff + MIN_AGE,
+        now: cutoff + ETHEREUM_SLOT_DURATION,
         parent,
         isLastBlock,
         cutoffTimestamp: cutoff,
@@ -359,12 +436,49 @@ describe('selectInboxBucketForBlock', () => {
     expect(await sufficiencyAt({ seq: 6n, totalMsgCount: 771n })).toBe(false);
   });
 
+  it('makes a bucket opened at the cutoff confirmable within the build frame', async () => {
+    // The censorship floor is only satisfiable if a bucket opened at the very last moment L1 makes mandatory still
+    // becomes eligible while the checkpoint is being built. Slot S's cutoff is one Ethereum slot before the build
+    // frame opens, so the bucket's child block lands ~2s into the frame, before the first block is proposed.
+    const cutoff = cutoffForSlot(10n);
+    const buildFrameStart = GENESIS_TIME + 9n * SLOT_DURATION;
+    expect(cutoff).toBe(buildFrameStart - ETHEREUM_SLOT_DURATION);
+
+    const { source } = makeSource([{ seq: 1n, timestamp: cutoff, msgCount: 2 }]);
+    const childVisibleAt = cutoff + 14n;
+    let now = buildFrameStart;
+    const l1Client = {
+      getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
+        blockNumber === 2n && now >= childVisibleAt
+          ? Promise.resolve({ parentHash: Buffer32.fromBigInt(1n).toString() })
+          : Promise.reject(new BlockNotFoundError({ blockNumber })),
+    } as unknown as L1BlockReader;
+    const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: 12 });
+
+    // First sub-slot of the build frame: the child is already visible, so the mandatory bucket is consumable
+    // without falling back on the cutoff override.
+    now = buildFrameStart + 3n;
+    const result = await selectInboxBucketForBlock({
+      ...baseInput,
+      isEligible: tracker.isEligible,
+      messageSource: source,
+      now,
+      parent: GENESIS_PARENT,
+      isLastBlock: false,
+      cutoffTimestamp: cutoff,
+    });
+    expect(result).toMatchObject({ consume: true });
+    if (result.consume) {
+      expect(result.bucket.seq).toBe(1n);
+    }
+  });
+
   it('consumes nothing when even the first bucket past the parent exceeds the per-checkpoint cap (cap-escape)', async () => {
     const { source } = makeSource([{ seq: 1n, timestamp: 100n, msgCount: 2000 }]);
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       messageSource: source,
-      now: 100n + MIN_AGE,
+      now: 100n + ETHEREUM_SLOT_DURATION,
       parent: GENESIS_PARENT,
       perBlockCap: 4096,
       perCheckpointCap: 1024,

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
@@ -235,14 +235,17 @@ describe('selectInboxBucketForBlock', () => {
     ]);
     // Block 100 has no child yet; block 99 does, and it is the bucket's own opening block.
     const reads: bigint[] = [];
-    const l1Client = {
-      getBlock: ({ blockNumber }: { blockNumber: bigint }) => {
+    const l1Client: L1BlockReader = {
+      getBlock({ blockNumber }) {
         reads.push(blockNumber);
         return blockNumber === 100n
-          ? Promise.resolve({ parentHash: Buffer32.fromBigInt(99n).toString() })
+          ? Promise.resolve({
+              hash: Buffer32.fromBigInt(100n).toString(),
+              parentHash: Buffer32.fromBigInt(99n).toString(),
+            })
           : Promise.reject(new BlockNotFoundError({ blockNumber }));
       },
-    } as unknown as L1BlockReader;
+    };
     const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: 12 });
 
     const result = await selectInboxBucketForBlock({
@@ -515,12 +518,15 @@ describe('selectInboxBucketForBlock', () => {
     const { source } = makeSource([{ seq: 1n, timestamp: cutoff, msgCount: 2 }]);
     const childVisibleAt = cutoff + 14n;
     let now = buildFrameStart;
-    const l1Client = {
-      getBlock: ({ blockNumber }: { blockNumber: bigint }) =>
+    const l1Client: L1BlockReader = {
+      getBlock: ({ blockNumber }) =>
         blockNumber === 2n && now >= childVisibleAt
-          ? Promise.resolve({ parentHash: Buffer32.fromBigInt(1n).toString() })
+          ? Promise.resolve({
+              hash: Buffer32.fromBigInt(2n).toString(),
+              parentHash: Buffer32.fromBigInt(1n).toString(),
+            })
           : Promise.reject(new BlockNotFoundError({ blockNumber })),
-    } as unknown as L1BlockReader;
+    };
     const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: 12 });
 
     // First sub-slot of the build frame: the child is already visible, so the mandatory bucket is consumable

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.test.ts
@@ -12,8 +12,12 @@ import {
 } from './inbox_bucket_eligibility.js';
 import { type InboxBucketSource, selectInboxBucketForBlock } from './inbox_bucket_selector.js';
 
-/** A test bucket: its cumulative totals and leaves are derived from a running message count. */
-type TestBucketSpec = { seq: bigint; timestamp: bigint; msgCount: number };
+/**
+ * A test bucket: its cumulative totals and leaves are derived from a running message count. `l1BlockNumber` defaults
+ * to the sequence number (one bucket per L1 block); set it explicitly to model an L1 block that rolled the Inbox over
+ * more than once.
+ */
+type TestBucketSpec = { seq: bigint; timestamp: bigint; msgCount: number; l1BlockNumber?: bigint };
 
 /**
  * Builds an in-memory {@link InboxBucketSource} from a list of bucket specs, mirroring the archiver's dense,
@@ -39,8 +43,8 @@ function makeSource(specs: TestBucketSpec[]): {
       timestamp: spec.timestamp,
       msgCount: spec.msgCount,
       lastMessageIndex: total - 1n,
-      l1BlockNumber: spec.seq,
-      l1BlockHash: Buffer32.fromBigInt(spec.seq),
+      l1BlockNumber: spec.l1BlockNumber ?? spec.seq,
+      l1BlockHash: Buffer32.fromBigInt(spec.l1BlockNumber ?? spec.seq),
     });
   }
 
@@ -100,6 +104,7 @@ function trackingEligibility(inner: InboxBucketEligibility): InboxBucketEligibil
 describe('selectInboxBucketForBlock', () => {
   const baseInput = {
     isEligible: eligibleAfterOneEthereumSlot,
+    ethereumSlotDuration: Number(ETHEREUM_SLOT_DURATION),
     checkpointStartTotalMsgCount: 0n,
     perBlockCap: 1024,
     perCheckpointCap: 1024,
@@ -176,12 +181,35 @@ describe('selectInboxBucketForBlock', () => {
     expect(result.consume).toBe(false);
   });
 
-  it('stops the eligibility walk after a bounded number of buckets', async () => {
-    const { source } = makeSource(
-      Array.from({ length: 12 }, (_, i) => ({ seq: BigInt(i + 1), timestamp: BigInt((i + 1) * 10), msgCount: 1 })),
-    );
-    // Only the oldest bucket is eligible, which is well past the walk bound from the head.
-    const isEligible = trackingEligibility(bucket => Promise.resolve(bucket.seq === 1n));
+  it('falls back to the newest settled bucket once the walk runs out of L1 blocks', async () => {
+    // Buckets 5..12 were all opened within the last Ethereum slot and none of them is confirmed; buckets 1..4 are
+    // old enough that eligibility no longer depends on a descendant showing up.
+    const { source } = makeSource([
+      ...Array.from({ length: 4 }, (_, i) => ({ seq: BigInt(i + 1), timestamp: BigInt((i + 1) * 100), msgCount: 1 })),
+      ...Array.from({ length: 8 }, (_, i) => ({ seq: BigInt(i + 5), timestamp: 977n + BigInt(i), msgCount: 1 })),
+    ]);
+    const isEligible = trackingEligibility(bucket => Promise.resolve(bucket.seq <= 4n));
+    const result = await selectInboxBucketForBlock({
+      ...baseInput,
+      isEligible,
+      messageSource: source,
+      now: 1_000n,
+      parent: GENESIS_PARENT,
+    });
+    expect(result).toMatchObject({ consume: true });
+    if (result.consume) {
+      expect(result.bucket.seq).toBe(4n);
+    }
+    // Eight distinct L1 blocks are walked, then the newest bucket at or before now - 2 * ethereumSlotDuration (976).
+    expect(isEligible.asked).toEqual([12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n, 4n]);
+  });
+
+  it('consumes nothing when the settled fallback bucket is ineligible too', async () => {
+    const { source } = makeSource([
+      ...Array.from({ length: 4 }, (_, i) => ({ seq: BigInt(i + 1), timestamp: BigInt((i + 1) * 100), msgCount: 1 })),
+      ...Array.from({ length: 8 }, (_, i) => ({ seq: BigInt(i + 5), timestamp: 977n + BigInt(i), msgCount: 1 })),
+    ]);
+    const isEligible = trackingEligibility(() => Promise.resolve(false));
     const result = await selectInboxBucketForBlock({
       ...baseInput,
       isEligible,
@@ -190,7 +218,47 @@ describe('selectInboxBucketForBlock', () => {
       parent: GENESIS_PARENT,
     });
     expect(result.consume).toBe(false);
-    expect(isEligible.asked).toEqual([12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n]);
+    expect(isEligible.asked).toEqual([12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n, 4n]);
+  });
+
+  it('spends one L1 read on all the buckets a single L1 block opened', async () => {
+    // One busy L1 block rolled the Inbox over ten times. Those ten buckets share an opening block, so they share one
+    // eligibility answer and must not crowd out the confirmed bucket behind them.
+    const { source } = makeSource([
+      { seq: 1n, timestamp: 100n, msgCount: 1, l1BlockNumber: 99n },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        seq: BigInt(i + 2),
+        timestamp: 200n,
+        msgCount: 1,
+        l1BlockNumber: 100n,
+      })),
+    ]);
+    // Block 100 has no child yet; block 99 does, and it is the bucket's own opening block.
+    const reads: bigint[] = [];
+    const l1Client = {
+      getBlock: ({ blockNumber }: { blockNumber: bigint }) => {
+        reads.push(blockNumber);
+        return blockNumber === 100n
+          ? Promise.resolve({ parentHash: Buffer32.fromBigInt(99n).toString() })
+          : Promise.reject(new BlockNotFoundError({ blockNumber }));
+      },
+    } as unknown as L1BlockReader;
+    const tracker = new InboxBucketConfirmationTracker({ l1Client, ethereumSlotDuration: 12 });
+
+    const result = await selectInboxBucketForBlock({
+      ...baseInput,
+      isEligible: tracker.isEligible,
+      messageSource: source,
+      now: 214n, // block 100 could have a child by now, but none is visible; block 99's child is block 100
+      parent: GENESIS_PARENT,
+    });
+
+    expect(result).toMatchObject({ consume: true });
+    if (result.consume) {
+      expect(result.bucket.seq).toBe(1n);
+    }
+    // One read per distinct opening L1 block, not per bucket: the ten siblings cost a single lookup.
+    expect(reads).toEqual([101n, 100n]);
   });
 
   it('consumes every bucket the archiver has under immediate eligibility', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.ts
@@ -5,10 +5,12 @@ import { type InboxBucket, type L1ToL2MessageSource, isInboxConsumptionSufficien
 import type { InboxBucketEligibility } from './inbox_bucket_eligibility.js';
 
 /**
- * How many buckets back from the archiver's head the eligibility walk looks before giving up for this sub-slot. On a
- * healthy chain only the newest bucket or two can still be unconfirmed, so a longer walk only burns L1 reads.
+ * How many distinct L1 blocks back from the archiver's head the eligibility walk looks before falling back. The bound
+ * counts L1 blocks rather than buckets because eligibility is a property of the opening block: a busy L1 block that
+ * rolls the Inbox over several times yields many buckets that all resolve from a single L1 read, and bounding by
+ * buckets would let one such block hide every older, already-confirmed bucket behind it.
  */
-const MAX_ELIGIBILITY_WALK = 8;
+const MAX_ELIGIBILITY_WALK_L1_BLOCKS = 8;
 
 const log: Logger = createLogger('sequencer:inbox-bucket-selector');
 
@@ -39,6 +41,12 @@ export type SelectInboxBucketInput = {
    * censorship cutoff and the caps allow, whenever it is proposed.
    */
   isEligible: InboxBucketEligibility;
+  /**
+   * Ethereum slot duration in seconds. Only used to pick the fallback bucket when the eligibility walk hits its
+   * bound: a bucket opened at or before `now - 2 * ethereumSlotDuration` can be decided outright, without waiting
+   * for a descendant to appear.
+   */
+  ethereumSlotDuration: number;
   /** The last bucket consumed by this checkpoint so far (parent checkpoint's at the first block). */
   parent: ConsumedBucketCursor;
   /** Cumulative Inbox message count consumed as of the parent checkpoint; the per-checkpoint cap origin. */
@@ -87,7 +95,9 @@ export type InboxBucketSelection = InboxBucketConsumption & {
  * `ProposeLib.validateInboxConsumption`. The policy, per block:
  *
  * 1. Pick the newest eligible bucket per the caller's eligibility rule (descendant-confirmed for the live sequencer,
- *    immediate for automine), walking back from the archiver's head bucket and stopping at the first eligible one. On
+ *    immediate for automine), walking back from the archiver's head bucket and stopping at the first eligible one.
+ *    The walk spans a bounded number of distinct opening L1 blocks, past which it jumps straight to the newest bucket
+ *    old enough to decide without waiting for a descendant. On
  *    the checkpoint's last block, also consider the cutoff bucket (newest opened at or before `cutoffTimestamp`) and
  *    take whichever is newer, so the checkpoint reaches the censorship floor even when eligibility preferred less: a
  *    mandatory bucket is consumed whether or not it is confirmed.
@@ -171,23 +181,31 @@ async function selectConsumption(input: SelectInboxBucketInput): Promise<InboxBu
   return { consume: false };
 }
 
+/** Identity of the L1 block a bucket was opened in; buckets sharing it also share their eligibility answer. */
+const openingL1Block = (bucket: InboxBucket) => `${bucket.l1BlockNumber}:${bucket.l1BlockHash.toString()}`;
+
 /**
  * Step 1 of {@link selectInboxBucketForBlock}: the newest bucket the caller's eligibility rule admits, found by
- * walking back from the archiver's head bucket. The walk is bounded by {@link MAX_ELIGIBILITY_WALK}; hitting the
- * bound means the whole visible tail is unconfirmed, which on a healthy chain does not happen.
+ * walking back from the archiver's head bucket. The walk is bounded by {@link MAX_ELIGIBILITY_WALK_L1_BLOCKS} distinct
+ * opening L1 blocks; hitting the bound means the whole visible tail is unconfirmed, which on a healthy chain does not
+ * happen, and the walk then falls back to the newest bucket old enough to be decided outright
+ * ({@link selectSettledBucket}) rather than consuming nothing.
  */
 async function selectEligibleBucket(input: SelectInboxBucketInput): Promise<InboxBucket | undefined> {
   const { messageSource, now, isEligible, parent } = input;
 
+  const walkedL1Blocks = new Set<string>();
   let candidate = await messageSource.getLatestInboxBucketAtOrBefore(now);
-  for (let walked = 0; candidate !== undefined && candidate.seq > parent.seq; walked++) {
-    if (walked === MAX_ELIGIBILITY_WALK) {
-      log.warn(`Gave up looking for a consumable Inbox bucket after ${MAX_ELIGIBILITY_WALK} buckets`, {
-        headBucketSeq: candidate.seq,
-        parentBucketSeq: parent.seq,
-        now,
-      });
-      return undefined;
+  while (candidate !== undefined && candidate.seq > parent.seq) {
+    walkedL1Blocks.add(openingL1Block(candidate));
+    if (walkedL1Blocks.size > MAX_ELIGIBILITY_WALK_L1_BLOCKS) {
+      const settled = await selectSettledBucket(input);
+      log.warn(
+        `No eligible Inbox bucket within ${MAX_ELIGIBILITY_WALK_L1_BLOCKS} L1 blocks of the head bucket; ` +
+          (settled === undefined ? 'consuming nothing' : `falling back to bucket ${settled.seq}`),
+        { headBucketSeq: candidate.seq, parentBucketSeq: parent.seq, fallbackBucketSeq: settled?.seq, now },
+      );
+      return settled;
     }
     if (await isEligible(candidate, now)) {
       return candidate;
@@ -195,4 +213,21 @@ async function selectEligibleBucket(input: SelectInboxBucketInput): Promise<Inbo
     candidate = await messageSource.getInboxBucket(candidate.seq - 1n);
   }
   return candidate;
+}
+
+/**
+ * The newest bucket whose opening L1 block is old enough that eligibility no longer depends on a descendant showing
+ * up: past `now - 2 * ethereumSlotDuration` the descendant-confirmed rule decides from the opening block alone, so
+ * one read settles it. Used only when the eligibility walk gives up, so a long tail of unconfirmed buckets still
+ * lets a checkpoint consume the messages behind it.
+ */
+async function selectSettledBucket(input: SelectInboxBucketInput): Promise<InboxBucket | undefined> {
+  const { messageSource, now, isEligible, parent, ethereumSlotDuration } = input;
+
+  const settledBy = now - 2n * BigInt(ethereumSlotDuration);
+  const settled = await messageSource.getLatestInboxBucketAtOrBefore(settledBy);
+  if (settled === undefined || settled.seq <= parent.seq) {
+    return undefined;
+  }
+  return (await isEligible(settled, now)) ? settled : undefined;
 }

--- a/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.ts
+++ b/yarn-project/sequencer-client/src/sequencer/inbox_bucket_selector.ts
@@ -1,5 +1,16 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type InboxBucket, type L1ToL2MessageSource, isInboxConsumptionSufficient } from '@aztec/stdlib/messaging';
+
+import type { InboxBucketEligibility } from './inbox_bucket_eligibility.js';
+
+/**
+ * How many buckets back from the archiver's head the eligibility walk looks before giving up for this sub-slot. On a
+ * healthy chain only the newest bucket or two can still be unconfirmed, so a longer walk only burns L1 reads.
+ */
+const MAX_ELIGIBILITY_WALK = 8;
+
+const log: Logger = createLogger('sequencer:inbox-bucket-selector');
 
 /** The subset of the archiver's Inbox-bucket queries the selector needs. */
 export type InboxBucketSource = Pick<
@@ -19,14 +30,15 @@ export type ConsumedBucketCursor = Pick<InboxBucket, 'seq' | 'totalMsgCount'>;
 export type SelectInboxBucketInput = {
   /** Archiver Inbox-bucket queries. */
   messageSource: InboxBucketSource;
-  /** Wall-clock time of this sub-slot, in seconds; the lag-eligibility anchor. */
+  /** Wall-clock time of this sub-slot, in seconds; the anchor eligibility is evaluated at. */
   now: bigint;
   /**
-   * Minimum bucket age in seconds for a bucket to be lag-eligible this sub-slot: one configured Ethereum slot, the
-   * same value the validator's acceptance check applies (which documents why age in seconds is only a proxy for the
-   * L1 reorg depth this really guards against).
+   * Whether a bucket may be consumed in this sub-slot. The live sequencer passes an
+   * `InboxBucketConfirmationTracker`, which waits for the bucket's opening L1 block to gain a canonical descendant;
+   * automine passes `immediateEligibility`. Eligibility is proposer policy: L1 and validators accept whatever the
+   * censorship cutoff and the caps allow, whenever it is proposed.
    */
-  minBucketAgeSeconds: bigint;
+  isEligible: InboxBucketEligibility;
   /** The last bucket consumed by this checkpoint so far (parent checkpoint's at the first block). */
   parent: ConsumedBucketCursor;
   /** Cumulative Inbox message count consumed as of the parent checkpoint; the per-checkpoint cap origin. */
@@ -74,9 +86,11 @@ export type InboxBucketSelection = InboxBucketConsumption & {
  * Selects the newest Inbox bucket a block streams from, mirroring the L1 consumption predicate in
  * `ProposeLib.validateInboxConsumption`. The policy, per block:
  *
- * 1. Pick the newest lag-eligible bucket: the newest bucket opened at or before `now - minBucketAgeSeconds`. On the
- *    checkpoint's last block, also consider the cutoff bucket (newest opened at or before `cutoffTimestamp`) and take
- *    whichever is newer, so the checkpoint reaches the censorship floor even if the sub-slot lag preferred less.
+ * 1. Pick the newest eligible bucket per the caller's eligibility rule (descendant-confirmed for the live sequencer,
+ *    immediate for automine), walking back from the archiver's head bucket and stopping at the first eligible one. On
+ *    the checkpoint's last block, also consider the cutoff bucket (newest opened at or before `cutoffTimestamp`) and
+ *    take whichever is newer, so the checkpoint reaches the censorship floor even when eligibility preferred less: a
+ *    mandatory bucket is consumed whether or not it is confirmed.
  * 2. If nothing is newer than the parent bucket, consume nothing.
  * 3. Otherwise walk back from the candidate to the newest bucket whose consumption fits both the per-block cap
  *    (`bucket.totalMsgCount - parent.totalMsgCount`) and the per-checkpoint cap
@@ -88,8 +102,8 @@ export type InboxBucketSelection = InboxBucketConsumption & {
  *    onto a prefix that still leaves a mandatory bucket behind; that is reported as
  *    `insufficientFinalBlockCapacity` rather than passed off as a usable selection.
  *
- * The `<=` comparisons make a bucket exactly `minBucketAgeSeconds` old lag-eligible and a bucket exactly at the cutoff
- * mandatory, matching the strict `>` "past cutoff" test on L1 (`next.timestamp > cutoff` leaves it optional).
+ * The `<=` comparison on the cutoff makes a bucket exactly at the cutoff mandatory, matching the strict `>` "past
+ * cutoff" test on L1 (`next.timestamp > cutoff` leaves it optional).
  *
  * A single bucket never exceeds the per-block cap by construction (the Inbox bucket size is at most the per-block cap),
  * so per-block walk-back always lands on at least one bucket; only the per-checkpoint cap can force consuming nothing.
@@ -116,8 +130,6 @@ export async function selectInboxBucketForBlock(input: SelectInboxBucketInput): 
 async function selectConsumption(input: SelectInboxBucketInput): Promise<InboxBucketConsumption> {
   const {
     messageSource,
-    now,
-    minBucketAgeSeconds,
     parent,
     checkpointStartTotalMsgCount,
     perBlockCap,
@@ -126,7 +138,7 @@ async function selectConsumption(input: SelectInboxBucketInput): Promise<InboxBu
     cutoffTimestamp,
   } = input;
 
-  let candidate = await messageSource.getLatestInboxBucketAtOrBefore(now - minBucketAgeSeconds);
+  let candidate = await selectEligibleBucket(input);
 
   if (isLastBlock) {
     const cutoffBucket = await messageSource.getLatestInboxBucketAtOrBefore(cutoffTimestamp);
@@ -157,4 +169,30 @@ async function selectConsumption(input: SelectInboxBucketInput): Promise<InboxBu
   }
 
   return { consume: false };
+}
+
+/**
+ * Step 1 of {@link selectInboxBucketForBlock}: the newest bucket the caller's eligibility rule admits, found by
+ * walking back from the archiver's head bucket. The walk is bounded by {@link MAX_ELIGIBILITY_WALK}; hitting the
+ * bound means the whole visible tail is unconfirmed, which on a healthy chain does not happen.
+ */
+async function selectEligibleBucket(input: SelectInboxBucketInput): Promise<InboxBucket | undefined> {
+  const { messageSource, now, isEligible, parent } = input;
+
+  let candidate = await messageSource.getLatestInboxBucketAtOrBefore(now);
+  for (let walked = 0; candidate !== undefined && candidate.seq > parent.seq; walked++) {
+    if (walked === MAX_ELIGIBILITY_WALK) {
+      log.warn(`Gave up looking for a consumable Inbox bucket after ${MAX_ELIGIBILITY_WALK} buckets`, {
+        headBucketSeq: candidate.seq,
+        parentBucketSeq: parent.seq,
+        now,
+      });
+      return undefined;
+    }
+    if (await isEligible(candidate, now)) {
+      return candidate;
+    }
+    candidate = await messageSource.getInboxBucket(candidate.seq - 1n);
+  }
+  return candidate;
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -780,6 +780,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.p2pClient,
       this.worldState,
       this.l1ToL2MessageSource,
+      this.rollupContract.client,
       this.l2BlockSource,
       this.checkpointsBuilder,
       this.l2BlockSource,

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -879,8 +879,7 @@ describe('ProposalHandler checkpoint validation', () => {
 
     it('processes a rebuilt proposal once the stale fork at this number is pruned', async () => {
       const { proposal, blockHandler } = await setupGenesisProposal(Fr.random());
-      // Past the minimum bucket age but well before the slot-1 attestation deadline (40s), so the prune wait has
-      // budget to retry.
+      // Well before the slot-1 attestation deadline (40s), so the prune wait has budget to retry.
       dateProvider.setTime(5_000);
       // Stale block (different archive) on the first read, then pruned (undefined) on the retry.
       blockSource.getBlockData.mockResolvedValueOnce(blockAt(Fr.random())).mockResolvedValue(undefined);
@@ -992,7 +991,6 @@ describe('ProposalHandler checkpoint validation', () => {
       const txProvider = mock<ITxProvider>();
       txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
 
-      // Well past the minimum bucket age (one 12s Ethereum slot) for a bucket opened at t=100, unless overridden.
       dateProvider.setTime(options.nowMs ?? 1_000_000);
 
       const blockHandler = new ProposalHandler(
@@ -1104,7 +1102,7 @@ describe('ProposalHandler checkpoint validation', () => {
       const PAST_DEADLINE_MS = DEADLINE_MS + 1_000;
       const WAIT_INTERVAL_MS = 500;
 
-      /** A bucket old enough to be lag-eligible at {@link BEFORE_DEADLINE_MS}. */
+      /** The bucket a proposal under test consumes through. */
       const eligibleBucket = (overrides: Partial<InboxBucket> = {}) => bucket({ timestamp: 10n, ...overrides });
 
       /** Wires the parent-bucket lookup and the bundle read for a proposal that consumes `eligibleBucket()`. */

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -1084,14 +1084,11 @@ export class ProposalHandler {
       // divergence, and `awaitStreamingBlockMetadata` waits it out by re-running the whole check after a sync.
       return { accepted: false, reason: 'bucket_unknown' };
     }
-    const nowSeconds = BigInt(Math.floor(this.dateProvider.now() / 1000));
     return checkStreamingBlockProposalMetadata({
       messageSource: this.l1ToL2MessageSource,
       bucketRef: proposal.bucketRef,
       parentTotalMsgCount,
       checkpointStartTotalMsgCount,
-      nowSeconds,
-      minBucketAgeSeconds: this.epochCache.getL1Constants().ethereumSlotDuration,
       perBlockCap: MAX_L1_TO_L2_MSGS_PER_BLOCK,
       perCheckpointCap: MAX_L1_TO_L2_MSGS_PER_CHECKPOINT,
     });

--- a/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.test.ts
@@ -11,7 +11,6 @@ import {
   checkStreamingBlockProposal,
 } from './streaming_inbox_checks.js';
 
-const MIN_BUCKET_AGE_SECONDS = 12;
 const PER_BLOCK_CAP = 1024;
 const PER_CHECKPOINT_CAP = 1024;
 const NOW = 10_000n;
@@ -98,8 +97,6 @@ function baseInput(overrides: Partial<StreamingBlockCheckInput>): StreamingBlock
     bucketRef: undefined,
     parentTotalMsgCount: 0n,
     checkpointStartTotalMsgCount: 0n,
-    nowSeconds: NOW,
-    minBucketAgeSeconds: MIN_BUCKET_AGE_SECONDS,
     perBlockCap: PER_BLOCK_CAP,
     perCheckpointCap: PER_CHECKPOINT_CAP,
     ...overrides,
@@ -154,23 +151,17 @@ describe('checkStreamingBlockProposal', () => {
     });
   });
 
-  describe('check 3: bucket is at least one Ethereum slot old', () => {
-    it('accepts a bucket exactly at the minimum age (inclusive boundary)', async () => {
+  describe('bucket age is not a check', () => {
+    it('accepts a bucket opened one second ago', async () => {
+      // How long a proposer waits before consuming a bucket is its own policy; L1 has no age rule, so neither do we.
       const view = new FakeInboxView();
-      const bucket = view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS); // timestamp == now - minBucketAgeSeconds
+      const bucket = view.addBucket(1, 2, Number(NOW) - 1);
       const result = await checkStreamingBlockProposal(baseInput({ messageSource: view, bucketRef: refFor(bucket) }));
-      expect(result.accepted).toBe(true);
-    });
-
-    it('rejects a bucket one second too new', async () => {
-      const view = new FakeInboxView();
-      const bucket = view.addBucket(1, 2, Number(NOW) - MIN_BUCKET_AGE_SECONDS + 1);
-      const result = await checkStreamingBlockProposal(baseInput({ messageSource: view, bucketRef: refFor(bucket) }));
-      expect(result).toEqual({ accepted: false, reason: 'bucket_too_new' });
+      expect(result).toEqual({ accepted: true, bundle: [new Fr(1000), new Fr(1001)] });
     });
   });
 
-  describe('check 4: caps', () => {
+  describe('check 3: caps', () => {
     it('accepts a block consuming exactly the per-block cap', async () => {
       const view = new FakeInboxView();
       const bucket = view.addBucket(1, PER_BLOCK_CAP, 100);

--- a/yarn-project/validator-client/src/streaming_inbox_checks.ts
+++ b/yarn-project/validator-client/src/streaming_inbox_checks.ts
@@ -10,7 +10,6 @@ export type StreamingBlockCheckReason =
   | 'bucket_hash_mismatch'
   | 'parent_bucket_unresolved'
   | 'bucket_moves_backwards'
-  | 'bucket_too_new'
   | 'bundle_over_block_cap'
   | 'checkpoint_over_msg_cap';
 
@@ -30,18 +29,6 @@ export type StreamingBlockMetadataCheckInput = {
   parentTotalMsgCount: bigint;
   /** Cumulative Inbox message count consumed as of the parent checkpoint; the per-checkpoint cap origin. */
   checkpointStartTotalMsgCount: bigint;
-  /** Validation-time wall clock in seconds; the lag-eligibility anchor. */
-  nowSeconds: bigint;
-  /**
-   * Minimum bucket age in seconds for a bucket to be lag-eligible: one configured Ethereum slot, the same value the
-   * sequencer's selection uses.
-   *
-   * Age in seconds is a proxy for L1 reorg depth, and only an exact one when no L1 slot is missed: with missed slots a
-   * bucket can be a full Ethereum slot old and still sit in the latest L1 block. A block-depth rule would be
-   * stronger — require at least one later L1 block to have synced — and is implementable without new L1 state, since
-   * the archiver records each bucket's `l1BlockNumber`.
-   */
-  minBucketAgeSeconds: number;
   /** Maximum number of messages this block may consume (`MAX_L1_TO_L2_MSGS_PER_BLOCK`). */
   perBlockCap: number;
   /** Maximum number of messages the checkpoint may consume in total (`MAX_L1_TO_L2_MSGS_PER_CHECKPOINT`). */
@@ -99,12 +86,16 @@ export type StreamingBlockCheckResult =
  *    never from the wire.
  * 2. **Moves forward**: the bucket's cumulative total is at least the parent block's, so consumption never rewinds.
  *    Equal totals mean the block consumes nothing (empty bundle).
- * 3. **Not too new**: the bucket is at least `minBucketAgeSeconds` old at validation time
- *    (`timestamp <= now - minBucketAgeSeconds`, inclusive — a bucket exactly that old is eligible, matching L1's
- *    strict `>` "too new" test).
- * 4. **Caps**: the per-block message count and the running per-checkpoint total fit their respective caps.
- * 5. **Parent boundary**: the parent block's cumulative total sits on a bucket boundary, so the consumed range is
+ * 3. **Caps**: the per-block message count and the running per-checkpoint total fit their respective caps.
+ * 4. **Parent boundary**: the parent block's cumulative total sits on a bucket boundary, so the consumed range is
  *    well defined.
+ *
+ * There is deliberately no check on how recently the bucket was opened. *When* a bucket becomes consumable is the
+ * proposer's own policy — it waits for the bucket's opening L1 block to gain a canonical descendant so it does not
+ * build on a block its archiver will disown — and L1 has no matching rule: `propose` accepts any bucket the
+ * censorship cutoff and the caps allow, whenever it is proposed. A validator that rejected a young bucket would
+ * therefore refuse to attest to a checkpoint L1 accepts, so validators check only what L1 checks plus consistency
+ * with their own Inbox view.
  *
  * Because this phase is cheap and needs nothing off the network, a caller can run it before committing to any
  * expensive work on a proposal — notably before collecting the proposal's transactions over P2P.
@@ -115,16 +106,8 @@ export type StreamingBlockCheckResult =
 export async function checkStreamingBlockProposalMetadata(
   input: StreamingBlockMetadataCheckInput,
 ): Promise<StreamingBlockMetadataCheckResult> {
-  const {
-    messageSource,
-    bucketRef,
-    parentTotalMsgCount,
-    checkpointStartTotalMsgCount,
-    nowSeconds,
-    minBucketAgeSeconds,
-    perBlockCap,
-    perCheckpointCap,
-  } = input;
+  const { messageSource, bucketRef, parentTotalMsgCount, checkpointStartTotalMsgCount, perBlockCap, perCheckpointCap } =
+    input;
 
   // A streaming proposal must carry a bucket reference to derive its bundle from.
   if (bucketRef === undefined) {
@@ -145,24 +128,19 @@ export async function checkStreamingBlockProposalMetadata(
     return { accepted: false, reason: 'bucket_moves_backwards' };
   }
 
-  // Check 3: the bucket is at least `minBucketAgeSeconds` old at validation time.
-  if (bucket.timestamp > nowSeconds - BigInt(minBucketAgeSeconds)) {
-    return { accepted: false, reason: 'bucket_too_new' };
-  }
-
-  // Check 4a: the per-block message count fits the per-block cap.
+  // Check 3a: the per-block message count fits the per-block cap.
   const blockCount = bucket.totalMsgCount - parentTotalMsgCount;
   if (blockCount > BigInt(perBlockCap)) {
     return { accepted: false, reason: 'bundle_over_block_cap' };
   }
 
-  // Check 4b: the running per-checkpoint total fits the per-checkpoint cap.
+  // Check 3b: the running per-checkpoint total fits the per-checkpoint cap.
   const checkpointCount = bucket.totalMsgCount - checkpointStartTotalMsgCount;
   if (checkpointCount > BigInt(perCheckpointCap)) {
     return { accepted: false, reason: 'checkpoint_over_msg_cap' };
   }
 
-  // Check 5: the parent bucket is the one whose cumulative total equals the parent block's leaf count (messages are
+  // Check 4: the parent bucket is the one whose cumulative total equals the parent block's leaf count (messages are
   // indexed compactly, with no padding); a parent whose count does not sit on a bucket boundary is unresolvable.
   const parentBucket = await messageSource.getInboxBucketByTotalMsgCount(parentTotalMsgCount);
   if (parentBucket === undefined) {

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -53,8 +53,6 @@ jest.setTimeout(60_000);
 describe('ValidatorClient Integration', () => {
   // Constants for L1
   const l1Constants: L1RollupConstants = {
-    // Non-zero genesis time so the slot-1 validation clock is well past the minimum bucket age; otherwise the
-    // streaming Inbox acceptance check rejects even a genesis-timestamp (0) bucket as `bucket_too_new`.
     l1GenesisTime: 1_700_000_000n,
     slotDuration: 24,
     epochDuration: 16,


### PR DESCRIPTION
Stacked on #25350

Replaces the fixed "bucket must be one Ethereum slot old" rule with one that waits for actual evidence that the bucket's opening L1 block is on the canonical chain.

## Why the age rule buys nothing

An L1 block `N` (number `h`, hash `H`, timestamp `T`) that gets reorged out is replaced by a block built on `N-1`, and that replacement lands at roughly `T+13..15` — the `S+1` proposer must decide within a second or two of `T+12` and publish, and the head only flips once the replacement is imported. Aztec sub-slot ticks and L1 block timestamps sit on the same 12s grid, so the proposer's `T+12` tick — the first moment the age rule made the bucket consumable — always precedes the window in which it would have learned the block was gone. The rule delayed consumption by a full Ethereum slot and caught nothing.

```
T+1..3    N becomes latest
T+4       attestation deadline; a late/weak N gets no boost
T+12      slot S+1 starts. Age rule releases the bucket here.
T+13..15  N' imported, head flips to a different block at height h
T+16      S+1 attestation deadline; N (if still canonical) is now heavily voted
T+24      slot S+1 over; an honest reorg of N is no longer possible
```

## The rule

A bucket opened in L1 block `N` is eligible once either

- block `h+1` is visible and its `parentHash` is `H` — `N` then survives even if that child is itself reorged, since the replacement builds on the same parent (usually about `T+14`); or
- `now >= T + 2E` (slot `S+1` fully elapsed) and block `h` still hashes to `H`, which covers a missed slot `S+1`. Past that point the honest fork-choice mechanism can no longer displace `N`: it only ever reorgs the head's immediate successor slot.

A child with a different parent, or a different block at height `h`, means `N` is already orphaned — the bucket is skipped rather than waited on, and the archiver rolls it back shortly.

No L1 change is needed. `propose` has no age rule, and a bucket opened exactly at the censorship cutoff (`toTimestamp(S-1) - E`) gets its child about 2s into the build frame, so the mandatory consumption floor stays satisfiable; a unit test pins this. The cutoff override is unchanged: a mandatory bucket is consumed whether or not it is confirmed.

## Caching and RPC budget

`InboxBucketConfirmationTracker` (new, `sequencer-client/src/sequencer/inbox_bucket_eligibility.ts`) is the only place the sequencer reads L1 blocks for this. One tracker per `CheckpointProposalJob`, i.e. per slot. It

- makes no call at all before `T + E`, since no child can exist yet;
- keys both caches by opening L1 block identity (`${l1BlockNumber}:${l1BlockHash}`), so the several buckets a busy L1 block opens all resolve from one read;
- caches confirmations for the tracker's life (confirmed never becomes unconfirmed);
- caches rejections against the `nowSeconds` they were computed at, so repeated selector calls within the same second cost nothing;
- decides each branch from a single response — behind a load-balanced RPC two calls may see different heads, so no branch compares two of them;
- time-boxes every read (2s by default, configurable), since these sit on the block-building path where viem's 10s default plus retries would eat the sub-slot;
- treats a timed-out or failed L1 read as "not eligible yet" rather than as an orphaned block, and caches it like any other rejection so a flaky endpoint costs one read per second, logged at `debug`. A bucket at or below the cutoff is consumed by the last block regardless, so a flaky endpoint costs latency, not liveness.

The selector walks newest-first from the archiver's head bucket and stops at the first eligible one. The walk is bounded by 8 **distinct opening L1 blocks** rather than by buckets: a single L1 block can roll the Inbox over many times, and a bucket-counted bound would let one unconfirmed block hide every confirmed bucket behind it, leaving the block consuming nothing. When the bound is hit the selector jumps to the newest bucket opened at or before `now - 2E`, which the `T+2E` branch decides outright, before giving up. On a healthy chain only the newest bucket or two can be unconfirmed, so the steady-state cost is one `eth_getBlockByNumber` per sub-slot.

The selector now takes an eligibility function rather than a minimum age, and ships two: the tracker's, and `immediateEligibility`. Automine passes `immediateEligibility` unconditionally — anvil mines on demand, so a bucket's opening block gains a descendant only when the next transaction is sent, which may be long after the block that consumes it.

## The node predicts with the same rule

When the node simulates a transaction's public calls it appends the message bundle the next block is expected to consume. That prediction has to use the proposer's eligibility rule: a transaction simulated against an unconfirmed bucket passes simulation, enters the pool, and then fails when the block that includes it consumes less. The node therefore keeps one `InboxBucketConfirmationTracker` of its own, over the L1 client it already holds — a node-lifetime cache, which is sound because confirmations are permanent facts about L1. Automine nodes (`useAutomineSequencer`), and nodes with no L1 client at all (TXE), keep predicting against every synced bucket.

## Validators stop checking bucket age

The validator's `bucket_too_new` check is removed along with the reason string. L1 has no age rule: `propose` accepts any bucket the censorship cutoff and the caps allow, whenever it is proposed. A validator that rejected a young bucket would refuse to attest to a checkpoint L1 would accept, and could be griefed into missing attestations by a proposer that is simply faster than its own clock. When a bucket becomes consumable is now purely proposer policy; validators check what L1 checks (hash matches their own archiver view, cutoff floor, caps) plus local-view consistency.

## Configuration

No configuration is removed or added: the old minimum age was derived from `ethereumSlotDuration` at each call site and was never an environment variable.

## Tests

- `inbox_bucket_eligibility.test.ts` (new): the six algorithm branches plus explicit RPC-count assertions — no call before `T+E`, exactly one call per decision, a confirmation served from cache, a rejection reused within the same second and re-checked in the next one. Also the clock-tolerance boundary, the genesis sentinel bucket (eligible with no RPC), a failing L1 read (not retried within the second), and a read that never answers (timed out, treated as pending).
- `inbox_bucket_selector.test.ts`: unconfirmed head bucket falls back to the previous confirmed one; nothing eligible consumes nothing; the walk bound and its settled-bucket fallback (both when the fallback is eligible and when it is not); a rollover case where one L1 block opened ten buckets and the confirmed bucket behind them is still selected, for one read per distinct L1 block; immediate eligibility; and a cutoff-compatibility case showing a bucket opened exactly at `cutoff(S)` is confirmed by the first sub-slot of the build frame.
- `node_public_calls_simulator.test.ts`: the node predicts nothing from a bucket the proposer would still be waiting on, predicts the bundle once the opening block has a canonical child, and never reads L1 under automine or without an L1 client.
- `streaming_inbox_checks.test.ts`: age cases deleted, replaced by one asserting a bucket opened a second ago is accepted.

Gates: full `yarn build`; `yarn format` and `yarn lint` clean on sequencer-client, aztec-node, end-to-end. Suites: sequencer-client `src/sequencer` 190 passed / 1 skipped across 8 files (`l1_publisher.integration.test.ts` needs a local anvil and was not run), validator-client 273 passed / 3 skipped across 10 suites, aztec-node `node_public_calls_simulator.test.ts` and `server.test.ts` 100/100. No e2e run; `streaming_inbox.test.ts` was updated to wait on the descendant rule instead of the age rule and compiles.

#25341 was closed as superseded: with the validator age check gone there is nothing left to apply a clock tolerance to.

Fixes A-1879

