### PR TITLE
chore: Update activity score to only track full epoch proofs

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -15,10 +15,10 @@
 | Function             | Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|-----------|---------------|--------------|
 | propose              | 199,366 |   225,550 |           996 |       15,936 |
-| submitEpochRootProof | 991,032 | 1,029,525 |        14,148 |      226,368 |
+| submitEpochRootProof | 994,761 | 1,033,254 |        14,148 |      226,368 |
 | setupEpoch           |  32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,643.2 gas/second
+**Avg Gas Cost per Second**: 3,646.4 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
@@ -26,10 +26,10 @@
 | Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
 |----------------------|-----------|-----------|---------------|--------------|
 | propose              |   327,774 |   355,591 |         4,516 |       72,256 |
-| submitEpochRootProof | 1,572,081 | 1,669,921 |        16,644 |      266,304 |
+| submitEpochRootProof | 1,575,811 | 1,673,651 |        16,644 |      266,304 |
 | aggregate3           |   376,665 |   390,039 |             - |            - |
 | setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,937.3 gas/second
+**Avg Gas Cost per Second**: 5,940.5 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -18,10 +18,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 972329,
-      "mean": 991032,
-      "median": 981138,
-      "max": 1029525,
+      "min": 976058,
+      "mean": 994761,
+      "median": 984867,
+      "max": 1033254,
       "calldata_size": 14148,
       "calldata_gas": 226368
     }
@@ -45,10 +45,10 @@
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 1460323,
-      "mean": 1572081,
-      "median": 1579041,
-      "max": 1669921,
+      "min": 1464053,
+      "mean": 1575811,
+      "median": 1582771,
+      "max": 1673651,
       "calldata_size": 16644,
       "calldata_gas": 266304
     },

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -233,6 +233,13 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
       Errors.Staking__ExitDelayAboveSlasherDelay(_config.exitDelaySeconds, StakingLib.SLASHER_EXECUTION_DELAY)
     );
 
+    // We can only figure out if the epoch is full once it closes,
+    // so we need to allow proofs to be accepted in a later epoch
+    require(
+      _config.aztecProofSubmissionEpochs > 0,
+      Errors.Rollup__InvalidProofSubmissionEpochs(1, _config.aztecProofSubmissionEpochs)
+    );
+
     TimeLib.initialize(
       block.timestamp,
       _config.aztecSlotDuration,

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -65,6 +65,7 @@ library Errors {
   error Rollup__InvalidOutHash(bytes32 expected, bytes32 actual); // 0x8eb39062
   error Rollup__InvalidPreviousArchive(bytes32 expected, bytes32 actual); // 0xb682a40e
   error Rollup__InvalidProof(); // 0xa5b2ba17
+  error Rollup__InvalidProofSubmissionEpochs(uint256 minimum, uint256 provided);
   error Rollup__InvalidProposedArchive(bytes32 expected, bytes32 actual); // 0x32532e73
   error Rollup__InvalidTimestamp(Timestamp expected, Timestamp actual); // 0x3132e895
   error Rollup__InvalidAttestations();

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -140,7 +140,10 @@ library EpochProofLib {
       }
     }
 
-    RewardLib.handleRewardsAndFees(_args, endEpoch);
+    bool fullEpochProof = isFullEpochProof(_args.end, endEpoch);
+
+    // Activity score depends on whether the proof is a full epoch proof
+    RewardLib.handleRewardsAndFees(_args, endEpoch, fullEpochProof);
 
     emit IRollupCore.L2ProofVerified(_args.end, _args.args.proverId);
   }
@@ -466,6 +469,34 @@ library EpochProofLib {
     );
 
     return endEpoch;
+  }
+
+  /*
+  * @notice Checks if the submitted proof is a full epoch proof
+  *
+  * @param _end End checkpoint of the proof
+  * @param _endEpoch Proof epoch
+  * @return true if the proof covers the whole epoch
+  */
+  function isFullEpochProof(uint256 _end, Epoch _endEpoch) private view returns (bool) {
+    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
+
+    // Another checkpoint could be proposed if the epoch being proven is the current one, so we can't be sure that the
+    // proof is a full epoch proof
+    if (_endEpoch >= currentEpoch) {
+      return false;
+    }
+
+    uint256 pendingCheckpointNumber = STFLib.getStorage().tips.getPending();
+
+    // If the last proof checkpoint is a pending checkpoint while the epoch is closed, then it's the last checkpoint of
+    // proof epoch
+    if (_end == pendingCheckpointNumber) {
+      return true;
+    }
+
+    // If the next checkpoint is in a different epoch, then this one is the final one in the proof epoch
+    return STFLib.getEpochForCheckpoint(_end + 1) > _endEpoch;
   }
 
   /**

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -107,7 +107,7 @@ library EpochProofLib {
       STFLib.prune();
     }
 
-    Epoch endEpoch = assertAcceptable(_args.start, _args.end);
+    (Epoch endEpoch, Epoch currentEpoch) = assertAcceptable(_args.start, _args.end);
 
     // Rehash the supplied headers against storage once, here: the public-input assembly below reads the fee
     // recipient/value out of them and relies on this call having run.
@@ -121,10 +121,13 @@ library EpochProofLib {
     require(verifyEpochRootProof(_args), Errors.Rollup__InvalidProof());
 
     RollupStore storage rollupStore = STFLib.getStorage();
+    CompressedChainTips tips = rollupStore.tips;
+
+    bool fullEpochProof = isFullEpochProof(_args.end, endEpoch, currentEpoch, tips.getPending());
 
     // Advance the proven block number and insert the out hash if the chain is extended.
-    if (_args.end > rollupStore.tips.getProven()) {
-      rollupStore.tips = rollupStore.tips.updateProven(_args.end);
+    if (_args.end > tips.getProven()) {
+      rollupStore.tips = tips.updateProven(_args.end);
 
       // Handle L2->L1 message processing.
       // The circuit outputs an empty out hash tree root if the epoch contains no messages.
@@ -139,8 +142,6 @@ library EpochProofLib {
         rollupStore.config.outbox.insert(endEpoch, numCheckpointsInEpoch, _args.args.outHash);
       }
     }
-
-    bool fullEpochProof = isFullEpochProof(_args.end, endEpoch);
 
     // Activity score depends on whether the proof is a full epoch proof
     RewardLib.handleRewardsAndFees(_args, endEpoch, fullEpochProof);
@@ -432,18 +433,19 @@ library EpochProofLib {
    *
    * @param _start The first checkpoint number in the epoch (inclusive)
    * @param _end The last checkpoint number in the epoch (inclusive)
-   * @return The epoch number that the proof covers
+   * @return endEpoch The epoch number that the proof covers
+   * @return currentEpoch The epoch at the time the proof is submitted
    */
-  function assertAcceptable(uint256 _start, uint256 _end) private view returns (Epoch) {
+  function assertAcceptable(uint256 _start, uint256 _end) private view returns (Epoch endEpoch, Epoch currentEpoch) {
     RollupStore storage rollupStore = STFLib.getStorage();
 
     Epoch startEpoch = STFLib.getEpochForCheckpoint(_start);
     // This also checks for existence of the checkpoint.
-    Epoch endEpoch = STFLib.getEpochForCheckpoint(_end);
+    endEpoch = STFLib.getEpochForCheckpoint(_end);
 
     require(startEpoch == endEpoch, Errors.Rollup__StartAndEndNotSameEpoch(startEpoch, endEpoch));
 
-    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
+    currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
 
     require(
       startEpoch.isAcceptingProofsAtEpoch(currentEpoch),
@@ -467,36 +469,36 @@ library EpochProofLib {
       claimedNumCheckpointsInEpoch,
       Errors.Rollup__TooManyCheckpointsInEpoch(Constants.MAX_CHECKPOINTS_PER_EPOCH, _end - _start)
     );
-
-    return endEpoch;
   }
 
-  /*
-  * @notice Checks if the submitted proof is a full epoch proof
-  *
-  * @param _end End checkpoint of the proof
-  * @param _endEpoch Proof epoch
-  * @return true if the proof covers the whole epoch
-  */
-  function isFullEpochProof(uint256 _end, Epoch _endEpoch) private view returns (bool) {
-    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-
+  /**
+   * @notice Checks if the submitted proof is a full epoch proof
+   *
+   * @param _end End checkpoint of the proof
+   * @param _endEpoch Proof epoch
+   * @param _currentEpoch Epoch at the time the proof is submitted
+   * @param _pendingCheckpointNumber Current pending checkpoint number
+   * @return true if the proof covers the whole epoch
+   */
+  function isFullEpochProof(uint256 _end, Epoch _endEpoch, Epoch _currentEpoch, uint256 _pendingCheckpointNumber)
+    private
+    view
+    returns (bool)
+  {
     // Another checkpoint could be proposed if the epoch being proven is the current one, so we can't be sure that the
     // proof is a full epoch proof
-    if (_endEpoch >= currentEpoch) {
+    if (_endEpoch >= _currentEpoch) {
       return false;
     }
 
-    uint256 pendingCheckpointNumber = STFLib.getStorage().tips.getPending();
-
     // If the last proof checkpoint is a pending checkpoint while the epoch is closed, then it's the last checkpoint of
     // proof epoch
-    if (_end == pendingCheckpointNumber) {
+    if (_end == _pendingCheckpointNumber) {
       return true;
     }
 
     // If the next checkpoint is in a different epoch, then this one is the final one in the proof epoch
-    return STFLib.getEpochForCheckpoint(_end + 1) > _endEpoch;
+    return STFLib.getSlotNumber(_end + 1).epochFromSlot() > _endEpoch;
   }
 
   /**

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -151,7 +151,9 @@ library RewardLib {
     return accumulatedRewards;
   }
 
-  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) internal {
+  function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch, bool _fullEpochProof)
+    internal
+  {
     RollupStore storage rollupStore = STFLib.getStorage();
     RewardStorage storage rewardStorage = getStorage();
 
@@ -163,10 +165,10 @@ library RewardLib {
       address prover = _args.args.proverId;
 
       require($sr.shares[prover] == 0, Errors.Rollup__ProverHaveAlreadySubmitted(prover, _endEpoch));
-      // Beware that it is possible to get marked active in an epoch even if you did not provide the longest
-      // proof. This is acceptable, as they were actually active. And boosting this way is not the most
-      // efficient way to do it, so this is fine.
-      uint256 shares = rewardStorage.config.booster.updateAndGetShares(prover);
+      // The prover is only marked active if they have provided a full epoch proof
+      uint256 shares = _fullEpochProof
+        ? rewardStorage.config.booster.updateAndGetShares(prover)
+        : rewardStorage.config.booster.getSharesFor(prover);
 
       // The duplicate-submission guard above uses `shares == 0` as the sentinel for "not yet
       // submitted". A booster that ever returns zero would let the same prover submit again

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -258,4 +258,99 @@ contract MultiProofTest is RollupBase {
       abi.encodeWithSelector(Errors.Rollup__StartAndEndNotSameEpoch.selector, 0, 1)
     );
   }
+
+  function testPartialEpochProofDoesNotUpdateActivityScore() public setUpFor("mixed_checkpoint_1") {
+    address alice = address(bytes20("alice"));
+
+    // Mint some fee asset to the portal to cover the 30M mana spent.
+    deal(address(testERC20), address(feeJuicePortal), 30e6 * 1e18);
+
+    // Propose 2 checkpoints (we need 2 to ensure a partial proof is possible)
+    _proposeCheckpoint("mixed_checkpoint_1", 1, 15e6);
+    _proposeCheckpoint("mixed_checkpoint_2", 2, 15e6);
+
+    // Close epoch 0 by advancing time to the first slot of epoch 1
+    warpToL2Slot(EPOCH_DURATION);
+
+    // Record, prove, record
+    uint256 activityScoreBefore = rewardBooster.getActivityScore(alice).value;
+
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, alice);
+
+    uint256 activityScoreAfter = rewardBooster.getActivityScore(alice).value;
+
+    assertEq(
+      activityScoreBefore, activityScoreAfter, "Alice's activity score changed despite not proving a whole epoch"
+    );
+  }
+
+  function testFullEpochProofUpdatesActivityScore() public setUpFor("mixed_checkpoint_1") {
+    address alice = address(bytes20("alice"));
+
+    // We need to mint some fee asset to the portal to cover the 30M mana spent.
+    deal(address(testERC20), address(feeJuicePortal), 30e6 * 1e18);
+
+    _proposeCheckpoint("mixed_checkpoint_1", 1, 15e6);
+    _proposeCheckpoint("mixed_checkpoint_2", 2, 15e6);
+
+    // Close epoch 0 by advancing time to the first slot of epoch 1
+    warpToL2Slot(EPOCH_DURATION);
+
+    uint256 activityScoreBefore = rewardBooster.getActivityScore(alice).value;
+
+    _proveCheckpoints("mixed_checkpoint_", 1, 2, alice);
+
+    uint256 activityScoreAfter = rewardBooster.getActivityScore(alice).value;
+
+    assertGt(
+      activityScoreAfter, activityScoreBefore, "Alice's activity score didn't increase despite proving a whole epoch"
+    );
+  }
+
+  function testSingleCheckpointFullEpochUpdatesActivityScore() public setUpFor("mixed_checkpoint_1") {
+    address alice = address(bytes20("alice"));
+
+    // We need to mint fee asset to the portal to cover the spent mana
+    deal(address(testERC20), address(feeJuicePortal), 30e6 * 1e18);
+
+    // Single checkpoint that will constitute the epoch
+    _proposeCheckpoint("mixed_checkpoint_1", 1, 15e6);
+
+    // Additional checkpoint in the new epoch to move the pending tip and close the previous epoch
+    _proposeCheckpoint("mixed_checkpoint_2", EPOCH_DURATION, 15e6);
+
+    uint256 activityScoreBefore = rewardBooster.getActivityScore(alice).value;
+
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, alice);
+
+    uint256 activityScoreAfter = rewardBooster.getActivityScore(alice).value;
+
+    assertGt(
+      activityScoreAfter,
+      activityScoreBefore,
+      "Alice's score didn't increase despite proving a whole epoch, though it was only 1 checkpoint"
+    );
+  }
+
+  function testOpenEpochProofDoesNotUpdateActivityScore() public setUpFor("mixed_checkpoint_1") {
+    address alice = address(bytes20("alice"));
+
+    // We need to mint fee asset to the portal to cover the spend mana
+    deal(address(testERC20), address(feeJuicePortal), 15e6 * 1e18);
+
+    // Go to epoch 1 immediately. Booster only updates once in an epoch and epoch 0 is chosen as default, so we will not
+    // be able to update the score without warping
+    warpToL2Slot(EPOCH_DURATION);
+
+    _proposeCheckpoint("mixed_checkpoint_1", EPOCH_DURATION, 15e6);
+
+    uint256 activityScoreBefore = rewardBooster.getActivityScore(alice).value;
+
+    // Prove without closing
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, alice);
+
+    uint256 activityScoreAfter = rewardBooster.getActivityScore(alice).value;
+
+    assertEq(activityScoreBefore, activityScoreAfter, "Proving an open epoch should not increase activity score");
+  }
 }

--- a/l1-contracts/test/rollup/constructorProofSubmissionEpochs.t.sol
+++ b/l1-contracts/test/rollup/constructorProofSubmissionEpochs.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.27;
+// solhint-disable func-name-mixedcase
+// solhint-disable comprehensive-interface
+
+import {RollupConfigInput} from "@aztec/core/interfaces/IRollup.sol";
+import {IVerifier} from "@aztec/core/interfaces/IVerifier.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {GenesisState} from "@aztec/core/libraries/rollup/STFLib.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {GSE} from "@aztec/governance/GSE.sol";
+import {MockVerifier} from "@aztec/mock/MockVerifier.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {RollupBuilder, Config as BuilderConfig} from "@test/builder/RollupBuilder.sol";
+import {Test} from "forge-std/Test.sol";
+
+/// @notice Verifies that it is impossible to set aztecProofSubmissionEpochs to zero
+///         since this would cause painful edgecase effects. For example, proof submissions
+///         could never update prover activity scores
+contract ConstructorProofSubmissionEpochsTest is Test {
+  RollupBuilder internal builder;
+  TestERC20 internal token;
+  GSE internal gse;
+  GenesisState internal genesisState;
+  IVerifier internal verifier;
+
+  function test_revertsWhenProofSubmissionEpochIsZero() external {
+    RollupConfigInput memory config = _buildDefaultConfig();
+    config.aztecProofSubmissionEpochs = 0;
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidProofSubmissionEpochs.selector, 1, 0));
+
+    new Rollup(token, token, gse, verifier, address(this), genesisState, config);
+  }
+
+  function test_succeedsWithOneProofSubmissionEpoch() external {
+    RollupConfigInput memory config = _buildDefaultConfig();
+    config.aztecProofSubmissionEpochs = 1;
+
+    Rollup rollup = new Rollup(token, token, gse, verifier, address(this), genesisState, config);
+
+    assertEq(rollup.getProofSubmissionEpochs(), 1);
+  }
+
+  function setUp() public {
+    builder = new RollupBuilder(address(this));
+    builder.deploy();
+
+    BuilderConfig memory cfg = builder.getConfig();
+    token = cfg.testERC20;
+    gse = cfg.gse;
+    genesisState = cfg.genesisState;
+    verifier = new MockVerifier();
+  }
+
+  function _buildDefaultConfig() internal view returns (RollupConfigInput memory) {
+    return builder.getConfig().rollupConfigInput;
+  }
+}

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -129,7 +129,7 @@ contract RewardLibWrapper {
   }
 
   function handleRewardsAndFees(SubmitEpochRootProofArgs calldata _args, Epoch _endEpoch) external {
-    RewardLib.handleRewardsAndFees(_args, _endEpoch);
+    RewardLib.handleRewardsAndFees(_args, _endEpoch, true);
   }
 
   function getSequencerRewards(address _sequencer) external view returns (uint256) {


### PR DESCRIPTION
Start updating provers' activity scores only when submitted proofs cover the whole epoch. Previously provers could cheat by only submitting the first checkpoint, which was cheaper.
Also changes  the requirement for aztecProofSubmissionEpochs to be at least 1