### PR TITLE
refactor(pxe): migrate FactStore to BaseStagingStore (backport of aztec-labs-eng/aztec-node#98)

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -118,6 +118,7 @@ describe('Utility Execution test suite', () => {
     taggingSecretSourcesStore = mock<TaggingSecretSourcesStore>();
     capsuleStore = mock<CapsuleStore>();
     factStore = new FactStore(await openTmpStore('utility-exec-fact-test'));
+    factStore.beginChangeSet('test-change-set-id');
     privateEventStore = mock<PrivateEventStore>();
     contractSyncService = mock<ContractSyncService>();
     l2TipsStore = mock<L2TipsProvider>();

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -223,6 +223,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
     writeToStore: async kvStore => {
       const factStore = new FactStore(kvStore);
       const changeSetId = 'fixture-change-set';
+      factStore.beginChangeSet(changeSetId);
       const contract = AztecAddress.fromBigIntUnsafe(100n);
       const scope = AztecAddress.fromBigIntUnsafe(1n);
       const factCollectionTypeId = new Fr(7n);

--- a/yarn-project/pxe/src/storage/base_staging_store.test.ts
+++ b/yarn-project/pxe/src/storage/base_staging_store.test.ts
@@ -15,7 +15,7 @@ describe('BaseStagingStore', () => {
     store = new TestStore(kv);
   });
 
-  describe('withChangeSet', () => {
+  describe('withChangeSetAndDb', () => {
     it('accepts operations between beginChangeSet and the end of the change set', async () => {
       store.beginChangeSet('cs1');
       await store.write('key', 1, 'cs1');
@@ -120,6 +120,41 @@ describe('BaseStagingStore', () => {
     });
   });
 
+  describe('withChangeSet', () => {
+    it('accepts operations between beginChangeSet and the end of the change set', async () => {
+      store.beginChangeSet('cs1');
+      await store.stage('key', 1, 'cs1');
+      await expect(store.staged('key', 'cs1')).resolves.toBe(1);
+    });
+
+    it('rejects staging for a change set that is not open', async () => {
+      await expect(store.stage('key', 1, 'cs1')).rejects.toThrow('Store "test": change set "cs1" is not open');
+    });
+
+    it('takes the same lock as withChangeSetAndDb, so it cannot interleave with an operation in flight', async () => {
+      store.beginChangeSet('cs1');
+      const gate = promiseWithResolvers<void>();
+      const order: string[] = [];
+
+      const inFlight = store.op(async changeSet => {
+        order.push('op-start');
+        await gate.promise;
+        changeSet.set('key', 1);
+        order.push('op-end');
+      }, 'cs1');
+      await tick();
+
+      const staged = store.stage('key', 2, 'cs1').then(() => order.push('stage-end'));
+      await tick();
+      expect(order).toEqual(['op-start']);
+
+      gate.resolve();
+      await Promise.all([inFlight, staged]);
+      expect(order).toEqual(['op-start', 'op-end', 'stage-end']);
+      await expect(store.readStaged('key', 'cs1')).resolves.toBe(2);
+    });
+  });
+
   describe('beginChangeSet', () => {
     it('rejects opening a change set while another is open', async () => {
       store.beginChangeSet('cs1');
@@ -181,6 +216,21 @@ describe('BaseStagingStore', () => {
   });
 
   describe('discardChangeSet', () => {
+    it('drops the staged writes without touching committed state', async () => {
+      store.beginChangeSet('cs1');
+      await store.write('key', 1, 'cs1');
+      await store.commitChangeSet('cs1');
+
+      store.beginChangeSet('cs2');
+      await store.write('key', 2, 'cs2');
+      store.discardChangeSet('cs2');
+
+      // Commit the next change set: a discarded change set's staged write must not ride along on it.
+      store.beginChangeSet('cs3');
+      await store.commitChangeSet('cs3');
+      await expect(store.committed('key')).resolves.toBe(1);
+    });
+
     it('leaves the open change set alone when discarding a different one', async () => {
       store.beginChangeSet('cs1');
       await store.write('key', 1, 'cs1');
@@ -263,19 +313,29 @@ class TestStore extends BaseStagingStore<Map<string, number>, TestDb> {
   }
 
   write(key: string, value: number, changeSetId: ChangeSetId): Promise<void> {
-    return this.withChangeSet(changeSetId, changeSet => {
+    return this.withChangeSetAndDb(changeSetId, changeSet => {
       changeSet.set(key, value);
       return Promise.resolve();
     });
   }
 
+  stage(key: string, value: number, changeSetId: ChangeSetId): Promise<void> {
+    return this.withChangeSet(changeSetId, changeSet => {
+      changeSet.set(key, value);
+    });
+  }
+
+  staged(key: string, changeSetId: ChangeSetId): Promise<number | undefined> {
+    return this.withChangeSet(changeSetId, changeSet => changeSet.get(key));
+  }
+
   // Runs an arbitrary operation body under the change set's lock.
   op<R>(fn: (changeSet: Map<string, number>) => Promise<R>, changeSetId: ChangeSetId): Promise<R> {
-    return this.withChangeSet(changeSetId, changeSet => fn(changeSet));
+    return this.withChangeSetAndDb(changeSetId, changeSet => fn(changeSet));
   }
 
   readStaged(key: string, changeSetId: ChangeSetId): Promise<number | undefined> {
-    return this.withChangeSet(changeSetId, changeSet => Promise.resolve(changeSet.get(key)));
+    return this.withChangeSetAndDb(changeSetId, changeSet => Promise.resolve(changeSet.get(key)));
   }
 
   committed(key: string): Promise<number | undefined> {

--- a/yarn-project/pxe/src/storage/base_staging_store.ts
+++ b/yarn-project/pxe/src/storage/base_staging_store.ts
@@ -12,12 +12,13 @@ import type { ChangeSetId, StagedStore } from './staged_write_coordinator.js';
  * abort) finds no matching change set and throws, so it cannot stage new data for a dead one.
  *
  * The staged data and the store's kv handles live in this base class and are only reachable through
- * {@link withChangeSet} (change set operations, with the DB read-only), {@link flushChangeSet} (the commit-time
- * write-back) and {@link applyRollback} (the reorg truncation).
+ * {@link withChangeSet} (change set operations, staged data only), {@link withChangeSetAndDb} (change set operations
+ * that also read the DB), {@link flushChangeSet} (the commit-time write-back) and {@link applyRollback} (the reorg
+ * truncation).
  *
- * The class is thread safe: an internal lock serializes the operations run through {@link withChangeSet}, so two of
- * them issued concurrently (e.g. under `Promise.all`) never interleave across awaits. Subclasses can therefore read
- * staged data and write it back without handling atomicity themselves.
+ * The class is thread safe: an internal lock serializes the operations run through {@link withChangeSet} and
+ * {@link withChangeSetAndDb}, so two of them issued concurrently (e.g. under `Promise.all`) never interleave across
+ * awaits. Subclasses can therefore read staged data and write it back without handling atomicity themselves.
  *
  * @typeParam TChangeSet - The in-memory buffer a change set accumulates its writes in, built empty by `buildChangeSet`
  * on every {@link beginChangeSet} and dropped when the change set ends. A store keyed by id might stage
@@ -117,40 +118,65 @@ export abstract class BaseStagingStore<TChangeSet, TDb> implements StagedStore, 
 
   /**
    * Writes the change set's staged data to persistent storage. Runs inside the caller's transaction: it must not
-   * open a transaction of its own or call {@link withChangeSet}.
+   * open a transaction of its own or call {@link withChangeSetAndDb}.
    */
   protected abstract flushChangeSet(changeSet: TChangeSet, db: TDb): Promise<void>;
 
   /**
    * Deletes the state originating from blocks strictly above `toBlock`. Runs inside the transaction owned by
-   * {@link rollbackToBlock}'s caller: it must not open a transaction of its own or call {@link withChangeSet}.
+   * {@link rollbackToBlock}'s caller: it must not open a transaction of its own or call {@link withChangeSetAndDb}.
    */
   protected abstract applyRollback(toBlock: number, db: TDb): Promise<void>;
 
   /**
-   * Runs a change set operation (read or write). Takes the store's lock, opens a transaction, and calls `fn` with the
-   * change set's staged data and a read-only view of the DB (writes are staged in memory until {@link flushChangeSet}
-   * runs on commit).
+   * Runs a change set operation that reads the DB. Takes the store's lock, opens a transaction, and calls `fn` with
+   * the change set's staged data and a read-only view of the DB (writes are staged in memory until
+   * {@link flushChangeSet} runs on commit).
+   *
+   * Prefer {@link withChangeSet} unless `fn` actually reads the DB.
    *
    * The lock makes the store thread safe: two operations issued concurrently (e.g. under `Promise.all`) cannot
    * interleave across awaits, so `fn` can read staged data and write it back without handling atomicity itself.
    *
    * @throws If the change set is not open.
    */
-  protected async withChangeSet<R>(
+  protected withChangeSetAndDb<R>(
     changeSetId: ChangeSetId,
     fn: (changeSet: TChangeSet, db: ReadonlyDb<TDb>) => Promise<R>,
   ): Promise<R> {
+    return this.#runLocked(changeSetId, () =>
+      this.#store.transactionAsync(() => {
+        // Re-resolve after the wait: the change set may have been discarded while this operation queued on the lock
+        // or on the store's transaction queue.
+        const current = this.#currentOrThrow(changeSetId);
+        return fn(current.changeSet, this.#db);
+      }),
+    );
+  }
+
+  /**
+   * Runs a change set operation over the staged data alone: takes the store's lock and calls `fn` with the change
+   * set's staged data, opening no db transaction.
+   *
+   * Use {@link withChangeSetAndDb} instead when `fn` reads the DB.
+   *
+   * @throws If the change set is not open.
+   */
+  protected withChangeSet<R>(changeSetId: ChangeSetId, fn: (changeSet: TChangeSet) => R | Promise<R>): Promise<R> {
+    return this.#runLocked(changeSetId, async () => {
+      // Re-resolve after the wait: the change set may have been discarded while this operation queued on the lock.
+      const current = this.#currentOrThrow(changeSetId);
+      return await fn(current.changeSet);
+    });
+  }
+
+  async #runLocked<R>(changeSetId: ChangeSetId, run: () => Promise<R>): Promise<R> {
     const entered = this.#currentOrThrow(changeSetId);
     entered.inFlight++;
     try {
       await this.#lock.acquire();
       try {
-        return await this.#store.transactionAsync(() => {
-          // Re-resolve after the wait: the change set may have been discarded while this operation queued on the lock.
-          const current = this.#currentOrThrow(changeSetId);
-          return fn(current.changeSet, this.#db);
-        });
+        return await run();
       } finally {
         this.#lock.release();
       }

--- a/yarn-project/pxe/src/storage/fact_store/fact_service.test.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_service.test.ts
@@ -34,6 +34,7 @@ describe('FactService', () => {
   beforeEach(async () => {
     kv = await openTmpStore('fact-service-test');
     store = new FactStore(kv);
+    store.beginChangeSet(changeSetId);
   });
 
   it('delegates record+get for an allowed scope', async () => {

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.test.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.test.ts
@@ -57,6 +57,9 @@ describe('FactStore', () => {
 
     kv = await openTmpStore('fact-store-test');
     store = new FactStore(kv);
+
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    store.beginChangeSet(CHANGE_SET);
   });
   afterEach(async () => {
     await kv.close();
@@ -65,11 +68,30 @@ describe('FactStore', () => {
   const collectionIdsOf = (collections: { key: FactCollectionKey }[]) => collections.map(c => c.key.factCollectionId);
   const hexSet = (frs: Fr[]) => new Set(frs.map(f => f.toString()));
 
+  // Commits the open change set and opens it again: a commit closes the change set, and every operation needs one open.
+  const commit = async (changeSetId: string = CHANGE_SET) => {
+    await kv.transactionAsync(() => store.commitChangeSet(changeSetId));
+    store.beginChangeSet(changeSetId);
+  };
+
+  // Ends the open change set and opens `next` in its place: only one change set may be open at a time.
+  const switchTo = (next: string, current: string = CHANGE_SET) => {
+    store.discardChangeSet(current);
+    store.beginChangeSet(next);
+  };
+
+  // Rolls back with no change set open, since the store refuses a rollback while one is, and reopens it afterwards.
+  const rollbackTo = async (toBlock: number, changeSetId: string = CHANGE_SET) => {
+    store.discardChangeSet(changeSetId);
+    await kv.transactionAsync(() => store.rollbackToBlock(toBlock));
+    store.beginChangeSet(changeSetId);
+  };
+
   describe('recording and reading', () => {
     it('records facts and reads a collection back after commit (implicit collection creation)', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeB, [], { blockNumber: 5, blockHash: Fr.random() }, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET))!;
       expect(hexSet(facts.map(f => f.factTypeId))).toEqual(hexSet([factTypeA, factTypeB]));
@@ -82,7 +104,7 @@ describe('FactStore', () => {
     it('lists collections via getFactCollectionsByType', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const collections = await store.getFactCollectionsByType(typeKey, CHANGE_SET);
       expect(hexSet(collectionIdsOf(collections))).toEqual(hexSet([collectionId1, collectionId2]));
@@ -91,7 +113,7 @@ describe('FactStore', () => {
     it('getFactCollectionsByType returns each collection complete with its facts', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeB, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const collections = await store.getFactCollectionsByType(typeKey, CHANGE_SET);
       expect(collections).toHaveLength(1);
@@ -104,7 +126,7 @@ describe('FactStore', () => {
       const payload = Fr.random();
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
     });
@@ -125,7 +147,7 @@ describe('FactStore', () => {
         { blockNumber: 10, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET))!;
       expect(facts).toHaveLength(2);
@@ -135,20 +157,21 @@ describe('FactStore', () => {
     it('re-recording an identical fact across change sets is a no-op', async () => {
       const payload = Fr.random();
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const CHANGE_SET_2 = 'rerecord-change-set';
+      switchTo(CHANGE_SET_2);
       await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET_2);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
+      await commit(CHANGE_SET_2);
 
-      expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
+      expect((await store.getFactCollection(collectionKey1, CHANGE_SET_2))!.facts).toHaveLength(1);
     });
   });
 
   describe('scope isolation', () => {
     it('a collection recorded under one scope is a different collection under another scope', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeDefined();
       expect(await store.getFactCollection(collectionKey1ScopeB, CHANGE_SET)).toBeUndefined();
@@ -160,7 +183,7 @@ describe('FactStore', () => {
       const origin = { blockNumber: 5, blockHash: Fr.random() };
       await store.recordFact(collectionKey1, factTypeA, [payload], origin, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeB, [payload], origin, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeA,
@@ -173,7 +196,7 @@ describe('FactStore', () => {
     it('getFactCollectionsByType only returns collections for the queried scope', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET))).toEqual([collectionId1]);
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKeyScopeB, CHANGE_SET))).toEqual([collectionId1]);
@@ -181,25 +204,23 @@ describe('FactStore', () => {
   });
 
   describe('read-your-writes', () => {
-    it("reflects a change set's own staged facts before commit; other change sets do not see them", async () => {
+    it("reflects a change set's own staged facts before commit", async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
 
       expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeA,
       ]);
       expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET))).toEqual([collectionId1]);
-
-      expect(await store.getFactCollection(collectionKey1, 'other-change-set')).toBeUndefined();
-      expect(await store.getFactCollectionsByType(typeKey, 'other-change-set')).toHaveLength(0);
     });
 
     it('staged facts combine with committed ones', async () => {
       const payloads = Array.from({ length: 4 }, () => Fr.random());
       await store.recordFact(collectionKey1, factTypeA, [payloads[0]], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1, factTypeA, [payloads[1]], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const CHANGE_SET_2 = 'staged-change-set';
+      switchTo(CHANGE_SET_2);
       await store.recordFact(collectionKey1, factTypeA, [payloads[2]], undefined, CHANGE_SET_2);
       await store.recordFact(collectionKey1, factTypeA, [payloads[3]], undefined, CHANGE_SET_2);
 
@@ -212,67 +233,75 @@ describe('FactStore', () => {
     it('deletes the collection and leaves neighbouring collections untouched', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const DEL = 'delete-change-set';
+      switchTo(DEL);
       await store.deleteFactCollection(collectionKey1, DEL);
-      await kv.transactionAsync(() => store.commitChangeSet(DEL));
+      await commit(DEL);
 
-      expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
-      expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET))).toEqual([collectionId2]);
+      expect(await store.getFactCollection(collectionKey1, DEL)).toBeUndefined();
+      expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, DEL))).toEqual([collectionId2]);
     });
 
     it('only deletes the queried scope: the same (contract,type,id) under another scope survives', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
       await store.recordFact(collectionKey1ScopeB, factTypeB, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const DEL = 'delete-change-set';
+      switchTo(DEL);
       await store.deleteFactCollection(collectionKey1, DEL);
-      await kv.transactionAsync(() => store.commitChangeSet(DEL));
+      await commit(DEL);
 
-      expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
-      expect((await store.getFactCollection(collectionKey1ScopeB, CHANGE_SET))!.facts.map(f => f.factTypeId)).toEqual([
+      expect(await store.getFactCollection(collectionKey1, DEL)).toBeUndefined();
+      expect((await store.getFactCollection(collectionKey1ScopeB, DEL))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeB,
       ]);
     });
 
     it('is a no-op for a collection that does not exist', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const DEL = 'delete-change-set';
+      switchTo(DEL);
       await store.deleteFactCollection(collectionKey2, DEL);
-      await kv.transactionAsync(() => store.commitChangeSet(DEL));
+      await commit(DEL);
 
-      expect((await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts).toHaveLength(1);
+      expect((await store.getFactCollection(collectionKey1, DEL))!.facts).toHaveLength(1);
     });
 
     it('hides a collection from its own change set after a staged delete, even over committed facts', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const DEL = 'delete-change-set';
+      switchTo(DEL);
       await store.deleteFactCollection(collectionKey1, DEL);
 
       expect(await store.getFactCollection(collectionKey1, DEL)).toBeUndefined();
       expect(await store.getFactCollectionsByType(typeKey, DEL)).toHaveLength(0);
+
+      // Discarding the staged delete leaves the committed facts in place.
+      switchTo('reader', DEL);
       expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts).toHaveLength(1);
     });
 
     it('a staged delete-then-record re-creates the collection within the same change set', async () => {
       await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       const CHANGE_SET_2 = 'recreate-change-set';
+      switchTo(CHANGE_SET_2);
       await store.deleteFactCollection(collectionKey1, CHANGE_SET_2);
       await store.recordFact(collectionKey1, factTypeB, [Fr.random()], undefined, CHANGE_SET_2);
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET_2))!;
       expect(facts.map(f => f.factTypeId)).toEqual([factTypeB]);
 
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
-      expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.factTypeId)).toEqual([
+      await commit(CHANGE_SET_2);
+      expect((await store.getFactCollection(collectionKey1, CHANGE_SET_2))!.facts.map(f => f.factTypeId)).toEqual([
         factTypeB,
       ]);
     });
@@ -283,8 +312,8 @@ describe('FactStore', () => {
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
 
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
-      expect(await store.getFactCollection(collectionKey1, 'reader')).toBeUndefined();
+      await commit();
+      expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
     });
   });
 
@@ -300,9 +329,9 @@ describe('FactStore', () => {
         { blockNumber: 6, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
-      await kv.transactionAsync(() => store.rollbackToBlock(5));
+      await rollbackTo(5);
 
       const { facts } = (await store.getFactCollection(collectionKey1, CHANGE_SET))!;
       expect(hexSet(facts.map(f => f.payload[0]))).toEqual(hexSet([nonRetractable]));
@@ -316,9 +345,9 @@ describe('FactStore', () => {
         { blockNumber: 6, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
-      await kv.transactionAsync(() => store.rollbackToBlock(5));
+      await rollbackTo(5);
 
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
       expect(await store.getFactCollectionsByType(typeKey, CHANGE_SET)).toHaveLength(0);
@@ -340,34 +369,15 @@ describe('FactStore', () => {
         { blockNumber: 10, blockHash: Fr.random() },
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
-      await kv.transactionAsync(() => store.rollbackToBlock(7));
+      await rollbackTo(7);
       expect(
         (await store.getFactCollection(collectionKey1, CHANGE_SET))!.facts.map(f => f.originBlock?.blockNumber),
       ).toEqual([5]);
-      store.discardChangeSet(CHANGE_SET);
 
-      await kv.transactionAsync(() => store.rollbackToBlock(4));
+      await rollbackTo(4);
       expect(await store.getFactCollection(collectionKey1, CHANGE_SET)).toBeUndefined();
-    });
-
-    it('rollback throws while a change set has staged writes', async () => {
-      await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, 'uncommitted-change-set');
-      await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).rejects.toThrow(
-        'PXE fact store rollback is not allowed while staged writes are pending',
-      );
-      store.discardChangeSet('uncommitted-change-set');
-      await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).resolves.not.toThrow();
-    });
-
-    it('a change set that has only read still blocks rollback until it is discarded', async () => {
-      await store.getFactCollection(collectionKey1, 'reader-change-set');
-      await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).rejects.toThrow(
-        'PXE fact store rollback is not allowed while staged writes are pending',
-      );
-      store.discardChangeSet('reader-change-set');
-      await expect(kv.transactionAsync(() => store.rollbackToBlock(0))).resolves.not.toThrow();
     });
   });
 
@@ -400,7 +410,7 @@ describe('FactStore', () => {
         undefined,
         CHANGE_SET,
       );
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
+      await commit();
 
       expect(await store.getFactCollectionsByType(typeKey, CHANGE_SET)).toHaveLength(1);
       expect(
@@ -415,55 +425,6 @@ describe('FactStore', () => {
           CHANGE_SET,
         ),
       ).toHaveLength(1);
-    });
-  });
-
-  describe('cross-change set behavior', () => {
-    it("commit persists only the given change set's facts", async () => {
-      const payloads = [Fr.random(), Fr.random()];
-      await store.recordFact(collectionKey1, factTypeA, [payloads[0]], undefined, CHANGE_SET);
-      const CHANGE_SET_2 = 'second-change-set';
-      await store.recordFact(collectionKey1, factTypeA, [payloads[1]], undefined, CHANGE_SET_2);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
-
-      expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.payload[0])).toEqual([
-        payloads[0],
-      ]);
-      expect(
-        hexSet((await store.getFactCollection(collectionKey1, CHANGE_SET_2))!.facts.map(f => f.payload[0])),
-      ).toEqual(hexSet(payloads));
-
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
-      expect(hexSet((await store.getFactCollection(collectionKey1, 'reader'))!.facts.map(f => f.payload[0]))).toEqual(
-        hexSet(payloads),
-      );
-    });
-
-    it('discardChangeSet drops staged writes without touching committed state', async () => {
-      await store.recordFact(collectionKey1, factTypeA, [Fr.random()], undefined, CHANGE_SET);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
-
-      const CHANGE_SET_2 = 'discarded-change-set';
-      await store.recordFact(collectionKey2, factTypeA, [Fr.random()], undefined, CHANGE_SET_2);
-      await store.recordFact(collectionKey1, factTypeB, [Fr.random()], undefined, CHANGE_SET_2);
-      store.discardChangeSet(CHANGE_SET_2);
-
-      expect(collectionIdsOf(await store.getFactCollectionsByType(typeKey, CHANGE_SET_2))).toEqual([collectionId1]);
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2));
-      expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts).toHaveLength(1);
-      expect(await store.getFactCollection(collectionKey2, 'reader')).toBeUndefined();
-    });
-
-    it('a fact recorded by two change sets racing to the same collection dedups on commit', async () => {
-      const payload = Fr.random();
-      const CHANGE_SET_2 = 'racing-change-set';
-      await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET);
-      await store.recordFact(collectionKey1, factTypeA, [payload], undefined, CHANGE_SET_2);
-
-      await kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET));
-      await expect(kv.transactionAsync(() => store.commitChangeSet(CHANGE_SET_2))).resolves.not.toThrow();
-
-      expect((await store.getFactCollection(collectionKey1, 'reader'))!.facts).toHaveLength(1);
     });
   });
 });

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.ts
@@ -1,11 +1,10 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { allToCompletion } from '@aztec/foundation/promise';
-import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 
-import type { Rollbackable } from '../rollbackable.js';
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 import { FactCollectionKey, type FactCollectionTypeKey, type OriginBlock } from './fact_store_keys.js';
 import { type Fact, StoredFact, factKeyStrOf } from './stored_fact.js';
 
@@ -51,35 +50,20 @@ type StagedOp = { kind: 'recordFact'; fact: StoredFact } | { kind: 'deleteFactCo
  *
  * As with most other PXE stores, writes are staged per change set ID and flushed atomically on commit.
  */
-export class FactStore implements StagedStore, Rollbackable {
-  readonly storeName: string = 'fact';
-
-  #store: AztecAsyncKVStore;
-
-  /** Primary index of fact records. */
-  #facts: AztecAsyncMap<FactKeyStr, FactBuffer>;
-
-  /** Index for per-collection fact enumeration and by-type collection discovery. */
-  #factsByCollection: AztecAsyncMultiMap<FactCollectionKeyStr, FactKeyStr>;
-
-  /** Index for delete-on-prune of retractable facts (those with an origin block). */
-  #factsByBlock: AztecAsyncMultiMap<BlockNum, FactKeyStr>;
-
-  /** Uncommitted data, keyed by change set ID */
-  #opsForChangeSet: Map<ChangeSetId, StagedOp[]>;
-
-  /** Per-change-set locks */
-  #changeSetLocks: Map<ChangeSetId, Semaphore>;
-
+export class FactStore extends BaseStagingStore<FactStoreChangeSet, FactStoreDb> {
   logger = createLogger('fact_store');
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-    this.#facts = store.openMap('facts');
-    this.#factsByCollection = store.openMultiMap('facts_by_collection');
-    this.#factsByBlock = store.openMultiMap('facts_by_block');
-    this.#opsForChangeSet = new Map();
-    this.#changeSetLocks = new Map();
+    super({
+      storeName: 'fact',
+      store,
+      buildChangeSet: () => [],
+      buildDb: db => ({
+        facts: db.openMap('facts'),
+        factsByCollection: db.openMultiMap('facts_by_collection'),
+        factsByBlock: db.openMultiMap('facts_by_block'),
+      }),
+    });
   }
 
   /**
@@ -101,12 +85,11 @@ export class FactStore implements StagedStore, Rollbackable {
     originBlock: OriginBlock | undefined,
     changeSetId: ChangeSetId,
   ): Promise<void> {
-    return this.#withChangeSetLock(changeSetId, () => {
-      this.#stagedOpsFor(changeSetId).push({
+    return this.withChangeSet(changeSetId, changeSet => {
+      changeSet.push({
         kind: 'recordFact',
         fact: new StoredFact(factCollectionKey, factTypeId, payload, originBlock),
       });
-      return Promise.resolve();
     });
   }
 
@@ -116,62 +99,57 @@ export class FactStore implements StagedStore, Rollbackable {
    * Idempotent: deleting a collection that does not exist is a no-op.
    */
   deleteFactCollection(factCollectionKey: FactCollectionKey, changeSetId: ChangeSetId): Promise<void> {
-    return this.#withChangeSetLock(changeSetId, () => {
-      this.#stagedOpsFor(changeSetId).push({ kind: 'deleteFactCollection', key: factCollectionKey });
-      return Promise.resolve();
+    return this.withChangeSet(changeSetId, changeSet => {
+      changeSet.push({ kind: 'deleteFactCollection', key: factCollectionKey });
     });
   }
 
   /**
    * Returns the fact collection for the (scope-qualified) key, or undefined if it has no facts.
    */
-  async getFactCollection(
+  getFactCollection(
     factCollectionKey: FactCollectionKey,
     changeSetId: ChangeSetId,
   ): Promise<FactCollection | undefined> {
-    const collectionKey = factCollectionKey.toString();
-    const committed = await this.#store.transactionAsync(() => this.#readCollectionsFromDb([factCollectionKey]));
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
+      const collectionKey = factCollectionKey.toString();
+      const committedCollection = await this.#loadCommittedCollection(db, factCollectionKey);
+      const committed = new Map(committedCollection ? [[collectionKey, committedCollection]] : []);
 
-    const collection = this.#foldStagedOps(committed, changeSetId).get(collectionKey);
-    if (!collection) {
-      return undefined;
-    }
-    const facts = [...collection.facts.values()];
-    return facts.length > 0 ? { key: factCollectionKey, facts } : undefined;
+      const collection = this.#foldStagedOps(committed, changeSet).get(collectionKey);
+      if (!collection) {
+        return undefined;
+      }
+      const facts = [...collection.facts.values()];
+      return facts.length > 0 ? { key: factCollectionKey, facts } : undefined;
+    });
   }
 
   /**
    * Returns every fact collection of the given type for the queried scope, each holding its facts.
    */
-  async getFactCollectionsByType(
+  getFactCollectionsByType(
     factCollectionTypeKey: FactCollectionTypeKey,
     changeSetId: ChangeSetId,
   ): Promise<FactCollection[]> {
-    const typeKey = factCollectionTypeKey.toString();
-    const committed = await this.#readCollectionsFromDbByType(typeKey);
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
+      const typeKey = factCollectionTypeKey.toString();
+      const committed = await this.#readCollectionsFromDbByType(db, typeKey);
 
-    return Array.from(this.#foldStagedOps(committed, changeSetId, typeKey).values())
-      .map(collection => ({ key: collection.key, facts: [...collection.facts.values()] }))
-      .filter(collection => collection.facts.length > 0);
+      return Array.from(this.#foldStagedOps(committed, changeSet, typeKey).values())
+        .map(collection => ({ key: collection.key, facts: [...collection.facts.values()] }))
+        .filter(collection => collection.facts.length > 0);
+    });
   }
 
-  /**
-   * Commits all staged operations for the given change set to persistent storage.
-   *
-   * Must be called inside a transaction owned by the caller (StagedWriteCoordinator wraps all commits in a single
-   * transactionAsync, and IndexedDB does not support nested transactions).
-   *
-   * DO NOT call `#withChangeSetLock` here: awaiting the lock creates a microtask boundary that causes IndexedDB to
-   * auto-commit the outer transaction.
-   */
-  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
-    for (const op of this.#stagedOpsFor(changeSetId)) {
+  protected async flushChangeSet(changeSet: FactStoreChangeSet, db: FactStoreDb): Promise<void> {
+    for (const op of changeSet) {
       switch (op.kind) {
         case 'recordFact':
-          await this.#commitFact(op.fact);
+          await this.#commitFact(db, op.fact);
           break;
         case 'deleteFactCollection':
-          await this.#deleteCollection(op.key.toString());
+          await this.#deleteCollection(db, op.key.toString());
           break;
         default: {
           const _exhaustive: never = op;
@@ -179,30 +157,15 @@ export class FactStore implements StagedStore, Rollbackable {
         }
       }
     }
-    this.#clearChangeSetData(changeSetId);
-  }
-
-  /** Discards all staged operations for the given change set without persisting them. */
-  discardChangeSet(changeSetId: ChangeSetId): void {
-    this.#clearChangeSetData(changeSetId);
   }
 
   /**
    * Removes every retractable fact originating from blocks over height `toBlock`, across all scopes.
    *
-   * Non-retractable facts are untouched. Must run inside a caller-owned transaction (because it needs to share the
-   * transaction with other stores and IndexedDB has no nested transactions).
-   *
-   * Throws if any change set is in flight (has accessed the store and not yet committed or discarded), since rolling
-   * back mid-change-set could re-introduce records originating from deleted blocks or change state underneath a change
-   * set's view.
+   * Non-retractable facts are untouched.
    */
-  async rollbackToBlock(toBlock: BlockNum): Promise<void> {
-    if (this.#opsForChangeSet.size > 0) {
-      throw new Error('PXE fact store rollback is not allowed while staged writes are pending');
-    }
-
-    const removedFacts = await this.#retractFacts(toBlock);
+  protected async applyRollback(toBlock: BlockNum, db: FactStoreDb): Promise<void> {
+    const removedFacts = await this.#retractFacts(db, toBlock);
 
     this.logger.verbose('rolled back fact store', { removedFacts, toBlock });
   }
@@ -213,13 +176,13 @@ export class FactStore implements StagedStore, Rollbackable {
    *
    * Requires to be run in a transactionAsync context.
    */
-  async #retractFacts(toBlock: BlockNum): Promise<number> {
+  async #retractFacts(db: FactStoreDb, toBlock: BlockNum): Promise<number> {
     // Snapshot the orphaned fact keys before mutating so we never delete from the cursor we are iterating, kicking off
     // each fact-body read during the scan so a DB request stays pending across the cursor-to-delete boundary (a drained
     // cursor with no read in flight would let the transaction auto-commit before the deletes).
     const factReads = new Map<FactKeyStr, Promise<FactBuffer | undefined>>();
-    for await (const [, factKey] of this.#factsByBlock.entriesAsync({ start: toBlock + 1 })) {
-      factReads.set(factKey, this.#facts.getAsync(factKey));
+    for await (const [, factKey] of db.factsByBlock.entriesAsync({ start: toBlock + 1 })) {
+      factReads.set(factKey, db.facts.getAsync(factKey));
     }
     await allToCompletion(
       Array.from(factReads, async ([factKey, read]) => {
@@ -232,61 +195,48 @@ export class FactStore implements StagedStore, Rollbackable {
           });
           return;
         }
-        await this.#deleteFact(factKey, StoredFact.fromBuffer(buf));
+        await this.#deleteFact(db, factKey, StoredFact.fromBuffer(buf));
       }),
     );
     return factReads.size;
   }
 
-  /**
-   * Reads the given collections (their facts) by key into a Map keyed by collection key, skipping
-   * keys with no committed facts.
-   *
-   * Reads are not wrapped in a transaction: the caller owns the transaction boundary.
-   */
-  async #readCollectionsFromDb(keys: FactCollectionKey[]): Promise<Map<FactCollectionKeyStr, CollectionWithFacts>> {
-    const result = new Map<FactCollectionKeyStr, CollectionWithFacts>();
-    for (const key of keys) {
-      const collection = await this.#loadCommittedCollection(key);
-      if (collection) {
-        result.set(key.toString(), collection);
+  async #readCollectionsFromDbByType(
+    db: ReadonlyDb<FactStoreDb>,
+    typeKey: FactCollectionTypeKeyStr,
+  ): Promise<Map<FactCollectionKeyStr, CollectionWithFacts>> {
+    const factReadsByCollection = new Map<FactCollectionKeyStr, Map<FactKeyStr, Promise<FactBuffer | undefined>>>();
+    for await (const [collectionKey, factKey] of db.factsByCollection.entriesAsync({
+      start: `${typeKey}:`,
+      end: `${typeKey};`,
+    })) {
+      let reads = factReadsByCollection.get(collectionKey);
+      if (!reads) {
+        reads = new Map<FactKeyStr, Promise<FactBuffer | undefined>>();
+        factReadsByCollection.set(collectionKey, reads);
       }
+      reads.set(factKey, db.facts.getAsync(factKey));
+    }
+
+    const result = new Map<FactCollectionKeyStr, CollectionWithFacts>();
+    for (const [collectionKey, reads] of factReadsByCollection) {
+      const collection = await this.#assembleCollection(FactCollectionKey.fromString(collectionKey), reads);
+      result.set(collectionKey, collection);
     }
     return result;
   }
 
-  #readCollectionsFromDbByType(typeKey: FactCollectionTypeKeyStr) {
-    return this.#store.transactionAsync(async () => {
-      const factReadsByCollection = new Map<FactCollectionKeyStr, Map<FactKeyStr, Promise<FactBuffer | undefined>>>();
-      for await (const [collectionKey, factKey] of this.#factsByCollection.entriesAsync({
-        start: `${typeKey}:`,
-        end: `${typeKey};`,
-      })) {
-        let reads = factReadsByCollection.get(collectionKey);
-        if (!reads) {
-          reads = new Map<FactKeyStr, Promise<FactBuffer | undefined>>();
-          factReadsByCollection.set(collectionKey, reads);
-        }
-        reads.set(factKey, this.#facts.getAsync(factKey));
-      }
-
-      const result = new Map<FactCollectionKeyStr, CollectionWithFacts>();
-      for (const [collectionKey, reads] of factReadsByCollection) {
-        const collection = await this.#assembleCollection(FactCollectionKey.fromString(collectionKey), reads);
-        result.set(collectionKey, collection);
-      }
-      return result;
-    });
-  }
-
-  async #loadCommittedCollection(collectionKey: FactCollectionKey): Promise<CollectionWithFacts | undefined> {
+  async #loadCommittedCollection(
+    db: ReadonlyDb<FactStoreDb>,
+    collectionKey: FactCollectionKey,
+  ): Promise<CollectionWithFacts | undefined> {
     // Kick off each fact read while iterating the index so a DB request is always pending. Draining the cursor and only
     // then reading the facts one `await` at a time would let the IndexedDB transaction auto-commit at the boundary
     // (IndexedDB auto-commits once control returns to the event loop with no pending request), throwing mid-read on the
     // browser backend.
     const factReads = new Map<FactKeyStr, Promise<FactBuffer | undefined>>();
-    for await (const factKey of this.#factsByCollection.getValuesAsync(collectionKey.toString())) {
-      factReads.set(factKey, this.#facts.getAsync(factKey));
+    for await (const factKey of db.factsByCollection.getValuesAsync(collectionKey.toString())) {
+      factReads.set(factKey, db.facts.getAsync(factKey));
     }
     if (factReads.size === 0) {
       return undefined;
@@ -334,7 +284,7 @@ export class FactStore implements StagedStore, Rollbackable {
    */
   #foldStagedOps(
     committed: Map<FactCollectionKeyStr, CollectionWithFacts>,
-    changeSetId: ChangeSetId,
+    changeSet: FactStoreChangeSet,
     typeKey?: FactCollectionTypeKeyStr,
   ): Map<FactCollectionKeyStr, CollectionWithFacts> {
     const result = new Map<FactCollectionKeyStr, CollectionWithFacts>();
@@ -343,7 +293,7 @@ export class FactStore implements StagedStore, Rollbackable {
     for (const [collectionKey, { key, facts }] of committed) {
       result.set(collectionKey, { key, facts: new Map(facts) });
     }
-    for (const op of this.#stagedOpsFor(changeSetId)) {
+    for (const op of changeSet) {
       switch (op.kind) {
         case 'recordFact':
           this.#foldRecordFact(result, op, typeKey);
@@ -405,16 +355,16 @@ export class FactStore implements StagedStore, Rollbackable {
   /**
    * Writes a fact to persistent storage. Idempotent: an identical fact (same scope-qualified key) is left untouched.
    */
-  async #commitFact(fact: StoredFact): Promise<void> {
+  async #commitFact(db: FactStoreDb, fact: StoredFact): Promise<void> {
     const factKey = factKeyStrOf(fact);
-    if (await this.#facts.hasAsync(factKey)) {
+    if (await db.facts.hasAsync(factKey)) {
       this.logger.debug(`Ignoring already recorded fact`, { factKey });
       return;
     }
-    await this.#facts.set(factKey, fact.toBuffer());
-    await this.#factsByCollection.set(fact.factCollectionKey.toString(), factKey);
+    await db.facts.set(factKey, fact.toBuffer());
+    await db.factsByCollection.set(fact.factCollectionKey.toString(), factKey);
     if (fact.originBlock !== undefined) {
-      await this.#factsByBlock.set(fact.originBlock.blockNumber, factKey);
+      await db.factsByBlock.set(fact.originBlock.blockNumber, factKey);
     }
   }
 
@@ -423,13 +373,13 @@ export class FactStore implements StagedStore, Rollbackable {
    *
    * Caller must wrap in a transaction.
    */
-  async #deleteCollection(collectionKey: FactCollectionKeyStr): Promise<void> {
+  async #deleteCollection(db: FactStoreDb, collectionKey: FactCollectionKeyStr): Promise<void> {
     // Snapshot the fact index before mutating so we never delete from the cursor we are iterating, kicking off each
     // fact-body read during the scan so a DB request stays pending across the cursor-to-mutation boundary (a drained
     // cursor with no read in flight would let the transaction auto-commit before the deletes).
     const factReads = new Map<FactKeyStr, Promise<FactBuffer | undefined>>();
-    for await (const factKey of this.#factsByCollection.getValuesAsync(collectionKey)) {
-      factReads.set(factKey, this.#facts.getAsync(factKey));
+    for await (const factKey of db.factsByCollection.getValuesAsync(collectionKey)) {
+      factReads.set(factKey, db.facts.getAsync(factKey));
     }
     await allToCompletion(
       Array.from(factReads, async ([factKey, read]) => {
@@ -439,53 +389,36 @@ export class FactStore implements StagedStore, Rollbackable {
           // corrupt.
           throw new Error(`Fact not found for factKey ${factKey}`);
         }
-        await this.#deleteFact(factKey, StoredFact.fromBuffer(buf));
+        await this.#deleteFact(db, factKey, StoredFact.fromBuffer(buf));
       }),
     );
   }
 
   /**
-   * Deletes a fact from the primary store and all its indexes (`#factsByCollection`, plus `#factsByBlock` if
+   * Deletes a fact from the primary store and all its indexes (`factsByCollection`, plus `factsByBlock` if
    * retractable).
    *
    * Caller must wrap in a transaction.
    */
-  async #deleteFact(factKey: FactKeyStr, fact: StoredFact): Promise<void> {
-    await this.#facts.delete(factKey);
-    await this.#factsByCollection.deleteValue(fact.factCollectionKey.toString(), factKey);
+  async #deleteFact(db: FactStoreDb, factKey: FactKeyStr, fact: StoredFact): Promise<void> {
+    await db.facts.delete(factKey);
+    await db.factsByCollection.deleteValue(fact.factCollectionKey.toString(), factKey);
     if (fact.originBlock !== undefined) {
-      await this.#factsByBlock.deleteValue(fact.originBlock.blockNumber, factKey);
-    }
-  }
-
-  /**
-   * Returns the change set's staged-ops array, creating it on first access.
-   * */
-  #stagedOpsFor(changeSetId: ChangeSetId): StagedOp[] {
-    let ops = this.#opsForChangeSet.get(changeSetId);
-    if (ops === undefined) {
-      ops = [];
-      this.#opsForChangeSet.set(changeSetId, ops);
-    }
-    return ops;
-  }
-
-  #clearChangeSetData(changeSetId: ChangeSetId) {
-    this.#opsForChangeSet.delete(changeSetId);
-    this.#changeSetLocks.delete(changeSetId);
-  }
-
-  async #withChangeSetLock<T>(changeSetId: ChangeSetId, fn: () => Promise<T>): Promise<T> {
-    let lock = this.#changeSetLocks.get(changeSetId);
-    if (!lock) {
-      lock = new Semaphore(1);
-      this.#changeSetLocks.set(changeSetId, lock);
-    }
-    await lock.acquire();
-    try {
-      return await fn();
-    } finally {
-      lock.release();
+      await db.factsByBlock.deleteValue(fact.originBlock.blockNumber, factKey);
     }
   }
 }
+
+/** A change set's staged data: the ops it has accumulated, replayed over committed state on read and on flush. */
+type FactStoreChangeSet = StagedOp[];
+
+type FactStoreDb = {
+  /** Primary index of fact records. */
+  facts: AztecAsyncMap<FactKeyStr, FactBuffer>;
+
+  /** Index for per-collection fact enumeration and by-type collection discovery. */
+  factsByCollection: AztecAsyncMultiMap<FactCollectionKeyStr, FactKeyStr>;
+
+  /** Index for delete-on-prune of retractable facts (those with an origin block). */
+  factsByBlock: AztecAsyncMultiMap<BlockNum, FactKeyStr>;
+};

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -50,7 +50,7 @@ export class NoteStore extends BaseStagingStore<NoteStoreChangeSet, NoteStoreDb>
    * @param changeSetId - The change set to stage writes under
    */
   public addNotes(notes: NoteDao[], scope: AztecAddress, changeSetId: ChangeSetId): Promise<void[]> {
-    return this.withChangeSet(changeSetId, (changeSet, db) =>
+    return this.withChangeSetAndDb(changeSetId, (changeSet, db) =>
       allToCompletion(
         notes.map(async note => {
           const noteForChangeSet =
@@ -103,7 +103,7 @@ export class NoteStore extends BaseStagingStore<NoteStoreChangeSet, NoteStoreDb>
    * @returns Filtered and deduplicated notes (a note might be present in multiple scopes, but returned at most once)
    */
   getNotes(filter: NotesFilter, changeSetId: ChangeSetId): Promise<NoteDao[]> {
-    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       if (filter.scopes.length === 0) {
         return [];
       }
@@ -227,7 +227,7 @@ export class NoteStore extends BaseStagingStore<NoteStoreChangeSet, NoteStoreDb>
       return Promise.reject(new Error('applyNullifiers: nullifiers cannot have been emitted at block 0'));
     }
 
-    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       // Kick off the note read and the existing-emission read together during the synchronous map so all are in
       // flight before the first await, which keeps the IndexedDB transaction alive.
       const resolved = await allToCompletion(

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -63,13 +63,13 @@ export class RecipientTaggingStore extends BaseStagingStore<RecipientTaggingChan
   }
 
   getHighestAgedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
-    return this.withChangeSet(changeSetId, (changeSet, db) =>
+    return this.withChangeSetAndDb(changeSetId, (changeSet, db) =>
       this.#readHighestAgedIndex(changeSet, db, secret.toString()),
     );
   }
 
   updateHighestAgedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
-    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       const currentIndex = await this.#readHighestAgedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index <= currentIndex) {
         // Log sync should never set a lower highest aged index.
@@ -80,13 +80,13 @@ export class RecipientTaggingStore extends BaseStagingStore<RecipientTaggingChan
   }
 
   getHighestFinalizedIndex(secret: AppTaggingSecret, changeSetId: ChangeSetId): Promise<Index | undefined> {
-    return this.withChangeSet(changeSetId, (changeSet, db) =>
+    return this.withChangeSetAndDb(changeSetId, (changeSet, db) =>
       this.#readHighestFinalizedIndex(changeSet, db, secret.toString()),
     );
   }
 
   updateHighestFinalizedIndex(secret: AppTaggingSecret, index: Index, changeSetId: ChangeSetId): Promise<void> {
-    return this.withChangeSet(changeSetId, async (changeSet, db) => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       const currentIndex = await this.#readHighestFinalizedIndex(changeSet, db, secret.toString());
       if (currentIndex !== undefined && index < currentIndex) {
         // Log sync should never set a lower highest finalized index but it can happen that it would try to set the same


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/98 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `4a7a2e233528f717e6c22e894526831367d80be3`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff 4a7a2e2335^..4a7a2e2335 origin/nico/port-node-98-fact-store-staging^..origin/nico/port-node-98-fact-store-staging
   ```

   Expected: the `(cherry picked from commit …)` trailer, and exactly one patch-level difference, in `yarn-project/pxe/src/storage/fact_store/fact_store.ts`:

   ```
   --import { Semaphore } from '@aztec-labs/foundation/queue';
   +-import { Semaphore } from '@aztec/foundation/queue';
   ```

   Same removal on both sides; the package scope differs because upstream renamed its packages from `@aztec/*` to `@aztec-labs/*` (aztec-labs-eng/aztec-node#93) before this PR merged there, and this repo keeps `@aztec/*`. For the same reason the surrounding import lines show up as context-only differences (a single `-` or `+` followed by a space). No other file differs.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.
4. Confirm the upstream scope rename leaked nothing into this repo: `git grep -c @aztec-labs -- yarn-project` on this PR's head must return no matches.

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#100 (base branch `nico/port-node-100-coordinator-failure-paths`); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 → #101 → #108 → #110 (aztec-node numbers).

