### PR TITLE
fix(pxe): harden change set failure paths in the coordinator (backport of aztec-labs-eng/aztec-node#100)

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -492,6 +492,7 @@ async function createTestLogService(
 ) {
   const keyStore = new KeyStore(await openTmpStore('test'));
   const recipientTaggingStore = new RecipientTaggingStore(await openTmpStore('test'));
+  recipientTaggingStore.beginChangeSet('test');
   const taggingSecretSourcesStore = new TaggingSecretSourcesStore(await openTmpStore('test'));
   const addressStore = new AddressStore(await openTmpStore('test'));
   const aztecNode = mock<AztecNode>();

--- a/yarn-project/pxe/src/operation_lifecycle.test.ts
+++ b/yarn-project/pxe/src/operation_lifecycle.test.ts
@@ -136,6 +136,34 @@ describe('runOperation', () => {
     expect(notified).toEqual(['committed', 'discarded']);
   });
 
+  it('reports the operation error and still notifies contributors when the abort fails', async () => {
+    coordinator = new StagedWriteCoordinator({
+      kvStore: store,
+      stagedStores: [
+        {
+          storeName: 'undiscardable_store',
+          commitChangeSet: () => Promise.resolve(),
+          discardChangeSet: () => {
+            throw new Error('cannot discard');
+          },
+        },
+      ],
+    });
+    const notified: string[] = [];
+    const contributors: OperationContributor[] = [
+      {
+        onOperationEnd: (_, outcome) => {
+          notified.push(outcome);
+        },
+      },
+    ];
+
+    await expect(run(contributors, () => Promise.reject(new Error('operation failed'))).operation).rejects.toThrow(
+      'operation failed',
+    );
+    expect(notified).toEqual(['discarded']);
+  });
+
   /** Begins a change set and runs `fn` as an operation over it. */
   function run<T>(contributors: OperationContributor[], fn: () => Promise<T>) {
     const changeSetId = coordinator.begin();

--- a/yarn-project/pxe/src/operation_lifecycle.ts
+++ b/yarn-project/pxe/src/operation_lifecycle.ts
@@ -52,7 +52,13 @@ export async function runOperation<T>(args: RunOperationArgs, fn: () => Promise<
   } catch (err) {
     log.verbose(`Aborting operation ${changeSetId}`, { changeSetId });
     await settleContributorsLoggingFailures(args);
-    stagedWriteCoordinator.abort(changeSetId);
+    try {
+      stagedWriteCoordinator.abort(changeSetId);
+    } catch (abortErr) {
+      // Nothing here can undo a failed abort, so it is logged, but the error that ended the operation is the one
+      // reported.
+      log.error(`Failed to abort operation ${changeSetId}`, abortErr, { changeSetId });
+    }
     notifyOperationEnd(args, 'discarded');
     throw err;
   }

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -536,6 +536,8 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const recipientTaggingStore = new RecipientTaggingStore(kvStore);
 
       const changeSetId = 'fixture-change-set';
+      recipientTaggingStore.beginChangeSet(changeSetId);
+
       const secretA = new AppTaggingSecret(new Fr(2n), AztecAddress.fromBigIntUnsafe(3n));
       const secretB = new AppTaggingSecret(new Fr(5n), AztecAddress.fromBigIntUnsafe(7n));
       // A constrained secret keys under the `constrained:` prefix, so the snapshot pins both kinds side by side.

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
@@ -29,12 +29,10 @@ describe('StagedWriteCoordinator', () => {
 
     it('notifies its stores of the change set it opened', async () => {
       const opened: ChangeSetId[] = [];
-      const mockStore: StagedStore = {
+      const mockStore = makeStagedStore({
         storeName: 'mock_store',
         beginChangeSet: changeSetId => opened.push(changeSetId),
-        commitChangeSet: () => Promise.resolve(),
-        discardChangeSet: () => {},
-      };
+      });
 
       coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
 
@@ -45,6 +43,33 @@ describe('StagedWriteCoordinator', () => {
       const second = coordinator.begin();
       expect(opened).toEqual([first, second]);
       coordinator.abort(second);
+    });
+
+    it('opens no change set at all when a store fails to open one', () => {
+      const opened: ChangeSetId[] = [];
+      const discarded: ChangeSetId[] = [];
+      const healthyStore = makeStagedStore({
+        storeName: 'healthy_store',
+        beginChangeSet: changeSetId => opened.push(changeSetId),
+        discardChangeSet: changeSetId => discarded.push(changeSetId),
+      });
+      let failNextBegin = true;
+      const failingStore = makeStagedStore({
+        storeName: 'failing_store',
+        beginChangeSet: () => {
+          if (failNextBegin) {
+            failNextBegin = false;
+            throw new Error('cannot open');
+          }
+        },
+      });
+
+      coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [healthyStore, failingStore] });
+
+      expect(() => coordinator.begin()).toThrow('cannot open');
+      expect(opened).toHaveLength(1);
+      expect(discarded).toEqual(opened);
+      expect(() => coordinator.begin()).not.toThrow();
     });
   });
 
@@ -83,14 +108,13 @@ describe('StagedWriteCoordinator', () => {
       });
 
       const committed: { changeSetId: ChangeSetId; inTransaction: boolean }[] = [];
-      const mockStore: StagedStore = {
+      const mockStore = makeStagedStore({
         storeName: 'mock_store',
         commitChangeSet: changeSetId => {
           committed.push({ changeSetId, inTransaction });
           return Promise.resolve();
         },
-        discardChangeSet: () => {},
-      };
+      });
 
       coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
 
@@ -130,11 +154,11 @@ describe('StagedWriteCoordinator', () => {
     it('calls discardChangeSet on all its stores', () => {
       const commitMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const discardChangeSetMock = jest.fn<() => void>();
-      const mockStore: StagedStore = {
+      const mockStore = makeStagedStore({
         storeName: 'mock_store',
         commitChangeSet: commitMock,
         discardChangeSet: discardChangeSetMock,
-      };
+      });
 
       coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore] });
 
@@ -144,21 +168,86 @@ describe('StagedWriteCoordinator', () => {
 
       expect(discardChangeSetMock).toHaveBeenCalledWith(changeSetId);
     });
+
+    it('ends the change set and discards the other stores when one store fails to discard', () => {
+      const discarded: ChangeSetId[] = [];
+      const failingStore = makeStagedStore({
+        storeName: 'failing_store',
+        discardChangeSet: () => {
+          throw new Error('discard failed');
+        },
+      });
+      const healthyStore = makeStagedStore({
+        storeName: 'healthy_store',
+        discardChangeSet: changeSetId => {
+          discarded.push(changeSetId);
+        },
+      });
+
+      coordinator = new StagedWriteCoordinator({ kvStore: store, stagedStores: [failingStore, healthyStore] });
+
+      const changeSetId = coordinator.begin();
+
+      expect(() => coordinator.abort(changeSetId)).toThrow(/failing_store/);
+
+      // The store behind the failing one still drops its staged data, and the change set still ends.
+      expect(discarded).toEqual([changeSetId]);
+      expect(() => coordinator.begin()).not.toThrow();
+    });
+
+    it('reports every failed discard as one aggregate error', () => {
+      const failingStore = (storeName: string) =>
+        makeStagedStore({
+          storeName,
+          discardChangeSet: () => {
+            throw new Error(`${storeName} cannot discard`);
+          },
+        });
+
+      coordinator = new StagedWriteCoordinator({
+        kvStore: store,
+        stagedStores: [failingStore('first_store'), failingStore('second_store')],
+      });
+
+      const changeSetId = coordinator.begin();
+
+      let abortError: AggregateError | undefined;
+      try {
+        coordinator.abort(changeSetId);
+      } catch (err) {
+        abortError = err as AggregateError;
+      }
+
+      expect(abortError).toBeInstanceOf(AggregateError);
+      expect(abortError!.errors.map((err: Error) => err.message)).toEqual([
+        expect.stringContaining('Store "first_store" failed to discard'),
+        expect.stringContaining('Store "second_store" failed to discard'),
+      ]);
+      expect(abortError!.errors.map((err: Error) => err.cause)).toEqual([
+        new Error('first_store cannot discard'),
+        new Error('second_store cannot discard'),
+      ]);
+    });
   });
 
   describe('construction', () => {
     it('throws on stores with duplicate names', () => {
       const commitMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const discardChangeSetMock = jest.fn<() => void>();
-      const mockStore: StagedStore = {
+      const mockStore = makeStagedStore({
         storeName: 'mock_store',
         commitChangeSet: commitMock,
         discardChangeSet: discardChangeSetMock,
-      };
+      });
 
       expect(() => new StagedWriteCoordinator({ kvStore: store, stagedStores: [mockStore, mockStore] })).toThrow(
         /already registered/,
       );
     });
   });
+
+  /** A staged store that does nothing on commit and discard, so a test only spells out the part it exercises. */
+  function makeStagedStore(overrides: Partial<StagedStore> & Pick<StagedStore, 'storeName'>): StagedStore {
+    return { commitChangeSet: () => Promise.resolve(), discardChangeSet: () => {}, ...overrides };
+  }
 });

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.ts
@@ -87,7 +87,11 @@ export class StagedWriteCoordinator {
   /**
    * Opens a change set and returns its ID for staged writes.
    *
+   * All or nothing: if a store fails to open the change set, the stores that already opened it discard it again and
+   * nothing is left active, so a later change set can still be opened on this PXE instance.
+   *
    * @returns Change set ID to pass to store operations
+   * @throws If a change set is already open, or if a store rejects the new one.
    */
   begin(): ChangeSetId {
     if (this.#currentChangeSetId) {
@@ -98,12 +102,8 @@ export class StagedWriteCoordinator {
     }
 
     const changeSetId = randomBytes(8).toString('hex');
+    this.#beginChangeSetOnStores(changeSetId);
     this.#currentChangeSetId = changeSetId;
-
-    for (const store of this.#stagedStores.values()) {
-      store.beginChangeSet?.(changeSetId);
-    }
-
     this.#log.debug(`Opened change set ${changeSetId}`, { changeSetId });
     return changeSetId;
   }
@@ -111,7 +111,11 @@ export class StagedWriteCoordinator {
   /**
    * Commits by promoting all staged data to persistent storage.
    *
+   * Unlike {@link begin} and {@link abort}, a failed commit leaves the change set open, so the caller must still
+   * {@link abort} it before another can be opened.
+   *
    * @param changeSetId - The change set ID returned from begin
+   * @throws If `changeSetId` is not the open change set, or if a store failed to commit.
    */
   async commit(changeSetId: ChangeSetId): Promise<void> {
     if (this.#currentChangeSetId !== changeSetId) {
@@ -137,7 +141,11 @@ export class StagedWriteCoordinator {
   /**
    * Aborts by discarding all staged data.
    *
+   * Every store gets to drop its staged data even if an earlier one failed, and the change set always ends, so a
+   * failed abort never blocks later change sets.
+   *
    * @param changeSetId - The change set ID returned from begin
+   * @throws If `changeSetId` is not the open change set, or if any store failed to discard.
    */
   abort(changeSetId: ChangeSetId): void {
     if (this.#currentChangeSetId !== changeSetId) {
@@ -149,12 +157,56 @@ export class StagedWriteCoordinator {
 
     this.#log.debug(`Aborting change set ${changeSetId}`, { changeSetId });
 
-    for (const store of this.#stagedStores.values()) {
-      store.discardChangeSet(changeSetId);
+    this.#currentChangeSetId = undefined;
+    this.#discardChangeSetOnStores(this.#stagedStores.values(), changeSetId);
+
+    this.#log.debug(`Change set ${changeSetId} aborted`, { changeSetId });
+  }
+
+  /** Opens the change set on every store, undoing it on any that accepted if a later one rejects, and rethrows. */
+  #beginChangeSetOnStores(changeSetId: ChangeSetId): void {
+    const begunStores: StagedStore[] = [];
+    try {
+      for (const store of this.#stagedStores.values()) {
+        store.beginChangeSet?.(changeSetId);
+        begunStores.push(store);
+      }
+    } catch (err) {
+      try {
+        this.#discardChangeSetOnStores(begunStores, changeSetId);
+      } catch (discardError) {
+        // The original error is that a store failed to begin the changeset, and we're throwing that
+        // unconditionally, so we just log this additional failure.
+        this.#log.error(`Failed to roll back change set ${changeSetId} after a store rejected it`, discardError, {
+          changeSetId,
+        });
+      }
+      throw err;
+    }
+  }
+
+  /** Discards the change set on every store in `stores`, throwing only once they have all had the chance. */
+  #discardChangeSetOnStores(stores: Iterable<StagedStore>, changeSetId: ChangeSetId): void {
+    // A store that fails must not stop the ones after it, so the failures are collected and thrown at the end.
+    const failures: Error[] = [];
+    for (const store of stores) {
+      try {
+        store.discardChangeSet(changeSetId);
+      } catch (err) {
+        failures.push(
+          new Error(
+            `Store "${store.storeName}" failed to discard change set ${changeSetId} and may still hold staged data.`,
+            { cause: err },
+          ),
+        );
+      }
     }
 
-    this.#currentChangeSetId = undefined;
-    this.#log.debug(`Change set ${changeSetId} aborted`, { changeSetId });
+    if (failures.length === 1) {
+      throw failures[0];
+    } else if (failures.length > 1) {
+      throw new AggregateError(failures);
+    }
   }
 }
 

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.test.ts
@@ -13,26 +13,27 @@ describe('RecipientTaggingStore', () => {
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
     secret1 = await randomAppTaggingSecret(AppTaggingSecretKind.UNCONSTRAINED);
     secret2 = await randomAppTaggingSecret(AppTaggingSecretKind.UNCONSTRAINED);
+
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    taggingStore.beginChangeSet('change-set-1');
   });
 
   describe('staged writes', () => {
     it('persists staged highest aged index to the store', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
 
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBeUndefined();
-
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
     });
 
     it('persists staged highest finalized index to the store', async () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 10, 'change-set-1');
 
-      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBeUndefined();
-
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBe(10);
     });
 
@@ -44,6 +45,7 @@ describe('RecipientTaggingStore', () => {
 
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(5);
       expect(await taggingStore.getHighestAgedIndex(secret2, 'change-set-2')).toBe(8);
       expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBe(3);
@@ -54,35 +56,29 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
       await taggingStore.commitChangeSet('change-set-1');
 
-      // Updating again with a higher value in the same change set should work
-      // (if staged data wasn't cleared, it would still have the old value cached)
+      // Updating again with a higher value in a new change set should work
+      // (if staged data wasn't cleared on commit, the old value would still be cached)
+      taggingStore.beginChangeSet('change-set-2');
       await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
       expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBe(10);
       await taggingStore.commitChangeSet('change-set-2');
 
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(10);
-    });
-
-    it('does not affect other change sets when committing', async () => {
-      await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
-      await taggingStore.updateHighestAgedIndex(secret1, 10, 'change-set-2');
-
-      await taggingStore.commitChangeSet('change-set-2');
-
-      // change-set-1's staged value should still be intact
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBe(5);
+      taggingStore.beginChangeSet('change-set-3');
+      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-3')).toBe(10);
     });
 
     it('discards staged highest aged index without persisting', async () => {
       await taggingStore.updateHighestAgedIndex(secret1, 5, 'change-set-1');
       taggingStore.discardChangeSet('change-set-1');
-      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-1')).toBeUndefined();
+      taggingStore.beginChangeSet('change-set-2');
+      expect(await taggingStore.getHighestAgedIndex(secret1, 'change-set-2')).toBeUndefined();
     });
 
     it('discards staged highest finalized index without persisting', async () => {
       await taggingStore.updateHighestFinalizedIndex(secret1, 5, 'change-set-1');
       taggingStore.discardChangeSet('change-set-1');
-      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-1')).toBeUndefined();
+      taggingStore.beginChangeSet('change-set-2');
+      expect(await taggingStore.getHighestFinalizedIndex(secret1, 'change-set-2')).toBeUndefined();
     });
   });
 
@@ -102,6 +98,7 @@ describe('RecipientTaggingStore', () => {
       await taggingStore.updateHighestFinalizedIndex(constrained, 9, 'change-set-1');
       await taggingStore.commitChangeSet('change-set-1');
 
+      taggingStore.beginChangeSet('change-set-2');
       expect(await taggingStore.getHighestFinalizedIndex(unconstrained, 'change-set-2')).toBe(4);
       expect(await taggingStore.getHighestFinalizedIndex(constrained, 'change-set-2')).toBe(9);
     });

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -1,7 +1,8 @@
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AppTaggingSecret } from '@aztec/stdlib/logs';
 
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 
 /**
  * Data provider of tagging data used when syncing the logs as a recipient. The sender counterpart of this class
@@ -11,129 +12,103 @@ import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
  * @dev Chain reorgs do not need to be handled here because both the finalized and aged indexes refer to finalized
  * blocks, which by definition cannot be affected by reorgs.
  */
-export class RecipientTaggingStore implements StagedStore {
-  storeName: string = 'recipient_tagging';
-
-  #store: AztecAsyncKVStore;
-
-  #highestAgedIndex: AztecAsyncMap<string, number>;
-  #highestFinalizedIndex: AztecAsyncMap<string, number>;
-
-  // changeSetId => secret => number
-  #highestAgedIndexForChangeSet: Map<ChangeSetId, Map<string, number>>;
-
-  // changeSetId => secret => number
-  #highestFinalizedIndexForChangeSet: Map<ChangeSetId, Map<string, number>>;
-
+export class RecipientTaggingStore extends BaseStagingStore<RecipientTaggingChangeSet, RecipientTaggingDb> {
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-
-    this.#highestAgedIndex = this.#store.openMap('highest_aged_index');
-    this.#highestFinalizedIndex = this.#store.openMap('highest_finalized_index');
-
-    this.#highestAgedIndexForChangeSet = new Map();
-    this.#highestFinalizedIndexForChangeSet = new Map();
+    super({
+      storeName: 'recipient_tagging',
+      store,
+      buildChangeSet: () => ({ highestAgedIndexes: new Map(), highestFinalizedIndexes: new Map() }),
+      buildDb: db => ({
+        highestAgedIndex: db.openMap('highest_aged_index'),
+        highestFinalizedIndex: db.openMap('highest_finalized_index'),
+      }),
+    });
   }
 
-  #getHighestAgedIndexForChangeSet(changeSetId: ChangeSetId): Map<string, number> {
-    let highestAgedIndexForChangeSet = this.#highestAgedIndexForChangeSet.get(changeSetId);
-    if (!highestAgedIndexForChangeSet) {
-      highestAgedIndexForChangeSet = new Map();
-      this.#highestAgedIndexForChangeSet.set(changeSetId, highestAgedIndexForChangeSet);
-    }
-    return highestAgedIndexForChangeSet;
-  }
-
-  async #readHighestAgedIndex(changeSetId: ChangeSetId, secret: string): Promise<number | undefined> {
+  async #readHighestAgedIndex(
+    changeSet: RecipientTaggingChangeSet,
+    db: ReadonlyDb<RecipientTaggingDb>,
+    secret: SecretStr,
+  ): Promise<Index | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const dbValue = await this.#highestAgedIndex.getAsync(secret);
-    const staged = this.#getHighestAgedIndexForChangeSet(changeSetId).get(secret);
-    return staged ?? dbValue;
+    const dbValue = await db.highestAgedIndex.getAsync(secret);
+    return changeSet.highestAgedIndexes.get(secret) ?? dbValue;
   }
 
-  #writeHighestAgedIndex(changeSetId: ChangeSetId, secret: string, index: number) {
-    this.#getHighestAgedIndexForChangeSet(changeSetId).set(secret, index);
-  }
-
-  #getHighestFinalizedIndexForChangeSet(changeSetId: ChangeSetId): Map<string, number> {
-    let stagedHighestFinalizedIndex = this.#highestFinalizedIndexForChangeSet.get(changeSetId);
-    if (!stagedHighestFinalizedIndex) {
-      stagedHighestFinalizedIndex = new Map();
-      this.#highestFinalizedIndexForChangeSet.set(changeSetId, stagedHighestFinalizedIndex);
-    }
-    return stagedHighestFinalizedIndex;
-  }
-
-  async #readHighestFinalizedIndex(changeSetId: ChangeSetId, secret: string): Promise<number | undefined> {
+  async #readHighestFinalizedIndex(
+    changeSet: RecipientTaggingChangeSet,
+    db: ReadonlyDb<RecipientTaggingDb>,
+    secret: SecretStr,
+  ): Promise<Index | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const dbValue = await this.#highestFinalizedIndex.getAsync(secret);
-    const staged = this.#getHighestFinalizedIndexForChangeSet(changeSetId).get(secret);
-    return staged ?? dbValue;
+    const dbValue = await db.highestFinalizedIndex.getAsync(secret);
+    return changeSet.highestFinalizedIndexes.get(secret) ?? dbValue;
   }
 
-  #writeHighestFinalizedIndex(changeSetId: ChangeSetId, secret: string, index: number) {
-    this.#getHighestFinalizedIndexForChangeSet(changeSetId).set(secret, index);
-  }
-
-  /**
-   * Writes all change set-specific in-memory data to persistent storage.
-   *
-   * @remark This method must run in a DB transaction context. It's designed to be called from
-   * {@link StagedWriteCoordinator.commit}.
-   */
-  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
-    const highestAgedIndexForChangeSet = this.#highestAgedIndexForChangeSet.get(changeSetId);
-    if (highestAgedIndexForChangeSet) {
-      for (const [secret, index] of highestAgedIndexForChangeSet.entries()) {
-        await this.#highestAgedIndex.set(secret, index);
-      }
+  protected async flushChangeSet(changeSet: RecipientTaggingChangeSet, db: RecipientTaggingDb): Promise<void> {
+    for (const [secret, index] of changeSet.highestAgedIndexes) {
+      await db.highestAgedIndex.set(secret, index);
     }
 
-    const highestFinalizedIndexForChangeSet = this.#highestFinalizedIndexForChangeSet.get(changeSetId);
-    if (highestFinalizedIndexForChangeSet) {
-      for (const [secret, index] of highestFinalizedIndexForChangeSet.entries()) {
-        await this.#highestFinalizedIndex.set(secret, index);
-      }
+    for (const [secret, index] of changeSet.highestFinalizedIndexes) {
+      await db.highestFinalizedIndex.set(secret, index);
     }
-
-    this.discardChangeSet(changeSetId);
   }
 
-  discardChangeSet(changeSetId: ChangeSetId): void {
-    this.#highestAgedIndexForChangeSet.delete(changeSetId);
-    this.#highestFinalizedIndexForChangeSet.delete(changeSetId);
+  /** No-op: both indexes refer to finalized blocks, which a prune cannot remove. */
+  protected applyRollback(): Promise<void> {
+    return Promise.resolve();
   }
 
-  getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<number | undefined> {
-    return this.#store.transactionAsync(() => this.#readHighestAgedIndex(changeSetId, secret.toString()));
+  getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
+    return this.withChangeSet(changeSetId, (changeSet, db) =>
+      this.#readHighestAgedIndex(changeSet, db, secret.toString()),
+    );
   }
 
-  updateHighestAgedIndex(secret: AppTaggingSecret, index: number, changeSetId: ChangeSetId): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      const currentIndex = await this.#readHighestAgedIndex(changeSetId, secret.toString());
+  updateHighestAgedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      const currentIndex = await this.#readHighestAgedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index <= currentIndex) {
         // Log sync should never set a lower highest aged index.
         throw new Error(`New highest aged index (${index}) must be higher than the current one (${currentIndex})`);
       }
-      this.#writeHighestAgedIndex(changeSetId, secret.toString(), index);
+      changeSet.highestAgedIndexes.set(secret.toString(), index);
     });
   }
 
-  getHighestFinalizedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<number | undefined> {
-    return this.#store.transactionAsync(() => this.#readHighestFinalizedIndex(changeSetId, secret.toString()));
+  getHighestFinalizedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
+    return this.withChangeSet(changeSetId, (changeSet, db) =>
+      this.#readHighestFinalizedIndex(changeSet, db, secret.toString()),
+    );
   }
 
-  updateHighestFinalizedIndex(secret: AppTaggingSecret, index: number, changeSetId: ChangeSetId): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      const currentIndex = await this.#readHighestFinalizedIndex(changeSetId, secret.toString());
+  updateHighestFinalizedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+      const currentIndex = await this.#readHighestFinalizedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index < currentIndex) {
         // Log sync should never set a lower highest finalized index but it can happen that it would try to set the same
         // one because we are loading logs from highest aged index + 1 and not from the highest finalized index.
         throw new Error(`New highest finalized index (${index}) must be higher than the current one (${currentIndex})`);
       }
-      this.#writeHighestFinalizedIndex(changeSetId, secret.toString(), index);
+      changeSet.highestFinalizedIndexes.set(secret.toString(), index);
     });
   }
 }
+
+/// Alias types for kv map readability
+type SecretStr = string;
+type Index = number;
+
+/** A change set's staged data, created and discarded as a unit: both indexes, each keyed by tagging secret. */
+type RecipientTaggingChangeSet = {
+  highestAgedIndexes: Map<SecretStr, Index>;
+  highestFinalizedIndexes: Map<SecretStr, Index>;
+};
+
+type RecipientTaggingDb = {
+  highestAgedIndex: AztecAsyncMap<SecretStr, Index>;
+  highestFinalizedIndex: AztecAsyncMap<SecretStr, Index>;
+};

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.bench.test.ts
@@ -164,6 +164,7 @@ describeBench('syncTaggedPrivateLogs constrained-sync bench', () => {
 
     aztecNode.getPrivateLogsByTags.mockReset();
     const taggingStore = new RecipientTaggingStore(await openTmpStore('bench'));
+    taggingStore.beginChangeSet(CHANGE_SET_ID);
     const secrets = await Promise.all(Array.from({ length: secretCount }, () => randomAppTaggingSecret(kind)));
 
     // Seed the persisted finalized indexes to simulate a recipient that already synced prior finalized messages. The

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
@@ -104,6 +104,7 @@ describe('syncTaggedPrivateLogs', () => {
   beforeEach(async () => {
     aztecNode.getPrivateLogsByTags.mockReset();
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
+    taggingStore.beginChangeSet(CHANGE_SET_ID);
   });
 
   it('returns empty array when given no secrets', async () => {


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/100 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `61dee49ea1931d562df6cf54f59dd72d646d7b44`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff 61dee49ea1^..61dee49ea1 origin/nico/port-node-100-coordinator-failure-paths^..origin/nico/port-node-100-coordinator-failure-paths
   ```

   Expected: only the `(cherry picked from commit …)` trailer under the commit message and nothing else — no `-`/`+` lines under any file header. The patch applied without conflicts and was not edited.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.
4. End-state check for the stack up to this PR. `aztec-node/main` at this PR's squash commit (`61dee49ea1`) is the last point before that repo renamed its packages to the `@aztec-labs` scope, so `yarn-project/pxe/src` must differ from it only by drift that already existed before the backports (`3c35735616` is the train tip the stack was built on, `10ab86541e^` is `aztec-node/main` right before the first backported PR):

   ```
   diff <(git diff 3c35735616 10ab86541e^ -- yarn-project/pxe/src | grep -vE '^(index |@@ )') \
        <(git diff origin/nico/port-node-100-coordinator-failure-paths 61dee49ea1 -- yarn-project/pxe/src | grep -vE '^(index |@@ )')
   ```

   Expected: two context lines in `sync_tagged_private_logs.test.ts` where `JOB_ID` became `CHANGE_SET_ID` (the rename from #35 landing on a v5-only hunk), nothing else. Any other output means a hunk was dropped or invented somewhere in the stack. (The check cannot extend past this PR: #98 merged after the scope rename, which reshuffled import blocks repo-wide there; #98 is covered by its own range-diff instead.)

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#94 (base branch `nico/port-node-94-recipient-tagging-store`); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 (aztec-node numbers).
