### PR TITLE
fix(stdlib): keep recursive zod schemas identity-stable

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -82,7 +82,7 @@
     "lodash.omit": "^4.5.0",
     "tslib": "^2.5.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -105,7 +105,7 @@
     "axios": "^1.15.1",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/builder": "workspace:^",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -70,7 +70,7 @@
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "files": [
     "dest",

--- a/yarn-project/blob-client/package.json
+++ b/yarn-project/blob-client/package.json
@@ -67,7 +67,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/bot/package.json
+++ b/yarn-project/bot/package.json
@@ -71,7 +71,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -105,7 +105,7 @@
     "typescript": "^5.3.3",
     "util": "^0.12.5",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "0x": "^5.7.0",

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -73,7 +73,7 @@
     "@aztec/standard-contracts": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -35,7 +35,7 @@
     "jest-mock-extended": "^4.0.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -59,7 +59,7 @@
     "lodash.pickby": "^4.5.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -167,7 +167,7 @@
     "pino-pretty": "^13.0.0",
     "sha3": "^2.1.4",
     "undici": "^5.28.5",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/node-keystore/package.json
+++ b/yarn-project/node-keystore/package.json
@@ -70,7 +70,7 @@
     "@ethersproject/wallet": "^5.7.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -87,7 +87,7 @@
     "lodash.chunk": "^4.2.0",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/noir-contracts.js": "workspace:^",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -66,7 +66,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -110,7 +110,7 @@
     "pako": "^2.1.0",
     "tslib": "^2.4.0",
     "viem": "npm:@aztec/viem@2.38.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/expect": "^30.0.0",

--- a/yarn-project/stdlib/src/tx/private_execution_result.test.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.test.ts
@@ -41,6 +41,12 @@ describe('execution_result', () => {
       const instance = await PrivateExecutionResult.random();
       expect(jsonParseWithSchema(jsonStringify(instance), PrivateExecutionResult.schema)).toEqual(instance);
     });
+
+    // The schema refers to itself through `z.lazy`, and zod ties that recursion together by object identity:
+    // handing back a fresh schema on each access makes it recurse until the stack overflows (zod >= 4.5).
+    it('hands out the same call execution result schema instance on every access', () => {
+      expect(PrivateCallExecutionResult.schema).toBe(PrivateCallExecutionResult.schema);
+    });
   });
 
   describe('collectNoteHashNullifierCounterMap', () => {

--- a/yarn-project/stdlib/src/tx/private_execution_result.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.ts
@@ -115,6 +115,31 @@ export class PrivateExecutionResult {
 }
 
 /**
+ * Built once on first use and reused rather than rebuilt on every `schema` access: the recursion is tied
+ * together by object identity, and a `z.lazy` target that hands back a fresh schema each time it is
+ * dereferenced makes zod recurse until the stack overflows (zod >= 4.5, at any nesting depth).
+ */
+let privateCallExecutionResultSchema: ZodFor<PrivateCallExecutionResult> | undefined;
+
+function getPrivateCallExecutionResultSchema(): ZodFor<PrivateCallExecutionResult> {
+  return (privateCallExecutionResultSchema ??= z
+    .object({
+      acir: schemas.Buffer,
+      vk: schemas.Buffer,
+      partialWitness: mapSchema(z.coerce.number(), z.string()),
+      publicInputs: PrivateCircuitPublicInputs.schema,
+      newNotes: z.array(NoteAndSlot.schema),
+      noteHashNullifierCounterMap: mapSchema(z.coerce.number(), z.number()),
+      returnValues: z.array(schemas.Fr),
+      offchainEffects: z.array(z.object({ data: z.array(schemas.Fr) })),
+      taggingIndexRanges: z.array(TaggingIndexRangeSchema),
+      nestedExecutionResults: z.array(z.lazy(() => getPrivateCallExecutionResultSchema())),
+      contractClassLogs: z.array(CountedContractClassLog.schema),
+    })
+    .transform(fields => PrivateCallExecutionResult.from(fields)));
+}
+
+/**
  * The result of executing a call to a private function.
  */
 export class PrivateCallExecutionResult {
@@ -151,21 +176,7 @@ export class PrivateCallExecutionResult {
   ) {}
 
   static get schema(): ZodFor<PrivateCallExecutionResult> {
-    return z
-      .object({
-        acir: schemas.Buffer,
-        vk: schemas.Buffer,
-        partialWitness: mapSchema(z.coerce.number(), z.string()),
-        publicInputs: PrivateCircuitPublicInputs.schema,
-        newNotes: z.array(NoteAndSlot.schema),
-        noteHashNullifierCounterMap: mapSchema(z.coerce.number(), z.number()),
-        returnValues: z.array(schemas.Fr),
-        offchainEffects: z.array(z.object({ data: z.array(schemas.Fr) })),
-        taggingIndexRanges: z.array(TaggingIndexRangeSchema),
-        nestedExecutionResults: z.array(z.lazy(() => PrivateCallExecutionResult.schema)),
-        contractClassLogs: z.array(CountedContractClassLog.schema),
-      })
-      .transform(PrivateCallExecutionResult.from);
+    return getPrivateCallExecutionResultSchema();
   }
 
   static from(fields: FieldsOf<PrivateCallExecutionResult>) {

--- a/yarn-project/stdlib/src/tx/public_simulation_output.test.ts
+++ b/yarn-project/stdlib/src/tx/public_simulation_output.test.ts
@@ -1,11 +1,25 @@
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
-import { PublicSimulationOutput } from './public_simulation_output.js';
+import { NestedProcessReturnValues, PublicSimulationOutput } from './public_simulation_output.js';
 
 describe('PublicSimulationOutput', () => {
   it('serializes to JSON', async () => {
     const output = await PublicSimulationOutput.random();
     const json = jsonStringify(output);
     expect(PublicSimulationOutput.schema.parse(JSON.parse(json))).toEqual(output);
+  });
+});
+
+describe('NestedProcessReturnValues', () => {
+  // The schema refers to itself through `z.lazy`, and zod ties that recursion together by object identity:
+  // handing back a fresh schema on each access makes it recurse until the stack overflows (zod >= 4.5).
+  it('hands out the same schema instance on every access', () => {
+    expect(NestedProcessReturnValues.schema).toBe(NestedProcessReturnValues.schema);
+  });
+
+  it('round trips nested return values', () => {
+    const values = NestedProcessReturnValues.random(3);
+    const parsed = NestedProcessReturnValues.schema.parse(JSON.parse(jsonStringify(values)));
+    expect(parsed.equals(values)).toBe(true);
   });
 });

--- a/yarn-project/stdlib/src/tx/public_simulation_output.ts
+++ b/yarn-project/stdlib/src/tx/public_simulation_output.ts
@@ -35,12 +35,7 @@ export class NestedProcessReturnValues {
   }
 
   static get schema(): ZodFor<NestedProcessReturnValues> {
-    return z
-      .object({
-        values: NullishToUndefined(z.array(schemas.Fr)),
-        nested: z.array(z.lazy(() => NestedProcessReturnValues.schema)),
-      })
-      .transform(({ values, nested }) => new NestedProcessReturnValues(values, nested));
+    return getNestedProcessReturnValuesSchema();
   }
 
   static fromPlainObject(obj: any): NestedProcessReturnValues {
@@ -60,6 +55,22 @@ export class NestedProcessReturnValues {
       depth > 0 ? [NestedProcessReturnValues.random(depth - 1)] : [],
     );
   }
+}
+
+/**
+ * Built once on first use and reused rather than rebuilt on every `schema` access: the recursion is tied
+ * together by object identity, and a `z.lazy` target that hands back a fresh schema each time it is
+ * dereferenced makes zod recurse until the stack overflows (zod >= 4.5, at any nesting depth).
+ */
+let nestedProcessReturnValuesSchema: ZodFor<NestedProcessReturnValues> | undefined;
+
+function getNestedProcessReturnValuesSchema(): ZodFor<NestedProcessReturnValues> {
+  return (nestedProcessReturnValuesSchema ??= z
+    .object({
+      values: NullishToUndefined(z.array(schemas.Fr)),
+      nested: z.array(z.lazy(() => getNestedProcessReturnValuesSchema())),
+    })
+    .transform(({ values, nested }) => new NestedProcessReturnValues(values, nested)));
 }
 
 /**

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -86,7 +86,7 @@
     "@aztec/stdlib": "workspace:^",
     "@aztec/world-state": "workspace:^",
     "msgpackr": "^1.11.2",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-ha-signer/package.json
+++ b/yarn-project/validator-ha-signer/package.json
@@ -83,7 +83,7 @@
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.11.3",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.14",

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -74,7 +74,7 @@
     "@aztec/telemetry-client": "workspace:^",
     "msgpackr": "^1.11.2",
     "tslib": "^2.4.0",
-    "zod": "^4"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -745,7 +745,7 @@ __metadata:
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -826,7 +826,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -904,7 +904,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   bin:
     aztec: ./scripts/aztec.sh
   languageName: unknown
@@ -990,7 +990,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   bin:
     blob-client: ./dest/client/bin/index.js
   languageName: unknown
@@ -1045,7 +1045,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1278,7 +1278,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1298,7 +1298,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1322,7 +1322,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1351,7 +1351,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1411,7 +1411,7 @@ __metadata:
     typescript-eslint: "npm:^8.32.1"
     undici: "npm:^5.28.5"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1556,7 +1556,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -1836,7 +1836,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2057,7 +2057,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2135,7 +2135,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
     vitest: "npm:^4.0.0"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2201,7 +2201,7 @@ __metadata:
     msgpackr: "npm:^1.11.2"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   bin:
     txe: ./dest/bin/index.js
   languageName: unknown
@@ -2270,7 +2270,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -2344,7 +2344,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    zod: "npm:^4"
+    zod: "npm:~4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -22205,7 +22205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4":
+"zod@npm:~4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36


### PR DESCRIPTION
## The symptom

Any wallet/PXE talking to a node with npm-installed Aztec packages dies as soon as it simulates a transaction:

```
ERROR: pxe:service RangeError: RangeError: Maximum call stack size exceeded
    at get schema (.../@aztec/stdlib/dest/tx/public_simulation_output.js:23:42)
    at Object.getter (.../@aztec/stdlib/dest/tx/public_simulation_output.js:24:66)
```

It shows up in the `aztec-up` release tests (`bridge_and_claim`) and for anyone installing the published
packages. It does not show up anywhere in yarn-project CI.

## What is going on

Two schemas describe recursive data and refer to themselves through `z.lazy`:

- `NestedProcessReturnValues` — return values of a public call tree
- `PrivateCallExecutionResult` — a private call and its nested calls

Both were written as `static get schema()` that builds a brand new schema object on every access:

```ts
static get schema() {
  return z.object({
    // every dereference of this lazy calls the getter again, which builds another schema
    nested: z.array(z.lazy(() => NestedProcessReturnValues.schema)),
  });
}
```

zod ties a recursive schema together by **object identity**: the lazy target is expected to be the same
schema instance each time it is dereferenced. Up to zod 4.4.x this only cost extra allocations. From
**4.5.0** onwards the schema graph is walked eagerly, so a lazy target that hands back a fresh instance
every time never closes the loop and recurses until the stack overflows — at *any* nesting depth, including
none at all (`{ nested: [] }` is enough).

Why it is invisible in CI: the monorepo's `yarn.lock` pins zod 4.4.3, but every package declares
`"zod": "^4"`. The release tests and real users npm-install the published packages, so they resolve
whatever is latest — zod 4.5.0 was published on 2026-08-28, and CI started failing on the first
`aztec-up` run after that.

## When was this introduced

The pattern is old, the breakage is new — and it is **not** the zod 4 migration.

| | |
|---|---|
| `NestedProcessReturnValues.schema` written as a rebuilt-per-access recursive getter | #9672, reverted in #9875, relanded as #9878 — Nov 2024 |
| `PrivateCallExecutionResult.schema` written the same way | #11155 — Jan 2025 |
| yarn-project migrated zod 3 → zod 4 | #23410 — May 2026 |
| zod 4.5.0 published, pattern becomes fatal | 2026-08-28 18:14 UTC |
| first `aztec-up` CI run after that | 2026-08-29 01:55 UTC — fails |

Verified directly by parsing a rebuilt-per-access recursive schema against each release: zod **3.25.76**,
**4.0.0** and **4.4.3** all accept it; **4.5.0**, **4.5.2** and **4.5.4** all overflow the stack. So the
schemas were latently wrong for ~21 months, survived the zod 4 migration untouched, and only started
failing when 4.5.0 began walking the schema graph eagerly. Nothing in this repo changed — the dependency
did.

## The fix

Build each schema once on first use and hand out that same instance:

```ts
let nestedProcessReturnValuesSchema: ZodFor<NestedProcessReturnValues> | undefined;

function getNestedProcessReturnValuesSchema(): ZodFor<NestedProcessReturnValues> {
  return (nestedProcessReturnValuesSchema ??= z.object({
    nested: z.array(z.lazy(() => getNestedProcessReturnValuesSchema())),
  }) /* ... */);
}
```

Construction stays lazy (no module-eval-time schema building, so no new circular-import hazards), and the
recursion now closes on a stable object.

The other `z.lazy` uses in the tree (`AbiValueSchema`, `AbiTypeSchema`, `AbiDecodedSchema`,
`callTraceSchema`) already point at a single module-level schema, and were verified to parse fine under
zod 4.5.x.

## Pinning zod to a minor

Fixing the schemas removes today's breakage; the range is what let a dependency change behaviour for users
without anyone here choosing it. All 17 workspaces declared `"zod": "^4"`, so the published packages accept
any 4.x while the monorepo's lockfile quietly held 4.4.3 — CI and consumers were never running the same
zod, which is precisely why this reached users without a single failing test in yarn-project.

The range is now `~4.4.3` everywhere: patch releases still flow, a minor bump has to be deliberate. The
lockfile resolution is unchanged (4.4.3), so the only lockfile diff is the descriptor rename — no
transitive churn.

## Verification

With zod 4.5.2 swapped into `node_modules` locally:

- before the change: 5 failures across the two test files, each `RangeError: Maximum call stack size exceeded` — the exact CI error;
- after the change: all 10 pass, and the full stdlib suite is green (132 suites, 1060 tests);
- with the repo's pinned zod 4.4.3 the suite is green as well.

Reproduced independently against zod 4.5.0, 4.5.2 and 4.5.4 (all fail on a rebuilt-per-access lazy target,
all pass on a stable one); zod 4.4.3 tolerates both.

Each schema also gets a regression test asserting it hands out the same instance on every access, which is
the invariant that keeps the recursion closed.

## Note

Split out of #25357, whose CI surfaced this. Unrelated to that PR's changes — the failure reproduces on the
base branch with zod 4.5.x installed.

Fixes A-1886
