### PR TITLE
feat(fast-inbox): detect inbox bucket reorgs by L1 block hash and roll back to the last canonical bucket

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1568,6 +1568,181 @@ describe('Archiver Sync', () => {
     }, 15_000);
   });
 
+  describe('inbox bucket canonicality', () => {
+    // Counts the reads of a specific L1 block, which is how the canonicality check verifies a bucket.
+    const countBlockReads = (spy: jest.Spied<ViemPublicClient['getBlock']>, l1BlockNumber: bigint) =>
+      spy.mock.calls.filter(([args]) => (args as { blockNumber?: bigint } | undefined)?.blockNumber === l1BlockNumber)
+        .length;
+
+    const countReorgWarnings = (spy: jest.Spied<Logger['warn']>) =>
+      spy.mock.calls.filter(([msg]) => msg.includes('no longer canonical')).length;
+
+    it('re-times a bucket whose L1 block was replaced with one carrying the same messages', async () => {
+      const msgs = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const before = await archiverStore.messages.getInboxBucket(1n);
+      expect(before).toMatchObject({
+        seq: 1n,
+        msgCount: 2,
+        l1BlockNumber: 100n,
+        timestamp: fake.getTimestampAtL1Block(100n),
+      });
+
+      // Block 100 is orphaned and its two messages are re-mined in block 101: same messages in the same order, so
+      // the Inbox's total and rolling hash are untouched and only the bucket metadata moves.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.retimeMessages(100n, 101n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toEqual({
+        ...before,
+        timestamp: fake.getTimestampAtL1Block(101n),
+        l1BlockNumber: 101n,
+        l1BlockHash: fake.getL1BlockHash(101n),
+      });
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+    });
+
+    it('merges two buckets when a reorg re-mines a block into the next one', async () => {
+      const msgsA = [Fr.random(), Fr.random()];
+      const msgsB = [Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgsA);
+      fake.addMessages(CheckpointNumber(2), 101n, msgsB);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({ msgCount: 2, totalMsgCount: 2n });
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ msgCount: 1, totalMsgCount: 3n });
+
+      fake.retimeMessages(100n, 101n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // The three messages keep their indices, but they now belong to a single bucket opened at block 101.
+      expect(await getStoredLeaves()).toEqual(asHex([...msgsA, ...msgsB]));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
+        msgCount: 3,
+        totalMsgCount: 3n,
+        lastMessageIndex: 2n,
+        l1BlockNumber: 101n,
+        timestamp: fake.getTimestampAtL1Block(101n),
+      });
+      expect(await archiverStore.messages.getInboxBucket(2n)).toBeUndefined();
+    });
+
+    it('rolls back to the last canonical bucket when a reorg reorders a block', async () => {
+      const msgs1 = [Fr.random(), Fr.random()];
+      const msgs2 = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs1);
+      fake.addMessages(CheckpointNumber(2), 102n, msgs2);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const canonicalBucket = await archiverStore.messages.getInboxBucket(1n);
+      const rollingHashBefore = (await archiverStore.messages.getInboxBucket(2n))!.inboxRollingHash;
+
+      // Only block 102 is replaced, so bucket 1 stays canonical and the rollback stops at it.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
+      fake.reorderMessagesAtL1Block(102n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // The bucket walk resolves this on its own: the per-message log queries of the rolling-hash fallback are
+      // never reached.
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(eventByHashSpy).not.toHaveBeenCalled();
+      expect(await getStoredLeaves()).toEqual(asHex([...msgs1, msgs2[1], msgs2[0]]));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toEqual(canonicalBucket);
+      expect((await archiverStore.messages.getInboxBucket(2n))!.inboxRollingHash).not.toEqual(rollingHashBefore);
+    });
+
+    it('checks a bucket that is already below the finalized block, then never again', async () => {
+      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+      fake.setFinalizedL1BlockNumber(105n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      // The bucket is downloaded on this pass, so nothing has been verified yet.
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+
+      const getBlockSpy = jest.spyOn(publicClient, 'getBlock');
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // Being below the finalized block does not exempt a bucket this node has never checked itself.
+      expect(countBlockReads(getBlockSpy, 100n)).toEqual(1);
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(1n);
+
+      getBlockSpy.mockClear();
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      expect(countBlockReads(getBlockSpy, 100n)).toEqual(0);
+    });
+
+    it('keeps checking a bucket that has not been finalized yet', async () => {
+      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const getBlockSpy = jest.spyOn(publicClient, 'getBlock');
+      for (const l1BlockNumber of [111n, 112n]) {
+        fake.setL1BlockNumber(l1BlockNumber);
+        await archiver.syncImmediate();
+      }
+
+      expect(countBlockReads(getBlockSpy, 100n)).toEqual(2);
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+    });
+
+    it('detects a bucket reorged out while it was not syncing, even below the finalized block', async () => {
+      const msgs = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs);
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({ l1BlockNumber: 100n });
+
+      // The archiver holds no bucket state in memory, so an outage is just a gap between sync passes. Across that
+      // gap block 100 is orphaned, its messages are re-mined one block later, and finality moves past both.
+      fake.retimeMessages(100n, 101n);
+      fake.setFinalizedL1BlockNumber(105n);
+      fake.setL1BlockNumber(120n);
+      await archiver.syncImmediate();
+
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
+        l1BlockNumber: 101n,
+        l1BlockHash: fake.getL1BlockHash(101n),
+        timestamp: fake.getTimestampAtL1Block(101n),
+      });
+    });
+
+    it('catches up over many buckets from bulk events alone', async () => {
+      // Nothing here reads per-bucket state from L1, so it makes no difference how many buckets the on-chain ring
+      // has overwritten since the archiver last synced.
+      const msgs = times(20, () => Fr.random());
+      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+
+      const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
+      const eventsSpy = jest.spyOn(inboxContract, 'getMessageSentEvents');
+      fake.setL1BlockNumber(200n);
+      await archiver.syncImmediate();
+
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect((await archiverStore.messages.getNewestInboxBucket())!.seq).toEqual(20n);
+      expect(eventsSpy).toHaveBeenCalled();
+      expect(eventByHashSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('finalized checkpoint', () => {
     it('reports no finalized blocks before any checkpoint is proven', async () => {
       fake.setL1BlockNumber(100n);

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -44,6 +44,9 @@ import { type ArchiverDataStores, createArchiverDataStores } from './store/data_
 import { L2TipsCache } from './store/l2_tips_cache.js';
 import { FakeL1State } from './test/fake_l1_state.js';
 
+/** How many L2 slots' worth of L1 blocks the archiver covers per L1 log query. */
+const MESSAGE_BATCH_SIZE = 1000;
+
 describe('Archiver Sync', () => {
   const rollupAddress = EthAddress.random();
   const inboxAddress = EthAddress.random();
@@ -86,7 +89,7 @@ describe('Archiver Sync', () => {
 
     const config = {
       pollingIntervalMs: 1000,
-      batchSize: 1000,
+      batchSize: MESSAGE_BATCH_SIZE,
       maxAllowedEthClientDriftSeconds: 300,
       ethereumAllowNoDebugHosts: true,
       skipHistoricalLogsCheck: true,
@@ -1749,132 +1752,381 @@ describe('Archiver Sync', () => {
       });
     });
 
-    it('checks a bucket that is already below the finalized block, then never again', async () => {
-      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
-      fake.setFinalizedL1BlockNumber(105n);
-      fake.setL1BlockNumber(110n);
-      await archiver.syncImmediate();
-
-      // The bucket is downloaded on this pass, so nothing has been verified yet.
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-
-      fake.clearL1BlockReads();
-      fake.setL1BlockNumber(111n);
-      await archiver.syncImmediate();
-
-      // Being below the finalized block does not exempt a bucket this node has never checked itself.
-      expect(fake.countL1BlockReads(100n)).toEqual(1);
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(1n);
-
-      fake.clearL1BlockReads();
-      fake.setL1BlockNumber(112n);
-      await archiver.syncImmediate();
-
-      expect(fake.countL1BlockReads(100n)).toEqual(0);
-    });
-
-    it('keeps checking a bucket that has not been finalized yet', async () => {
-      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+    it('detects a metadata-only reorg of the newest bucket on the next pass however many buckets it holds', async () => {
+      const msgs = times(40, () => Fr.random());
+      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+      // Finality is held below every bucket, so none of them is exempt from the check on any grounds.
       fake.setFinalizedL1BlockNumber(90n);
-      fake.setL1BlockNumber(110n);
+      fake.setL1BlockNumber(200n);
+      await archiver.syncImmediate();
+      expect(await archiverStore.messages.getNewestInboxBucket()).toMatchObject({ seq: 40n, l1BlockNumber: 139n });
+
+      // The newest bucket is the one a proposer is about to consume. Its block is orphaned and its message re-mined
+      // one block later, which leaves the Inbox's total and rolling hash untouched.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.retimeMessages(139n, 140n);
+      fake.setL1BlockNumber(201n);
       await archiver.syncImmediate();
 
-      fake.clearL1BlockReads();
-      for (const l1BlockNumber of [111n, 112n]) {
-        fake.setL1BlockNumber(l1BlockNumber);
-        await archiver.syncImmediate();
-      }
-
-      expect(fake.countL1BlockReads(100n)).toEqual(2);
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-    });
-
-    it('keeps checking a spanning bucket until the block it closed in is finalized', async () => {
-      fake.shareTimestampWithL1Block(101n, 100n);
-      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
-      fake.addMessages(CheckpointNumber(2), 101n, [Fr.random()]);
-      fake.setFinalizedL1BlockNumber(100n);
-      fake.setL1BlockNumber(110n);
-      await archiver.syncImmediate();
-
-      fake.clearL1BlockReads();
-      fake.setL1BlockNumber(111n);
-      await archiver.syncImmediate();
-
-      // The bucket is only as final as the last block it absorbed messages from.
-      expect(fake.countL1BlockReads(101n)).toEqual(1);
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-
-      fake.setFinalizedL1BlockNumber(101n);
-      fake.setL1BlockNumber(112n);
-      await archiver.syncImmediate();
-
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(1n);
-    });
-
-    it('detects a bucket reorged out while it was not syncing, even below the finalized block', async () => {
-      const msgs = [Fr.random(), Fr.random()];
-      fake.addMessages(CheckpointNumber(1), 100n, msgs);
-      fake.setFinalizedL1BlockNumber(90n);
-      fake.setL1BlockNumber(110n);
-      await archiver.syncImmediate();
-      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({ l1BlockNumber: 100n });
-
-      // The archiver holds no bucket state in memory, so an outage is just a gap between sync passes. Across that
-      // gap block 100 is orphaned, its messages are re-mined one block later, and finality moves past both.
-      fake.retimeMessages(100n, 101n);
-      fake.setFinalizedL1BlockNumber(105n);
-      fake.setL1BlockNumber(120n);
-      await archiver.syncImmediate();
-
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
       expect(await getStoredLeaves()).toEqual(asHex(msgs));
-      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
-        l1BlockNumber: 101n,
-        l1BlockHash: fake.getL1BlockHash(101n),
-        timestamp: fake.getTimestampAtL1Block(101n),
+      expect(await archiverStore.messages.getInboxBucket(40n)).toMatchObject({
+        l1BlockNumber: 140n,
+        l1BlockHash: fake.getL1BlockHash(140n),
+        timestamp: fake.getTimestampAtL1Block(140n),
       });
     });
 
-    it('warns and verifies nothing when the L1 block of a bucket cannot be read', async () => {
-      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
-      fake.addMessages(CheckpointNumber(2), 102n, [Fr.random()]);
-      fake.setFinalizedL1BlockNumber(105n);
-      fake.setL1BlockNumber(110n);
-      await archiver.syncImmediate();
-
-      const warnSpy = jest.spyOn(syncLogger, 'warn');
-      fake.failL1BlockReads(100n);
-      fake.setL1BlockNumber(111n);
-      await archiver.syncImmediate();
-
-      // The failing read is on the oldest unverified bucket, and the watermark is a prefix, so nothing advances.
-      expect(countWarnings(warnSpy, 'whether Inbox bucket 1 is canonical')).toEqual(1);
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-      expect(await getStoredLeaves()).toHaveLength(2);
-
-      fake.restoreL1BlockReads(100n);
-      fake.setL1BlockNumber(112n);
-      await archiver.syncImmediate();
-
-      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(2n);
-    });
-
-    it('spreads the check over several passes when many buckets are unverified', async () => {
+    it('reads only the L1 block of the newest bucket on every pass', async () => {
       const msgs = times(40, () => Fr.random());
       msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
-      // Nothing is finalized, so no bucket is ever skipped and the unverified tail keeps growing.
       fake.setFinalizedL1BlockNumber(90n);
       fake.setL1BlockNumber(200n);
       await archiver.syncImmediate();
 
       fake.clearL1BlockReads();
+      for (const l1BlockNumber of [201n, 202n]) {
+        fake.setL1BlockNumber(l1BlockNumber);
+        await archiver.syncImmediate();
+      }
+
+      // A reorg that touched any stored bucket's block would have touched the newest one's, so that is the only
+      // block compared against the live chain, and it is compared again on every pass.
+      expect(fake.countL1BlockReads(139n)).toEqual(2);
+      expect(fake.countL1BlockReads(138n)).toEqual(0);
+      expect(fake.countL1BlockReads(100n)).toEqual(0);
+    });
+
+    it('checks both L1 blocks of a newest bucket that spans co-timestamped blocks', async () => {
+      fake.shareTimestampWithL1Block(101n, 100n);
+      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+      fake.addMessages(CheckpointNumber(2), 101n, [Fr.random()]);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      fake.clearL1BlockReads();
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      expect(fake.countL1BlockReads(101n)).toEqual(1);
+      expect(fake.countL1BlockReads(100n)).toEqual(1);
+    });
+
+    it('walks back to the last canonical bucket when a reorg orphans the newest buckets', async () => {
+      const msgs = times(40, () => Fr.random());
+      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(200n);
+      await archiver.syncImmediate();
+      const lastCanonicalBucket = await archiverStore.messages.getInboxBucket(37n);
+      expect(lastCanonicalBucket).toMatchObject({ l1BlockNumber: 136n });
+
+      // Blocks 137 to 139 are orphaned and their messages each re-mined one block later, so buckets 38 to 40 sit on
+      // blocks that are gone while bucket 37 is the newest one still on the chain.
+      fake.retimeMessages(139n, 140n);
+      fake.retimeMessages(138n, 139n);
+      fake.retimeMessages(137n, 138n);
+      fake.clearL1BlockReads();
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
       fake.setL1BlockNumber(201n);
       await archiver.syncImmediate();
 
-      // A pass checks a bounded number of buckets from the oldest unverified one and leaves the rest for later.
-      expect(fake.countL1BlockReads(100n)).toEqual(1);
-      expect(fake.countL1BlockReads(131n)).toEqual(1);
-      expect(fake.countL1BlockReads(132n)).toEqual(0);
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(countWarnings(warnSpy, 'rolling back to bucket 37')).toEqual(1);
+      // The walk reads one block per orphaned bucket and stops at the first canonical one, which the re-fetch that
+      // follows checks once more; the buckets below it are never read, and neither are the per-message logs of the
+      // rolling-hash fallback.
+      expect(fake.countL1BlockReads(136n)).toEqual(2);
+      expect(fake.countL1BlockReads(134n)).toEqual(0);
+      expect(fake.countL1BlockReads(100n)).toEqual(0);
+      expect(eventByHashSpy).not.toHaveBeenCalled();
+
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(37n)).toEqual(lastCanonicalBucket);
+      for (const [seq, l1BlockNumber] of [
+        [38n, 138n],
+        [39n, 139n],
+        [40n, 140n],
+      ]) {
+        expect(await archiverStore.messages.getInboxBucket(seq)).toMatchObject({
+          l1BlockNumber,
+          l1BlockHash: fake.getL1BlockHash(l1BlockNumber),
+        });
+      }
+    });
+
+    it('walks past a bucket whose co-timestamped closing block was reorged', async () => {
+      // Bucket 2 spans blocks 102 and 103, mined with one timestamp; bucket 3 sits on block 105 above it.
+      const msgs = times(4, () => Fr.random());
+      fake.shareTimestampWithL1Block(103n, 102n);
+      fake.addMessages(CheckpointNumber(1), 100n, [msgs[0]]);
+      fake.addMessages(CheckpointNumber(2), 102n, [msgs[1]]);
+      fake.addMessages(CheckpointNumber(3), 103n, [msgs[2]]);
+      fake.addMessages(CheckpointNumber(4), 105n, [msgs[3]]);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const canonicalBucket = await archiverStore.messages.getInboxBucket(1n);
+      expect(await archiverStore.messages.getInboxBucketL1Span(2n)).toMatchObject({
+        openedAt: { l1BlockNumber: 102n },
+        closedAt: { l1BlockNumber: 103n },
+      });
+      expect(await archiverStore.messages.getInboxBucket(3n)).toMatchObject({ l1BlockNumber: 105n });
+
+      // Block 103 is re-mined with a timestamp of its own, replacing every block from it to the head. Bucket 3's
+      // block is gone, and bucket 2 keeps its opening block but not the one it closed in, so the walk must not stop
+      // at it.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.splitCoTimestampedL1Block(103n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      expect(countWarnings(warnSpy, 'rolling back to bucket 1')).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toEqual(canonicalBucket);
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ msgCount: 1, l1BlockNumber: 102n });
+      expect(await archiverStore.messages.getInboxBucket(3n)).toMatchObject({ msgCount: 1, l1BlockNumber: 103n });
+      expect(await archiverStore.messages.getInboxBucket(4n)).toMatchObject({ msgCount: 1, l1BlockNumber: 105n });
+    });
+
+    it('detects a reorg of the newest bucket that finality has buried while it was not syncing', async () => {
+      const msgs = times(40, () => Fr.random());
+      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(200n);
+      await archiver.syncImmediate();
+      expect(await archiverStore.messages.getInboxBucket(40n)).toMatchObject({ l1BlockNumber: 139n });
+
+      // The archiver holds no bucket state in memory, so an outage is just a gap between sync passes. Across that
+      // gap block 139 is orphaned, its message is re-mined one block later, and finality moves past every bucket.
+      // Being finalized is no reason to trust a bucket this node never compared against the chain that finalized it.
+      fake.retimeMessages(139n, 140n);
+      fake.setFinalizedL1BlockNumber(150n);
+      fake.setL1BlockNumber(220n);
+      await archiver.syncImmediate();
+
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(40n)).toMatchObject({
+        l1BlockNumber: 140n,
+        l1BlockHash: fake.getL1BlockHash(140n),
+        timestamp: fake.getTimestampAtL1Block(140n),
+      });
+    });
+
+    it('skips the fetch and fails the pass when the L1 block of the newest bucket cannot be read', async () => {
+      const msgs = [Fr.random(), Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, [msgs[0]]);
+      fake.addMessages(CheckpointNumber(2), 102n, [msgs[1]]);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+      const newestBucket = await archiverStore.messages.getInboxBucket(2n);
+
+      // Bucket 2 is re-timed and a new message arrives, but the block bucket 2 sits on cannot be read. Fetching the new
+      // message anyway would make its bucket the one checked from here on and bucket 2 would never be looked at again,
+      // so the pass gives up before fetching.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.retimeMessages(102n, 103n);
+      fake.addMessages(CheckpointNumber(3), 111n, [msgs[2]]);
+      fake.failL1BlockReads(102n);
+      fake.setL1BlockNumber(111n);
+      await expect(archiver.syncImmediate()).rejects.toThrow('Retries exhausted');
+
+      expect(countWarnings(warnSpy, 'whether Inbox bucket 2 is canonical')).toEqual(1);
+      expect(countReorgWarnings(warnSpy)).toEqual(0);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs.slice(0, 2)));
+      expect(await archiverStore.messages.getInboxBucket(2n)).toEqual(newestBucket);
+
+      fake.restoreL1BlockReads(102n);
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ l1BlockNumber: 103n });
+      expect(await archiverStore.messages.getInboxBucket(3n)).toMatchObject({ l1BlockNumber: 111n });
+    });
+
+    it('fails the pass without rolling back when the L1 block of a bucket below the reorged one cannot be read', async () => {
+      const msgs = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, [msgs[0]]);
+      fake.addMessages(CheckpointNumber(2), 102n, [msgs[1]]);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+      const reorgedBucket = await archiverStore.messages.getInboxBucket(2n);
+
+      // Bucket 2 is re-timed, but the block of bucket 1, which is where the rollback would stop, cannot be read, so
+      // nothing is known about where the canonical chain resumes and the store is left as it is.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.retimeMessages(102n, 103n);
+      fake.failL1BlockReads(100n);
+      fake.setL1BlockNumber(111n);
+      await expect(archiver.syncImmediate()).rejects.toThrow('Retries exhausted');
+
+      expect(countWarnings(warnSpy, 'whether Inbox bucket 1 is canonical')).toEqual(1);
+      expect(countReorgWarnings(warnSpy)).toEqual(0);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(2n)).toEqual(reorgedBucket);
+
+      fake.restoreL1BlockReads(100n);
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ l1BlockNumber: 103n });
+    });
+
+    it('detects a reorg that lands between the canonicality check and the fetch', async () => {
+      const msgs = [Fr.random(), Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs.slice(0, 2));
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      // Once bucket 1 has been checked and right before its logs are queried, a reorg re-mines its messages one block
+      // earlier, below the syncpoint, so the fetch only sees the new message in block 111 and stores it in a bucket the
+      // next pass would check instead of the orphaned one.
+      fake.addMessages(CheckpointNumber(2), 111n, [msgs[2]]);
+      const readLogs = inboxContract.getMessageSentEvents.getMockImplementation()!;
+      inboxContract.getMessageSentEvents.mockImplementationOnce((fromBlock, toBlock) => {
+        fake.retimeMessages(100n, 99n);
+        return readLogs(fromBlock, toBlock);
+      });
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
+        msgCount: 2,
+        l1BlockNumber: 99n,
+        l1BlockHash: fake.getL1BlockHash(99n),
+        timestamp: fake.getTimestampAtL1Block(99n),
+      });
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ l1BlockNumber: 111n });
+    });
+
+    describe('catch-up over several log queries', () => {
+      // Messages are fetched in log queries of a fixed span of L1 blocks, the first one starting at block 1.
+      let firstQueryEnd: bigint;
+
+      beforeEach(() => {
+        const l1BlocksPerLogQuery = (MESSAGE_BATCH_SIZE * l1Constants.slotDuration) / l1Constants.ethereumSlotDuration;
+        firstQueryEnd = 1n + BigInt(l1BlocksPerLogQuery);
+      });
+
+      /** Makes the given reorg land once the first log query has been answered and before the second one is issued. */
+      const reorgBetweenLogQueries = (reorg: () => void) => {
+        const readLogs = inboxContract.getMessageSentEvents.getMockImplementation()!;
+        let landed = false;
+        inboxContract.getMessageSentEvents.mockImplementation((fromBlock, toBlock) => {
+          if (!landed && fromBlock > firstQueryEnd) {
+            landed = true;
+            reorg();
+          }
+          return readLogs(fromBlock, toBlock);
+        });
+      };
+
+      it('detects a reorg that lands between the log queries of a catch-up fetch', async () => {
+        const msgs1 = [Fr.random()];
+        const msgs2 = [Fr.random()];
+        fake.addMessages(CheckpointNumber(1), 100n, msgs1);
+        fake.addMessages(CheckpointNumber(2), firstQueryEnd + 500n, msgs2);
+        fake.setFinalizedL1BlockNumber(90n);
+        fake.setL1BlockNumber(firstQueryEnd + 1000n);
+
+        // Block 100 is orphaned and its message re-mined in block 101 while the fetch is under way, so bucket 1 is
+        // stored from the orphaned fork and bucket 2, which the next pass would anchor its check on, from the
+        // canonical one.
+        reorgBetweenLogQueries(() => fake.retimeMessages(100n, 101n));
+        const warnSpy = jest.spyOn(syncLogger, 'warn');
+        await archiver.syncImmediate();
+
+        expect(countReorgWarnings(warnSpy)).toEqual(1);
+        expect(await getStoredLeaves()).toEqual(asHex([...msgs1, ...msgs2]));
+        expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
+          l1BlockNumber: 101n,
+          l1BlockHash: fake.getL1BlockHash(101n),
+          timestamp: fake.getTimestampAtL1Block(101n),
+        });
+        expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({
+          l1BlockNumber: firstQueryEnd + 500n,
+          l1BlockHash: fake.getL1BlockHash(firstQueryEnd + 500n),
+        });
+      });
+
+      it('unwinds the fetch when the block of an earlier log query cannot be read', async () => {
+        const msgs = [Fr.random(), Fr.random()];
+        fake.addMessages(CheckpointNumber(1), 100n, [msgs[0]]);
+        fake.addMessages(CheckpointNumber(2), firstQueryEnd + 500n, [msgs[1]]);
+        fake.setFinalizedL1BlockNumber(90n);
+        fake.setL1BlockNumber(firstQueryEnd + 1000n);
+
+        // Nothing stored by the fetch survives: bucket 1 could not be checked, and had bucket 2 stayed, it would be the
+        // only bucket ever checked again.
+        const warnSpy = jest.spyOn(syncLogger, 'warn');
+        fake.failL1BlockReads(100n);
+        await expect(archiver.syncImmediate()).rejects.toThrow('Retries exhausted');
+
+        expect(countWarnings(warnSpy, 'whether Inbox bucket 1 is canonical')).toBeGreaterThanOrEqual(1);
+        expect(countWarnings(warnSpy, 'Unwinding 2 L1 to L2 messages')).toBeGreaterThanOrEqual(1);
+        expect(await getStoredLeaves()).toEqual([]);
+        expect(await archiverStore.messages.getNewestInboxBucket()).toBeUndefined();
+
+        fake.restoreL1BlockReads(100n);
+        await archiver.syncImmediate();
+
+        expect(await getStoredLeaves()).toEqual(asHex(msgs));
+        expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({ l1BlockNumber: 100n });
+        expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ l1BlockNumber: firstQueryEnd + 500n });
+      });
+
+      it('checks the buckets an interrupted fetch left above the syncpoint on the next pass', async () => {
+        const msgs = [Fr.random(), Fr.random()];
+        fake.addMessages(CheckpointNumber(1), 100n, [msgs[0]]);
+        fake.addMessages(CheckpointNumber(2), firstQueryEnd + 500n, [msgs[1]]);
+        fake.setFinalizedL1BlockNumber(90n);
+        fake.setL1BlockNumber(firstQueryEnd + 1000n);
+
+        // The reorg lands between the two log queries, and the pass dies right after the second one is stored, before
+        // either could be checked. Bucket 1 is left on the orphaned fork under a canonical bucket 2, with the syncpoint
+        // still where the fetch started.
+        reorgBetweenLogQueries(() => fake.retimeMessages(100n, 101n));
+        let batchesStored = 0;
+        instrumentation.processNewMessages.mockImplementation(() => {
+          if (++batchesStored === 2) {
+            throw new Error('Simulated interruption after storing a batch');
+          }
+        });
+        await expect(archiver.syncImmediate()).rejects.toThrow('Simulated interruption');
+        expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({ l1BlockNumber: 100n });
+        expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({ l1BlockNumber: firstQueryEnd + 500n });
+
+        instrumentation.processNewMessages.mockImplementation(() => {});
+        const warnSpy = jest.spyOn(syncLogger, 'warn');
+        await archiver.syncImmediate();
+
+        expect(countReorgWarnings(warnSpy)).toEqual(1);
+        expect(await getStoredLeaves()).toEqual(asHex(msgs));
+        expect(await archiverStore.messages.getInboxBucket(1n)).toMatchObject({
+          l1BlockNumber: 101n,
+          l1BlockHash: fake.getL1BlockHash(101n),
+        });
+      });
+
+      it('does not check the buckets of log queries at or below the finalized block', async () => {
+        fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+        fake.addMessages(CheckpointNumber(2), firstQueryEnd + 500n, [Fr.random()]);
+        fake.setFinalizedL1BlockNumber(firstQueryEnd);
+        fake.setL1BlockNumber(firstQueryEnd + 1000n);
+        await archiver.syncImmediate();
+
+        expect(await getStoredLeaves()).toHaveLength(2);
+        expect(fake.countL1BlockReads(100n)).toEqual(0);
+      });
     });
 
     it('catches up over many buckets after an outage without per-message log lookups', async () => {

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1569,13 +1569,11 @@ describe('Archiver Sync', () => {
   });
 
   describe('inbox bucket canonicality', () => {
-    // Counts the reads of a specific L1 block, which is how the canonicality check verifies a bucket.
-    const countBlockReads = (spy: jest.Spied<ViemPublicClient['getBlock']>, l1BlockNumber: bigint) =>
-      spy.mock.calls.filter(([args]) => (args as { blockNumber?: bigint } | undefined)?.blockNumber === l1BlockNumber)
-        .length;
-
     const countReorgWarnings = (spy: jest.Spied<Logger['warn']>) =>
       spy.mock.calls.filter(([msg]) => msg.includes('no longer canonical')).length;
+
+    const countWarnings = (spy: jest.Spied<Logger['warn']>, match: string) =>
+      spy.mock.calls.filter(([msg]) => msg.includes(match)).length;
 
     it('re-times a bucket whose L1 block was replaced with one carrying the same messages', async () => {
       const msgs = [Fr.random(), Fr.random()];
@@ -1635,6 +1633,48 @@ describe('Archiver Sync', () => {
       expect(await archiverStore.messages.getInboxBucket(2n)).toBeUndefined();
     });
 
+    it('splits a bucket when the co-timestamped L1 block it closed in is reorged', async () => {
+      // Blocks 100 and 101 are mined with the same timestamp, so the messages of both are absorbed into one bucket
+      // that spans them. Bucket 1, in an earlier block, is the one the rollback should stop at.
+      const msgs0 = [Fr.random()];
+      const msgsA = [Fr.random()];
+      const msgsB = [Fr.random()];
+      fake.shareTimestampWithL1Block(101n, 100n);
+      fake.addMessages(CheckpointNumber(1), 98n, msgs0);
+      fake.addMessages(CheckpointNumber(2), 100n, msgsA);
+      fake.addMessages(CheckpointNumber(3), 101n, msgsB);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const canonicalBucket = await archiverStore.messages.getInboxBucket(1n);
+      expect(await archiverStore.messages.getInboxBucketL1Span(2n)).toMatchObject({
+        openedAt: { l1BlockNumber: 100n },
+        closedAt: { l1BlockNumber: 101n },
+      });
+
+      // Only block 101 is replaced, and it is re-mined with a timestamp of its own. Bucket 2 keeps its opening
+      // block and all of its messages survive in the same order, so neither the opening block hash nor the Inbox's
+      // total and rolling hash show that it has been cut in two.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.splitCoTimestampedL1Block(101n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex([...msgs0, ...msgsA, ...msgsB]));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toEqual(canonicalBucket);
+      expect(await archiverStore.messages.getInboxBucket(2n)).toMatchObject({
+        msgCount: 1,
+        l1BlockNumber: 100n,
+        timestamp: fake.getTimestampAtL1Block(100n),
+      });
+      expect(await archiverStore.messages.getInboxBucket(3n)).toMatchObject({
+        msgCount: 1,
+        l1BlockNumber: 101n,
+        timestamp: fake.getTimestampAtL1Block(101n),
+      });
+    });
+
     it('rolls back to the last canonical bucket when a reorg reorders a block', async () => {
       const msgs1 = [Fr.random(), Fr.random()];
       const msgs2 = [Fr.random(), Fr.random()];
@@ -1662,6 +1702,53 @@ describe('Archiver Sync', () => {
       expect((await archiverStore.messages.getInboxBucket(2n))!.inboxRollingHash).not.toEqual(rollingHashBefore);
     });
 
+    it('detects a reorg that re-mines the L1 head at the same height', async () => {
+      const msgs = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs);
+      fake.setL1BlockNumber(100n);
+      await archiver.syncImmediate();
+      expect(await getStoredLeaves()).toEqual(asHex(msgs));
+
+      // The head is re-mined at the same number with its messages in the opposite order. L1 never advances, so the
+      // syncpoint the archiver holds is by block number as recent as the chain itself.
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.reorderMessagesAtL1Block(100n);
+      await archiver.syncImmediate();
+
+      expect(countReorgWarnings(warnSpy)).toEqual(1);
+      expect(await getStoredLeaves()).toEqual(asHex([msgs[1], msgs[0]]));
+    });
+
+    it('re-downloads the rollover siblings of the bucket it rolls back to', async () => {
+      // A single L1 block with more messages than a bucket holds spills into a rollover bucket that shares its
+      // opening block, so rolling back to one of them re-downloads the other.
+      const rollover = times(260, () => Fr.random());
+      const later = [Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, rollover);
+      fake.addMessages(CheckpointNumber(2), 102n, later);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const firstBucket = await archiverStore.messages.getInboxBucket(1n);
+      const secondBucket = await archiverStore.messages.getInboxBucket(2n);
+      expect(firstBucket).toMatchObject({ msgCount: 256, l1BlockNumber: 100n });
+      expect(secondBucket).toMatchObject({ msgCount: 4, l1BlockNumber: 100n });
+
+      fake.retimeMessages(102n, 103n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // Both siblings are re-delivered from their first message and come back unchanged.
+      expect(await getStoredLeaves()).toEqual(asHex([...rollover, ...later]));
+      expect(await archiverStore.messages.getInboxBucket(1n)).toEqual(firstBucket);
+      expect(await archiverStore.messages.getInboxBucket(2n)).toEqual(secondBucket);
+      expect(await archiverStore.messages.getInboxBucket(3n)).toMatchObject({
+        msgCount: 1,
+        l1BlockNumber: 103n,
+        timestamp: fake.getTimestampAtL1Block(103n),
+      });
+    });
+
     it('checks a bucket that is already below the finalized block, then never again', async () => {
       fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
       fake.setFinalizedL1BlockNumber(105n);
@@ -1671,19 +1758,19 @@ describe('Archiver Sync', () => {
       // The bucket is downloaded on this pass, so nothing has been verified yet.
       expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
 
-      const getBlockSpy = jest.spyOn(publicClient, 'getBlock');
+      fake.clearL1BlockReads();
       fake.setL1BlockNumber(111n);
       await archiver.syncImmediate();
 
       // Being below the finalized block does not exempt a bucket this node has never checked itself.
-      expect(countBlockReads(getBlockSpy, 100n)).toEqual(1);
+      expect(fake.countL1BlockReads(100n)).toEqual(1);
       expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(1n);
 
-      getBlockSpy.mockClear();
+      fake.clearL1BlockReads();
       fake.setL1BlockNumber(112n);
       await archiver.syncImmediate();
 
-      expect(countBlockReads(getBlockSpy, 100n)).toEqual(0);
+      expect(fake.countL1BlockReads(100n)).toEqual(0);
     });
 
     it('keeps checking a bucket that has not been finalized yet', async () => {
@@ -1692,14 +1779,37 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(110n);
       await archiver.syncImmediate();
 
-      const getBlockSpy = jest.spyOn(publicClient, 'getBlock');
+      fake.clearL1BlockReads();
       for (const l1BlockNumber of [111n, 112n]) {
         fake.setL1BlockNumber(l1BlockNumber);
         await archiver.syncImmediate();
       }
 
-      expect(countBlockReads(getBlockSpy, 100n)).toEqual(2);
+      expect(fake.countL1BlockReads(100n)).toEqual(2);
       expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+    });
+
+    it('keeps checking a spanning bucket until the block it closed in is finalized', async () => {
+      fake.shareTimestampWithL1Block(101n, 100n);
+      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+      fake.addMessages(CheckpointNumber(2), 101n, [Fr.random()]);
+      fake.setFinalizedL1BlockNumber(100n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      fake.clearL1BlockReads();
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // The bucket is only as final as the last block it absorbed messages from.
+      expect(fake.countL1BlockReads(101n)).toEqual(1);
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+
+      fake.setFinalizedL1BlockNumber(101n);
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(1n);
     });
 
     it('detects a bucket reorged out while it was not syncing, even below the finalized block', async () => {
@@ -1725,19 +1835,67 @@ describe('Archiver Sync', () => {
       });
     });
 
-    it('catches up over many buckets from bulk events alone', async () => {
-      // Nothing here reads per-bucket state from L1, so it makes no difference how many buckets the on-chain ring
-      // has overwritten since the archiver last synced.
-      const msgs = times(20, () => Fr.random());
-      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+    it('warns and verifies nothing when the L1 block of a bucket cannot be read', async () => {
+      fake.addMessages(CheckpointNumber(1), 100n, [Fr.random()]);
+      fake.addMessages(CheckpointNumber(2), 102n, [Fr.random()]);
+      fake.setFinalizedL1BlockNumber(105n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
 
+      const warnSpy = jest.spyOn(syncLogger, 'warn');
+      fake.failL1BlockReads(100n);
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      // The failing read is on the oldest unverified bucket, and the watermark is a prefix, so nothing advances.
+      expect(countWarnings(warnSpy, 'whether Inbox bucket 1 is canonical')).toEqual(1);
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+      expect(await getStoredLeaves()).toHaveLength(2);
+
+      fake.restoreL1BlockReads(100n);
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      expect(await archiverStore.messages.getCanonicalVerifiedThroughSeq()).toEqual(2n);
+    });
+
+    it('spreads the check over several passes when many buckets are unverified', async () => {
+      const msgs = times(40, () => Fr.random());
+      msgs.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+      // Nothing is finalized, so no bucket is ever skipped and the unverified tail keeps growing.
+      fake.setFinalizedL1BlockNumber(90n);
+      fake.setL1BlockNumber(200n);
+      await archiver.syncImmediate();
+
+      fake.clearL1BlockReads();
+      fake.setL1BlockNumber(201n);
+      await archiver.syncImmediate();
+
+      // A pass checks a bounded number of buckets from the oldest unverified one and leaves the rest for later.
+      expect(fake.countL1BlockReads(100n)).toEqual(1);
+      expect(fake.countL1BlockReads(131n)).toEqual(1);
+      expect(fake.countL1BlockReads(132n)).toEqual(0);
+    });
+
+    it('catches up over many buckets after an outage without per-message log lookups', async () => {
+      const early = times(3, () => Fr.random());
+      early.forEach((msg, i) => fake.addMessages(CheckpointNumber(1), 100n + BigInt(i), [msg]));
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+      expect((await archiverStore.messages.getNewestInboxBucket())!.seq).toEqual(3n);
+
+      // While the archiver is down, L1 opens more buckets than the on-chain ring holds. Catching up reads the
+      // Inbox state and the message logs in bulk, plus the L1 blocks of the buckets already stored; no per-bucket
+      // state is read from the ring, so it makes no difference how much of it has been overwritten.
+      const later = times(20, () => Fr.random());
+      later.forEach((msg, i) => fake.addMessages(CheckpointNumber(2), 120n + BigInt(i), [msg]));
       const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
       const eventsSpy = jest.spyOn(inboxContract, 'getMessageSentEvents');
       fake.setL1BlockNumber(200n);
       await archiver.syncImmediate();
 
-      expect(await getStoredLeaves()).toEqual(asHex(msgs));
-      expect((await archiverStore.messages.getNewestInboxBucket())!.seq).toEqual(20n);
+      expect(await getStoredLeaves()).toEqual(asHex([...early, ...later]));
+      expect((await archiverStore.messages.getNewestInboxBucket())!.seq).toEqual(23n);
       expect(eventsSpy).toHaveBeenCalled();
       expect(eventByHashSpy).not.toHaveBeenCalled();
     });

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -8,7 +8,7 @@ import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
 import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
-import { compactArray, partition, pick, unique } from '@aztec/foundation/collection';
+import { compactArray, partition, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -51,50 +51,30 @@ import { ArchiverDataStoreUpdater } from './data_store_updater.js';
 import type { ArchiverInstrumentation } from './instrumentation.js';
 import { validateCheckpointAttestationsFromCalldata } from './validation.js';
 
-/**
- * How many Inbox buckets are compared against the live chain per sync pass. The unverified tail grows for as long as
- * L1 finality does not advance, so the walk is capped and resumes where it left off on the next pass.
- */
-const MAX_BUCKETS_CHECKED_PER_SYNC = 32;
-
-/** How many L1 block reads the Inbox bucket check issues in parallel. */
-const BUCKET_CHECK_READ_CONCURRENCY = 4;
-
 /** After the first one, how often a bucket check that keeps failing to read its L1 block is logged at warn. */
 const BUCKET_CHECK_FAILURE_WARN_EVERY = 20;
 
-/** The live hash of an L1 block, or the error that reading it raised. */
-type L1BlockHashRead = { hash: Buffer32; error?: undefined } | { hash?: undefined; error: unknown };
+/** A stored L1 block that the live chain has replaced, and what it was replaced with. */
+type BucketReorg = { stored: L1BlockId; liveL1BlockHash: Buffer32 };
 
 /** The outcome of comparing the L1 blocks an Inbox bucket sits on against the live chain. */
 type BucketCanonicality =
   | { status: 'canonical' }
-  | { status: 'reorged'; stored: L1BlockId; liveL1BlockHash: Buffer32 }
+  | ({ status: 'reorged' } & BucketReorg)
   | { status: 'unverifiable'; l1BlockNumber: bigint; error: unknown };
 
-/**
- * Compares the L1 blocks a bucket was opened and closed in against the live chain. Both ends are checked: a bucket
- * that absorbed messages from a later co-timestamped L1 block is split when that block alone is reorged, and neither
- * its opening block nor the Inbox's message count and rolling hash change when it happens.
- */
-function checkBucketCanonicality(
-  bucket: InboxBucketL1Span,
-  liveBlocks: Map<bigint, L1BlockHashRead>,
-): BucketCanonicality {
-  const storedBlocks =
-    bucket.closedAt.l1BlockNumber === bucket.openedAt.l1BlockNumber
-      ? [bucket.openedAt]
-      : [bucket.openedAt, bucket.closedAt];
-  for (const stored of storedBlocks) {
-    const live = liveBlocks.get(stored.l1BlockNumber);
-    if (live?.hash === undefined) {
-      return { status: 'unverifiable', l1BlockNumber: stored.l1BlockNumber, error: live?.error };
-    }
-    if (!live.hash.equals(stored.l1BlockHash)) {
-      return { status: 'reorged', stored, liveL1BlockHash: live.hash };
-    }
-  }
-  return { status: 'canonical' };
+/** Whether the stored Inbox buckets were found canonical, rolled back to the last canonical one, or could not be checked. */
+type BucketsCanonicality =
+  | { status: 'canonical' }
+  | { status: 'rolled-back'; syncPoint: L1BlockId }
+  | { status: 'unverifiable' };
+
+/** Whether a message fetch was stored and found canonical, rolled back, or unwound because it could not be checked. */
+type MessageFetchOutcome = 'stored' | 'rolled-back' | 'unverifiable';
+
+/** Whether an L1 block is at or below the finalized one, so it can no longer be reorged. */
+function isFinalized(l1Block: L1BlockId, finalizedL1Block: L1BlockId | undefined): boolean {
+  return finalizedL1Block !== undefined && l1Block.l1BlockNumber <= finalizedL1Block.l1BlockNumber;
 }
 
 type RollupStatus = {
@@ -476,8 +456,14 @@ export class ArchiverL1Synchronizer implements Traceable {
     // compared below untouched while rewriting the bucket metadata built from that block, so check the buckets we
     // hold against the live chain first. This runs before the check that L1 has moved forward below, because a reorg
     // can replace the head with a block of the same number, which advances nothing. A rollback here rewinds the
-    // syncpoint, and we resume from the new one.
-    const syncFrom = (await this.ensureBucketsAreCanonical(finalizedL1Block)) ?? messagesSynchedTo;
+    // syncpoint, and we resume from the new one. If the check could not be completed the pass is retried instead:
+    // storing newer buckets on top of one we could not check would make them the ones checked from here on, and the
+    // unchecked one would never be looked at again.
+    const canonicality = await this.ensureBucketsAreCanonical(messagesSynchedTo, finalizedL1Block);
+    if (canonicality.status === 'unverifiable') {
+      return false;
+    }
+    const syncFrom = canonicality.status === 'rolled-back' ? canonicality.syncPoint : messagesSynchedTo;
 
     // Nothing to do if L1 has not moved past our syncpoint
     const currentL1BlockNumber = currentL1Block.l1BlockNumber;
@@ -501,7 +487,10 @@ export class ArchiverL1Synchronizer implements Traceable {
     // If that's the case, we'd get an exception out of the message store since the rolling hash of the first message
     // we try to insert would not match the one in the db, in which case we rollback to the last common message with L1.
     try {
-      await this.retrieveAndStoreMessages(syncFrom.l1BlockNumber, currentL1BlockNumber);
+      const outcome = await this.retrieveAndStoreMessages(syncFrom, currentL1BlockNumber, finalizedL1Block);
+      if (outcome !== 'stored') {
+        return false;
+      }
     } catch (error) {
       if (isErrorClass(error, MessageStoreError)) {
         this.log.warn(
@@ -533,99 +522,113 @@ export class ArchiverL1Synchronizer implements Traceable {
   }
 
   /**
-   * Verifies that the Inbox buckets this archiver holds were opened in L1 blocks that are still canonical, and rolls
-   * back to the last canonical bucket when one of them was not. Returns the new message syncpoint if it rolled back.
+   * Verifies that the newest Inbox bucket this archiver holds sits on L1 blocks that are still canonical, and rolls
+   * back to the last canonical bucket when it does not.
    *
    * The message count and consensus rolling hash the sync compares against the Inbox do not change when an L1 reorg
    * re-mines the same messages in a different block, but the bucket timestamps, sequence numbers and boundaries
-   * derived from that block do, and consumers depend on them. So every bucket the node has not positively verified is
-   * compared against the live chain by the hashes of the L1 blocks it was opened and closed in. Buckets sharing a
-   * block (a full bucket rolling over within one L1 block) cost a single read, and the reads run in parallel.
+   * derived from that block do, and consumers depend on them. Checking the newest bucket alone catches every such
+   * reorg: a reorg replaces a suffix of the L1 chain, and stored buckets are ordered by the height of their L1 blocks,
+   * so a reorg that touches any stored bucket's block also touches the newest one's. Inductively, when the newest
+   * bucket still matches the live chain, so does everything below it that matched on the previous pass, and the
+   * buckets stored by this pass are what the next pass checks. Whether the blocks are finalized makes no difference:
+   * a node that was not watching when a block was reorged out holds an orphaned block that may since have been buried
+   * below finality, and its newest bucket is exactly as stale as the rest. The check costs one L1 block read per pass,
+   * or two for a bucket that spans co-timestamped blocks.
    *
-   * Sitting at or below the finalized L1 block is not on its own a reason to skip a bucket: a node that was not
-   * watching when its block was reorged out holds an orphaned block that has since been buried below finality. A
-   * bucket is skipped only once this node has itself compared it against a chain that had it finalized, which is what
-   * the store's canonicality watermark records. Until finality advances the unverified tail keeps growing, so at most
-   * `MAX_BUCKETS_CHECKED_PER_SYNC` buckets are checked per pass and the rest wait for the next one.
+   * The induction relies on every stored bucket having been checked once. The message syncpoint advances only after
+   * a fetch has been stored and checked, so buckets closed above it were stored by a fetch that was interrupted before
+   * its check, and are checked here as well; only the ones above the finalized block, since finalized blocks cannot be
+   * reorged. There are normally none: after a rollback the last canonical bucket is above the syncpoint, but it is the
+   * newest one and checked regardless.
+   *
+   * On a mismatch the stored buckets are walked newest-first until one still matches the live chain: that is the last
+   * canonical bucket and the rollback target, so the walk is as long as the reorg is deep. If an L1 block cannot be
+   * read nothing is rolled back and the check is reported as not completed, so the caller can abandon the pass.
    */
-  private async ensureBucketsAreCanonical(finalizedL1Block: L1BlockId | undefined): Promise<L1BlockId | undefined> {
-    const verifiedThroughSeq = await this.stores.messages.getCanonicalVerifiedThroughSeq();
-    const buckets: InboxBucketL1Span[] = [];
-    for await (const bucket of this.stores.messages.iterateInboxBucketL1Spans({ start: verifiedThroughSeq + 1n })) {
-      buckets.push(bucket);
-      if (buckets.length === MAX_BUCKETS_CHECKED_PER_SYNC) {
+  private async ensureBucketsAreCanonical(
+    messagesSynchedTo: L1BlockId,
+    finalizedL1Block: L1BlockId | undefined,
+  ): Promise<BucketsCanonicality> {
+    let isNewest = true;
+    for await (const bucket of this.stores.messages.iterateInboxBucketL1Spans({ reverse: true })) {
+      const storedByInterruptedFetch =
+        bucket.closedAt.l1BlockNumber > messagesSynchedTo.l1BlockNumber &&
+        !isFinalized(bucket.closedAt, finalizedL1Block);
+      if (!isNewest && !storedByInterruptedFetch) {
         break;
       }
-    }
-    if (buckets.length === 0) {
-      return undefined;
-    }
+      isNewest = false;
 
-    const liveBlocks = await this.readL1BlockHashes(buckets);
-    let lastCanonicalBucket: InboxBucketL1Span | undefined;
-    let verifyThroughSeq: bigint | undefined;
-    let finalizedSoFar = true;
-    let readFailed = false;
-
-    for (const bucket of buckets) {
-      const result = checkBucketCanonicality(bucket, liveBlocks);
+      const result = await this.checkBucketCanonicality(bucket);
       if (result.status === 'unverifiable') {
-        // The L1 read failed, so we learned nothing about this bucket: leave it for the next sync pass.
-        readFailed = true;
         this.warnBucketNotVerifiable(bucket.seq, result.l1BlockNumber, result.error);
-        break;
+        return { status: 'unverifiable' };
       }
       if (result.status === 'reorged') {
-        return await this.rollbackToCanonicalBucket(
-          bucket,
-          // The watermark points at a bucket this node verified in an earlier pass, so it is canonical by induction.
-          lastCanonicalBucket ?? (await this.stores.messages.getInboxBucketL1Span(verifiedThroughSeq)),
-          result,
-        );
-      }
-      lastCanonicalBucket = bucket;
-      // The watermark is a prefix, so it stops advancing at the first bucket that is not yet finalized. A bucket
-      // counts as finalized only once the block it was closed in is, since that is the last one that can move.
-      finalizedSoFar &&=
-        finalizedL1Block !== undefined && bucket.closedAt.l1BlockNumber <= finalizedL1Block.l1BlockNumber;
-      if (finalizedSoFar) {
-        verifyThroughSeq = bucket.seq;
+        const syncPoint = await this.rollbackReorgedBucket(bucket.seq, result);
+        return syncPoint === undefined ? { status: 'unverifiable' } : { status: 'rolled-back', syncPoint };
       }
     }
-
-    if (!readFailed) {
-      this.failedBucketCheck = undefined;
-    }
-    if (verifyThroughSeq !== undefined) {
-      await this.stores.messages.setCanonicalVerifiedThroughSeq(verifyThroughSeq);
-    }
-    return undefined;
+    this.failedBucketCheck = undefined;
+    return { status: 'canonical' };
   }
 
   /**
-   * Reads the live hashes of the L1 blocks the given buckets were opened and closed in, with bounded parallelism.
-   * Blocks shared by several buckets, and buckets that neither span blocks nor roll over, cost a single read. A block
-   * whose read failed maps to the error instead of a hash.
+   * Compares the L1 blocks a bucket was opened and closed in against the live chain. The closing block is read first:
+   * it is the highest block the bucket sits on, so it is the one a reorg reaches first. The opening block is read as
+   * well when it differs, since a bucket that absorbed messages from a later co-timestamped L1 block is split when that
+   * block alone is reorged, without its opening block or the Inbox's message count and rolling hash changing.
    */
-  private async readL1BlockHashes(buckets: InboxBucketL1Span[]): Promise<Map<bigint, L1BlockHashRead>> {
-    const l1BlockNumbers = unique(
-      buckets.flatMap(bucket => [bucket.openedAt.l1BlockNumber, bucket.closedAt.l1BlockNumber]),
-    );
-    const reads = new Map<bigint, L1BlockHashRead>();
-    await asyncPool(BUCKET_CHECK_READ_CONCURRENCY, l1BlockNumbers, async l1BlockNumber => {
+  private checkBucketCanonicality(bucket: InboxBucketL1Span): Promise<BucketCanonicality> {
+    const storedBlocks =
+      bucket.closedAt.l1BlockNumber === bucket.openedAt.l1BlockNumber
+        ? [bucket.closedAt]
+        : [bucket.closedAt, bucket.openedAt];
+    return this.compareL1BlocksWithChain(storedBlocks);
+  }
+
+  /** Compares stored L1 blocks against the live chain, stopping at the first one that was replaced or cannot be read. */
+  private async compareL1BlocksWithChain(storedBlocks: L1BlockId[]): Promise<BucketCanonicality> {
+    for (const stored of storedBlocks) {
+      let liveL1BlockHash: Buffer32;
       try {
-        reads.set(l1BlockNumber, { hash: await this.getL1BlockHash(l1BlockNumber) });
+        liveL1BlockHash = await this.getL1BlockHash(stored.l1BlockNumber);
       } catch (error) {
-        reads.set(l1BlockNumber, { error });
+        return { status: 'unverifiable', l1BlockNumber: stored.l1BlockNumber, error };
       }
-    });
-    return reads;
+      if (!liveL1BlockHash.equals(stored.l1BlockHash)) {
+        return { status: 'reorged', stored, liveL1BlockHash };
+      }
+    }
+    return { status: 'canonical' };
   }
 
   /**
-   * Reports a bucket that could not be checked because the L1 block it sits on could not be read. Such a read blocks
-   * every bucket above it from ever being verified for as long as it keeps failing, while the sync itself carries on,
-   * so it is logged at warn; repeated failures on the same bucket are thinned out to keep the log readable.
+   * Rolls back to the newest stored bucket below the reorged one that still sits on canonical L1 blocks, walking the
+   * stored buckets one at a time, newest first. Running out of buckets means every stored message is orphaned, and
+   * the store is rolled back to the genesis sentinel. Returns the new message syncpoint, or undefined without rolling
+   * anything back if an L1 block could not be read.
+   */
+  private async rollbackReorgedBucket(reorgedBucketSeq: bigint, reorg: BucketReorg): Promise<L1BlockId | undefined> {
+    const bucketsBelow = this.stores.messages.iterateInboxBucketL1Spans({ end: reorgedBucketSeq - 1n, reverse: true });
+    for await (const bucket of bucketsBelow) {
+      const result = await this.checkBucketCanonicality(bucket);
+      if (result.status === 'unverifiable') {
+        this.warnBucketNotVerifiable(bucket.seq, result.l1BlockNumber, result.error);
+        return undefined;
+      }
+      if (result.status === 'canonical') {
+        return await this.rollbackToCanonicalBucket(reorgedBucketSeq, bucket, reorg);
+      }
+    }
+    return await this.rollbackToCanonicalBucket(reorgedBucketSeq, undefined, reorg);
+  }
+
+  /**
+   * Reports a bucket that could not be checked because the L1 block it sits on could not be read. The sync carries on
+   * without knowing whether the stored buckets are canonical for as long as the read keeps failing, so it is logged at
+   * warn; repeated failures on the same bucket are thinned out to keep the log readable.
    */
   private warnBucketNotVerifiable(bucketSeq: bigint, l1BlockNumber: bigint, error: unknown): void {
     const previous = this.failedBucketCheck;
@@ -646,14 +649,14 @@ export class ArchiverL1Synchronizer implements Traceable {
    * are downloaded again, with the bucket timestamps and sequence numbers the canonical chain gives them.
    */
   private async rollbackToCanonicalBucket(
-    reorgedBucket: InboxBucketL1Span,
+    reorgedBucketSeq: bigint,
     lastCanonicalBucket: InboxBucketL1Span | undefined,
-    reorg: { stored: L1BlockId; liveL1BlockHash: Buffer32 },
+    reorg: BucketReorg,
   ): Promise<L1BlockId> {
     this.log.warn(
-      `Inbox bucket ${reorgedBucket.seq} sits on an L1 block that is no longer canonical; rolling back to bucket ${lastCanonicalBucket?.seq ?? 0n}`,
+      `Inbox bucket ${reorgedBucketSeq} sits on an L1 block that is no longer canonical; rolling back to bucket ${lastCanonicalBucket?.seq ?? 0n}`,
       {
-        bucketSeq: reorgedBucket.seq,
+        bucketSeq: reorgedBucketSeq,
         l1BlockNumber: reorg.stored.l1BlockNumber,
         storedL1BlockHash: reorg.stored.l1BlockHash.toString(),
         liveL1BlockHash: reorg.liveL1BlockHash.toString(),
@@ -711,13 +714,33 @@ export class ArchiverL1Synchronizer implements Traceable {
   /**
    * Retrieves L1 to L2 messages from L1 in batches and stores them. Batches must span whole L1 blocks so that every
    * message of an Inbox bucket is stored in a single call, which the message store requires.
+   *
+   * Once stored, the new buckets are the ones the canonicality check looks at from the next pass on, so a reorg that
+   * lands while the fetch is under way must be caught here or never. It can orphan the bucket that was checked before
+   * the fetch, re-mining its messages below the syncpoint so they are not fetched again while a newer message is, and
+   * it can orphan the earlier batches of a fetch while the last one comes from the canonical chain. Each batch is a
+   * suffix of its own, though: a reorg that touched it touched the block of its last message. So once everything is
+   * stored, the bucket that was newest before the fetch and the block of the last message of every batch but the final
+   * one are compared against the live chain, skipping what is at or below the finalized block, and a mismatch rolls
+   * back right away. In the steady state a fetch is a single batch on top of a newest bucket that is checked again, so
+   * this costs one L1 block read per fetch that stored something.
+   *
+   * If a block cannot be read, the fetch is unwound to the syncpoint it started from and reported as not verified, so
+   * that nothing is stored on top of buckets that were never checked; the caller retries the pass.
    */
-  private async retrieveAndStoreMessages(fromL1Block: bigint, toL1Block: bigint): Promise<void> {
+  private async retrieveAndStoreMessages(
+    syncFrom: L1BlockId,
+    toL1Block: bigint,
+    finalizedL1Block: L1BlockId | undefined,
+  ): Promise<MessageFetchOutcome> {
+    const newestBucketBeforeFetch = await this.stores.messages.getNewestInboxBucketL1Span();
     let searchStartBlock: bigint = 0n;
-    let searchEndBlock: bigint = fromL1Block;
+    let searchEndBlock: bigint = syncFrom.l1BlockNumber;
 
+    let firstMessage: InboxMessage | undefined;
     let lastMessage: InboxMessage | undefined;
     let messageCount = 0;
+    const unfinalizedBatchTails: InboxMessage[] = [];
 
     do {
       [searchStartBlock, searchEndBlock] = this.nextRange(searchEndBlock, toL1Block);
@@ -729,17 +752,62 @@ export class ArchiverL1Synchronizer implements Traceable {
       this.instrumentation.processNewMessages(messages.length, perMsg);
       for (const msg of messages) {
         this.log.debug(`Downloaded L1 to L2 message`, { ...msg, leaf: msg.leaf.toString() });
+        firstMessage ??= msg;
         lastMessage = msg;
         messageCount++;
       }
+      const batchTail = messages.at(-1);
+      const isLastBatch = searchEndBlock >= toL1Block;
+      if (batchTail !== undefined && !isLastBatch && !isFinalized(batchTail, finalizedL1Block)) {
+        unfinalizedBatchTails.push(batchTail);
+      }
     } while (searchEndBlock < toL1Block);
 
-    if (messageCount > 0) {
-      this.log.info(`Retrieved ${messageCount} new L1 to L2 messages up to message with index ${lastMessage?.index}`, {
-        lastMessage,
-        messageCount,
-      });
+    if (firstMessage === undefined || lastMessage === undefined) {
+      return 'stored';
     }
+    this.log.info(`Retrieved ${messageCount} new L1 to L2 messages up to message with index ${lastMessage.index}`, {
+      lastMessage,
+      messageCount,
+    });
+
+    // The fetch may have re-delivered the bucket that was newest before it, so it is compared as it is stored now.
+    const newestBucketToRecheck =
+      newestBucketBeforeFetch && !isFinalized(newestBucketBeforeFetch.closedAt, finalizedL1Block)
+        ? await this.stores.messages.getInboxBucketL1Span(newestBucketBeforeFetch.seq)
+        : undefined;
+    const checks: { bucketSeq: bigint; check: () => Promise<BucketCanonicality> }[] = compactArray([
+      newestBucketToRecheck && {
+        bucketSeq: newestBucketToRecheck.seq,
+        check: () => this.checkBucketCanonicality(newestBucketToRecheck),
+      },
+      ...unfinalizedBatchTails.map(tail => ({
+        bucketSeq: tail.bucketSeq,
+        check: () =>
+          this.compareL1BlocksWithChain([{ l1BlockNumber: tail.l1BlockNumber, l1BlockHash: tail.l1BlockHash }]),
+      })),
+    ]);
+    for (const { bucketSeq, check } of checks) {
+      const canonicality = await check();
+      if (canonicality.status === 'canonical') {
+        continue;
+      }
+      if (canonicality.status === 'reorged') {
+        const syncPoint = await this.rollbackReorgedBucket(bucketSeq, canonicality);
+        if (syncPoint !== undefined) {
+          return 'rolled-back';
+        }
+      } else {
+        this.warnBucketNotVerifiable(bucketSeq, canonicality.l1BlockNumber, canonicality.error);
+      }
+      this.log.warn(
+        `Unwinding ${messageCount} L1 to L2 messages fetched from L1 block ${syncFrom.l1BlockNumber} that could not be checked against the live chain`,
+        { syncFrom, firstRemovedIndex: firstMessage.index, messageCount },
+      );
+      await this.rewindMessagesTo(syncFrom, firstMessage.index);
+      return 'unverifiable';
+    }
+    return 'stored';
   }
 
   /**

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -8,7 +8,7 @@ import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
 import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
-import { compactArray, partition, pick } from '@aztec/foundation/collection';
+import { compactArray, partition, pick, unique } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -30,7 +30,6 @@ import {
   PublishedCheckpoint,
 } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
-import type { InboxBucket } from '@aztec/stdlib/messaging';
 import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
@@ -46,11 +45,57 @@ import {
 import type { RejectedCheckpoint } from '../store/block_store.js';
 import { type ArchiverDataStores, getArchiverSynchPoint } from '../store/data_stores.js';
 import type { L2TipsCache } from '../store/l2_tips_cache.js';
-import { MessageStoreError } from '../store/message_store.js';
+import { type InboxBucketL1Span, MessageStoreError } from '../store/message_store.js';
 import type { InboxMessage } from '../structs/inbox_message.js';
 import { ArchiverDataStoreUpdater } from './data_store_updater.js';
 import type { ArchiverInstrumentation } from './instrumentation.js';
 import { validateCheckpointAttestationsFromCalldata } from './validation.js';
+
+/**
+ * How many Inbox buckets are compared against the live chain per sync pass. The unverified tail grows for as long as
+ * L1 finality does not advance, so the walk is capped and resumes where it left off on the next pass.
+ */
+const MAX_BUCKETS_CHECKED_PER_SYNC = 32;
+
+/** How many L1 block reads the Inbox bucket check issues in parallel. */
+const BUCKET_CHECK_READ_CONCURRENCY = 4;
+
+/** After the first one, how often a bucket check that keeps failing to read its L1 block is logged at warn. */
+const BUCKET_CHECK_FAILURE_WARN_EVERY = 20;
+
+/** The live hash of an L1 block, or the error that reading it raised. */
+type L1BlockHashRead = { hash: Buffer32; error?: undefined } | { hash?: undefined; error: unknown };
+
+/** The outcome of comparing the L1 blocks an Inbox bucket sits on against the live chain. */
+type BucketCanonicality =
+  | { status: 'canonical' }
+  | { status: 'reorged'; stored: L1BlockId; liveL1BlockHash: Buffer32 }
+  | { status: 'unverifiable'; l1BlockNumber: bigint; error: unknown };
+
+/**
+ * Compares the L1 blocks a bucket was opened and closed in against the live chain. Both ends are checked: a bucket
+ * that absorbed messages from a later co-timestamped L1 block is split when that block alone is reorged, and neither
+ * its opening block nor the Inbox's message count and rolling hash change when it happens.
+ */
+function checkBucketCanonicality(
+  bucket: InboxBucketL1Span,
+  liveBlocks: Map<bigint, L1BlockHashRead>,
+): BucketCanonicality {
+  const storedBlocks =
+    bucket.closedAt.l1BlockNumber === bucket.openedAt.l1BlockNumber
+      ? [bucket.openedAt]
+      : [bucket.openedAt, bucket.closedAt];
+  for (const stored of storedBlocks) {
+    const live = liveBlocks.get(stored.l1BlockNumber);
+    if (live?.hash === undefined) {
+      return { status: 'unverifiable', l1BlockNumber: stored.l1BlockNumber, error: live?.error };
+    }
+    if (!live.hash.equals(stored.l1BlockHash)) {
+      return { status: 'reorged', stored, liveL1BlockHash: live.hash };
+    }
+  }
+  return { status: 'canonical' };
+}
 
 type RollupStatus = {
   provenCheckpointNumber: CheckpointNumber;
@@ -74,6 +119,8 @@ export class ArchiverL1Synchronizer implements Traceable {
   private l1BlockNumber: bigint | undefined;
   private l1BlockHash: Buffer32 | undefined;
   private l1Timestamp: bigint | undefined;
+  /** The bucket whose canonicality check last failed to read its L1 block, and for how many passes in a row. */
+  private failedBucketCheck: { bucketSeq: bigint; passes: number } | undefined;
 
   private readonly updater: ArchiverDataStoreUpdater;
   public readonly tracer: Tracer;
@@ -425,16 +472,18 @@ export class ArchiverL1Synchronizer implements Traceable {
       },
     } = await getArchiverSynchPoint(this.stores);
 
-    // Nothing to do if L1 block number has not moved forward
-    const currentL1BlockNumber = currentL1Block.l1BlockNumber;
-    if (currentL1BlockNumber <= messagesSynchedTo.l1BlockNumber) {
-      return true;
-    }
-
     // An L1 reorg that re-mines the same messages in a different block leaves the message count and rolling hash
     // compared below untouched while rewriting the bucket metadata built from that block, so check the buckets we
-    // hold against the live chain first. A rollback here resets the syncpoint, and we resume from the new one.
+    // hold against the live chain first. This runs before the check that L1 has moved forward below, because a reorg
+    // can replace the head with a block of the same number, which advances nothing. A rollback here rewinds the
+    // syncpoint, and we resume from the new one.
     const syncFrom = (await this.ensureBucketsAreCanonical(finalizedL1Block)) ?? messagesSynchedTo;
+
+    // Nothing to do if L1 has not moved past our syncpoint
+    const currentL1BlockNumber = currentL1Block.l1BlockNumber;
+    if (currentL1BlockNumber <= syncFrom.l1BlockNumber) {
+      return true;
+    }
 
     // Compare local message store state with the remote. If they match, we just advance the match pointer. The
     // remote state is the Inbox's live chain position (cumulative total and consensus rolling hash), read in a
@@ -490,77 +539,106 @@ export class ArchiverL1Synchronizer implements Traceable {
    * The message count and consensus rolling hash the sync compares against the Inbox do not change when an L1 reorg
    * re-mines the same messages in a different block, but the bucket timestamps, sequence numbers and boundaries
    * derived from that block do, and consumers depend on them. So every bucket the node has not positively verified is
-   * compared against the live chain by the hash of the L1 block it was opened in. Buckets that share an opening block
-   * (a full bucket rolling over within one L1 block) cost a single read.
+   * compared against the live chain by the hashes of the L1 blocks it was opened and closed in. Buckets sharing a
+   * block (a full bucket rolling over within one L1 block) cost a single read, and the reads run in parallel.
    *
    * Sitting at or below the finalized L1 block is not on its own a reason to skip a bucket: a node that was not
    * watching when its block was reorged out holds an orphaned block that has since been buried below finality. A
    * bucket is skipped only once this node has itself compared it against a chain that had it finalized, which is what
-   * the store's canonicality watermark records.
+   * the store's canonicality watermark records. Until finality advances the unverified tail keeps growing, so at most
+   * `MAX_BUCKETS_CHECKED_PER_SYNC` buckets are checked per pass and the rest wait for the next one.
    */
   private async ensureBucketsAreCanonical(finalizedL1Block: L1BlockId | undefined): Promise<L1BlockId | undefined> {
     const verifiedThroughSeq = await this.stores.messages.getCanonicalVerifiedThroughSeq();
-    const newestBucket = await this.stores.messages.getNewestInboxBucket();
-    if (newestBucket === undefined || newestBucket.seq <= verifiedThroughSeq) {
+    const buckets: InboxBucketL1Span[] = [];
+    for await (const bucket of this.stores.messages.iterateInboxBucketL1Spans({ start: verifiedThroughSeq + 1n })) {
+      buckets.push(bucket);
+      if (buckets.length === MAX_BUCKETS_CHECKED_PER_SYNC) {
+        break;
+      }
+    }
+    if (buckets.length === 0) {
       return undefined;
     }
 
-    let lastCanonicalBucket: InboxBucket | undefined;
+    const liveBlocks = await this.readL1BlockHashes(buckets);
+    let lastCanonicalBucket: InboxBucketL1Span | undefined;
     let verifyThroughSeq: bigint | undefined;
     let finalizedSoFar = true;
-    const liveHashes = new Map<bigint, Buffer32>();
+    let readFailed = false;
 
-    for await (const bucket of this.stores.messages.iterateInboxBuckets({ start: verifiedThroughSeq + 1n })) {
-      const liveHash = await this.readCachedL1BlockHash(bucket.l1BlockNumber, liveHashes);
-      if (liveHash === undefined) {
+    for (const bucket of buckets) {
+      const result = checkBucketCanonicality(bucket, liveBlocks);
+      if (result.status === 'unverifiable') {
         // The L1 read failed, so we learned nothing about this bucket: leave it for the next sync pass.
+        readFailed = true;
+        this.warnBucketNotVerifiable(bucket.seq, result.l1BlockNumber, result.error);
         break;
       }
-      if (!liveHash.equals(bucket.l1BlockHash)) {
+      if (result.status === 'reorged') {
         return await this.rollbackToCanonicalBucket(
           bucket,
-          lastCanonicalBucket ?? (await this.getVerifiedBucket(verifiedThroughSeq)),
-          liveHash,
+          // The watermark points at a bucket this node verified in an earlier pass, so it is canonical by induction.
+          lastCanonicalBucket ?? (await this.stores.messages.getInboxBucketL1Span(verifiedThroughSeq)),
+          result,
         );
       }
       lastCanonicalBucket = bucket;
-      // The watermark is a prefix, so it stops advancing at the first bucket that is not yet finalized.
-      finalizedSoFar &&= finalizedL1Block !== undefined && bucket.l1BlockNumber <= finalizedL1Block.l1BlockNumber;
+      // The watermark is a prefix, so it stops advancing at the first bucket that is not yet finalized. A bucket
+      // counts as finalized only once the block it was closed in is, since that is the last one that can move.
+      finalizedSoFar &&=
+        finalizedL1Block !== undefined && bucket.closedAt.l1BlockNumber <= finalizedL1Block.l1BlockNumber;
       if (finalizedSoFar) {
         verifyThroughSeq = bucket.seq;
       }
     }
 
+    if (!readFailed) {
+      this.failedBucketCheck = undefined;
+    }
     if (verifyThroughSeq !== undefined) {
       await this.stores.messages.setCanonicalVerifiedThroughSeq(verifyThroughSeq);
     }
     return undefined;
   }
 
-  /** Reads an L1 block hash through a per-iteration cache, returning undefined if the read failed. */
-  private async readCachedL1BlockHash(
-    l1BlockNumber: bigint,
-    cache: Map<bigint, Buffer32>,
-  ): Promise<Buffer32 | undefined> {
-    const cached = cache.get(l1BlockNumber);
-    if (cached !== undefined) {
-      return cached;
-    }
-    try {
-      const hash = await this.getL1BlockHash(l1BlockNumber);
-      cache.set(l1BlockNumber, hash);
-      return hash;
-    } catch (error) {
-      this.log.debug(`Failed to read L1 block ${l1BlockNumber} to verify Inbox buckets`, { error, l1BlockNumber });
-      return undefined;
-    }
+  /**
+   * Reads the live hashes of the L1 blocks the given buckets were opened and closed in, with bounded parallelism.
+   * Blocks shared by several buckets, and buckets that neither span blocks nor roll over, cost a single read. A block
+   * whose read failed maps to the error instead of a hash.
+   */
+  private async readL1BlockHashes(buckets: InboxBucketL1Span[]): Promise<Map<bigint, L1BlockHashRead>> {
+    const l1BlockNumbers = unique(
+      buckets.flatMap(bucket => [bucket.openedAt.l1BlockNumber, bucket.closedAt.l1BlockNumber]),
+    );
+    const reads = new Map<bigint, L1BlockHashRead>();
+    await asyncPool(BUCKET_CHECK_READ_CONCURRENCY, l1BlockNumbers, async l1BlockNumber => {
+      try {
+        reads.set(l1BlockNumber, { hash: await this.getL1BlockHash(l1BlockNumber) });
+      } catch (error) {
+        reads.set(l1BlockNumber, { error });
+      }
+    });
+    return reads;
   }
 
-  /** Returns the bucket the canonicality watermark points at, or undefined if no bucket has been verified. */
-  private getVerifiedBucket(verifiedThroughSeq: bigint): Promise<InboxBucket | undefined> {
-    return verifiedThroughSeq === 0n
-      ? Promise.resolve(undefined)
-      : this.stores.messages.getInboxBucket(verifiedThroughSeq);
+  /**
+   * Reports a bucket that could not be checked because the L1 block it sits on could not be read. Such a read blocks
+   * every bucket above it from ever being verified for as long as it keeps failing, while the sync itself carries on,
+   * so it is logged at warn; repeated failures on the same bucket are thinned out to keep the log readable.
+   */
+  private warnBucketNotVerifiable(bucketSeq: bigint, l1BlockNumber: bigint, error: unknown): void {
+    const previous = this.failedBucketCheck;
+    const passes = previous?.bucketSeq === bucketSeq ? previous.passes + 1 : 1;
+    this.failedBucketCheck = { bucketSeq, passes };
+
+    const message = `Failed to read L1 block ${l1BlockNumber} to check whether Inbox bucket ${bucketSeq} is canonical`;
+    const context = { bucketSeq, l1BlockNumber, passes, error };
+    if (passes === 1 || passes % BUCKET_CHECK_FAILURE_WARN_EVERY === 0) {
+      this.log.warn(message, context);
+    } else {
+      this.log.debug(message, context);
+    }
   }
 
   /**
@@ -568,34 +646,35 @@ export class ArchiverL1Synchronizer implements Traceable {
    * are downloaded again, with the bucket timestamps and sequence numbers the canonical chain gives them.
    */
   private async rollbackToCanonicalBucket(
-    reorgedBucket: InboxBucket,
-    lastCanonicalBucket: InboxBucket | undefined,
-    liveL1BlockHash: Buffer32,
+    reorgedBucket: InboxBucketL1Span,
+    lastCanonicalBucket: InboxBucketL1Span | undefined,
+    reorg: { stored: L1BlockId; liveL1BlockHash: Buffer32 },
   ): Promise<L1BlockId> {
     this.log.warn(
-      `Inbox bucket ${reorgedBucket.seq} was opened in an L1 block that is no longer canonical; rolling back to bucket ${lastCanonicalBucket?.seq ?? 0n}`,
+      `Inbox bucket ${reorgedBucket.seq} sits on an L1 block that is no longer canonical; rolling back to bucket ${lastCanonicalBucket?.seq ?? 0n}`,
       {
         bucketSeq: reorgedBucket.seq,
-        l1BlockNumber: reorgedBucket.l1BlockNumber,
-        storedL1BlockHash: reorgedBucket.l1BlockHash.toString(),
-        liveL1BlockHash: liveL1BlockHash.toString(),
+        l1BlockNumber: reorg.stored.l1BlockNumber,
+        storedL1BlockHash: reorg.stored.l1BlockHash.toString(),
+        liveL1BlockHash: reorg.liveL1BlockHash.toString(),
         lastCanonicalBucketSeq: lastCanonicalBucket?.seq ?? 0n,
       },
     );
 
-    await this.stores.messages.removeL1ToL2Messages(
-      lastCanonicalBucket ? lastCanonicalBucket.lastMessageIndex + 1n : 0n,
+    // Resume from the block before the last canonical bucket's opening one, so that bucket is re-delivered from its
+    // first message and any bucket that rolled over after it within the same L1 block is downloaded again. The
+    // syncpoint is resolved before anything is written, so the removal and the rewind can commit together.
+    const syncPoint = await this.resolveMessagesSyncPoint(
+      lastCanonicalBucket && lastCanonicalBucket.openedAt.l1BlockNumber - 1n,
     );
-    // Resume from the block before the last canonical bucket's, so that bucket is re-delivered from its first message
-    // and any bucket that rolled over after it within the same L1 block is downloaded again.
-    return this.resetMessagesSyncPoint(lastCanonicalBucket && lastCanonicalBucket.l1BlockNumber - 1n);
+    return this.rewindMessagesTo(syncPoint, lastCanonicalBucket ? lastCanonicalBucket.lastMessageIndex + 1n : 0n);
   }
 
   /**
-   * Rewinds the message syncpoint to the given L1 block, so the next retrieval starts at the one after it. Never goes
-   * below the L1 start block, nor below `notBelow` when one is given.
+   * Resolves the L1 block the message syncpoint should be rewound to, so the next retrieval starts at the one after
+   * it. Never goes below the L1 start block, nor below `notBelow` when one is given.
    */
-  private async resetMessagesSyncPoint(l1BlockNumber: bigint | undefined, notBelow?: L1BlockId): Promise<L1BlockId> {
+  private async resolveMessagesSyncPoint(l1BlockNumber: bigint | undefined, notBelow?: L1BlockId): Promise<L1BlockId> {
     const syncPointL1BlockNumber = maxBigint(
       ...compactArray([l1BlockNumber, notBelow?.l1BlockNumber, this.l1Constants.l1StartBlock]),
     );
@@ -603,9 +682,15 @@ export class ArchiverL1Synchronizer implements Traceable {
       syncPointL1BlockNumber === notBelow?.l1BlockNumber
         ? notBelow.l1BlockHash
         : await this.getL1BlockHash(syncPointL1BlockNumber);
+    return { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
+  }
 
-    const messagesSyncPoint = { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
-    await this.stores.messages.setMessageSyncState(messagesSyncPoint);
+  /**
+   * Rewinds the message syncpoint to the given L1 block, dropping the messages from `removeFromIndex` on in the same
+   * transaction, so an interruption cannot leave truncated messages behind a syncpoint that would never fetch them.
+   */
+  private async rewindMessagesTo(messagesSyncPoint: L1BlockId, removeFromIndex?: bigint): Promise<L1BlockId> {
+    await this.stores.messages.rewindMessagesTo(messagesSyncPoint, removeFromIndex);
     this.log.verbose(`Updated messages syncpoint to L1 block ${messagesSyncPoint.l1BlockNumber}`, {
       ...messagesSyncPoint,
     });
@@ -718,19 +803,25 @@ export class ArchiverL1Synchronizer implements Traceable {
       }
     }
 
-    // Delete everything after the common message we found, if anything needs to be deleted.
-    // Do not exit early if there are no messages to delete, we still want to update the syncpoint.
-    if (messagesToDelete > 0) {
-      const lastGoodIndex = commonMsg?.index;
-      this.log.warn(`Rolling back all local L1 to L2 messages after index ${lastGoodIndex ?? 'initial'}`);
-      await this.stores.messages.removeL1ToL2Messages(lastGoodIndex !== undefined ? lastGoodIndex + 1n : 0n);
-    }
-
-    // Update the syncpoint so the loop below reprocesses the changed messages. We go to the block before
+    // Resolve the syncpoint the messages will be rewound to before writing anything. We go to the block before
     // the last common one, so we force reprocessing it, in case new messages were added on that same L1 block
     // after the last common message. Cap at the finalized L1 block: messages at or below finalized cannot
     // have been reorged, so there is no need to walk back any further than that.
-    return this.resetMessagesSyncPoint(commonMsg && commonMsg.l1BlockNumber - 1n, messagesFinalizedL1Block);
+    const messagesSyncPoint = await this.resolveMessagesSyncPoint(
+      commonMsg && commonMsg.l1BlockNumber - 1n,
+      messagesFinalizedL1Block,
+    );
+
+    // Delete everything after the common message we found, if anything needs to be deleted, in the same transaction
+    // that moves the syncpoint. Do not exit early if there are no messages to delete, we still want to update it.
+    const lastGoodIndex = commonMsg?.index;
+    if (messagesToDelete > 0) {
+      this.log.warn(`Rolling back all local L1 to L2 messages after index ${lastGoodIndex ?? 'initial'}`);
+    }
+    return this.rewindMessagesTo(
+      messagesSyncPoint,
+      messagesToDelete > 0 ? (lastGoodIndex !== undefined ? lastGoodIndex + 1n : 0n) : undefined,
+    );
   }
 
   private async getL1BlockHash(l1BlockNumber: bigint): Promise<Buffer32> {

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -30,6 +30,7 @@ import {
   PublishedCheckpoint,
 } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
+import type { InboxBucket } from '@aztec/stdlib/messaging';
 import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
@@ -430,6 +431,11 @@ export class ArchiverL1Synchronizer implements Traceable {
       return true;
     }
 
+    // An L1 reorg that re-mines the same messages in a different block leaves the message count and rolling hash
+    // compared below untouched while rewriting the bucket metadata built from that block, so check the buckets we
+    // hold against the live chain first. A rollback here resets the syncpoint, and we resume from the new one.
+    const syncFrom = (await this.ensureBucketsAreCanonical(finalizedL1Block)) ?? messagesSynchedTo;
+
     // Compare local message store state with the remote. If they match, we just advance the match pointer. The
     // remote state is the Inbox's live chain position (cumulative total and consensus rolling hash), read in a
     // single atomic call.
@@ -446,7 +452,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     // If that's the case, we'd get an exception out of the message store since the rolling hash of the first message
     // we try to insert would not match the one in the db, in which case we rollback to the last common message with L1.
     try {
-      await this.retrieveAndStoreMessages(messagesSynchedTo.l1BlockNumber, currentL1BlockNumber);
+      await this.retrieveAndStoreMessages(syncFrom.l1BlockNumber, currentL1BlockNumber);
     } catch (error) {
       if (isErrorClass(error, MessageStoreError)) {
         this.log.warn(
@@ -475,6 +481,135 @@ export class ArchiverL1Synchronizer implements Traceable {
     // Advance the syncpoint after a successful sync
     await this.stores.messages.setMessageSyncState(currentL1Block, finalizedL1Block);
     return true;
+  }
+
+  /**
+   * Verifies that the Inbox buckets this archiver holds were opened in L1 blocks that are still canonical, and rolls
+   * back to the last canonical bucket when one of them was not. Returns the new message syncpoint if it rolled back.
+   *
+   * The message count and consensus rolling hash the sync compares against the Inbox do not change when an L1 reorg
+   * re-mines the same messages in a different block, but the bucket timestamps, sequence numbers and boundaries
+   * derived from that block do, and consumers depend on them. So every bucket the node has not positively verified is
+   * compared against the live chain by the hash of the L1 block it was opened in. Buckets that share an opening block
+   * (a full bucket rolling over within one L1 block) cost a single read.
+   *
+   * Sitting at or below the finalized L1 block is not on its own a reason to skip a bucket: a node that was not
+   * watching when its block was reorged out holds an orphaned block that has since been buried below finality. A
+   * bucket is skipped only once this node has itself compared it against a chain that had it finalized, which is what
+   * the store's canonicality watermark records.
+   */
+  private async ensureBucketsAreCanonical(finalizedL1Block: L1BlockId | undefined): Promise<L1BlockId | undefined> {
+    const verifiedThroughSeq = await this.stores.messages.getCanonicalVerifiedThroughSeq();
+    const newestBucket = await this.stores.messages.getNewestInboxBucket();
+    if (newestBucket === undefined || newestBucket.seq <= verifiedThroughSeq) {
+      return undefined;
+    }
+
+    let lastCanonicalBucket: InboxBucket | undefined;
+    let verifyThroughSeq: bigint | undefined;
+    let finalizedSoFar = true;
+    const liveHashes = new Map<bigint, Buffer32>();
+
+    for await (const bucket of this.stores.messages.iterateInboxBuckets({ start: verifiedThroughSeq + 1n })) {
+      const liveHash = await this.readCachedL1BlockHash(bucket.l1BlockNumber, liveHashes);
+      if (liveHash === undefined) {
+        // The L1 read failed, so we learned nothing about this bucket: leave it for the next sync pass.
+        break;
+      }
+      if (!liveHash.equals(bucket.l1BlockHash)) {
+        return await this.rollbackToCanonicalBucket(
+          bucket,
+          lastCanonicalBucket ?? (await this.getVerifiedBucket(verifiedThroughSeq)),
+          liveHash,
+        );
+      }
+      lastCanonicalBucket = bucket;
+      // The watermark is a prefix, so it stops advancing at the first bucket that is not yet finalized.
+      finalizedSoFar &&= finalizedL1Block !== undefined && bucket.l1BlockNumber <= finalizedL1Block.l1BlockNumber;
+      if (finalizedSoFar) {
+        verifyThroughSeq = bucket.seq;
+      }
+    }
+
+    if (verifyThroughSeq !== undefined) {
+      await this.stores.messages.setCanonicalVerifiedThroughSeq(verifyThroughSeq);
+    }
+    return undefined;
+  }
+
+  /** Reads an L1 block hash through a per-iteration cache, returning undefined if the read failed. */
+  private async readCachedL1BlockHash(
+    l1BlockNumber: bigint,
+    cache: Map<bigint, Buffer32>,
+  ): Promise<Buffer32 | undefined> {
+    const cached = cache.get(l1BlockNumber);
+    if (cached !== undefined) {
+      return cached;
+    }
+    try {
+      const hash = await this.getL1BlockHash(l1BlockNumber);
+      cache.set(l1BlockNumber, hash);
+      return hash;
+    } catch (error) {
+      this.log.debug(`Failed to read L1 block ${l1BlockNumber} to verify Inbox buckets`, { error, l1BlockNumber });
+      return undefined;
+    }
+  }
+
+  /** Returns the bucket the canonicality watermark points at, or undefined if no bucket has been verified. */
+  private getVerifiedBucket(verifiedThroughSeq: bigint): Promise<InboxBucket | undefined> {
+    return verifiedThroughSeq === 0n
+      ? Promise.resolve(undefined)
+      : this.stores.messages.getInboxBucket(verifiedThroughSeq);
+  }
+
+  /**
+   * Drops every message absorbed after the last canonical bucket and rewinds the syncpoint so the reorged L1 blocks
+   * are downloaded again, with the bucket timestamps and sequence numbers the canonical chain gives them.
+   */
+  private async rollbackToCanonicalBucket(
+    reorgedBucket: InboxBucket,
+    lastCanonicalBucket: InboxBucket | undefined,
+    liveL1BlockHash: Buffer32,
+  ): Promise<L1BlockId> {
+    this.log.warn(
+      `Inbox bucket ${reorgedBucket.seq} was opened in an L1 block that is no longer canonical; rolling back to bucket ${lastCanonicalBucket?.seq ?? 0n}`,
+      {
+        bucketSeq: reorgedBucket.seq,
+        l1BlockNumber: reorgedBucket.l1BlockNumber,
+        storedL1BlockHash: reorgedBucket.l1BlockHash.toString(),
+        liveL1BlockHash: liveL1BlockHash.toString(),
+        lastCanonicalBucketSeq: lastCanonicalBucket?.seq ?? 0n,
+      },
+    );
+
+    await this.stores.messages.removeL1ToL2Messages(
+      lastCanonicalBucket ? lastCanonicalBucket.lastMessageIndex + 1n : 0n,
+    );
+    // Resume from the block before the last canonical bucket's, so that bucket is re-delivered from its first message
+    // and any bucket that rolled over after it within the same L1 block is downloaded again.
+    return this.resetMessagesSyncPoint(lastCanonicalBucket && lastCanonicalBucket.l1BlockNumber - 1n);
+  }
+
+  /**
+   * Rewinds the message syncpoint to the given L1 block, so the next retrieval starts at the one after it. Never goes
+   * below the L1 start block, nor below `notBelow` when one is given.
+   */
+  private async resetMessagesSyncPoint(l1BlockNumber: bigint | undefined, notBelow?: L1BlockId): Promise<L1BlockId> {
+    const syncPointL1BlockNumber = maxBigint(
+      ...compactArray([l1BlockNumber, notBelow?.l1BlockNumber, this.l1Constants.l1StartBlock]),
+    );
+    const syncPointL1BlockHash =
+      syncPointL1BlockNumber === notBelow?.l1BlockNumber
+        ? notBelow.l1BlockHash
+        : await this.getL1BlockHash(syncPointL1BlockNumber);
+
+    const messagesSyncPoint = { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
+    await this.stores.messages.setMessageSyncState(messagesSyncPoint);
+    this.log.verbose(`Updated messages syncpoint to L1 block ${messagesSyncPoint.l1BlockNumber}`, {
+      ...messagesSyncPoint,
+    });
+    return messagesSyncPoint;
   }
 
   /** Checks if the local consensus rolling hash and message count match the remote Inbox live state. */
@@ -595,25 +730,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     // the last common one, so we force reprocessing it, in case new messages were added on that same L1 block
     // after the last common message. Cap at the finalized L1 block: messages at or below finalized cannot
     // have been reorged, so there is no need to walk back any further than that.
-    const syncPointL1BlockNumber = maxBigint(
-      ...compactArray([
-        commonMsg ? commonMsg.l1BlockNumber - 1n : undefined,
-        finalizedL1BlockNumber,
-        this.l1Constants.l1StartBlock,
-      ]),
-    );
-
-    const syncPointL1BlockHash =
-      syncPointL1BlockNumber === finalizedL1BlockNumber
-        ? messagesFinalizedL1Block!.l1BlockHash
-        : await this.getL1BlockHash(syncPointL1BlockNumber);
-
-    const messagesSyncPoint = { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
-    await this.stores.messages.setMessageSyncState(messagesSyncPoint);
-    this.log.verbose(`Updated messages syncpoint to L1 block ${messagesSyncPoint.l1BlockNumber}`, {
-      ...messagesSyncPoint,
-    });
-    return messagesSyncPoint;
+    return this.resetMessagesSyncPoint(commonMsg && commonMsg.l1BlockNumber - 1n, messagesFinalizedL1Block);
   }
 
   private async getL1BlockHash(l1BlockNumber: bigint): Promise<Buffer32> {

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -445,6 +445,63 @@ describe('MessageStore', () => {
       expect((await messageStore.getLatestInboxBucketAtOrBefore(200n))!.seq).toEqual(3n);
     });
 
+    it('returns the newest bucket', async () => {
+      expect(await messageStore.getNewestInboxBucket()).toBeUndefined();
+
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      expect(await messageStore.getNewestInboxBucket()).toEqual(await messageStore.getInboxBucket(3n));
+    });
+
+    it('iterates over buckets in sequence order', async () => {
+      await messageStore.addL1ToL2MessageBuckets(makeBucketedMessages(threeBucketSpec));
+
+      const seqs = async (range: Parameters<typeof messageStore.iterateInboxBuckets>[0]) =>
+        (await toArray(messageStore.iterateInboxBuckets(range))).map(bucket => bucket.seq);
+
+      expect(await seqs({})).toEqual([1n, 2n, 3n]);
+      expect(await seqs({ start: 2n })).toEqual([2n, 3n]);
+      expect(await seqs({ reverse: true })).toEqual([3n, 2n, 1n]);
+      expect(await seqs({ start: 4n })).toEqual([]);
+      expect((await toArray(messageStore.iterateInboxBuckets({ start: 3n })))[0]).toEqual(
+        await messageStore.getInboxBucket(3n),
+      );
+    });
+
+    it('tracks the sequence through which buckets have been verified as canonical', async () => {
+      await messageStore.addL1ToL2MessageBuckets(makeBucketedMessages(threeBucketSpec));
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+
+      await messageStore.setCanonicalVerifiedThroughSeq(2n);
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(2n);
+    });
+
+    it('lowers the canonicality watermark below the bucket a removal cuts into', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      await messageStore.setCanonicalVerifiedThroughSeq(3n);
+
+      // The removal leaves bucket 2 as the tip with a single message, so it is rewritten and must be verified again.
+      await messageStore.removeL1ToL2Messages(msgs[4].index);
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
+
+      // Removing everything leaves nothing verified.
+      await messageStore.setCanonicalVerifiedThroughSeq(1n);
+      await messageStore.removeL1ToL2Messages(0n);
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+    });
+
+    it('leaves the canonicality watermark alone when the removal is above it', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      await messageStore.setCanonicalVerifiedThroughSeq(1n);
+
+      await messageStore.removeL1ToL2Messages(msgs[5].index);
+
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
+    });
+
     it('returns messages between buckets in insertion order', async () => {
       const msgs = makeBucketedMessages(threeBucketSpec);
       await messageStore.addL1ToL2MessageBuckets(msgs);

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -490,6 +490,15 @@ describe('MessageStore', () => {
       expect(await messageStore.getNewestInboxBucket()).toEqual(await messageStore.getInboxBucket(3n));
     });
 
+    it('returns the L1 span of the newest bucket', async () => {
+      expect(await messageStore.getNewestInboxBucketL1Span()).toBeUndefined();
+
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      expect(await messageStore.getNewestInboxBucketL1Span()).toEqual(await messageStore.getInboxBucketL1Span(3n));
+    });
+
     it('iterates over bucket spans in sequence order', async () => {
       await messageStore.addL1ToL2MessageBuckets(makeBucketedMessages(threeBucketSpec));
 
@@ -499,62 +508,9 @@ describe('MessageStore', () => {
       expect(await seqs({})).toEqual([1n, 2n, 3n]);
       expect(await seqs({ start: 2n })).toEqual([2n, 3n]);
       expect(await seqs({ reverse: true })).toEqual([3n, 2n, 1n]);
+      expect(await seqs({ end: 2n, reverse: true })).toEqual([2n, 1n]);
+      expect(await seqs({ end: 0n, reverse: true })).toEqual([]);
       expect(await seqs({ start: 4n })).toEqual([]);
-    });
-
-    it('tracks the sequence through which buckets have been verified as canonical', async () => {
-      await messageStore.addL1ToL2MessageBuckets(makeBucketedMessages(threeBucketSpec));
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-
-      await messageStore.setCanonicalVerifiedThroughSeq(2n);
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(2n);
-    });
-
-    it('lowers the canonicality watermark below the bucket a removal cuts into', async () => {
-      const msgs = makeBucketedMessages(threeBucketSpec);
-      await messageStore.addL1ToL2MessageBuckets(msgs);
-      await messageStore.setCanonicalVerifiedThroughSeq(3n);
-
-      // The removal leaves bucket 2 as the tip with a single message, so it is rewritten and must be verified again.
-      await messageStore.removeL1ToL2Messages(msgs[4].index);
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
-
-      // Removing everything leaves nothing verified.
-      await messageStore.setCanonicalVerifiedThroughSeq(1n);
-      await messageStore.removeL1ToL2Messages(0n);
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(0n);
-    });
-
-    it('lowers the canonicality watermark when a verified bucket is re-delivered from another L1 block', async () => {
-      const msgs = makeBucketedMessages(threeBucketSpec);
-      await messageStore.addL1ToL2MessageBuckets(msgs);
-      await messageStore.setCanonicalVerifiedThroughSeq(3n);
-
-      // The same messages arrive again, this time from an L1 block the archiver has not checked.
-      const replayed = msgs.slice(3).map(msg => ({ ...msg, l1BlockHash: makeL1BlockHash(99n) }));
-      await messageStore.addL1ToL2MessageBuckets(replayed);
-
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
-    });
-
-    it('keeps the canonicality watermark when a verified bucket is re-delivered unchanged', async () => {
-      const msgs = makeBucketedMessages(threeBucketSpec);
-      await messageStore.addL1ToL2MessageBuckets(msgs);
-      await messageStore.setCanonicalVerifiedThroughSeq(3n);
-
-      await messageStore.addL1ToL2MessageBuckets(msgs.slice(3));
-
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(3n);
-    });
-
-    it('leaves the canonicality watermark alone when the removal is above it', async () => {
-      const msgs = makeBucketedMessages(threeBucketSpec);
-      await messageStore.addL1ToL2MessageBuckets(msgs);
-      await messageStore.setCanonicalVerifiedThroughSeq(1n);
-
-      await messageStore.removeL1ToL2Messages(msgs[5].index);
-
-      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
     });
 
     it('returns messages between buckets in insertion order', async () => {

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -390,9 +390,9 @@ describe('MessageStore', () => {
       expect(await messageStore.getTotalL1ToL2MessageCount()).toEqual(3n);
     });
 
-    it('records the opening L1 block of a bucket spanning co-timestamped L1 blocks', async () => {
+    it('records the opening and closing L1 blocks of a bucket spanning co-timestamped L1 blocks', async () => {
       // Chains that allow consecutive blocks to share a timestamp (anvil with manual mining) can spread one
-      // bucket over several L1 blocks; the snapshot keeps the block the bucket was opened in.
+      // bucket over several L1 blocks; the snapshot keeps both ends, since either can be reorged on its own.
       const msgs = makeBucketedMessages(threeBucketSpec);
       msgs[2].l1BlockNumber = msgs[0].l1BlockNumber + 1n;
       msgs[2].l1BlockHash = makeL1BlockHash(msgs[2].l1BlockNumber);
@@ -402,6 +402,42 @@ describe('MessageStore', () => {
         msgCount: 3,
         l1BlockNumber: msgs[0].l1BlockNumber,
         l1BlockHash: msgs[0].l1BlockHash,
+      });
+      expect(await messageStore.getInboxBucketL1Span(1n)).toEqual({
+        seq: 1n,
+        lastMessageIndex: msgs[2].index,
+        openedAt: { l1BlockNumber: msgs[0].l1BlockNumber, l1BlockHash: msgs[0].l1BlockHash },
+        closedAt: { l1BlockNumber: msgs[2].l1BlockNumber, l1BlockHash: msgs[2].l1BlockHash },
+      });
+    });
+
+    it('closes single-block buckets at the block they were opened in', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      const spans = await toArray(messageStore.iterateInboxBucketL1Spans());
+      expect(spans.map(span => span.seq)).toEqual([1n, 2n, 3n]);
+      expect(spans.map(span => span.openedAt)).toEqual(spans.map(span => span.closedAt));
+      expect(spans[1]).toEqual({
+        seq: 2n,
+        lastMessageIndex: msgs[4].index,
+        openedAt: { l1BlockNumber: msgs[3].l1BlockNumber, l1BlockHash: msgs[3].l1BlockHash },
+        closedAt: { l1BlockNumber: msgs[3].l1BlockNumber, l1BlockHash: msgs[3].l1BlockHash },
+      });
+      expect(await messageStore.getInboxBucketL1Span(4n)).toBeUndefined();
+    });
+
+    it('shortens a bucket span to the L1 block of its last surviving message', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      msgs[2].l1BlockNumber = msgs[0].l1BlockNumber + 1n;
+      msgs[2].l1BlockHash = makeL1BlockHash(msgs[2].l1BlockNumber);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      await messageStore.removeL1ToL2Messages(msgs[2].index);
+
+      expect(await messageStore.getInboxBucketL1Span(1n)).toMatchObject({
+        lastMessageIndex: msgs[1].index,
+        closedAt: { l1BlockNumber: msgs[1].l1BlockNumber, l1BlockHash: msgs[1].l1BlockHash },
       });
     });
 
@@ -454,19 +490,16 @@ describe('MessageStore', () => {
       expect(await messageStore.getNewestInboxBucket()).toEqual(await messageStore.getInboxBucket(3n));
     });
 
-    it('iterates over buckets in sequence order', async () => {
+    it('iterates over bucket spans in sequence order', async () => {
       await messageStore.addL1ToL2MessageBuckets(makeBucketedMessages(threeBucketSpec));
 
-      const seqs = async (range: Parameters<typeof messageStore.iterateInboxBuckets>[0]) =>
-        (await toArray(messageStore.iterateInboxBuckets(range))).map(bucket => bucket.seq);
+      const seqs = async (range: Parameters<typeof messageStore.iterateInboxBucketL1Spans>[0]) =>
+        (await toArray(messageStore.iterateInboxBucketL1Spans(range))).map(span => span.seq);
 
       expect(await seqs({})).toEqual([1n, 2n, 3n]);
       expect(await seqs({ start: 2n })).toEqual([2n, 3n]);
       expect(await seqs({ reverse: true })).toEqual([3n, 2n, 1n]);
       expect(await seqs({ start: 4n })).toEqual([]);
-      expect((await toArray(messageStore.iterateInboxBuckets({ start: 3n })))[0]).toEqual(
-        await messageStore.getInboxBucket(3n),
-      );
     });
 
     it('tracks the sequence through which buckets have been verified as canonical', async () => {
@@ -490,6 +523,28 @@ describe('MessageStore', () => {
       await messageStore.setCanonicalVerifiedThroughSeq(1n);
       await messageStore.removeL1ToL2Messages(0n);
       expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(0n);
+    });
+
+    it('lowers the canonicality watermark when a verified bucket is re-delivered from another L1 block', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      await messageStore.setCanonicalVerifiedThroughSeq(3n);
+
+      // The same messages arrive again, this time from an L1 block the archiver has not checked.
+      const replayed = msgs.slice(3).map(msg => ({ ...msg, l1BlockHash: makeL1BlockHash(99n) }));
+      await messageStore.addL1ToL2MessageBuckets(replayed);
+
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(1n);
+    });
+
+    it('keeps the canonicality watermark when a verified bucket is re-delivered unchanged', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      await messageStore.setCanonicalVerifiedThroughSeq(3n);
+
+      await messageStore.addL1ToL2MessageBuckets(msgs.slice(3));
+
+      expect(await messageStore.getCanonicalVerifiedThroughSeq()).toEqual(3n);
     });
 
     it('leaves the canonicality watermark alone when the removal is above it', async () => {

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -19,11 +19,12 @@ import { type InboxMessage, deserializeInboxMessage, serializeInboxMessage } fro
 
 /**
  * Persisted snapshot of an Inbox rolling-hash bucket. Mirrors the fields the on-chain Inbox tracks per bucket, plus
- * the number and hash of the L1 block the bucket was opened in and the index span of its messages, so rollbacks,
- * range queries and canonicality checks can work off bucket records alone without scanning messages.
+ * the L1 blocks the bucket was opened and closed in and the index span of its messages, so rollbacks, range queries
+ * and canonicality checks can work off bucket records alone without scanning messages.
  *
  * The Inbox keys buckets by `block.timestamp`, so on a chain that allows consecutive blocks to share a timestamp
- * (anvil with manual mining, for instance) a bucket may span several L1 blocks. Only the opening one is recorded.
+ * (anvil with manual mining, for instance) a bucket may absorb messages from several L1 blocks. The opening and the
+ * closing block are both recorded; on a chain with strictly increasing timestamps they are the same block.
  */
 type BucketSnapshot = {
   inboxRollingHash: Fr;
@@ -31,6 +32,9 @@ type BucketSnapshot = {
   timestamp: bigint;
   l1BlockNumber: bigint;
   l1BlockHash: Buffer32;
+  /** L1 block the bucket's last message was absorbed in; equal to `l1BlockNumber` unless the bucket spans blocks. */
+  lastL1BlockNumber: bigint;
+  lastL1BlockHash: Buffer32;
   msgCount: number;
   firstMessageIndex: bigint;
   lastMessageIndex: bigint;
@@ -43,6 +47,8 @@ function serializeBucketSnapshot(snapshot: BucketSnapshot): Buffer {
     bigintToUInt64BE(snapshot.timestamp),
     bigintToUInt64BE(snapshot.l1BlockNumber),
     snapshot.l1BlockHash,
+    bigintToUInt64BE(snapshot.lastL1BlockNumber),
+    snapshot.lastL1BlockHash,
     numToUInt32BE(snapshot.msgCount),
     bigintToUInt64BE(snapshot.firstMessageIndex),
     bigintToUInt64BE(snapshot.lastMessageIndex),
@@ -56,6 +62,8 @@ function deserializeBucketSnapshot(buffer: Buffer): BucketSnapshot {
   const timestamp = reader.readUInt64();
   const l1BlockNumber = reader.readUInt64();
   const l1BlockHash = Buffer32.fromBuffer(reader.readBytes(Buffer32.SIZE));
+  const lastL1BlockNumber = reader.readUInt64();
+  const lastL1BlockHash = Buffer32.fromBuffer(reader.readBytes(Buffer32.SIZE));
   const msgCount = reader.readNumber();
   const firstMessageIndex = reader.readUInt64();
   const lastMessageIndex = reader.readUInt64();
@@ -65,10 +73,47 @@ function deserializeBucketSnapshot(buffer: Buffer): BucketSnapshot {
     timestamp,
     l1BlockNumber,
     l1BlockHash,
+    lastL1BlockNumber,
+    lastL1BlockHash,
     msgCount,
     firstMessageIndex,
     lastMessageIndex,
   };
+}
+
+/**
+ * The L1 blocks an Inbox bucket was opened and closed in, plus the index of its last message. A bucket that absorbed
+ * messages from several co-timestamped L1 blocks can be split by a reorg of any of them, so both ends have to be
+ * compared against the live chain; `lastMessageIndex` is where a rollback to this bucket cuts the message log.
+ */
+export type InboxBucketL1Span = {
+  seq: bigint;
+  lastMessageIndex: bigint;
+  openedAt: L1BlockId;
+  closedAt: L1BlockId;
+};
+
+function toBucketL1Span(seq: bigint, snapshot: BucketSnapshot): InboxBucketL1Span {
+  return {
+    seq,
+    lastMessageIndex: snapshot.lastMessageIndex,
+    openedAt: { l1BlockNumber: snapshot.l1BlockNumber, l1BlockHash: snapshot.l1BlockHash },
+    closedAt: { l1BlockNumber: snapshot.lastL1BlockNumber, l1BlockHash: snapshot.lastL1BlockHash },
+  };
+}
+
+/**
+ * Whether two snapshots of the same bucket place it at the same point on L1: same timestamp, same opening and closing
+ * blocks.
+ */
+function sameL1Identity(a: BucketSnapshot, b: BucketSnapshot): boolean {
+  return (
+    a.timestamp === b.timestamp &&
+    a.l1BlockNumber === b.l1BlockNumber &&
+    a.l1BlockHash.equals(b.l1BlockHash) &&
+    a.lastL1BlockNumber === b.lastL1BlockNumber &&
+    a.lastL1BlockHash.equals(b.lastL1BlockHash)
+  );
 }
 
 /** The messages of a single Inbox bucket within an incoming batch, in insertion order. */
@@ -319,8 +364,8 @@ export class MessageStore {
    * Writes one snapshot per bucket in the batch, each derived from the bucket's complete message set. Cumulative
    * totals thread forward from the bucket preceding the batch, so a bucket re-delivered with extra messages shifts
    * the totals of the buckets after it within the same batch. A bucket always arrives complete from its first message
-   * (checked when the batch is validated), so the opening L1 block is read off that first message; a bucket whose
-   * later messages come from a co-timestamped L1 block still records the block it was opened in.
+   * (checked when the batch is validated), so the opening L1 block is read off that first message and the closing one
+   * off the last; a bucket whose later messages come from a co-timestamped L1 block records both.
    */
   private async writeIncomingBucketSnapshots(incomingBuckets: IncomingBucket[]): Promise<void> {
     let cumulativeTotal = await this.getTotalMsgCountBeforeBucket(incomingBuckets[0].seq);
@@ -342,6 +387,8 @@ export class MessageStore {
         timestamp: lastInBucket.bucketTimestamp,
         l1BlockNumber: openingMessage.l1BlockNumber,
         l1BlockHash: openingMessage.l1BlockHash,
+        lastL1BlockNumber: lastInBucket.l1BlockNumber,
+        lastL1BlockHash: lastInBucket.l1BlockHash,
         msgCount: messages.length,
         firstMessageIndex: openingMessage.index,
         lastMessageIndex: lastInBucket.index,
@@ -447,8 +494,23 @@ export class MessageStore {
       ...stored,
       inboxRollingHash: lastRemaining.inboxRollingHash,
       totalMsgCount: await this.getTotalL1ToL2MessageCount(),
+      lastL1BlockNumber: lastRemaining.l1BlockNumber,
+      lastL1BlockHash: lastRemaining.l1BlockHash,
       msgCount,
       lastMessageIndex: lastRemaining.index,
+    });
+  }
+
+  /**
+   * Atomically drops every message from `startIndex` on (when given) and rewinds the message sync point, so that an
+   * interruption cannot leave truncated messages behind a sync point that would never fetch them again.
+   */
+  public rewindMessagesTo(syncPoint: L1BlockId, startIndex?: bigint): Promise<void> {
+    return this.db.transactionAsync(async () => {
+      if (startIndex !== undefined) {
+        await this.removeL1ToL2Messages(startIndex);
+      }
+      await this.setSynchedL1Block(syncPoint);
     });
   }
 
@@ -539,13 +601,22 @@ export class MessageStore {
   }
 
   /**
-   * Iterates over the synced Inbox buckets in sequence order. The genesis sentinel (sequence 0) is never stored, so
-   * it is not yielded.
+   * Returns the L1 blocks the bucket with the given sequence number was opened and closed in, or undefined if it has
+   * not been synced. Sequence 0 is the genesis sentinel, which is never stored and has no L1 block of its own.
    */
-  public async *iterateInboxBuckets(range: CustomRange<bigint> = {}): AsyncIterableIterator<InboxBucket> {
+  public async getInboxBucketL1Span(seq: bigint): Promise<InboxBucketL1Span | undefined> {
+    const snapshot = await this.getBucketSnapshotBySeq(seq);
+    return snapshot && toBucketL1Span(seq, snapshot);
+  }
+
+  /**
+   * Iterates over the L1 spans of the synced Inbox buckets in sequence order. The genesis sentinel (sequence 0) is
+   * never stored, so it is not yielded.
+   */
+  public async *iterateInboxBucketL1Spans(range: CustomRange<bigint> = {}): AsyncIterableIterator<InboxBucketL1Span> {
     const entriesRange = mapRange(range, this.bucketSeqToKey);
     for await (const [seqKey, snapBuffer] of this.#inboxBuckets.entriesAsync(entriesRange)) {
-      yield this.toInboxBucket(BigInt(seqKey), deserializeBucketSnapshot(snapBuffer));
+      yield toBucketL1Span(BigInt(seqKey), deserializeBucketSnapshot(snapBuffer));
     }
   }
 
@@ -611,10 +682,16 @@ export class MessageStore {
   }
 
   private async writeBucketSnapshot(seq: bigint, snapshot: BucketSnapshot): Promise<void> {
-    // A reorg can re-deliver a bucket from an L1 block mined at a different timestamp, so drop the stale index entry.
     const stored = await this.getBucketSnapshotBySeq(seq);
-    if (stored !== undefined && stored.timestamp !== snapshot.timestamp) {
-      await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(stored.timestamp), this.bucketSeqToKey(seq));
+    if (stored !== undefined && !sameL1Identity(stored, snapshot)) {
+      // A reorg can re-deliver a bucket from an L1 block mined at a different timestamp, so drop the stale index
+      // entry, and stop trusting whatever canonicality check was run against the bucket's previous L1 blocks.
+      if (stored.timestamp !== snapshot.timestamp) {
+        await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(stored.timestamp), this.bucketSeqToKey(seq));
+      }
+      if ((await this.getCanonicalVerifiedThroughSeq()) >= seq) {
+        await this.setCanonicalVerifiedThroughSeq(seq - 1n);
+      }
     }
     await this.#inboxBuckets.set(this.bucketSeqToKey(seq), serializeBucketSnapshot(snapshot));
     await this.#bucketTimestampToSeq.set(this.timestampToKey(snapshot.timestamp), this.bucketSeqToKey(seq));

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -102,20 +102,6 @@ function toBucketL1Span(seq: bigint, snapshot: BucketSnapshot): InboxBucketL1Spa
   };
 }
 
-/**
- * Whether two snapshots of the same bucket place it at the same point on L1: same timestamp, same opening and closing
- * blocks.
- */
-function sameL1Identity(a: BucketSnapshot, b: BucketSnapshot): boolean {
-  return (
-    a.timestamp === b.timestamp &&
-    a.l1BlockNumber === b.l1BlockNumber &&
-    a.l1BlockHash.equals(b.l1BlockHash) &&
-    a.lastL1BlockNumber === b.lastL1BlockNumber &&
-    a.lastL1BlockHash.equals(b.lastL1BlockHash)
-  );
-}
-
 /** The messages of a single Inbox bucket within an incoming batch, in insertion order. */
 type IncomingBucket = {
   seq: bigint;
@@ -184,8 +170,6 @@ export class MessageStore {
    * leaves its rollover siblings indexed.
    */
   #bucketTimestampToSeq: AztecAsyncMultiMap<number, number>;
-  /** Stores the sequence number through which bucket canonicality has been verified against a finalized L1 chain. */
-  #canonicalVerifiedThroughSeq: AztecAsyncSingleton<bigint>;
 
   #log = createLogger('archiver:message_store');
 
@@ -197,7 +181,6 @@ export class MessageStore {
     this.#messagesFinalizedL1Block = db.openSingleton('archiver_messages_finalized_l1_block');
     this.#inboxBuckets = db.openMap('archiver_inbox_buckets');
     this.#bucketTimestampToSeq = db.openMultiMap('archiver_inbox_bucket_timestamps');
-    this.#canonicalVerifiedThroughSeq = db.openSingleton('archiver_inbox_canonical_verified_through_seq');
   }
 
   public async getTotalL1ToL2MessageCount(): Promise<bigint> {
@@ -456,9 +439,8 @@ export class MessageStore {
    *
    * The bucket holding the last surviving message is rewritten from the messages it has left, because a removal can
    * cut inside a bucket: the synchronizer rolls back to the last message it still shares with L1 after a reorg, and
-   * that message need not be the last of its bucket. The canonicality watermark is lowered to the surviving tip, so
-   * that buckets re-delivered above it are verified against L1 again. Must run inside the removal transaction, after
-   * the total message count has been updated.
+   * that message need not be the last of its bucket. Must run inside the removal transaction, after the total message
+   * count has been updated.
    */
   private async rewindBucketsAfterRemoval(): Promise<void> {
     const lastRemaining = await this.getLastMessage();
@@ -469,14 +451,6 @@ export class MessageStore {
       const snapshot = deserializeBucketSnapshot(snapBuffer);
       await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(snapshot.timestamp), seqKey);
       await this.#inboxBuckets.delete(seqKey);
-    }
-
-    // The surviving tip bucket is rewritten below from the messages it has left, so it is no longer the bucket that
-    // was verified either; the watermark stops one short of it.
-    const verifiedThroughSeq = await this.getCanonicalVerifiedThroughSeq();
-    const survivingVerifiedSeq = boundarySeq === undefined ? 0n : boundarySeq - 1n;
-    if (verifiedThroughSeq > survivingVerifiedSeq) {
-      await this.setCanonicalVerifiedThroughSeq(survivingVerifiedSeq);
     }
 
     if (lastRemaining === undefined || boundarySeq === undefined) {
@@ -600,6 +574,12 @@ export class MessageStore {
     return seq === undefined ? undefined : this.getInboxBucket(seq);
   }
 
+  /** Returns the L1 span of the Inbox bucket with the highest sequence number, or undefined if none has been synced. */
+  public async getNewestInboxBucketL1Span(): Promise<InboxBucketL1Span | undefined> {
+    const seq = await this.getNewestBucketSeq();
+    return seq === undefined ? undefined : this.getInboxBucketL1Span(seq);
+  }
+
   /**
    * Returns the L1 blocks the bucket with the given sequence number was opened and closed in, or undefined if it has
    * not been synced. Sequence 0 is the genesis sentinel, which is never stored and has no L1 block of its own.
@@ -618,21 +598,6 @@ export class MessageStore {
     for await (const [seqKey, snapBuffer] of this.#inboxBuckets.entriesAsync(entriesRange)) {
       yield toBucketL1Span(BigInt(seqKey), deserializeBucketSnapshot(snapBuffer));
     }
-  }
-
-  /**
-   * Returns the sequence number through which this archiver has verified that the buckets it holds were opened in L1
-   * blocks that are canonical and finalized, or 0 (the genesis sentinel) if it has verified none. Buckets at or below
-   * it need no further checking; buckets above it may still sit on an orphaned L1 block, even one that is now below
-   * the finalized block, if the node was not watching when it was reorged out.
-   */
-  public async getCanonicalVerifiedThroughSeq(): Promise<bigint> {
-    return (await this.#canonicalVerifiedThroughSeq.getAsync()) ?? 0n;
-  }
-
-  /** Records the sequence number through which bucket canonicality has been verified. */
-  public async setCanonicalVerifiedThroughSeq(seq: bigint): Promise<void> {
-    await this.#canonicalVerifiedThroughSeq.set(seq);
   }
 
   /**
@@ -683,15 +648,9 @@ export class MessageStore {
 
   private async writeBucketSnapshot(seq: bigint, snapshot: BucketSnapshot): Promise<void> {
     const stored = await this.getBucketSnapshotBySeq(seq);
-    if (stored !== undefined && !sameL1Identity(stored, snapshot)) {
-      // A reorg can re-deliver a bucket from an L1 block mined at a different timestamp, so drop the stale index
-      // entry, and stop trusting whatever canonicality check was run against the bucket's previous L1 blocks.
-      if (stored.timestamp !== snapshot.timestamp) {
-        await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(stored.timestamp), this.bucketSeqToKey(seq));
-      }
-      if ((await this.getCanonicalVerifiedThroughSeq()) >= seq) {
-        await this.setCanonicalVerifiedThroughSeq(seq - 1n);
-      }
+    if (stored !== undefined && stored.timestamp !== snapshot.timestamp) {
+      // A reorg can re-deliver a bucket from an L1 block mined at a different timestamp, so drop the stale index entry.
+      await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(stored.timestamp), this.bucketSeqToKey(seq));
     }
     await this.#inboxBuckets.set(this.bucketSeqToKey(seq), serializeBucketSnapshot(snapshot));
     await this.#bucketTimestampToSeq.set(this.timestampToKey(snapshot.timestamp), this.bucketSeqToKey(seq));

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -139,6 +139,8 @@ export class MessageStore {
    * leaves its rollover siblings indexed.
    */
   #bucketTimestampToSeq: AztecAsyncMultiMap<number, number>;
+  /** Stores the sequence number through which bucket canonicality has been verified against a finalized L1 chain. */
+  #canonicalVerifiedThroughSeq: AztecAsyncSingleton<bigint>;
 
   #log = createLogger('archiver:message_store');
 
@@ -150,6 +152,7 @@ export class MessageStore {
     this.#messagesFinalizedL1Block = db.openSingleton('archiver_messages_finalized_l1_block');
     this.#inboxBuckets = db.openMap('archiver_inbox_buckets');
     this.#bucketTimestampToSeq = db.openMultiMap('archiver_inbox_bucket_timestamps');
+    this.#canonicalVerifiedThroughSeq = db.openSingleton('archiver_inbox_canonical_verified_through_seq');
   }
 
   public async getTotalL1ToL2MessageCount(): Promise<bigint> {
@@ -406,8 +409,9 @@ export class MessageStore {
    *
    * The bucket holding the last surviving message is rewritten from the messages it has left, because a removal can
    * cut inside a bucket: the synchronizer rolls back to the last message it still shares with L1 after a reorg, and
-   * that message need not be the last of its bucket. Must run inside the removal transaction, after the total message
-   * count has been updated.
+   * that message need not be the last of its bucket. The canonicality watermark is lowered to the surviving tip, so
+   * that buckets re-delivered above it are verified against L1 again. Must run inside the removal transaction, after
+   * the total message count has been updated.
    */
   private async rewindBucketsAfterRemoval(): Promise<void> {
     const lastRemaining = await this.getLastMessage();
@@ -418,6 +422,14 @@ export class MessageStore {
       const snapshot = deserializeBucketSnapshot(snapBuffer);
       await this.#bucketTimestampToSeq.deleteValue(this.timestampToKey(snapshot.timestamp), seqKey);
       await this.#inboxBuckets.delete(seqKey);
+    }
+
+    // The surviving tip bucket is rewritten below from the messages it has left, so it is no longer the bucket that
+    // was verified either; the watermark stops one short of it.
+    const verifiedThroughSeq = await this.getCanonicalVerifiedThroughSeq();
+    const survivingVerifiedSeq = boundarySeq === undefined ? 0n : boundarySeq - 1n;
+    if (verifiedThroughSeq > survivingVerifiedSeq) {
+      await this.setCanonicalVerifiedThroughSeq(survivingVerifiedSeq);
     }
 
     if (lastRemaining === undefined || boundarySeq === undefined) {
@@ -518,6 +530,38 @@ export class MessageStore {
       latestSeqKey = latestSeqKey === undefined ? seqKey : Math.max(latestSeqKey, seqKey);
     }
     return latestSeqKey === undefined ? undefined : this.getInboxBucket(BigInt(latestSeqKey));
+  }
+
+  /** Returns the Inbox bucket with the highest sequence number, or undefined if none has been synced. */
+  public async getNewestInboxBucket(): Promise<InboxBucket | undefined> {
+    const seq = await this.getNewestBucketSeq();
+    return seq === undefined ? undefined : this.getInboxBucket(seq);
+  }
+
+  /**
+   * Iterates over the synced Inbox buckets in sequence order. The genesis sentinel (sequence 0) is never stored, so
+   * it is not yielded.
+   */
+  public async *iterateInboxBuckets(range: CustomRange<bigint> = {}): AsyncIterableIterator<InboxBucket> {
+    const entriesRange = mapRange(range, this.bucketSeqToKey);
+    for await (const [seqKey, snapBuffer] of this.#inboxBuckets.entriesAsync(entriesRange)) {
+      yield this.toInboxBucket(BigInt(seqKey), deserializeBucketSnapshot(snapBuffer));
+    }
+  }
+
+  /**
+   * Returns the sequence number through which this archiver has verified that the buckets it holds were opened in L1
+   * blocks that are canonical and finalized, or 0 (the genesis sentinel) if it has verified none. Buckets at or below
+   * it need no further checking; buckets above it may still sit on an orphaned L1 block, even one that is now below
+   * the finalized block, if the node was not watching when it was reorged out.
+   */
+  public async getCanonicalVerifiedThroughSeq(): Promise<bigint> {
+    return (await this.#canonicalVerifiedThroughSeq.getAsync()) ?? 0n;
+  }
+
+  /** Records the sequence number through which bucket canonicality has been verified. */
+  public async setCanonicalVerifiedThroughSeq(seq: bigint): Promise<void> {
+    await this.#canonicalVerifiedThroughSeq.set(seq);
   }
 
   /**

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -151,6 +151,11 @@ export class FakeL1State {
   // Computed from checkpoints based on L1 block visibility
   private pendingCheckpointNumber: CheckpointNumber = CheckpointNumber(0);
 
+  // L1 block hashes that changed because the block was reorged out and replaced. Blocks not listed here hash to
+  // their block number.
+  private l1BlockHashOverrides = new Map<bigint, Buffer32>();
+  private l1ReorgCount = 0;
+
   // The L1 block number reported as "finalized" (defaults to the start block).
   // `undefined` simulates the startup window on a fresh devnet where
   // `getBlock({ blockTag: 'finalized' })` fails with "finalized block not found".
@@ -314,6 +319,53 @@ export class FakeL1State {
   public getTimestampAtL1Block(l1BlockNumber: bigint): bigint {
     const { l1GenesisTime, l1StartBlock, ethereumSlotDuration } = this.config;
     return l1GenesisTime + (l1BlockNumber - l1StartBlock) * BigInt(ethereumSlotDuration);
+  }
+
+  /** The hash of an L1 block: derived from its number, unless the block was replaced by a reorg. */
+  getL1BlockHash(l1BlockNumber: bigint): Buffer32 {
+    return this.l1BlockHashOverrides.get(l1BlockNumber) ?? Buffer32.fromBigInt(l1BlockNumber);
+  }
+
+  /**
+   * Simulates an L1 reorg from the given block up to the chain head: every block in that range keeps its number but
+   * is replaced by one with a fresh hash. What the replacement blocks contain is up to the caller, so combine this
+   * with the message helpers (or leave the messages alone for a reorg that only replaces empty blocks).
+   */
+  reorgL1BlocksFrom(fromL1Block: bigint): void {
+    this.l1ReorgCount += 1;
+    for (let blockNumber = fromL1Block; blockNumber <= this.l1BlockNumber; blockNumber++) {
+      // The reorg counter goes in the high bits, so the hash still reads as "block N, replaced R times".
+      this.l1BlockHashOverrides.set(
+        blockNumber,
+        Buffer32.fromBigInt((BigInt(this.l1ReorgCount) << 128n) + blockNumber),
+      );
+    }
+  }
+
+  /**
+   * Simulates an L1 reorg that re-mines the messages of `fromL1Block` into `toL1Block`. The messages keep their
+   * contents and their order, so the Inbox's total and rolling hash are unchanged, but the buckets they are absorbed
+   * into are opened at a different L1 block and timestamp. Messages already at `toL1Block` are merged into the same
+   * buckets, in index order.
+   */
+  retimeMessages(fromL1Block: bigint, toL1Block: bigint): void {
+    this.moveMessagesToL1Block(fromL1Block, toL1Block);
+    this.recomputeDerivedMessageState();
+    this.reorgL1BlocksFrom(fromL1Block < toL1Block ? fromL1Block : toL1Block);
+  }
+
+  /**
+   * Simulates an L1 reorg that re-mines the given L1 block with its messages in the opposite order, which changes the
+   * Inbox's rolling hash as well as the block's hash.
+   */
+  reorderMessagesAtL1Block(l1BlockNumber: bigint): void {
+    const positions = this.messages
+      .map((msg, i) => (msg.l1BlockNumber === l1BlockNumber ? i : undefined))
+      .filter(i => i !== undefined);
+    const reordered = positions.map(i => this.messages[i]).reverse();
+    positions.forEach((position, i) => (this.messages[position] = reordered[i]));
+    this.recomputeDerivedMessageState();
+    this.reorgL1BlocksFrom(l1BlockNumber);
   }
 
   /**
@@ -550,7 +602,7 @@ export class FakeL1State {
       return {
         number: blockNum,
         timestamp: BigInt(blockNum) * BigInt(this.config.ethereumSlotDuration) + this.config.l1GenesisTime,
-        hash: Buffer32.fromBigInt(blockNum).toString(),
+        hash: this.getL1BlockHash(blockNum).toString(),
       } as FormattedBlock;
     }) as any);
 
@@ -571,7 +623,7 @@ export class FakeL1State {
     // The blockId is the L1 block hash, which we derive from the L1 block number
     blobClient.getBlobSidecar.mockImplementation((blockId: `0x${string}`) =>
       Promise.resolve(
-        this.checkpoints.find(cpData => Buffer32.fromBigInt(cpData.l1BlockNumber).toString() === blockId)?.blobs ?? [],
+        this.checkpoints.find(cpData => this.getL1BlockHash(cpData.l1BlockNumber).toString() === blockId)?.blobs ?? [],
       ),
     );
 
@@ -614,7 +666,7 @@ export class FakeL1State {
       .filter(cpData => cpData.l1BlockNumber >= fromBlock && cpData.l1BlockNumber <= toBlock)
       .map(cpData => ({
         l1BlockNumber: cpData.l1BlockNumber,
-        l1BlockHash: Buffer32.fromBigInt(cpData.l1BlockNumber),
+        l1BlockHash: this.getL1BlockHash(cpData.l1BlockNumber),
         l1TransactionHash: cpData.tx.hash as `0x${string}`,
         args: {
           checkpointNumber: cpData.checkpointNumber,
@@ -636,7 +688,7 @@ export class FakeL1State {
       )
       .map(msg => ({
         l1BlockNumber: msg.l1BlockNumber,
-        l1BlockHash: Buffer32.fromBigInt(msg.l1BlockNumber),
+        l1BlockHash: this.getL1BlockHash(msg.l1BlockNumber),
         l1TransactionHash: `0x${msg.l1BlockNumber.toString(16)}` as `0x${string}`,
         l1BlockTimestamp: this.getTimestampAtL1Block(msg.l1BlockNumber),
         args: {
@@ -661,7 +713,7 @@ export class FakeL1State {
     }
     return {
       l1BlockNumber: msg.l1BlockNumber,
-      l1BlockHash: Buffer32.fromBigInt(msg.l1BlockNumber),
+      l1BlockHash: this.getL1BlockHash(msg.l1BlockNumber),
       l1TransactionHash: `0x${msg.l1BlockNumber.toString(16)}` as `0x${string}`,
       l1BlockTimestamp: this.getTimestampAtL1Block(msg.l1BlockNumber),
       args: {

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -156,6 +156,14 @@ export class FakeL1State {
   private l1BlockHashOverrides = new Map<bigint, Buffer32>();
   private l1ReorgCount = 0;
 
+  // Blocks mined with the timestamp of an earlier block, as consecutive blocks may share one on a chain that does
+  // not require strictly increasing timestamps. Blocks not listed here get the timestamp of their own slot.
+  private l1BlockTimestampSource = new Map<bigint, bigint>();
+
+  // Every L1 block read by number since the last reset, and the blocks whose reads are made to fail.
+  private l1BlockReads: bigint[] = [];
+  private failingL1BlockReads = new Set<bigint>();
+
   // The L1 block number reported as "finalized" (defaults to the start block).
   // `undefined` simulates the startup window on a fresh devnet where
   // `getBlock({ blockTag: 'finalized' })` fails with "finalized block not found".
@@ -318,12 +326,58 @@ export class FakeL1State {
   /** Returns the timestamp at the given L1 block (assuming all L1 blocks are mined) */
   public getTimestampAtL1Block(l1BlockNumber: bigint): bigint {
     const { l1GenesisTime, l1StartBlock, ethereumSlotDuration } = this.config;
-    return l1GenesisTime + (l1BlockNumber - l1StartBlock) * BigInt(ethereumSlotDuration);
+    return l1GenesisTime + (this.getTimestampSource(l1BlockNumber) - l1StartBlock) * BigInt(ethereumSlotDuration);
+  }
+
+  /** The block whose slot gives a block its timestamp: itself, unless it was mined sharing an earlier one's. */
+  private getTimestampSource(l1BlockNumber: bigint): bigint {
+    return this.l1BlockTimestampSource.get(l1BlockNumber) ?? l1BlockNumber;
+  }
+
+  /**
+   * Mines `l1BlockNumber` carrying the timestamp of `sourceL1Block` rather than of its own slot, as consecutive
+   * blocks may on a chain that does not require strictly increasing timestamps (anvil with manual mining, for
+   * instance). Messages in both blocks are then absorbed into the same Inbox bucket, which spans the two.
+   */
+  shareTimestampWithL1Block(l1BlockNumber: bigint, sourceL1Block: bigint): void {
+    this.l1BlockTimestampSource.set(l1BlockNumber, sourceL1Block);
+    this.recomputeDerivedMessageState();
+  }
+
+  /**
+   * Simulates an L1 reorg that re-mines a block which had shared an earlier block's timestamp with a timestamp of its
+   * own. The messages keep their contents and their order, so the Inbox's total and rolling hash are unchanged, but
+   * the bucket that spanned the two blocks splits in two.
+   */
+  splitCoTimestampedL1Block(l1BlockNumber: bigint): void {
+    this.l1BlockTimestampSource.delete(l1BlockNumber);
+    this.recomputeDerivedMessageState();
+    this.reorgL1BlocksFrom(l1BlockNumber);
   }
 
   /** The hash of an L1 block: derived from its number, unless the block was replaced by a reorg. */
   getL1BlockHash(l1BlockNumber: bigint): Buffer32 {
     return this.l1BlockHashOverrides.get(l1BlockNumber) ?? Buffer32.fromBigInt(l1BlockNumber);
+  }
+
+  /** How many times the given L1 block has been read by number since the reads were last cleared. */
+  countL1BlockReads(l1BlockNumber: bigint): number {
+    return this.l1BlockReads.filter(read => read === l1BlockNumber).length;
+  }
+
+  /** Forgets the L1 block reads recorded so far. */
+  clearL1BlockReads(): void {
+    this.l1BlockReads = [];
+  }
+
+  /** Makes reads of the given L1 block by number throw, simulating an L1 node that cannot serve it. */
+  failL1BlockReads(l1BlockNumber: bigint): void {
+    this.failingL1BlockReads.add(l1BlockNumber);
+  }
+
+  /** Serves reads of the given L1 block again. */
+  restoreL1BlockReads(l1BlockNumber: bigint): void {
+    this.failingL1BlockReads.delete(l1BlockNumber);
   }
 
   /**
@@ -596,12 +650,19 @@ export class FakeL1State {
           });
         }
         blockNum = this.finalizedL1BlockNumber;
+      } else if (args.blockNumber !== undefined) {
+        blockNum = args.blockNumber;
+        this.l1BlockReads.push(blockNum);
+        if (this.failingL1BlockReads.has(blockNum)) {
+          throw new Error(`Simulated failure reading L1 block ${blockNum}`);
+        }
       } else {
-        blockNum = args.blockNumber ?? (await publicClient.getBlockNumber());
+        blockNum = await publicClient.getBlockNumber();
       }
       return {
         number: blockNum,
-        timestamp: BigInt(blockNum) * BigInt(this.config.ethereumSlotDuration) + this.config.l1GenesisTime,
+        timestamp:
+          this.getTimestampSource(blockNum) * BigInt(this.config.ethereumSlotDuration) + this.config.l1GenesisTime,
         hash: this.getL1BlockHash(blockNum).toString(),
       } as FormattedBlock;
     }) as any);

--- a/yarn-project/kv-store/src/interfaces/common.ts
+++ b/yarn-project/kv-store/src/interfaces/common.ts
@@ -18,8 +18,8 @@ export type CustomRange<K> = {
 /** Maps a custom range into a range of valid key types to iterate over. */
 export function mapRange<CK, K extends Key = Key>(range: CustomRange<CK>, mapFn: (key: CK) => K): Range<K> {
   return {
-    start: range.start ? mapFn(range.start) : undefined,
-    end: range.end ? mapFn(range.end) : undefined,
+    start: range.start !== undefined ? mapFn(range.start) : undefined,
+    end: range.end !== undefined ? mapFn(range.end) : undefined,
     reverse: range.reverse,
     limit: range.limit,
   };


### PR DESCRIPTION
The archiver now checks that the Inbox buckets it holds sit on L1 blocks that are still canonical, and rolls back to the last canonical bucket when one of them does not.

## Context

The archiver decides it is in sync with the Inbox by comparing two numbers against L1: the total message count and the consensus rolling hash (`l1_synchronizer.ts`, `localStateMatches`). With the rolling hash covering the messages and nothing else, this reorg is invisible to both:

```
Fork the node saw                          Canonical fork after the reorg
L1 block 100 (t=1200): A, B → bucket #7    L1 block 100' (t=1200): A, B → bucket #7 (ts 1200)
L1 block 101 (t=1212): C    → bucket #8    L1 block 101' (t=1224): C    → bucket #8 (ts 1224)
```

Same messages in the same order, so the same count and the same hash — and the existing rollback cannot help either, since it looks for the last message whose rolling hash still matches and they all do. What did change is the metadata the archiver derives from the L1 block: the bucket's timestamp, and (when the reorg merges or splits blocks) its sequence number and boundaries. A bucket's timestamp is what the censorship cutoff is compared against and the recency key the sequencer's bucket selection walks; its sequence number is the `bucketHint` L1 looks the bucket up with, so a stale one gets the proposal reverted with `Rollup__InvalidInboxRollingHash`.

#25319 / #25322 / #25327 close this by committing the bucket structure and timestamps into the rolling hash itself, which makes the re-time visible to the check that already exists. This PR is the alternative for keeping the rolling hash over messages only: leave the hash alone and check the bucket metadata directly.

## Approach

Each bucket snapshot records the number and hash of the L1 block it was opened in (#25350), and now of the block it was closed in as well. Every sync pass reads those blocks from L1 and compares hashes, before the count-and-hash comparison runs:

- **Only the newest stored bucket is checked each pass.** An L1 reorg replaces a suffix of the chain, and stored buckets are totally ordered by the height of their L1 blocks, so a reorg that touches *any* stored bucket's block touches the newest one's. Comparing that bucket's stored hashes against the live chain therefore catches every reorg affecting stored messages, and the argument carries inductively: if the anchor matches, the chain at and below its height is unchanged since the previous pass, so everything that pass verified is still canonical, and the buckets stored this pass become the next anchor. The bucket a proposer is about to consume is the first thing looked at, not the last.
- **Both ends of a bucket are checked.** The Inbox keys buckets by `block.timestamp`, so where consecutive L1 blocks may share a timestamp (anvil with manual mining) one bucket can absorb messages from several blocks. Reorging only the later one splits the bucket in two while its opening block stays canonical and the message count and rolling hash are untouched — nothing else in the pass would notice. The closing block is store-internal: the check reads bucket spans (`InboxBucketL1Span`), and the `InboxBucket` type consumers see is unchanged.
- On the first mismatch the archiver logs one `warn`, removes every message absorbed after the last canonical bucket, and rewinds the message syncpoint to just before that bucket's opening L1 block — both in a single store transaction, with the target syncpoint resolved beforehand, so an interruption cannot leave truncated messages behind a syncpoint that would never fetch them again. The normal flow then re-downloads the reorged blocks and rebuilds the snapshots with the timestamps and sequence numbers the canonical chain gives them. The last canonical bucket is found by walking stored buckets downward from the anchor, one bucket at a time (opening and closing hashes each), until one fully matches the live chain — the same shape as the per-message rolling-hash divergence walk. The walk has no fixed budget: its length is the reorg depth, and it ends at the genesis sentinel, which rolls the store back to empty.
- The check runs **before** the guard that skips the message sync when L1 has not moved forward, since a reorg can re-mine the head at the same number: by block number nothing advances, so without this the stale syncpoint would be kept and every later pass would short-circuit on it.
- **A fetch is re-checked after it stores.** A reorg landing between the check and the fetch, or between the paged log queries of one catch-up fetch, could store buckets from the orphaned fork under a canonical top page, and the anchor would then never flag them. The suffix argument applies per page: if a reorg touched a page at all, it touched that page's newest bucket. So after a fetch that stored messages, the pre-fetch anchor is re-read and re-checked, and so is the newest bucket of every log query except the last (the last one's is next pass's anchor); queries entirely at or below the finalized block are skipped. A check that cannot be completed fails the pass rather than letting it proceed, and a failed post-fetch read unwinds the fetch to the syncpoint it started from. Buckets closed above the message syncpoint — only ever left behind by an interrupted fetch — are checked too.
- The rolling-hash rollback stays as the fallback for everything this does not resolve (an empty store, a reorg that also changes the messages). Its removal and syncpoint rewind now go through the same atomic path.

**"Below finalized" is not a free pass.** The existing rollback may stop at the finalized block, because a message at or below it cannot have been reorged *while the node was watching*. That reasoning does not extend to a node that was not watching: it can hold a block that was orphaned before finalization and has since been buried below it, and no amount of finality will ever make that block canonical. The anchor check compares the stored hash against the live chain regardless of finality, so a node coming back from an outage still detects the orphaned bucket on its first pass.

**RPC cost.** One `eth_getBlockByNumber` per sync pass in the steady state — two when the anchor bucket spans co-timestamped blocks, and one more on a pass that stored messages (the pre-fetch anchor re-check). A catch-up over several log queries adds one read per unfinalized query beyond the last. A divergence costs roughly one read per reorged bucket. A read that fails is logged at `warn` (thinned out when it keeps failing on the same bucket) and ends the pass without rolling anything back; the next pass retries.

## Tests

`FakeL1State` can now replace a range of L1 blocks with fresh hashes (`reorgL1BlocksFrom`), re-mine one block's messages into another (`retimeMessages`, which also covers the merge case), re-mine a block with its messages reordered (`reorderMessagesAtL1Block`), mine a block carrying an earlier block's timestamp (`shareTimestampWithL1Block`) and re-mine such a block with a timestamp of its own (`splitCoTimestampedL1Block`). It also records the L1 blocks read by number and can make those reads fail, so tests assert on reads without reaching into mock call arguments.

New `archiver-sync` cases: a pure re-time (count and rolling hash unchanged, timestamp and block hash updated, exactly one warning); a merge of two buckets into one with message indices preserved; a bucket spanning two co-timestamped blocks split by a reorg of the later one; a reorder rolled back by the bucket walk without reaching the per-message log queries; a head re-mined at the same number; rollover siblings re-downloaded whole when the rollback lands on their shared opening block; a metadata-only reorg of the newest bucket with finality held far below it, detected on the very next pass; a pass reading only the newest bucket's block, and both blocks when it spans two; a deep reorg orphaning the newest three of forty buckets, with the walk landing on the right one, including past a co-timestamped closing block; a bucket reorged out across a gap in syncing and detected even though it is now below finality; an unverifiable anchor skipping the fetch and an unverifiable walk aborting the pass; a reorg landing between the check and the fetch; a mid-fetch reorg caught by the per-page re-check, a failed post-fetch read unwinding the fetch, and finalized pages being skipped; an interrupted fetch recovered on the next pass; and a catch-up over many buckets from a synced store using bulk events only. `message_store` gets the span accessors, reverse iteration over spans, the newest-span accessor, and the span shortening when a removal cuts a bucket.

The regressions were confirmed red before each fix: reverting the closing-block check fails the split case, moving the walk back after the "L1 did not advance" guard fails the same-height re-mine, and the starvation, deep-walk, buried-reorg and mid-fetch cases fail against the earlier budgeted forward walk.

Ran: full `yarn build`, `yarn format`, `yarn lint archiver kv-store`, archiver 600/600 (20 suites), kv-store 274/274. No e2e.

Targets `project/fast-inbox` directly now that the shared prefix (#25351 and below) has merged into it.

Fixes A-1880


