### PR TITLE
fix(ci): authenticate CI launchers with OIDC

### DIFF
--- a/.github/workflows/barretenberg-nightly-debug-build.yml
+++ b/.github/workflows/barretenberg-nightly-debug-build.yml
@@ -9,6 +9,10 @@ concurrency:
   group: nightly-debug-build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   debug-build:
     if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
@@ -19,11 +23,17 @@ jobs:
         with:
           ref: next
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: nightly-debug-${{ github.run_id }}
+          role-duration-seconds: 7200
+
       - name: Run debug build
         timeout-minutes: 120
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/barretenberg-nightly-slow-tests.yml
+++ b/.github/workflows/barretenberg-nightly-slow-tests.yml
@@ -9,6 +9,10 @@ concurrency:
   group: nightly-slow-tests-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   slow-tests:
     if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
@@ -19,11 +23,17 @@ jobs:
         with:
           ref: next
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: nightly-slow-${{ github.run_id }}
+          role-duration-seconds: 7200
+
       - name: Run slow tests
         timeout-minutes: 120
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -103,16 +104,19 @@ jobs:
           mapfile -t LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]')
           ./.github/ci3_labels_to_env.sh "${LABELS[@]}"
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: ci3-external-${{ github.run_id }}
+          role-duration-seconds: 7200
+
       - name: Run
         env:
           REF_NAME: repo-fork/${{ github.repository }}/${{ github.head_ref }}
           # We only test on amd64.
           ARCH: amd64
-          # We need to pass these creds to start the AWS ec2 instance.
-          # They are not injected into that instance. Instead, it has minimal
-          # creds for being able to upload to cache.
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           # DO NOT allow build instance key access to external jobs.
@@ -129,9 +133,6 @@ jobs:
         env:
           SHOULD_SQUASH_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge') && '1' || '0' }}
           BENCH_UPLOAD: "0"
-          # For updating success cache.
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary

- migrate the Barretenberg debug and slow-test nightlies from deleted static AWS keys to the existing CI3 OIDC role
- migrate authorized external-contributor CI to the same short-lived launcher credentials
- leave Socket automation unchanged because it has separate ownership and lifecycle

## External CI trust boundary

External CI uses pull_request_target, so the workflow definition comes from the base branch. Before OIDC is configured, it verifies the label was applied by an authorized watcher and rejects fork changes to .github, ci3, ci.sh, or scripts. Only those verified runner-side scripts can access the launcher credentials. Fork code executes on EC2 under its separate restricted instance profile; the runner OIDC credentials and token-request environment are not forwarded.

## Context

Normal CI3 already authenticates through AWS_OIDC_ROLE_ARN. These launchers retained AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY references after those repository secrets were removed, causing NoCredentials before a build instance could be requested.

## Verification

- all three edited workflows parse successfully with yq
- git diff --check passes
- configuration mirrors the OIDC setup in .github/workflows/ci3.yml
- audited the runner-to-EC2 path to confirm OIDC credentials are not forwarded to fork code