### PR TITLE
fix(ci3): scope the denoise and color_prefix leak checks to their own processes

### DIFF
--- a/ci3/denoise
+++ b/ci3/denoise
@@ -55,7 +55,9 @@ export FORCE_COLOR=${FORCE_COLOR:-1}
 
 key=$(uuid)
 url=$DASHBOARD_URL/$key
-outfile=/tmp/$key
+# DENOISE_TMPDIR gives a run a private output directory, so tests can scope their
+# leaked-process checks to their own denoise instead of every one on the machine.
+outfile=${DENOISE_TMPDIR:-/tmp}/$key
 touch $outfile
 
 function format_log_output {

--- a/ci3/tests/color_prefix_test
+++ b/ci3/tests/color_prefix_test
@@ -92,9 +92,9 @@ fi
 # --- 5. No leaked processes ---
 echo "--- 4. Process Cleanup ---"
 
-"$CP" "clean" "echo done" &>/dev/null
+"$CP" "clean_$$" "echo done" &>/dev/null
 sleep 0.3
-leaked_awk=$(pgrep -f "awk.*clean.*fflush" 2>/dev/null || true)
+leaked_awk=$(pgrep -f "awk.*clean_$$.*fflush" 2>/dev/null || true)
 leaked_fifo=$(ls /tmp/tmp.* 2>/dev/null | head -5 || true)
 if [[ -z "$leaked_awk" ]]; then
   pass "no leaked awk process"
@@ -119,8 +119,10 @@ fi
 # --- 7. SIGTERM kills cleanly ---
 echo "--- 5. Signal Handling ---"
 
+# A unique sleep duration: pgrep for a bare "sleep 60" matches other jobs on a CI machine.
+sig_sleep="60.0$$"
 # Use setsid to put color_prefix in its own session so SIGTERM doesn't reach us.
-setsid "$CP" "sig" "sleep 60" &>/dev/null &
+setsid "$CP" "sig" "sleep $sig_sleep" &>/dev/null &
 cp_pid=$!
 sleep 0.5
 # Send SIGTERM to color_prefix only (not the whole group).
@@ -136,11 +138,11 @@ fi
 
 # Ensure the sleep child was also killed.
 sleep 0.5
-if ! pgrep -f "sleep 60" &>/dev/null; then
+if ! pgrep -f "sleep $sig_sleep" &>/dev/null; then
   pass "child process killed on SIGTERM"
 else
-  fail "child process killed on SIGTERM" "sleep 60 still running"
-  pkill -f "sleep 60" 2>/dev/null || true
+  fail "child process killed on SIGTERM" "sleep $sig_sleep still running"
+  pkill -f "sleep $sig_sleep" 2>/dev/null || true
 fi
 
 # --- 8. Background children don't block exit ---
@@ -148,7 +150,8 @@ echo "--- 6. Fd Leak Prevention ---"
 
 start=$SECONDS
 code=0
-timeout 10 "$CP" "bg" "echo before; sleep 999 </dev/null >/dev/null 2>&1 & disown; echo after" &>/dev/null || code=$?
+bg_sleep="999.0$$"
+timeout 10 "$CP" "bg" "echo before; sleep $bg_sleep </dev/null >/dev/null 2>&1 & disown; echo after" &>/dev/null || code=$?
 elapsed=$((SECONDS - start))
 
 if [[ "$elapsed" -lt 8 ]]; then
@@ -156,7 +159,7 @@ if [[ "$elapsed" -lt 8 ]]; then
 else
   fail "exits promptly despite background child" "took ${elapsed}s"
 fi
-pkill -f "sleep 999" 2>/dev/null || true
+pkill -f "sleep $bg_sleep" 2>/dev/null || true
 
 # --- 9. Large output is fully flushed ---
 echo "--- 7. Output Flushing ---"

--- a/ci3/tests/denoise_test
+++ b/ci3/tests/denoise_test
@@ -23,9 +23,15 @@ fail() {
 
 echo "=== Denoise Test Suite ==="
 
+# A private output directory so the leak checks only see this test's tails: on a CI
+# machine every concurrent build runs denoise, so a global pgrep matches their tails too.
+denoise_tmp=$(mktemp -d)
+trap 'rm -rf "$denoise_tmp"' EXIT
+
 # Common env for denoise: enable it, disable redis, set narrow dot width for fast tests.
 DENOISE_ENV=(
   DENOISE=1
+  DENOISE_TMPDIR="$denoise_tmp"
   CI_REDIS_AVAILABLE=0
   DENOISE_WIDTH=4
   DUMP_FAIL=0
@@ -44,7 +50,7 @@ env "${DENOISE_ENV[@]}" "$ROOT/ci3/denoise" 'for i in $(seq 1 10); do echo line$
 # Check no tail -f is left from our denoise run.
 # Give a moment for any orphans to appear.
 sleep 0.5
-leftover=$(pgrep -f "tail --sleep-interval=0.2.*-f /tmp/" 2>/dev/null || true)
+leftover=$(pgrep -f "tail --sleep-interval=0.2.*-f $denoise_tmp/" 2>/dev/null || true)
 if [ -z "$leftover" ]; then
   pass "no leaked tail -f processes"
 else
@@ -81,7 +87,7 @@ wait $denoise_pid 2>/dev/null || true
 
 # After denoise exits, no tail should remain.
 sleep 0.3
-leftover_tail=$(pgrep -f "tail --sleep-interval=0.2.*-f /tmp/" 2>/dev/null || true)
+leftover_tail=$(pgrep -f "tail --sleep-interval=0.2.*-f $denoise_tmp/" 2>/dev/null || true)
 
 if [ "$tail_found" -eq 1 ]; then
   pass "tail -f was started during denoise"


### PR DESCRIPTION
On a shared CI machine every concurrent build runs denoise and color_prefix, so these tests' machine-global pgreps match other jobs' tails, awks and sleeps — wired into fast CI by #25326, they fail on any busy runner (and `pkill -f "sleep 60"` can kill other jobs' processes). denoise gains a `DENOISE_TMPDIR` override so its test watches a private directory; the color_prefix test uses per-run unique sleep durations and label. Verified red/green in the devbox with decoy processes simulating a busy machine.