### PR TITLE
fix: repoint the archiver tips cache before a write commits

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -1,6 +1,7 @@
 import { CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE } from '@aztec/constants';
 import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
@@ -528,6 +529,62 @@ describe('ArchiverDataStoreUpdater', () => {
       expect(tipsAfter).toEqual(tipsBefore);
 
       addProposedBlockSpy.mockRestore();
+    });
+
+    it('serves tips consistent with the store while a promotion is committing', async () => {
+      const initialBlockHash = await BlockHeader.empty().hash();
+      const tipsCache = new L2TipsCache(store.blocks, initialBlockHash);
+      const updaterWithCache = new ArchiverDataStoreUpdater(store, tipsCache);
+
+      const block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(100),
+      });
+      await updaterWithCache.addProposedBlock(block);
+      await updaterWithCache.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(1),
+        header: CheckpointHeader.empty(),
+        startBlock: BlockNumber(1),
+        blockCount: 1,
+        totalManaUsed: 0n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      // Park the promotion transaction after it has committed but before the updater regains control, which is
+      // the window a concurrent reader can land in.
+      const { promise: committed, resolve: markCommitted } = promiseWithResolvers<void>();
+      const { promise: gate, resolve: openGate } = promiseWithResolvers<void>();
+      const realTransactionAsync = store.db.transactionAsync.bind(store.db);
+      const transactionSpy = jest.spyOn(store.db, 'transactionAsync').mockImplementationOnce(async callback => {
+        const result = await realTransactionAsync(callback);
+        markCommitted();
+        await gate;
+        return result;
+      });
+
+      const publishedCheckpoint = makePublishedCheckpoint(makeCheckpoint([block]), 10);
+      const promotion = updaterWithCache.addCheckpoints([], undefined, {
+        l1: publishedCheckpoint.l1,
+        attestations: publishedCheckpoint.attestations,
+        checkpoint: publishedCheckpoint,
+      });
+
+      await committed;
+      const tipsPromise = tipsCache.getL2Tips();
+      const proposed = await store.blocks.getLastProposedCheckpoint();
+      openGate();
+      const tips = await tipsPromise;
+      await promotion;
+
+      // The proposed-checkpoint frontier and the proposed tip must describe the same chain: a reader that sees
+      // the promotion in the store must not be served tips from before it.
+      const frontier = proposed
+        ? BlockNumber.add(proposed.startBlock, proposed.blockCount - 1)
+        : tips.checkpointed.block.number;
+      expect(frontier).toEqual(tips.proposed.number);
+
+      transactionSpy.mockRestore();
     });
   });
 

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -50,6 +50,19 @@ export class ArchiverDataStoreUpdater {
   ) {}
 
   /**
+   * Runs the given body in a store transaction and keeps the tips cache consistent with it: the cache is
+   * pointed at the post-commit state before the write commits (see {@link L2TipsCache.refreshAfter}), so a
+   * concurrent reader cannot pair pre-commit cached tips with post-commit store reads. Awaits both promises
+   * together so a failed write cannot leave the refresh dangling as an unhandled rejection.
+   */
+  private async writeAndRefreshTips<T>(body: () => Promise<T>): Promise<T> {
+    const write = this.stores.db.transactionAsync(body);
+    const refreshed = this.l2TipsCache?.refreshAfter(write);
+    const [result] = await Promise.all([write, refreshed]);
+    return result;
+  }
+
+  /**
    * Adds a proposed block to the store with contract class/instance extraction from logs.
    * This is an uncheckpointed block that has been proposed by the sequencer but not yet included in a checkpoint on L1.
    * Extracts ContractClassPublished, ContractInstancePublished, ContractInstanceUpdated events from the block logs.
@@ -62,7 +75,7 @@ export class ArchiverDataStoreUpdater {
     block: L2Block,
     pendingChainValidationStatus?: ValidateCheckpointResult,
   ): Promise<boolean> {
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       await this.stores.blocks.addProposedBlock(block);
 
       const opResults = await Promise.all([
@@ -77,8 +90,6 @@ export class ArchiverDataStoreUpdater {
 
       return opResults.every(Boolean);
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   /**
@@ -119,7 +130,7 @@ export class ArchiverDataStoreUpdater {
       validateCheckpoint(promoteProposed.checkpoint.checkpoint, validateOpts);
     }
 
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       // Before adding checkpoints, check for conflicts with local blocks if any
       const { prunedBlocks, lastAlreadyInsertedBlockNumber } = await this.pruneMismatchingLocalBlocks(checkpoints);
 
@@ -156,16 +167,12 @@ export class ArchiverDataStoreUpdater {
 
       return { prunedBlocks, lastAlreadyInsertedBlockNumber };
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   public async addProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput) {
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       await this.stores.blocks.addProposedCheckpoint(proposedCheckpoint);
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   /**
@@ -263,7 +270,7 @@ export class ArchiverDataStoreUpdater {
    * @throws Error if any block to be removed is checkpointed.
    */
   public async removeUncheckpointedBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       // Verify we're only removing uncheckpointed blocks
       const lastCheckpointedBlockNumber = await this.stores.blocks.getCheckpointedL2BlockNumber();
       if (blockNumber < lastCheckpointedBlockNumber) {
@@ -277,8 +284,6 @@ export class ArchiverDataStoreUpdater {
 
       return prunedBlocks;
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   /**
@@ -292,7 +297,7 @@ export class ArchiverDataStoreUpdater {
    * @throws Error if any block to be removed is checkpointed.
    */
   public async removeBlocksWithoutProposedCheckpointAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       // Verify we're only removing uncheckpointed blocks
       const lastCheckpointedBlockNumber = await this.stores.blocks.getProposedCheckpointL2BlockNumber();
       if (blockNumber < lastCheckpointedBlockNumber) {
@@ -303,8 +308,6 @@ export class ArchiverDataStoreUpdater {
 
       return await this.removeBlocksAfter(blockNumber);
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   /**
@@ -347,7 +350,7 @@ export class ArchiverDataStoreUpdater {
    * @returns True if the operation is successful.
    */
   public async removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<boolean> {
-    const result = await this.stores.db.transactionAsync(async () => {
+    return await this.writeAndRefreshTips(async () => {
       const { blocksRemoved = [] } = await this.stores.blocks.removeCheckpointsAfter(checkpointNumber);
 
       const opResults = await Promise.all([
@@ -360,8 +363,6 @@ export class ArchiverDataStoreUpdater {
 
       return opResults.every(Boolean);
     });
-    await this.l2TipsCache?.refresh();
-    return result;
   }
 
   /**
@@ -369,10 +370,9 @@ export class ArchiverDataStoreUpdater {
    * @param checkpointNumber - The checkpoint number to set as proven.
    */
   public async setProvenCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
-    await this.stores.db.transactionAsync(async () => {
+    await this.writeAndRefreshTips(async () => {
       await this.stores.blocks.setProvenCheckpointNumber(checkpointNumber);
     });
-    await this.l2TipsCache?.refresh();
   }
 
   /**
@@ -380,10 +380,9 @@ export class ArchiverDataStoreUpdater {
    * @param checkpointNumber - The checkpoint number to set as finalized.
    */
   public async setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
-    await this.stores.db.transactionAsync(async () => {
+    await this.writeAndRefreshTips(async () => {
       await this.stores.blocks.setFinalizedCheckpointNumber(checkpointNumber);
     });
-    await this.l2TipsCache?.refresh();
   }
 
   /** Extracts and stores contract data from a single block. */

--- a/yarn-project/archiver/src/store/l2_tips_cache.test.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.test.ts
@@ -55,12 +55,74 @@ describe('L2TipsCache', () => {
     });
 
     // Without this the reload failure has no awaiter and surfaces as an unhandled rejection instead.
-    it('surfaces a failed post-commit reload to the caller', async () => {
+    it('surfaces a failed post-commit reload to the caller and recovers on the next read', async () => {
+      const tips = {} as L2Tips;
       const failure = new Error('store read failed');
-      const getL2TipsData = jest.fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>().mockRejectedValue(failure);
+      const getL2TipsData = jest
+        .fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>()
+        .mockRejectedValueOnce(failure)
+        .mockResolvedValue(tips);
       const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
 
       await expect(cache.refreshAfter(Promise.resolve())).rejects.toBe(failure);
+      // A transient reload failure must not be served to every subsequent reader: the cache drops the
+      // rejected promise and the next read retries from the store.
+      await expect(cache.getL2Tips()).resolves.toBe(tips);
+    });
+
+    it('recovers from a failed first load', async () => {
+      const tips = {} as L2Tips;
+      const getL2TipsData = jest
+        .fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>()
+        .mockRejectedValueOnce(new Error('store read failed'))
+        .mockResolvedValue(tips);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+
+      await expect(cache.getL2Tips()).rejects.toThrow('store read failed');
+      await expect(cache.getL2Tips()).resolves.toBe(tips);
+    });
+
+    // Store writes commit in registration order (single LMDB writer queue), so the cache installed by the
+    // later registration must win regardless of how the earlier write settles.
+    it('ends at the newest state across chained refreshes', async () => {
+      const tipsAfterA = { proposed: { number: 1 } } as unknown as L2Tips;
+      const tipsAfterB = { proposed: { number: 2 } } as unknown as L2Tips;
+      const getL2TipsData = jest
+        .fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>()
+        .mockResolvedValueOnce(tipsAfterA)
+        .mockResolvedValue(tipsAfterB);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+
+      const { promise: writeA, resolve: commitA } = promiseWithResolvers<void>();
+      const { promise: writeB, resolve: commitB } = promiseWithResolvers<void>();
+      const refreshedA = cache.refreshAfter(writeA);
+      const refreshedB = cache.refreshAfter(writeB);
+      commitA();
+      commitB();
+      await Promise.all([refreshedA, refreshedB]);
+
+      await expect(cache.getL2Tips()).resolves.toBe(tipsAfterB);
+    });
+
+    it('ends at the survivor state when the first of two chained writes fails', async () => {
+      const initialTips = { proposed: { number: 0 } } as unknown as L2Tips;
+      const tipsAfterB = { proposed: { number: 2 } } as unknown as L2Tips;
+      const getL2TipsData = jest
+        .fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>()
+        .mockResolvedValueOnce(initialTips)
+        .mockResolvedValue(tipsAfterB);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+      await cache.getL2Tips();
+
+      const { promise: writeA, reject: abortA } = promiseWithResolvers<void>();
+      const { promise: writeB, resolve: commitB } = promiseWithResolvers<void>();
+      const refreshedA = cache.refreshAfter(writeA);
+      const refreshedB = cache.refreshAfter(writeB);
+      abortA(new Error('write aborted'));
+      commitB();
+      await Promise.all([refreshedA, refreshedB]);
+
+      await expect(cache.getL2Tips()).resolves.toBe(tipsAfterB);
     });
   });
 });

--- a/yarn-project/archiver/src/store/l2_tips_cache.test.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.test.ts
@@ -1,3 +1,4 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { BlockHash, type L2Tips } from '@aztec/stdlib/block';
 
 import { jest } from '@jest/globals';
@@ -17,8 +18,49 @@ describe('L2TipsCache', () => {
     await cache.getL2Tips();
     expect(getL2TipsData).toHaveBeenCalledTimes(1);
 
-    await cache.refresh();
+    await cache.refreshAfter(Promise.resolve());
     await cache.getL2Tips();
     expect(getL2TipsData).toHaveBeenCalledTimes(2);
+  });
+
+  describe('refreshAfter', () => {
+    it('serves the post-commit tips to readers that arrive before the write resolves', async () => {
+      const staleTips = { proposed: { number: 1 } } as unknown as L2Tips;
+      const freshTips = { proposed: { number: 2 } } as unknown as L2Tips;
+      const getL2TipsData = jest
+        .fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>()
+        .mockResolvedValueOnce(staleTips)
+        .mockResolvedValue(freshTips);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+      await cache.getL2Tips();
+
+      const { promise: write, resolve: commit } = promiseWithResolvers<void>();
+      const refreshed = cache.refreshAfter(write);
+      const readDuringWrite = cache.getL2Tips();
+      commit();
+
+      await expect(readDuringWrite).resolves.toBe(freshTips);
+      await refreshed;
+    });
+
+    it('keeps the previous tips when the write fails', async () => {
+      const tips = {} as L2Tips;
+      const getL2TipsData = jest.fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>().mockResolvedValue(tips);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+      await cache.getL2Tips();
+
+      await expect(cache.refreshAfter(Promise.reject(new Error('write aborted')))).resolves.toBeUndefined();
+      await expect(cache.getL2Tips()).resolves.toBe(tips);
+      expect(getL2TipsData).toHaveBeenCalledTimes(1);
+    });
+
+    // Without this the reload failure has no awaiter and surfaces as an unhandled rejection instead.
+    it('surfaces a failed post-commit reload to the caller', async () => {
+      const failure = new Error('store read failed');
+      const getL2TipsData = jest.fn<(genesisBlockHash: BlockHash) => Promise<L2Tips>>().mockRejectedValue(failure);
+      const cache = new L2TipsCache({ getL2TipsData } as unknown as BlockStore, BlockHash.random());
+
+      await expect(cache.refreshAfter(Promise.resolve())).rejects.toBe(failure);
+    });
   });
 });

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -4,9 +4,8 @@ import type { BlockStore } from './block_store.js';
 
 /**
  * In-memory cache for L2 chain tips (proposed, checkpointed, proven, finalized).
- * Populated from the BlockStore on first access, then kept up-to-date by the ArchiverDataStoreUpdater.
- * Refresh calls should happen *after* the store transaction that mutates block data has committed,
- * so the cache loads from committed state and is never replaced if the writer aborts.
+ * Populated from the BlockStore on first access, then kept up-to-date by the ArchiverDataStoreUpdater
+ * calling {@link refreshAfter} around every store transaction that mutates block data.
  */
 export class L2TipsCache {
   #tipsPromise: Promise<L2Tips> | undefined;
@@ -27,9 +26,21 @@ export class L2TipsCache {
     return (this.#tipsPromise ??= this.blockStore.getL2TipsData(this.initialBlockHash));
   }
 
-  /** Reloads the L2 tips from the block store. Should be called after the writer transaction has committed. */
-  public async refresh(): Promise<void> {
-    this.#tipsPromise = this.blockStore.getL2TipsData(this.initialBlockHash);
-    await this.#tipsPromise;
+  /**
+   * Points the cache at the state the given write will leave behind, before that write commits. Readers that
+   * arrive while it is in flight then wait for committed state instead of being served tips from before it —
+   * which would otherwise pair stale tips with post-commit reads that go straight to the store. If the write
+   * fails the cache keeps the tips it had, since nothing was committed.
+   * @param write - The writer transaction whose committed state the cache should reflect.
+   * @returns A promise that settles once the reload has run; callers must await it so a failed reload
+   * surfaces to the writer instead of becoming an unhandled rejection.
+   */
+  public refreshAfter(write: Promise<unknown>): Promise<void> {
+    const previousTips = this.#tipsPromise;
+    this.#tipsPromise = write.then(
+      () => this.blockStore.getL2TipsData(this.initialBlockHash),
+      () => previousTips ?? this.blockStore.getL2TipsData(this.initialBlockHash),
+    );
+    return this.#tipsPromise.then(() => {});
   }
 }

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -6,6 +6,10 @@ import type { BlockStore } from './block_store.js';
  * In-memory cache for L2 chain tips (proposed, checkpointed, proven, finalized).
  * Populated from the BlockStore on first access, then kept up-to-date by the ArchiverDataStoreUpdater
  * calling {@link refreshAfter} around every store transaction that mutates block data.
+ *
+ * Correctness relies on store writes committing in {@link refreshAfter} registration order ("last
+ * registration wins" must mean "last commit wins"), which holds because the LMDB store serializes write
+ * transactions through a single writer queue.
  */
 export class L2TipsCache {
   #tipsPromise: Promise<L2Tips> | undefined;
@@ -23,7 +27,7 @@ export class L2TipsCache {
 
   /** Returns the cached L2 tips. Loads from the block store on first call. */
   public getL2Tips(): Promise<L2Tips> {
-    return (this.#tipsPromise ??= this.blockStore.getL2TipsData(this.initialBlockHash));
+    return this.#tipsPromise ?? this.#track(this.blockStore.getL2TipsData(this.initialBlockHash));
   }
 
   /**
@@ -37,10 +41,24 @@ export class L2TipsCache {
    */
   public refreshAfter(write: Promise<unknown>): Promise<void> {
     const previousTips = this.#tipsPromise;
-    this.#tipsPromise = write.then(
+    const nextTips = write.then(
       () => this.blockStore.getL2TipsData(this.initialBlockHash),
       () => previousTips ?? this.blockStore.getL2TipsData(this.initialBlockHash),
     );
-    return this.#tipsPromise.then(() => {});
+    return this.#track(nextTips).then(() => {});
+  }
+
+  /**
+   * Installs a tips promise as the cache, dropping it again if it rejects so the next read retries from the
+   * store — a transient load failure must not be served to every reader until the next write comes along.
+   */
+  #track(tips: Promise<L2Tips>): Promise<L2Tips> {
+    this.#tipsPromise = tips;
+    tips.catch(() => {
+      if (this.#tipsPromise === tips) {
+        this.#tipsPromise = undefined;
+      }
+    });
+    return tips;
   }
 }


### PR DESCRIPTION
Split out from #25357.

## The race

The archiver serves `getL2Tips()` from an in-memory cache (`L2TipsCache`) that is reloaded *after* each store write commits, while `getProposedCheckpointData()` reads the store directly. Between a write committing and the cache reload finishing, a concurrent reader can pair pre-commit cached tips with post-commit store reads. Concretely: a checkpoint promotion commits, a reader then sees the promotion gone from `getProposedCheckpointData()` but still-stale tips, and misclassifies the chain state — e.g. `NodePublicCallsSimulator` deriving next-block globals concludes the next block continues a checkpoint that is in fact already checkpointed, mis-pricing its fee.

#25357 adds reader-side detection (read tips, read the proposed checkpoint, re-read tips, retry on movement), which catches any write that moves the tips between the two halves — but both tips reads can land inside the commit-to-reload window and hit the same stale cache, so the reader-side check alone cannot close the race. This PR closes it from the writer side.

## The fix

- `L2TipsCache.refreshAfter(write)` points the cache at `write.then(reload)` **before** the write commits. Registration happens synchronously in the same tick as `transactionAsync`, so the commit cannot beat it: any reader arriving after the write starts waits for post-commit state instead of being served pre-commit tips. If the write fails, the cache keeps the tips it had (nothing was committed).
- A rejected tips load (a failed post-commit reload, or a failed first load) is dropped from the cache after the failure surfaces, so the next read retries from the store — one transient failure cannot leave every subsequent `getL2Tips()` rejecting until the next write happens to come along.
- Every store mutation in `ArchiverDataStoreUpdater` goes through a single `writeAndRefreshTips` helper that wraps the transaction and awaits the write and the reload together (`Promise.all`), so a failed write cannot leave the reload dangling as an unhandled rejection. The plain post-commit `refresh()` is deleted (no callers left).
- Correctness relies on store writes committing in registration order, which holds because the LMDB store serializes write transactions through a single writer queue; this is now documented on the class.

## Tests

- `l2_tips_cache.test.ts`: a reader arriving before the write resolves gets the post-commit tips; a failed write keeps the previous tips; a failed post-commit reload surfaces to the caller and the next read recovers; a failed first load recovers; chained refreshes end at the newest state, including when the first of two writes fails.
- `data_store_updater.test.ts`: parks a checkpoint promotion in the commit-to-return window and asserts a concurrent reader is served tips consistent with the store (the proposed-checkpoint frontier and the proposed tip describe the same chain).

## Note

A-1897 tracks the deeper fix: one atomic `getChainStatus()` snapshot (tips + proposed checkpoint read in a single store transaction, cached in memory), which would make both the reader-side retry in #25357 and this writer-side mechanism unnecessary. If A-1897 lands soon, this PR can be dropped in its favor; until then this closes the live race.
