### PR TITLE
chore: revert the operator docs from #25292 (in-tree docs/ is gone)

### DIFF
--- a/docs/docs-operate/operators/prerequisites.md
+++ b/docs/docs-operate/operators/prerequisites.md
@@ -54,15 +54,6 @@ The Aztec toolchain provides CLI utilities for key generation, validator registr
 - Generating validator keystores and creating staking registration data (`aztec validator-keys`)
 - Registering sequencers on L1 (`aztec add-l1-validator`)
 
-The toolchain requires Node.js 20.10 or later. Nodes themselves do not need Node.js on the host, since they run in Docker containers. Install Node.js using [nvm](https://github.com/nvm-sh/nvm):
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-source ~/.nvm/nvm.sh
-nvm install --lts
-nvm alias default node
-```
-
 Install the Aztec toolchain using the official installer:
 
 ```bash

--- a/docs/docs-operate/operators/setup/staking-provider.md
+++ b/docs/docs-operate/operators/setup/staking-provider.md
@@ -207,10 +207,6 @@ This command automatically:
 
 The public keystore file (`keyN_staker_output.json`) contains the data you'll use for provider registration.
 
-:::warning Key security
-The private keystore (`keyN.json`) and the mnemonic that generated it must stay secret. Anyone holding them can commit slashable offenses and redirect block rewards; they cannot steal the delegated stake itself. If you lose them, the keys cannot be rotated: the sequencer stays offline and is slashed for inactivity until it is ejected. At most 5% of the delegated stake can be slashed before ejection, but ejection permanently ends the delegation (see [Slashing](../concepts/slashing.md)).
-:::
-
 For more details on keystore creation, see the [Sequencer Setup Guide](./sequencer-setup.md#generating-keys).
 
 ### Building the Registration Command

--- a/docs/network_versioned_docs/version-v5.2.0/operators/prerequisites.md
+++ b/docs/network_versioned_docs/version-v5.2.0/operators/prerequisites.md
@@ -53,15 +53,6 @@ The Aztec toolchain provides CLI utilities for key generation, validator registr
 - Generating validator keystores and creating staking registration data (`aztec validator-keys`)
 - Registering sequencers on L1 (`aztec add-l1-validator`)
 
-The toolchain requires Node.js 20.10 or later. Nodes themselves do not need Node.js on the host, since they run in Docker containers. Install Node.js using [nvm](https://github.com/nvm-sh/nvm):
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-source ~/.nvm/nvm.sh
-nvm install --lts
-nvm alias default node
-```
-
 Install the Aztec toolchain using the official installer:
 
 ```bash

--- a/docs/network_versioned_docs/version-v5.2.0/operators/setup/staking-provider.md
+++ b/docs/network_versioned_docs/version-v5.2.0/operators/setup/staking-provider.md
@@ -195,10 +195,6 @@ This command automatically:
 
 The public keystore file (`keyN_staker_output.json`) contains the data you'll use for provider registration.
 
-:::warning Key security
-The private keystore (`keyN.json`) and the mnemonic that generated it must stay secret. Anyone holding them can commit slashable offenses and redirect block rewards; they cannot steal the delegated stake itself. If you lose them, the keys cannot be rotated: the sequencer stays offline and is slashed for inactivity until it is ejected. At most 5% of the delegated stake can be slashed before ejection, but ejection permanently ends the delegation (see [Slashing](../concepts/slashing.md)).
-:::
-
 For more details on keystore creation, see the [Sequencer Setup Guide](./sequencer-setup.md#generating-keys).
 
 ### Building the Registration Command


### PR DESCRIPTION
Unblocks #25375.

#25292 edited four files under the in-tree `docs/`, which #25321 deleted (those components are now built from the `labs/` submodule). Every merge of `next` into the train therefore hits a modify/delete conflict on:

- `docs/docs-operate/operators/prerequisites.md`
- `docs/docs-operate/operators/setup/staking-provider.md`
- `docs/network_versioned_docs/version-v5.2.0/operators/prerequisites.md`
- `docs/network_versioned_docs/version-v5.2.0/operators/setup/staking-provider.md`

Reverting restores those files to their pre-#25292 content, so `next`'s deletion applies cleanly and the automated next-to-train merge succeeds.

The docs content is re-landed against `docs/` in aztec-node: aztec-labs-eng/aztec-node#112.