### PR TITLE
fix: drive the fee provider from the archiver's L1 sync point

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -702,6 +702,8 @@ describe('Archiver Sync', () => {
       expect(write).toHaveBeenCalled();
       expect(anchor.mock.invocationCallOrder[0]).toBeLessThan(write.mock.invocationCallOrder[0]);
       expect((await subject.getL2Frontier()).l1SyncPoint?.blockNumber).toEqual(105n);
+      // The standalone accessor is what the fee provider follows, so it must report the same anchor.
+      expect(await subject.getL1SyncPoint()).toEqual((await subject.getL2Frontier()).l1SyncPoint);
 
       await subject.stop();
     });

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -15,6 +15,7 @@ import { DateProvider, elapsed } from '@aztec/foundation/timer';
 import {
   type ArchiverEmitter,
   type BlockHash,
+  type L1SyncPoint,
   L2Block,
   type L2BlockSink,
   L2BlockSourceEvents,
@@ -719,6 +720,10 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
 
   public getL2Frontier(): Promise<L2Frontier> {
     return this.l2FrontierCache.getL2Frontier();
+  }
+
+  public getL1SyncPoint(): Promise<L1SyncPoint | undefined> {
+    return Promise.resolve(this.l2FrontierCache.getL1SyncPoint());
   }
 
   public async rollbackTo(targetL2BlockNumber: BlockNumber): Promise<void> {

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -19,6 +19,7 @@ import {
   Body,
   type CheckpointQuery,
   type CheckpointsQuery,
+  type L1SyncPoint,
   L2Block,
   type L2Frontier,
   type L2Tips,
@@ -143,6 +144,8 @@ export abstract class ArchiverDataSourceBase
   abstract getL2Tips(): Promise<L2Tips>;
 
   abstract getL2Frontier(): Promise<L2Frontier>;
+
+  abstract getL1SyncPoint(): Promise<L1SyncPoint | undefined>;
 
   abstract getSyncedL2SlotNumber(): Promise<SlotNumber | undefined>;
 

--- a/yarn-project/archiver/src/store/l2_frontier_cache.ts
+++ b/yarn-project/archiver/src/store/l2_frontier_cache.ts
@@ -31,6 +31,14 @@ export class L2FrontierCache {
     return (this.#frontierPromise ??= this.#load());
   }
 
+  /**
+   * Returns the L1 block the frontier is anchored to, without loading the snapshot. Cheap enough to poll:
+   * it is a plain field read, never an L1 or store call.
+   */
+  public getL1SyncPoint(): L1SyncPoint | undefined {
+    return this.#l1SyncPoint;
+  }
+
   /** Returns the cached L2 tips. */
   public async getL2Tips(): Promise<L2Tips> {
     return (await this.getL2Frontier()).tips;

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -24,6 +24,7 @@ import {
   type CheckpointsQuery,
   GENESIS_BLOCK_HEADER_HASH,
   GENESIS_CHECKPOINT_HEADER_HASH,
+  type L1SyncPoint,
   L2Block,
   type L2BlockSource,
   type L2Frontier,
@@ -61,6 +62,9 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
   private initialHeaderHash: BlockHash = GENESIS_BLOCK_HEADER_HASH;
   private genesisArchiveRoot?: Fr;
   private genesisBlock?: L2Block;
+
+  /** L1 block the mock claims to be synced to; tests that exercise L1-pinned reads set it. */
+  public l1SyncPoint: L1SyncPoint | undefined = undefined;
 
   private log = createLogger('archiver:mock_l2_block_source');
 
@@ -426,6 +430,10 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     };
   }
 
+  getL1SyncPoint(): Promise<L1SyncPoint | undefined> {
+    return Promise.resolve(this.l1SyncPoint);
+  }
+
   // The mock never holds proposed checkpoints and its pending chain is always valid, so the frontier is just
   // the tips plus the headers of the latest block and the checkpoint holding the checkpointed tip.
   async getL2Frontier(): Promise<L2Frontier> {
@@ -434,7 +442,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return {
       tips,
       proposedCheckpoint: undefined,
-      l1SyncPoint: undefined,
+      l1SyncPoint: this.l1SyncPoint,
       latestBlockHeader: this.l2Blocks[tips.proposed.number - 1]?.header,
       checkpointedCheckpoint: checkpointed
         ? { header: checkpointed.header, l1: this.mockL1DataForCheckpoint(checkpointed) }

--- a/yarn-project/aztec-node/src/aztec-node/fee_quote_vs_simulation.integration.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/fee_quote_vs_simulation.integration.test.ts
@@ -7,6 +7,7 @@ import { deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contract
 import { type Anvil, EthCheatCodes, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { maxBy } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -14,7 +15,14 @@ import { createLogger } from '@aztec/foundation/log';
 import { ManualDateProvider } from '@aztec/foundation/timer';
 import type { P2P } from '@aztec/p2p';
 import { FeeProviderImpl, GlobalVariableBuilder, type GlobalVariableBuilderConfig } from '@aztec/sequencer-client';
-import { type BlockData, BlockHash, L2Block, type L2BlockSource, type L2Tips } from '@aztec/stdlib/block';
+import {
+  type BlockData,
+  BlockHash,
+  type L1SyncPoint,
+  L2Block,
+  type L2BlockSource,
+  type L2Tips,
+} from '@aztec/stdlib/block';
 import { L1PublishedData, type ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
@@ -70,6 +78,8 @@ describe('fee quote vs public simulation', () => {
 
   let feeProvider: FeeProviderImpl;
   let node: AztecNodeService;
+  /** L1 block the mocked archiver claims to be synced to; the fee provider prices at exactly this block. */
+  let l1SyncPoint: L1SyncPoint;
 
   /** First slot at which the stepped-down oracle value applies. */
   let changeSlot: SlotNumber;
@@ -87,8 +97,12 @@ describe('fee quote vs public simulation', () => {
   /** Stable per-block hash, so tips and the block-data mock agree on identity for hash lookups. */
   const blockHashOf = (blockNumber: BlockNumber): BlockHash => new BlockHash(new Fr(1000 + blockNumber));
 
-  const makeTips = (args: { proposed: BlockNumber; checkpointedBlock: BlockNumber }): L2Tips => {
-    const checkpointId = { number: PENDING_CHECKPOINT, hash: '0xc1' };
+  const makeTips = (args: {
+    proposed: BlockNumber;
+    checkpointedBlock: BlockNumber;
+    checkpointNumber?: CheckpointNumber;
+  }): L2Tips => {
+    const checkpointId = { number: args.checkpointNumber ?? PENDING_CHECKPOINT, hash: '0xc1' };
     const checkpointedBlockId = {
       number: args.checkpointedBlock,
       hash: blockHashOf(args.checkpointedBlock).toString(),
@@ -101,11 +115,22 @@ describe('fee quote vs public simulation', () => {
     };
   };
 
+  /**
+   * Points the mocked archiver at anvil's head, as a sync pass does. The fee provider follows this value and
+   * never polls L1 for a head of its own, so nothing moves its view until this is called again.
+   */
+  const syncArchiverToL1Head = async (): Promise<void> => {
+    const block = await publicClient.getBlock({ blockTag: 'latest' });
+    l1SyncPoint = { blockNumber: block.number, blockHash: Buffer32.fromString(block.hash) };
+    blockSource.getL1SyncPoint.mockResolvedValue(l1SyncPoint);
+  };
+
   /** Points the block source at one atomic L2 frontier snapshot, the single read the simulator makes. */
   const mockL2Frontier = (args: {
     proposed: BlockNumber;
     checkpointedBlock: BlockNumber;
     checkpointedTipSlot: SlotNumber;
+    checkpointNumber?: CheckpointNumber;
     proposedCheckpoint?: ProposedCheckpointData;
     /** Globals of the proposed tip's header, as the archiver reads them in the same snapshot. */
     latestBlockGlobals?: { slotNumber: SlotNumber; gasFees: GasFees };
@@ -113,7 +138,7 @@ describe('fee quote vs public simulation', () => {
     blockSource.getL2Frontier.mockResolvedValue({
       tips: makeTips(args),
       proposedCheckpoint: args.proposedCheckpoint,
-      l1SyncPoint: undefined,
+      l1SyncPoint,
       latestBlockHeader: args.latestBlockGlobals
         ? makeBlockData(args.proposed, args.latestBlockGlobals.slotNumber, args.latestBlockGlobals.gasFees).header
         : undefined,
@@ -148,8 +173,8 @@ describe('fee quote vs public simulation', () => {
   const startNodeAt = async (nodeClockSlotStart: bigint) => {
     dateProvider.setTime(Number(nodeClockSlotStart) * 1000);
 
-    feeProvider = new FeeProviderImpl(dateProvider, publicClient, globalVariableBuilderConfig);
-    // Long polling interval: the quote must stay pinned to the clock this scenario set.
+    feeProvider = new FeeProviderImpl(dateProvider, publicClient, globalVariableBuilderConfig, blockSource);
+    // Long polling interval: every refresh in these scenarios is driven explicitly, as an archiver pass would.
     await feeProvider.start(60_000);
 
     const config: AztecNodeConfig = {
@@ -287,7 +312,7 @@ describe('fee quote vs public simulation', () => {
     await anvil?.stop().catch(err => createLogger('cleanup').error(`Error stopping anvil`, err));
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     blockSource = mock<L2BlockSource>();
     worldStateSynchronizer = mock<WorldStateSynchronizer>();
     l1ToL2MessageSource = mock<L1ToL2MessageSource>();
@@ -300,6 +325,7 @@ describe('fee quote vs public simulation', () => {
     // The mocked archiver reports block numbers the fresh world state does not have, so every fork is taken
     // at its (empty) latest block.
     worldStateSynchronizer.fork.mockImplementation(() => worldState.fork());
+    await syncArchiverToL1Head();
   });
 
   afterEach(async () => {
@@ -378,5 +404,57 @@ describe('fee quote vs public simulation', () => {
 
     expect(output.globalVariables.slotNumber).toEqual(SlotNumber(changeSlot + 1));
     expect(output.globalVariables.gasFees.feePerL2Gas).toEqual(lowFee);
+  }, 120_000);
+
+  it('keeps quote and simulation on the archiver L1 view as a checkpoint lands', async () => {
+    await startNodeAt(tsOf(changeSlot));
+    mockL2Frontier({
+      proposed: BlockNumber(1),
+      checkpointedBlock: BlockNumber(1),
+      checkpointedTipSlot: SlotNumber(changeSlot - 1),
+      latestBlockGlobals: { slotNumber: SlotNumber(changeSlot - 1), gasFees: GasFees.empty() },
+    });
+
+    const before = await node.getPredictedMinFees(ManaUsageEstimate.Limit);
+    expect(before[0].feePerL2Gas).toEqual(lowFee);
+
+    // A checkpoint lands on L1 at slot `changeSlot + 1`, quartering `ethPerFeeAsset` so the fee it freezes in
+    // is far above the one the previous L1 view priced, and anvil mines on past it.
+    const previousFeeHeader = (await rollup.getCheckpoint(PENDING_CHECKPOINT)).feeHeader;
+    const landedCheckpoint = CheckpointNumber(PENDING_CHECKPOINT + 1);
+    await rollupCheatCodes.setPendingCheckpoint(landedCheckpoint, SlotNumber(changeSlot + 1), {
+      ...previousFeeHeader,
+      ethPerFeeAsset: previousFeeHeader.ethPerFeeAsset / 4n,
+    });
+    await rollupCheatCodes.markAsProven(landedCheckpoint);
+    await cheatCodes.mine();
+
+    const landedFee = await feeAt(SlotNumber(changeSlot + 2));
+    expect(landedFee).toBeGreaterThan((lowFee * 3n) / 2n);
+
+    // L1's head has moved, but the archiver has not run a pass. The provider prices at the L1 block the
+    // simulator still plans from, so a refresh here changes nothing.
+    await feeProvider.refresh();
+    const beforeArchiverPass = await node.getPredictedMinFees(ManaUsageEstimate.Limit);
+    expect(beforeArchiverPass[0].feePerL2Gas).toEqual(lowFee);
+
+    // The archiver's sync pass moves the anchor and the frontier together; the provider follows it.
+    await syncArchiverToL1Head();
+    mockL2Frontier({
+      proposed: BlockNumber(2),
+      checkpointedBlock: BlockNumber(2),
+      checkpointedTipSlot: SlotNumber(changeSlot + 1),
+      checkpointNumber: landedCheckpoint,
+      latestBlockGlobals: { slotNumber: SlotNumber(changeSlot + 1), gasFees: GasFees.empty() },
+    });
+    await feeProvider.refresh();
+
+    const after = await node.getPredictedMinFees(ManaUsageEstimate.Limit);
+    expect(after[0].feePerL2Gas).toEqual(landedFee);
+
+    const output = await node.simulatePublicCalls(await makeTx(0x40000, walletCap(after)));
+
+    expect(output.globalVariables.slotNumber).toEqual(SlotNumber(changeSlot + 2));
+    expect(output.globalVariables.gasFees.feePerL2Gas).toEqual(after[0].feePerL2Gas);
   }, 120_000);
 });

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
@@ -2,6 +2,7 @@ import { L1ToL2MessagesNotReadyError } from '@aztec/archiver';
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { type FeeHeader, RollupContract } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { unfreeze } from '@aztec/foundation/types';
@@ -9,6 +10,7 @@ import { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   BlockHash,
+  type L1SyncPoint,
   type L2BlockSource,
   type L2Frontier,
   type L2Tips,
@@ -71,6 +73,8 @@ describe('NodePublicCallsSimulator', () => {
     /** Omit the proposed tip's header from the snapshot, an invariant violation the simulator must reject. */
     omitLatestBlockHeader?: boolean;
     pendingChainValidationStatus?: ValidateCheckpointResult;
+    /** L1 block the archiver's snapshot reflects; the fee read must be pinned to it. */
+    l1SyncPoint?: L1SyncPoint;
   };
 
   const makeTips = (args: L2FrontierArgs): L2Tips => {
@@ -87,7 +91,7 @@ describe('NodePublicCallsSimulator', () => {
   const makeFrontier = (args: L2FrontierArgs): L2Frontier => ({
     tips: makeTips(args),
     proposedCheckpoint: args.proposedCheckpoint,
-    l1SyncPoint: undefined,
+    l1SyncPoint: args.l1SyncPoint,
     latestBlockHeader:
       args.omitLatestBlockHeader || !args.latestBlockGlobals
         ? undefined
@@ -405,6 +409,28 @@ describe('NodePublicCallsSimulator', () => {
         proposedCheckpointData.feeAssetPriceModifier,
         1000n,
       );
+    });
+
+    it('pins the fee read to the L1 block the frontier was read at', async () => {
+      const tx = await lowGasTx();
+      setupBoundary({ l1SyncPoint: { blockNumber: 4242n, blockHash: Buffer32.fromNumber(7) } });
+      mockNextL1Slot(SlotNumber(20));
+
+      await simulator.simulate(tx);
+
+      const [, , , , options] = globalVariableBuilder.buildCheckpointGlobalVariables.mock.calls[0];
+      expect(options).toEqual({ blockNumber: 4242n });
+    });
+
+    it('leaves the fee read unpinned before the archiver has synced', async () => {
+      const tx = await lowGasTx();
+      setupBoundary();
+      mockNextL1Slot(SlotNumber(20));
+
+      await simulator.simulate(tx);
+
+      const [, , , , options] = globalVariableBuilder.buildCheckpointGlobalVariables.mock.calls[0];
+      expect(options).toEqual({ blockNumber: undefined });
     });
 
     it('pins tips to firstInvalid - 1 when the pending chain is invalid', async () => {

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.ts
@@ -304,11 +304,14 @@ export class NodePublicCallsSimulator {
     const targetSlot = this.computeTargetSlot(proposedCheckpointData, checkpointedTipSlot);
     const plan = await this.buildSimulationOverridesPlan(frontier, checkpointedCheckpointNumber);
 
+    // Pinned to the L1 block the frontier was read at, so the fee describes the same L1 state the plan above
+    // derives from. Undefined before the archiver's first sync pass, where the read falls back to L1's head.
     const checkpointGlobalVariables = await this.globalVariableBuilder.buildCheckpointGlobalVariables(
       EthAddress.ZERO,
       AztecAddress.ZERO,
       targetSlot,
       plan,
+      { blockNumber: frontier.l1SyncPoint?.blockNumber },
     );
 
     return {

--- a/yarn-project/aztec-node/src/factory.ts
+++ b/yarn-project/aztec-node/src/factory.ts
@@ -250,7 +250,7 @@ export async function createAztecNodeService(
     };
 
     const globalVariableBuilder = new GlobalVariableBuilder(publicClient, globalVariableBuilderConfig);
-    const feeProvider = new FeeProviderImpl(dateProvider, publicClient, globalVariableBuilderConfig);
+    const feeProvider = new FeeProviderImpl(dateProvider, publicClient, globalVariableBuilderConfig, archiver);
     await feeProvider.start();
     started.push(feeProvider);
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -701,14 +701,17 @@ export class RollupContract {
     };
   }
 
-  /** Returns the pending checkpoint from the rollup contract */
-  getPendingCheckpoint() {
+  /**
+   * Returns the pending checkpoint from the rollup contract.
+   * @param options - Optional L1 block number to pin the queries to.
+   */
+  getPendingCheckpoint(options?: { blockNumber?: bigint }) {
     // We retry because of race conditions during prunes: we may get a pending checkpoint number which is immediately
     // reorged out due to a prune happening, causing the subsequent getCheckpoint call to fail. So we try again in that case.
     return retry(
       async () => {
-        const pendingCheckpointNumber = await this.getCheckpointNumber();
-        const pendingCheckpoint = await this.getCheckpoint(pendingCheckpointNumber);
+        const pendingCheckpointNumber = await this.getCheckpointNumber(options);
+        const pendingCheckpoint = await this.getCheckpoint(pendingCheckpointNumber, options);
         return pendingCheckpoint;
       },
       'getting pending checkpoint',
@@ -748,8 +751,13 @@ export class RollupContract {
     };
   }
 
-  getTimestampForSlot(slot: SlotNumber): Promise<bigint> {
-    return this.rollup.read.getTimestampForSlot([BigInt(slot)]);
+  /**
+   * Returns the timestamp at which the given slot starts.
+   * @param options - Optional L1 block number to pin the query to.
+   */
+  async getTimestampForSlot(slot: SlotNumber, options?: { blockNumber?: bigint }): Promise<bigint> {
+    await checkBlockTag(options?.blockNumber, this.client);
+    return await this.rollup.read.getTimestampForSlot([BigInt(slot)], options);
   }
 
   async getEntryQueueLength(): Promise<number> {
@@ -1134,8 +1142,18 @@ export class RollupContract {
     return this.rollup.read.getHasSubmitted([BigInt(epochNumber), BigInt(numberOfCheckpointsInEpoch), prover]);
   }
 
-  getManaMinFeeAt(timestamp: bigint, inFeeAsset: boolean, stateOverride?: StateOverride): Promise<bigint> {
-    return this.rollup.read.getManaMinFeeAt([timestamp, inFeeAsset], { stateOverride });
+  /**
+   * Returns the minimum mana fee at the given timestamp.
+   * @param options - Optional state override to simulate against, and optional L1 block number to pin the call
+   * to, so the fee describes a known L1 state rather than whatever the node considers latest.
+   */
+  async getManaMinFeeAt(
+    timestamp: bigint,
+    inFeeAsset: boolean,
+    options?: { stateOverride?: StateOverride; blockNumber?: bigint },
+  ): Promise<bigint> {
+    await checkBlockTag(options?.blockNumber, this.client);
+    return await this.rollup.read.getManaMinFeeAt([timestamp, inFeeAsset], options);
   }
 
   async getManaMinFeeComponentsAt(timestamp: bigint, inFeeAsset: boolean): Promise<ManaMinFeeComponents> {

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
@@ -12,7 +12,6 @@ import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { FEE_ORACLE_LAG, type GasFees, ManaUsageEstimate, computeExcessMana } from '@aztec/stdlib/gas';
 
-import { jest } from '@jest/globals';
 import { foundry } from 'viem/chains';
 
 import { FeePredictor } from './fee_predictor.js';
@@ -98,11 +97,11 @@ describe('FeePredictor', () => {
     return afterCheckpoint > BigInt(currentSlot) ? afterCheckpoint : BigInt(currentSlot);
   }
 
-  /** Builds a predictor and refreshes it against the current L1 block, mirroring how FeeProviderImpl drives it. */
-  async function makeRefreshedPredictor(): Promise<FeePredictor> {
+  /** Reads state at the current L1 block and predicts from it, mirroring how FeeProviderImpl drives the predictor. */
+  async function predictMinFees(manaUsage: ManaUsageEstimate): Promise<GasFees[]> {
     const predictor = new FeePredictor(rollup, dateProvider, feePredictorConfig);
-    await predictor.refreshState(await publicClient.getBlockNumber({ cacheTime: 0 }));
-    return predictor;
+    const state = await predictor.computeState(await publicClient.getBlockNumber({ cacheTime: 0 }));
+    return predictor.computePredictions(state, manaUsage);
   }
 
   it('slot 0 matches L1 getManaMinFeeAt for all ManaUsageEstimate values', async () => {
@@ -110,15 +109,13 @@ describe('FeePredictor', () => {
     const l1Fee = await rollup.getManaMinFeeAt(getTimestamp(startSlot), true);
 
     for (const manaUsage of Object.values(ManaUsageEstimate)) {
-      const predictor = await makeRefreshedPredictor();
-      const predicted = predictor.getPredictedMinFees(manaUsage);
+      const predicted = await predictMinFees(manaUsage);
       expect(predicted[0].feePerL2Gas).toBe(l1Fee);
     }
   });
 
   it('all slots match L1 with ManaUsageEstimate.None and zero congestion', async () => {
-    const predictor = await makeRefreshedPredictor();
-    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predicted = await predictMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -151,8 +148,7 @@ describe('FeePredictor', () => {
     await cheatCodes.mine();
     await rollupCheatCodes.updateL1GasFeeOracle();
 
-    const predictor = await makeRefreshedPredictor();
-    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predicted = await predictMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -182,8 +178,7 @@ describe('FeePredictor', () => {
     await cheatCodes.mine();
     await rollupCheatCodes.advanceSlots(3);
 
-    const predictor = await makeRefreshedPredictor();
-    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
+    const predicted = await predictMinFees(ManaUsageEstimate.None);
 
     const startSlot = await getPredictionStartSlot();
     const l1Fee = await rollup.getManaMinFeeAt(getTimestamp(startSlot), true);
@@ -191,8 +186,7 @@ describe('FeePredictor', () => {
   });
 
   it('returns exactly FEE_ORACLE_LAG entries', async () => {
-    const predictor = await makeRefreshedPredictor();
-    const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.Target);
+    const predicted = await predictMinFees(ManaUsageEstimate.Target);
     expect(predicted.length).toBe(FEE_ORACLE_LAG);
   });
 
@@ -220,8 +214,7 @@ describe('FeePredictor', () => {
       const assumedManaUsed =
         estimate === ManaUsageEstimate.None ? 0n : estimate === ManaUsageEstimate.Target ? manaTarget : manaLimit;
 
-      const predictor = await makeRefreshedPredictor();
-      const predicted = predictor.getPredictedMinFees(estimate);
+      const predicted = await predictMinFees(estimate);
 
       const startSlot = await getPredictionStartSlot();
       const pendingCheckpointNumber = await rollup.getCheckpointNumber();
@@ -293,8 +286,7 @@ describe('FeePredictor', () => {
 
     // Step through 6 successive slots, creating a fresh predictor each time.
     for (let step = 0; step < 6; step++) {
-      const predictor = await makeRefreshedPredictor();
-      const predicted = predictor.getPredictedMinFees(ManaUsageEstimate.None);
+      const predicted = await predictMinFees(ManaUsageEstimate.None);
 
       expect(predicted.length).toBe(FEE_ORACLE_LAG);
 
@@ -340,42 +332,4 @@ describe('FeePredictor', () => {
       nextCheckpointOffset++;
     }
   }, 60_000);
-});
-
-describe('FeePredictor state caching', () => {
-  it('getState() returns undefined until refreshState() has been called', () => {
-    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
-    expect(predictor.getState()).toBeUndefined();
-  });
-
-  it('refreshState() caches the fetched state for getState() to return, with no further I/O', async () => {
-    const state = { manaTarget: 1n } as unknown;
-    const fetchState = jest.fn<() => Promise<unknown>>().mockResolvedValue(state);
-
-    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
-    Reflect.set(predictor, 'fetchState', fetchState);
-
-    await expect(predictor.refreshState(1n)).resolves.toBe(state);
-    expect(predictor.getState()).toBe(state);
-    expect(predictor.getState()).toBe(state);
-    expect(fetchState).toHaveBeenCalledTimes(1);
-  });
-
-  it('preserves the last known-good state if refreshState() fails', async () => {
-    const goodState = { manaTarget: 1n } as unknown;
-    const fetchState = jest
-      .fn<() => Promise<unknown>>()
-      .mockResolvedValueOnce(goodState)
-      .mockRejectedValueOnce(new Error('L1 RPC request failed'));
-
-    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
-    Reflect.set(predictor, 'fetchState', fetchState);
-
-    await predictor.refreshState(1n);
-    expect(predictor.getState()).toBe(goodState);
-
-    await expect(predictor.refreshState(2n)).rejects.toThrow('L1 RPC request failed');
-    // The failed refresh must not have clobbered the last known-good state.
-    expect(predictor.getState()).toBe(goodState);
-  });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
@@ -12,8 +12,8 @@ import {
   computeManaMinFee,
 } from '@aztec/stdlib/gas';
 
-/** Cached rollup state for fee prediction. Refreshed once per L1 block. */
-type FeeOracleState = {
+/** Rollup state a set of fee predictions is computed from, read at a single L1 block. */
+export type FeeOracleState = {
   lastSlot: SlotNumber;
   excessMana: bigint;
   ethPerFeeAsset: bigint;
@@ -31,8 +31,6 @@ type FeeOracleState = {
  * are guaranteed stable.
  */
 export class FeePredictor {
-  private cachedState: FeeOracleState | undefined;
-
   private readonly slotDuration: number;
   private readonly l1GenesisTime: bigint;
   private readonly ethereumSlotDuration: number;
@@ -47,30 +45,12 @@ export class FeePredictor {
     this.ethereumSlotDuration = config.ethereumSlotDuration;
   }
 
-  /** Returns predicted min fees for each slot in the prediction window, from the cached state. */
-  getPredictedMinFees(manaUsage: ManaUsageEstimate): GasFees[] {
-    const state = this.getState();
-    if (state === undefined) {
-      throw new Error('FeePredictor.refreshState() must be called before getPredictedMinFees()');
-    }
-    return this.computePredictions(state, manaUsage);
-  }
-
-  /** Returns whatever rollup state is currently cached, or undefined if refreshState() has never been called. */
-  getState(): FeeOracleState | undefined {
-    return this.cachedState;
-  }
-
   /**
-   * Fetches and caches rollup state for the given L1 block.
+   * Reads the rollup state the predictions are derived from, pinned to the given L1 block. The state is
+   * returned rather than cached: its owner stores it alongside the L1 block it was read at, so a caller that
+   * asks for fees at a specific L1 block is answered from the state read at that block.
    */
-  async refreshState(blockNumber: bigint): Promise<FeeOracleState> {
-    const state = await this.fetchState(blockNumber);
-    this.cachedState = state;
-    return state;
-  }
-
-  private async fetchState(blockNumber: bigint): Promise<FeeOracleState> {
+  async computeState(blockNumber: bigint): Promise<FeeOracleState> {
     // Pin all non-constant queries to this L1 block number for a consistent snapshot.
     const opts = { blockNumber };
 
@@ -119,8 +99,8 @@ export class FeePredictor {
     };
   }
 
-  /** Computes per-slot fee predictions given cached state and a mana usage assumption. */
-  private computePredictions(state: FeeOracleState, manaUsage: ManaUsageEstimate): GasFees[] {
+  /** Computes per-slot fee predictions given rollup state and a mana usage assumption. */
+  computePredictions(state: FeeOracleState, manaUsage: ManaUsageEstimate): GasFees[] {
     const assumedManaUsed = this.getAssumedManaUsed(state, manaUsage);
 
     const result: GasFees[] = [];

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
@@ -1,6 +1,9 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import type { L1SyncPoint } from '@aztec/stdlib/block';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
 
 import { jest } from '@jest/globals';
@@ -8,156 +11,262 @@ import { jest } from '@jest/globals';
 import { FeeProviderImpl } from './fee_provider.js';
 
 describe('FeeProviderImpl', () => {
-  function makeProvider(currentMinFees: GasFees, predictedMinFees: GasFees[]) {
-    const getPredictedMinFees = jest.fn<(manaUsage: ManaUsageEstimate) => GasFees[]>(() => predictedMinFees);
-    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
-
-    Reflect.set(provider, 'currentMinFees', currentMinFees);
-    Reflect.set(provider, 'feePredictor', { getPredictedMinFees });
-
-    return { provider, getPredictedMinFees };
-  }
-
-  it('prepends current min fees to predicted future fees', async () => {
-    const currentMinFees = new GasFees(1, 2);
-    const predictedMinFees = [new GasFees(3, 4), new GasFees(5, 6)];
-    const { provider, getPredictedMinFees } = makeProvider(currentMinFees, predictedMinFees);
-
-    await expect(provider.getPredictedMinFees(ManaUsageEstimate.Limit)).resolves.toEqual([
-      currentMinFees,
-      ...predictedMinFees,
-    ]);
-    expect(getPredictedMinFees).toHaveBeenCalledWith(ManaUsageEstimate.Limit);
+  const syncPointAt = (blockNumber: bigint, hashSeed = Number(blockNumber)): L1SyncPoint => ({
+    blockNumber,
+    blockHash: Buffer32.fromNumber(hashSeed),
   });
 
-  it('defaults future fee prediction to target mana usage', async () => {
-    const { provider, getPredictedMinFees } = makeProvider(new GasFees(1, 2), [new GasFees(3, 4)]);
+  /**
+   * Builds a provider whose L1 reads are mocked and whose sync point is under the test's control. Every
+   * mocked read records the `blockNumber` option it was pinned to, which is what the refresh must carry.
+   */
+  function makeProvider() {
+    let syncPoint: L1SyncPoint | undefined = syncPointAt(1n);
+
+    const getPendingCheckpoint = jest
+      .fn<(options?: { blockNumber?: bigint }) => Promise<{ slotNumber: number }>>()
+      .mockResolvedValue({ slotNumber: 10 });
+    const getTimestampForSlot = jest
+      .fn<(slot: number, options?: { blockNumber?: bigint }) => Promise<bigint>>()
+      .mockResolvedValue(1_000n);
+    const getManaMinFeeAt = jest
+      .fn<(timestamp: bigint, inFeeAsset: boolean, options?: { blockNumber?: bigint }) => Promise<bigint>>()
+      .mockImplementation((_ts, _inFeeAsset, options) => Promise.resolve(100n + (options?.blockNumber ?? 0n)));
+    const computeState = jest
+      .fn<(blockNumber: bigint) => Promise<{ blockNumber: bigint }>>()
+      .mockImplementation(blockNumber => Promise.resolve({ blockNumber }));
+    const computePredictions = jest
+      .fn<(state: { blockNumber: bigint }, manaUsage: ManaUsageEstimate) => GasFees[]>()
+      .mockImplementation(state => [new GasFees(0, 900n + state.blockNumber)]);
+    const getBlock = jest
+      .fn<() => Promise<{ number: bigint; hash: string }>>()
+      .mockResolvedValue({ number: 7n, hash: Buffer32.fromNumber(77).toString() });
+
+    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
+    Reflect.set(provider, 'entries', []);
+    Reflect.set(provider, 'dateProvider', new TestDateProvider());
+    Reflect.set(provider, 'publicClient', { getBlock });
+    Reflect.set(provider, 'syncPointSource', { getL1SyncPoint: () => Promise.resolve(syncPoint) });
+    Reflect.set(provider, 'rollupContract', { getPendingCheckpoint, getTimestampForSlot, getManaMinFeeAt });
+    Reflect.set(provider, 'feePredictor', { computeState, computePredictions });
+    Reflect.set(provider, 'ethereumSlotDuration', 12);
+    Reflect.set(provider, 'l1GenesisTime', 0n);
+    Reflect.set(provider, 'log', createLogger('test:fee-provider'));
+
+    return {
+      provider,
+      getPendingCheckpoint,
+      getTimestampForSlot,
+      getManaMinFeeAt,
+      computeState,
+      computePredictions,
+      getBlock,
+      setSyncPoint: (next: L1SyncPoint | undefined) => (syncPoint = next),
+    };
+  }
+
+  /** Fee the mocked L1 reads produce for a refresh pinned to `blockNumber`. */
+  const currentFeeAt = (blockNumber: bigint) => new GasFees(0, 100n + blockNumber);
+  /** Prediction the mocked predictor produces from state read at `blockNumber`. */
+  const predictedFeeAt = (blockNumber: bigint) => new GasFees(0, 900n + blockNumber);
+
+  it('pins every read in a refresh to the sync point block', async () => {
+    const { provider, getPendingCheckpoint, getTimestampForSlot, getManaMinFeeAt, computeState } = makeProvider();
+
+    await provider.refresh();
+
+    expect(getPendingCheckpoint).toHaveBeenCalledWith({ blockNumber: 1n });
+    expect(getTimestampForSlot).toHaveBeenCalledWith(11, { blockNumber: 1n });
+    expect(getManaMinFeeAt).toHaveBeenCalledWith(expect.anything(), true, { blockNumber: 1n });
+    expect(computeState).toHaveBeenCalledWith(1n);
+  });
+
+  it('refreshes only when the sync point hash changes, never on an L1 head of its own', async () => {
+    const { provider, getPendingCheckpoint, getBlock, setSyncPoint } = makeProvider();
+
+    await provider.refresh();
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(1);
+
+    // Same anchor: no L1 reads at all, and no head poll to discover that.
+    await provider.refresh();
+    await provider.refresh();
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(1);
+    expect(getBlock).not.toHaveBeenCalled();
+
+    // A same-height L1 reorg moves the hash but not the number, and must still refresh.
+    setSyncPoint(syncPointAt(1n, 999));
+    await provider.refresh();
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(2);
+    expect(getBlock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to L1 head before the archiver has synced', async () => {
+    const { provider, getBlock, getPendingCheckpoint, setSyncPoint } = makeProvider();
+    setSyncPoint(undefined);
+
+    await provider.refresh();
+
+    expect(getBlock).toHaveBeenCalledWith({ blockTag: 'latest' });
+    expect(getPendingCheckpoint).toHaveBeenCalledWith({ blockNumber: 7n });
+    await expect(provider.getCurrentMinFees()).resolves.toEqual(currentFeeAt(7n));
+  });
+
+  it('serves the newest view when untagged', async () => {
+    const { provider, setSyncPoint } = makeProvider();
+
+    await provider.refresh();
+    setSyncPoint(syncPointAt(2n));
+    await provider.refresh();
+
+    await expect(provider.getCurrentMinFees()).resolves.toEqual(currentFeeAt(2n));
+    await expect(provider.getPredictedMinFees()).resolves.toEqual([currentFeeAt(2n), predictedFeeAt(2n)]);
+  });
+
+  it('defaults the prediction to target mana usage', async () => {
+    const { provider, computePredictions } = makeProvider();
+    await provider.refresh();
 
     await provider.getPredictedMinFees();
 
-    expect(getPredictedMinFees).toHaveBeenCalledWith(ManaUsageEstimate.Target);
+    expect(computePredictions.mock.calls[0][1]).toEqual(ManaUsageEstimate.Target);
   });
 
-  describe('background refresh loop', () => {
-    function makeBackgroundProvider() {
-      const getBlockNumber = jest.fn<() => Promise<bigint>>().mockResolvedValue(1n);
-      const computeCurrentMinFees = jest.fn<() => Promise<GasFees>>().mockResolvedValue(new GasFees(0, 42));
-      const feePredictorRefreshState = jest
-        .fn<(blockNumber: bigint) => Promise<unknown>>()
-        .mockResolvedValue(undefined);
-      const getPredictedMinFees = jest.fn<(manaUsage: ManaUsageEstimate) => GasFees[]>().mockReturnValue([]);
+  it('serves a tagged request from its own view even when a newer one exists', async () => {
+    const { provider, setSyncPoint } = makeProvider();
 
-      const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
-      Reflect.set(provider, 'publicClient', { getBlockNumber });
-      Reflect.set(provider, 'currentL1BlockNumber', undefined);
-      Reflect.set(provider, 'currentMinFees', new GasFees(0, 0));
-      Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
-      Reflect.set(provider, 'feePredictor', {
-        refreshState: feePredictorRefreshState,
-        getPredictedMinFees,
-      });
-      Reflect.set(provider, 'log', createLogger('test:fee-provider'));
+    await provider.refresh();
+    setSyncPoint(syncPointAt(2n));
+    await provider.refresh();
 
-      return { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState, getPredictedMinFees };
+    await expect(provider.getCurrentMinFees({ blockNumber: 1n })).resolves.toEqual(currentFeeAt(1n));
+    await expect(provider.getPredictedMinFees(ManaUsageEstimate.Limit, { blockNumber: 1n })).resolves.toEqual([
+      currentFeeAt(1n),
+      predictedFeeAt(1n),
+    ]);
+  });
+
+  it('refreshes and serves the new view when the tag is ahead of every entry', async () => {
+    const { provider, setSyncPoint, getPendingCheckpoint } = makeProvider();
+    await provider.refresh();
+
+    setSyncPoint(syncPointAt(2n));
+
+    await expect(provider.getCurrentMinFees({ blockNumber: 2n })).resolves.toEqual(currentFeeAt(2n));
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a single refresh between concurrent requests that miss', async () => {
+    const { provider, setSyncPoint, getPendingCheckpoint } = makeProvider();
+    await provider.refresh();
+
+    const gate = promiseWithResolvers<{ slotNumber: number }>();
+    getPendingCheckpoint.mockReturnValueOnce(gate.promise);
+    setSyncPoint(syncPointAt(2n));
+
+    const first = provider.getCurrentMinFees({ blockNumber: 2n });
+    const second = provider.getCurrentMinFees({ blockNumber: 2n });
+    await sleep(0);
+    gate.resolve({ slotNumber: 10 });
+
+    await expect(first).resolves.toEqual(currentFeeAt(2n));
+    await expect(second).resolves.toEqual(currentFeeAt(2n));
+    // One for the initial refresh, one shared by both requests.
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes again when the refresh it joined started from an older sync point', async () => {
+    const { provider, setSyncPoint, getPendingCheckpoint } = makeProvider();
+    await provider.refresh();
+
+    const gate = promiseWithResolvers<{ slotNumber: number }>();
+    getPendingCheckpoint.mockReturnValueOnce(gate.promise);
+    setSyncPoint(syncPointAt(2n));
+    const inFlight = provider.refresh();
+    await sleep(0);
+
+    // The archiver moves on while the refresh for block 2 is still pending; a request tagged with block 3 joins
+    // that refresh, misses, and must not settle for block 2.
+    setSyncPoint(syncPointAt(3n));
+    const request = provider.getCurrentMinFees({ blockNumber: 3n });
+    await sleep(0);
+    gate.resolve({ slotNumber: 10 });
+    await inFlight;
+
+    await expect(request).resolves.toEqual(currentFeeAt(3n));
+    expect(getPendingCheckpoint).toHaveBeenCalledTimes(3);
+  });
+
+  it('serves the newest view once the tagged wait is capped out', async () => {
+    const { provider, setSyncPoint, getPendingCheckpoint } = makeProvider();
+    await provider.refresh();
+
+    const gate = promiseWithResolvers<{ slotNumber: number }>();
+    getPendingCheckpoint.mockReturnValueOnce(gate.promise);
+    setSyncPoint(syncPointAt(2n));
+
+    await expect(provider.getCurrentMinFees({ blockNumber: 2n, maxWaitMs: 10 })).resolves.toEqual(currentFeeAt(1n));
+
+    gate.resolve({ slotNumber: 10 });
+    await provider.stop();
+  });
+
+  it('serves the oldest view when the tag predates the ring', async () => {
+    const { provider, setSyncPoint, getPendingCheckpoint } = makeProvider();
+
+    setSyncPoint(syncPointAt(5n));
+    await provider.refresh();
+    setSyncPoint(syncPointAt(6n));
+    await provider.refresh();
+    getPendingCheckpoint.mockClear();
+
+    await expect(provider.getCurrentMinFees({ blockNumber: 3n })).resolves.toEqual(currentFeeAt(5n));
+    expect(getPendingCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('retains the last four views', async () => {
+    const { provider, setSyncPoint } = makeProvider();
+
+    for (const blockNumber of [1n, 2n, 3n, 4n, 5n, 6n]) {
+      setSyncPoint(syncPointAt(blockNumber));
+      await provider.refresh();
     }
 
-    it('warms the cache on start() and serves it with no further L1 calls', async () => {
-      const { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState } = makeBackgroundProvider();
+    await expect(provider.getCurrentMinFees({ blockNumber: 3n })).resolves.toEqual(currentFeeAt(3n));
+    // Block 2 has fallen out of the ring, so the oldest retained view answers instead.
+    await expect(provider.getCurrentMinFees({ blockNumber: 2n })).resolves.toEqual(currentFeeAt(3n));
+  });
 
-      // A long polling interval so the loop's scheduled tick never fires again during this test.
-      await provider.start(60_000);
+  it('fails to start if the initial refresh fails', async () => {
+    const { provider, getPendingCheckpoint } = makeProvider();
+    getPendingCheckpoint.mockRejectedValue(new Error('L1 unavailable'));
 
-      // start() performs the required warmup, then RunningPromise begins with an immediate tick.
-      // The second block-number check is a cheap no-op since the block has not advanced.
-      expect(getBlockNumber).toHaveBeenCalledTimes(2);
-      expect(computeCurrentMinFees).toHaveBeenCalledTimes(1);
-      expect(feePredictorRefreshState).toHaveBeenCalledWith(1n);
+    await expect(provider.start(60_000)).rejects.toThrow('L1 unavailable');
+    await provider.stop();
+  });
 
-      getBlockNumber.mockClear();
-      computeCurrentMinFees.mockClear();
+  it('keeps serving the last known-good view when a background refresh fails', async () => {
+    const { provider, getPendingCheckpoint, setSyncPoint } = makeProvider();
+    await provider.refresh();
 
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
-      await expect(provider.getPredictedMinFees()).resolves.toEqual([new GasFees(0, 42)]);
+    setSyncPoint(syncPointAt(2n));
+    getPendingCheckpoint.mockRejectedValueOnce(new Error('transient L1 error'));
+    await expect(provider.refresh()).rejects.toThrow('transient L1 error');
 
-      expect(getBlockNumber).not.toHaveBeenCalled();
-      expect(computeCurrentMinFees).not.toHaveBeenCalled();
+    await expect(provider.getCurrentMinFees()).resolves.toEqual(currentFeeAt(1n));
 
-      await provider.stop();
-    });
+    await provider.refresh();
+    await expect(provider.getCurrentMinFees()).resolves.toEqual(currentFeeAt(2n));
+  });
 
-    it('fails to start if the initial cache refresh fails', async () => {
-      const { provider, getBlockNumber } = makeBackgroundProvider();
-      getBlockNumber.mockRejectedValue(new Error('L1 unavailable'));
+  it('stops refreshing once stopped', async () => {
+    const { provider, getPendingCheckpoint, setSyncPoint } = makeProvider();
+    await provider.start(10);
+    await provider.stop();
 
-      const startError = await provider.start(60_000).then(
-        () => undefined,
-        err => err,
-      );
-      await provider.stop();
+    setSyncPoint(syncPointAt(2n));
+    getPendingCheckpoint.mockClear();
+    await sleep(50);
 
-      expect(startError).toEqual(new Error('L1 unavailable'));
-    });
-
-    it('keeps serving the last known-good fees when a background tick fails, and retries the same block', async () => {
-      const { provider, getBlockNumber, computeCurrentMinFees } = makeBackgroundProvider();
-      await provider.start(60_000);
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
-
-      getBlockNumber.mockResolvedValue(2n);
-      computeCurrentMinFees.mockRejectedValueOnce(new Error('transient L1 error'));
-      const refreshFromL1 = Reflect.get(FeeProviderImpl.prototype, 'refreshFromL1') as () => Promise<void>;
-
-      await expect(refreshFromL1.call(provider)).rejects.toThrow('transient L1 error');
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
-
-      computeCurrentMinFees.mockResolvedValueOnce(new GasFees(0, 99));
-      await refreshFromL1.call(provider);
-
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 99));
-
-      await provider.stop();
-    });
-
-    it('serves the cached fees until the complete refresh has succeeded', async () => {
-      const { provider, getBlockNumber, computeCurrentMinFees, feePredictorRefreshState } = makeBackgroundProvider();
-      await provider.start(60_000);
-
-      getBlockNumber.mockResolvedValueOnce(2n);
-      const computeGate = promiseWithResolvers<GasFees>();
-      computeCurrentMinFees.mockReturnValueOnce(computeGate.promise);
-      const predictorGate = promiseWithResolvers<unknown>();
-      feePredictorRefreshState.mockReturnValueOnce(predictorGate.promise);
-
-      const refreshFromL1 = Reflect.get(FeeProviderImpl.prototype, 'refreshFromL1') as () => Promise<void>;
-      const tick = refreshFromL1.call(provider);
-      await sleep(0);
-
-      const whileCurrentFeesRefresh = await Promise.race([provider.getCurrentMinFees(), sleep(0, new GasFees(0, 999))]);
-      expect(whileCurrentFeesRefresh).toEqual(new GasFees(0, 42));
-      expect(feePredictorRefreshState).not.toHaveBeenCalledWith(2n);
-
-      computeGate.resolve(new GasFees(0, 77));
-      await sleep(0);
-
-      expect(feePredictorRefreshState).toHaveBeenCalledWith(2n);
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
-
-      predictorGate.resolve(undefined);
-      await tick;
-      await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 77));
-
-      await provider.stop();
-    });
-
-    it('stops polling once stopped', async () => {
-      const { provider, getBlockNumber } = makeBackgroundProvider();
-      await provider.start(10);
-      await provider.stop();
-
-      getBlockNumber.mockClear();
-      await sleep(50);
-
-      expect(getBlockNumber).not.toHaveBeenCalled();
-    });
+    expect(getPendingCheckpoint).not.toHaveBeenCalled();
   });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
@@ -1,26 +1,55 @@
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { RunningPromise } from '@aztec/foundation/running-promise';
-import type { DateProvider } from '@aztec/foundation/timer';
+import { type DateProvider, Timer } from '@aztec/foundation/timer';
+import type { L1SyncPoint, L2BlockSource } from '@aztec/stdlib/block';
 import { getNextL1SlotTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
-import type { FeeProvider } from '@aztec/stdlib/tx';
+import type { FeeAsOf, FeeProvider } from '@aztec/stdlib/tx';
 
-import { FeePredictor } from './fee_predictor.js';
+import { type FeeOracleState, FeePredictor } from './fee_predictor.js';
 import type { GlobalVariableBuilderConfig } from './global_builder.js';
 
-/** Default interval for the background L1 refresh loop, well below L1's block time. */
+/** Default interval for the background refresh loop, well below L1's block time. */
 const DEFAULT_REFRESH_POLLING_INTERVAL_MS = 1000;
 
+/** How many recent L1 views are retained, so a caller that planned a block or two ago is still answerable. */
+const RING_SIZE = 4;
+
 /**
- * Provides current and predicted fee information based on on-chain state.
+ * Refresh passes a tagged request waits through before settling for the closest view. The first pass it joins
+ * may have started from an older sync point than the one it is tagged with; the second is its own.
+ */
+const MAX_REFRESH_ATTEMPTS = 2;
+
+/** Fees as read at one L1 block. Every read that produced it was pinned to `blockNumber`. */
+type FeeEntry = L1SyncPoint & {
+  currentMinFees: GasFees;
+  predictorState: FeeOracleState;
+};
+
+/**
+ * Provides current and predicted fee information based on on-chain state, refreshed from the archiver's L1 sync
+ * point rather than from a poll of its own.
+ *
+ * Following the archiver means the fees and the block plans that consume them describe the same L1 block: two
+ * independent L1 pollers would otherwise disagree for up to a poll interval after a checkpoint lands, and the
+ * mana min fee is a step function of the slot, so that disagreement shows up as a wallet quote the node's own
+ * public simulation then rejects.
+ *
+ * Every L1 read in a refresh is pinned to the sync point's block number, and the resulting entry is kept in a
+ * small ring so a caller that planned from a slightly older archiver snapshot can be answered for that same
+ * block via {@link FeeAsOf}.
  */
 export class FeeProviderImpl implements FeeProvider {
-  private currentMinFees = new GasFees(0, 0);
-  private currentL1BlockNumber: bigint | undefined = undefined;
+  /** Recent L1 views, newest first. */
+  private entries: FeeEntry[] = [];
   private refreshLoop: RunningPromise | undefined;
+  private inFlightRefresh: Promise<void> | undefined;
 
   private readonly rollupContract: RollupContract;
   private readonly feePredictor: FeePredictor;
@@ -32,6 +61,7 @@ export class FeeProviderImpl implements FeeProvider {
     private readonly dateProvider: DateProvider,
     private readonly publicClient: ViemPublicClient,
     config: GlobalVariableBuilderConfig,
+    private readonly syncPointSource: Pick<L2BlockSource, 'getL1SyncPoint'>,
   ) {
     this.ethereumSlotDuration = config.ethereumSlotDuration;
     this.l1GenesisTime = config.l1GenesisTime;
@@ -45,43 +75,148 @@ export class FeeProviderImpl implements FeeProvider {
   }
 
   public async start(pollingIntervalMs = DEFAULT_REFRESH_POLLING_INTERVAL_MS): Promise<void> {
-    await this.refreshFromL1();
-    this.refreshLoop = new RunningPromise(() => this.refreshFromL1(), this.log, pollingIntervalMs);
+    await this.refresh();
+    this.refreshLoop = new RunningPromise(() => this.refresh(), this.log, pollingIntervalMs);
     this.refreshLoop.start();
   }
 
   public async stop(): Promise<void> {
     await this.refreshLoop?.stop();
+    await this.inFlightRefresh?.catch(() => {});
   }
 
   /**
-   * Checks the current L1 block number and, if it has advanced, refreshes both the current and
-   * predicted min fees for that block.
+   * Refreshes the fee entries against the archiver's current L1 sync point, unless the newest entry already
+   * describes it. Single-flight: a call made while a refresh is running joins that refresh instead of
+   * starting a second one, so the loop and any waiting requests share one round of L1 reads.
    */
-  private async refreshFromL1(): Promise<void> {
-    const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
-    if (this.currentL1BlockNumber !== undefined && blockNumber <= this.currentL1BlockNumber) {
+  public refresh(): Promise<void> {
+    return (this.inFlightRefresh ??= this.doRefresh().finally(() => {
+      this.inFlightRefresh = undefined;
+    }));
+  }
+
+  public async getCurrentMinFees(asOf?: FeeAsOf): Promise<GasFees> {
+    const entry = await this.getEntry(asOf);
+    return entry?.currentMinFees ?? new GasFees(0, 0);
+  }
+
+  public async getPredictedMinFees(manaUsage?: ManaUsageEstimate, asOf?: FeeAsOf): Promise<GasFees[]> {
+    const entry = await this.getEntry(asOf);
+    if (entry === undefined) {
+      throw new Error('FeeProviderImpl.start() must be called before getPredictedMinFees()');
+    }
+    const predictions = this.feePredictor.computePredictions(
+      entry.predictorState,
+      manaUsage ?? ManaUsageEstimate.Target,
+    );
+    return [entry.currentMinFees, ...predictions];
+  }
+
+  /**
+   * Picks the entry to serve: the newest one when untagged, otherwise the one for the tagged L1 block. A tag
+   * ahead of every entry waits for the shared refresh, and once more for its own if the one it joined was
+   * already under way from an older sync point, all within `maxWaitMs` when set; a tag behind the ring gets the
+   * oldest entry. A tagged miss never throws: the caller asked for a specific L1 view as a consistency
+   * preference, not as a precondition, so it is answered with the closest view available.
+   */
+  private async getEntry(asOf?: FeeAsOf): Promise<FeeEntry | undefined> {
+    if (asOf === undefined) {
+      return this.entries[0];
+    }
+
+    const findTagged = () => this.entries.find(entry => entry.blockNumber === asOf.blockNumber);
+    const timer = new Timer();
+    for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
+      const hit = findTagged();
+      if (hit) {
+        return hit;
+      }
+
+      const oldest = this.entries.at(-1);
+      if (oldest !== undefined && asOf.blockNumber < oldest.blockNumber) {
+        this.log.debug(`Requested fees for L1 block ${asOf.blockNumber} predate the retained views`, {
+          requestedBlockNumber: asOf.blockNumber,
+          servedBlockNumber: oldest.blockNumber,
+        });
+        return oldest;
+      }
+
+      const remainingMs = asOf.maxWaitMs === undefined ? undefined : asOf.maxWaitMs - timer.ms();
+      if (remainingMs !== undefined && remainingMs <= 0) {
+        break;
+      }
+      await this.awaitRefresh(remainingMs);
+    }
+
+    const refreshed = findTagged();
+    if (!refreshed) {
+      this.log.debug(`No fees available for L1 block ${asOf.blockNumber} after refreshing`, {
+        requestedBlockNumber: asOf.blockNumber,
+        servedBlockNumber: this.entries[0]?.blockNumber,
+      });
+    }
+    return refreshed ?? this.entries[0];
+  }
+
+  /** Waits for the shared refresh, giving up after `maxWaitMs` if set. Never rejects. */
+  private async awaitRefresh(maxWaitMs: number | undefined): Promise<void> {
+    const refresh = this.refresh().catch(err =>
+      this.log.warn(`Failed to refresh fees while serving a request`, { err }),
+    );
+    if (maxWaitMs === undefined) {
+      return refresh;
+    }
+
+    const cap = promiseWithResolvers<void>();
+    const timer = setTimeout(cap.resolve, maxWaitMs);
+    await Promise.race([refresh, cap.promise]).finally(() => clearTimeout(timer));
+  }
+
+  private async doRefresh(): Promise<void> {
+    const syncPoint = await this.resolveSyncPoint();
+    if (this.entries[0]?.blockHash.equals(syncPoint.blockHash)) {
       return;
     }
 
-    const currentMinFees = await this.computeCurrentMinFees();
-    await this.feePredictor.refreshState(blockNumber);
-    this.currentMinFees = currentMinFees;
-    this.currentL1BlockNumber = blockNumber;
+    const { blockNumber } = syncPoint;
+    const [currentMinFees, predictorState] = await Promise.all([
+      this.computeCurrentMinFees(blockNumber),
+      this.feePredictor.computeState(blockNumber),
+    ]);
+
+    this.entries = [{ ...syncPoint, currentMinFees, predictorState }, ...this.entries].slice(0, RING_SIZE);
+  }
+
+  /**
+   * The L1 block to price at: the archiver's sync point once it has run a pass, otherwise L1's head. The
+   * fallback only applies before the archiver's first pass, so a node can answer fee queries while it is still
+   * catching up rather than blocking startup on the archiver.
+   */
+  private async resolveSyncPoint(): Promise<L1SyncPoint> {
+    const syncPoint = await this.syncPointSource.getL1SyncPoint();
+    if (syncPoint !== undefined) {
+      return syncPoint;
+    }
+    const block = await this.publicClient.getBlock({ blockTag: 'latest' });
+    return { blockNumber: block.number, blockHash: Buffer32.fromString(block.hash) };
   }
 
   /**
    * Computes the "current" min fees, e.g., the price that you currently should pay to get include in the next block
+   * @param blockNumber - L1 block every read is pinned to.
    * @returns Min fees for the next block
    */
-  private async computeCurrentMinFees(): Promise<GasFees> {
+  private async computeCurrentMinFees(blockNumber: bigint): Promise<GasFees> {
     // Since this might be called in the middle of a slot where a block might have been published,
     // we need to fetch the last block written, and estimate the earliest timestamp for the next block.
     // The timestamp of that last block will act as a lower bound for the next block.
+    const options = { blockNumber };
 
-    const lastCheckpoint = await this.rollupContract.getPendingCheckpoint();
+    const lastCheckpoint = await this.rollupContract.getPendingCheckpoint(options);
     const earliestTimestamp = await this.rollupContract.getTimestampForSlot(
       SlotNumber.fromBigInt(BigInt(lastCheckpoint.slotNumber) + 1n),
+      options,
     );
     const nextEthTimestamp = getNextL1SlotTimestamp(this.dateProvider.nowInSeconds(), {
       l1GenesisTime: this.l1GenesisTime,
@@ -89,16 +224,6 @@ export class FeeProviderImpl implements FeeProvider {
     });
     const timestamp = earliestTimestamp > nextEthTimestamp ? earliestTimestamp : nextEthTimestamp;
 
-    return new GasFees(0, await this.rollupContract.getManaMinFeeAt(timestamp, true));
-  }
-
-  public getCurrentMinFees(): Promise<GasFees> {
-    return Promise.resolve(this.currentMinFees);
-  }
-
-  public getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]> {
-    const currentMinFees = this.currentMinFees;
-    const predictedMinFees = this.feePredictor.getPredictedMinFees(manaUsage ?? ManaUsageEstimate.Target);
-    return Promise.resolve([currentMinFees, ...predictedMinFees]);
+    return new GasFees(0, await this.rollupContract.getManaMinFeeAt(timestamp, true, options));
   }
 }

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -46,12 +46,17 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
     this.rollupContract = new RollupContract(this.publicClient, config.rollupAddress);
   }
 
-  /** Builds global variables that are constant throughout a checkpoint. */
+  /**
+   * Builds global variables that are constant throughout a checkpoint.
+   * @param options - Optional L1 block number to pin the fee read to, so the fee describes the same L1 state
+   * the caller planned the block from.
+   */
   public async buildCheckpointGlobalVariables(
     coinbase: EthAddress,
     feeRecipient: AztecAddress,
     slotNumber: SlotNumber,
     simulationOverridesPlan?: SimulationOverridesPlan,
+    options?: { blockNumber?: bigint },
   ): Promise<CheckpointGlobalVariables> {
     const { chainId, version } = this;
 
@@ -61,7 +66,10 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
     });
 
     const stateOverride = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
-    const gasFees = new GasFees(0, await this.rollupContract.getManaMinFeeAt(timestamp, true, stateOverride));
+    const gasFees = new GasFees(
+      0,
+      await this.rollupContract.getManaMinFeeAt(timestamp, true, { stateOverride, ...options }),
+    );
 
     return { chainId, version, slotNumber, timestamp, coinbase, feeRecipient, gasFees };
   }

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -247,6 +247,14 @@ export interface L2BlockSource {
   getL2Frontier(): Promise<L2Frontier>;
 
   /**
+   * Returns the L1 block whose state the block source's data reflects. Same value as
+   * {@link getL2Frontier}'s `l1SyncPoint` field; exposed on its own so a consumer that only needs the L1 anchor
+   * (such as pinning an L1 read to the same block the archiver read) does not load the whole snapshot.
+   * Undefined until the first sync pass.
+   */
+  getL1SyncPoint(): Promise<L1SyncPoint | undefined>;
+
+  /**
    * Returns the rollup constants for the current chain.
    */
   getL1Constants(): Promise<L1RollupConstants>;

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -19,6 +19,7 @@ import {
   type CheckpointQuery,
   type CheckpointsQuery,
   CheckpointsQuerySchema,
+  type L1SyncPoint,
   type L2Frontier,
   type L2Tips,
   type ProposedCheckpointQuery,
@@ -265,6 +266,11 @@ describe('ArchiverApiSchema', () => {
       totalManaUsed: 1n,
       feeAssetPriceModifier: 1n,
     });
+  });
+
+  it('getL1SyncPoint', async () => {
+    const result = await context.client.getL1SyncPoint();
+    expect(result).toEqual({ blockNumber: 42n, blockHash: Buffer32.fromField(new Fr(7)) });
   });
 
   it('getL2Frontier', async () => {
@@ -538,6 +544,9 @@ class MockArchiver implements ArchiverApi {
       proven: tipId,
       finalized: tipId,
     });
+  }
+  getL1SyncPoint(): Promise<L1SyncPoint | undefined> {
+    return Promise.resolve({ blockNumber: 42n, blockHash: Buffer32.fromField(new Fr(7)) });
   }
   async getL2Frontier(): Promise<L2Frontier> {
     return {

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -10,6 +10,7 @@ import {
   BlocksQuerySchema,
   CheckpointQuerySchema,
   CheckpointsQuerySchema,
+  L1SyncPointSchema,
   type L2BlockSource,
   L2FrontierSchema,
   L2TipsSchema,
@@ -121,6 +122,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   isEpochComplete: z.function({ input: z.tuple([EpochNumberSchema]), output: z.boolean() }),
   getL2Tips: z.function({ input: z.tuple([]), output: L2TipsSchema }),
   getL2Frontier: z.function({ input: z.tuple([]), output: L2FrontierSchema }),
+  getL1SyncPoint: z.function({ input: z.tuple([]), output: optional(L1SyncPointSchema) }),
   getPrivateLogsByTags: z.function({
     input: z.tuple([PrivateLogsQuerySchema]),
     output: z.array(z.array(LogResultSchema)),

--- a/yarn-project/stdlib/src/tx/fee_provider.ts
+++ b/yarn-project/stdlib/src/tx/fee_provider.ts
@@ -1,10 +1,27 @@
 import type { ManaUsageEstimate } from '../gas/fee_math.js';
 import type { GasFees } from '../gas/gas_fees.js';
 
+/**
+ * L1 view a caller wants its fees priced against. A caller that planned from an archiver snapshot passes that
+ * snapshot's L1 sync point, so its plan and the fees describe the same L1 block.
+ */
+export type FeeAsOf = {
+  /** L1 block number the fees should describe; the provider answers with its closest view when it cannot. */
+  blockNumber: bigint;
+  /** Upper bound on how long to wait for a refresh when the provider has not reached that block yet. */
+  maxWaitMs?: number;
+};
+
 /** Provides current and predicted fee information for transaction pricing. */
 export interface FeeProvider {
-  /** Returns the current minimum fees for inclusion in the next block. */
-  getCurrentMinFees(): Promise<GasFees>;
-  /** Returns current min fees first, followed by predicted min fees for each slot in the prediction window. */
-  getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]>;
+  /**
+   * Returns the current minimum fees for inclusion in the next block.
+   * @param asOf - L1 block to price at; defaults to the provider's newest view.
+   */
+  getCurrentMinFees(asOf?: FeeAsOf): Promise<GasFees>;
+  /**
+   * Returns current min fees first, followed by predicted min fees for each slot in the prediction window.
+   * @param asOf - L1 block to price at; defaults to the provider's newest view.
+   */
+  getPredictedMinFees(manaUsage?: ManaUsageEstimate, asOf?: FeeAsOf): Promise<GasFees[]>;
 }

--- a/yarn-project/stdlib/src/tx/global_variable_builder.ts
+++ b/yarn-project/stdlib/src/tx/global_variable_builder.ts
@@ -9,11 +9,16 @@ import type { CheckpointGlobalVariables } from './global_variables.js';
  * Interface for building global variables for Aztec blocks.
  */
 export interface GlobalVariableBuilder {
-  /** Builds global variables that are constant throughout a checkpoint. */
+  /**
+   * Builds global variables that are constant throughout a checkpoint.
+   * @param options - Optional L1 block number to pin the fee read to, so the fee describes the same L1 state
+   * the caller planned the block from.
+   */
   buildCheckpointGlobalVariables(
     coinbase: EthAddress,
     feeRecipient: AztecAddress,
     slotNumber: SlotNumber,
     simulationOverridesPlan?: SimulationOverridesPlan,
+    options?: { blockNumber?: bigint },
   ): Promise<CheckpointGlobalVariables>;
 }

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -65,6 +65,11 @@ export class TXEArchiver extends ArchiverDataSourceBase {
     return (await this.getL2Frontier()).tips;
   }
 
+  public getL1SyncPoint(): Promise<undefined> {
+    // The TXE has no L1 to sync from.
+    return Promise.resolve(undefined);
+  }
+
   public async getL2Frontier(): Promise<L2Frontier> {
     // In TXE there is no possibility of reorgs and no blocks are ever getting proven so we just set 'latest', 'proven'
     // and 'finalized' to the latest block. The TXE never holds proposed checkpoints: every checkpoint is added

--- a/yarn-project/txe/src/state_machine/global_variable_builder.ts
+++ b/yarn-project/txe/src/state_machine/global_variable_builder.ts
@@ -24,6 +24,7 @@ export class TXEGlobalVariablesBuilder implements GlobalVariableBuilder {
     _feeRecipient: AztecAddress,
     _slotNumber: SlotNumber,
     _simulationOverridesPlan?: SimulationOverridesPlan,
+    _options?: { blockNumber?: bigint },
   ): Promise<CheckpointGlobalVariables> {
     const vars = makeGlobalVariables();
     return Promise.resolve({


### PR DESCRIPTION
Fixes A-1904. Part of A-1903.
Design: https://claude.ai/code/artifact/e9b78bd2-501d-4c30-a81a-5a10cbeed392

Stacked on #25384. Third of five PRs on the fee-quote / public-simulation series.

## Problem

The node ran two independent L1 pollers. `FeeProviderImpl` polled `getBlockNumber()` on its own schedule and
the archiver polled L1 on its own, so for up to one poll interval the two held different views of the chain.
Both answer the same underlying question — the minimum mana fee for a block in slot X — and the answer is a
step function of the slot, so a disagreement about which checkpoints exist shows up as a wallet quote the
node's own public simulation then rejects.

Worked example. L1 mines checkpoint 14 at slot 41. The archiver's next pass runs 200ms later and its frontier
now reports checkpoint 14 as the checkpointed tip, so the simulator prices the next block at slot 42. The fee
provider's own poll has not fired yet, so its cached "current min fees" still describes the L1 block before
checkpoint 14 landed and prices slot 41. If the L1 gas oracle stepped at slot 42, the wallet quotes the slot-41
fee, pads it, and the simulation charges the slot-42 fee and rejects the transaction. The same window exists in
reverse when the fee provider polls first.

On top of that, the provider read the "current" fee at `latest` even though it pinned the predictor's reads to
a block number, so a single quote could mix two L1 blocks.

## Design

- **Sync point source.** `L2BlockSource` gains `getL1SyncPoint()`, returning the same `{ blockNumber,
  blockHash }` that `getL2Frontier().l1SyncPoint` carries (added in #25384). The archiver serves it from the
  frontier cache without awaiting the snapshot promise, so following it costs a field read, not a store or L1
  call. The fee provider depends on that one method only (`Pick<L2BlockSource, 'getL1SyncPoint'>`).
- **Refresh on hash change.** `FeeProviderImpl` no longer polls an L1 head of its own. Its loop reads the sync
  point and refreshes only when the hash differs from the newest entry's — hash, not number, so a same-height
  L1 reorg still invalidates. Before the archiver's first pass the sync point is undefined and the provider
  falls back to L1's latest block, so a starting node can answer fee queries while the archiver catches up.
- **Every read pinned.** `getPendingCheckpoint` and `getTimestampForSlot` gained an optional `{ blockNumber }`,
  and `getManaMinFeeAt` takes `{ stateOverride?, blockNumber? }` as a single options bag (threaded through
  `getCheckpointNumber` / `getCheckpoint`, guarded by `checkBlockTag` like the other pinned readers); the
  predictor's state read was already pinned. One refresh therefore describes exactly one L1 block.
- **Ring of 4.** Each refresh appends `{ blockNumber, blockHash, currentMinFees, predictorState }`,
  newest first. `FeePredictor` no longer caches state internally: `computeState(blockNumber)` returns it and
  `computePredictions(state, manaUsage)` derives fees from it, so each retained view carries its own state and
  a tagged answer is computed from the state read at that block.
- **Single-flight.** One in-flight refresh promise, shared by the loop and every waiting request. A burst of
  requests during a transition costs one round of L1 reads.
- **`asOf` tagging.** `getCurrentMinFees(asOf?)` and `getPredictedMinFees(manaUsage?, asOf?)` take an optional
  `{ blockNumber, maxWaitMs? }`. Untagged serves the newest view. A tag the ring holds is served from that
  view even when a newer one exists. A tag ahead of every view awaits the shared refresh and, if the pass it
  joined had already started from an older sync point and so did not produce its block, one more pass of its
  own — both within `maxWaitMs` when set, falling through to the newest view on timeout — and then serves the
  match, or the newest view with a debug log. A tag behind the ring serves the oldest view with a debug log. A tagged miss
  never throws; only the initial `start()` refresh propagates errors. `getPredictedMinFees` still returns
  `[currentMinFees, ...predictions]`, both halves from the same entry.
- **Who tags.** In this PR the only tagged caller is the public simulator, which passes its frontier's sync
  point when pricing a checkpoint boundary (`buildCheckpointGlobalVariables` gained a trailing
  `{ blockNumber }`). PR 4 adds the next-block predictor and PR 5 the fee quote. Admission — `isValidTx`,
  gossip validation, pool ingress and eviction — stays untagged and unchanged: it tolerates staleness and must
  not gain a wait.

## Residuals

- The overrides plan built for the simulation (`buildSimulationOverridesStateOverride` and the pipelined parent
  fee-header reads inside `buildCheckpointSimulationOverridesPlan`) is still read unpinned. Those reads describe
  the proposed parent, which the frontier snapshot already pins logically, but they are not yet pinned to an L1
  block number.
- Fee freshness is now bounded by the archiver's poll interval plus the provider's, rather than the provider's
  alone. That is the point of the change — both sides move together — but it does mean an L1-driven oracle step
  reaches the quote slightly later than before.

## Tests

- `fee_provider.test.ts` rewritten against a stub sync-point source and mocked contract/predictor: pinned reads
  (the block number passed to each contract call is asserted — here the pin is the behaviour), refresh only on
  hash change with no head poll, same-height reorg refreshes, L1-head fallback before the first archiver pass,
  tagged hit served past a newer view, tagged miss refreshing and serving, single-flight across two concurrent
  misses, capped wait serving the newest view, tag behind the ring serving the oldest, ring capped at four,
  start failing on a failed initial refresh, and a failed background refresh leaving the last view intact.
- `node_public_calls_simulator.test.ts`: the boundary fee read is pinned to the frontier's sync point, and left
  unpinned when the archiver has not synced.
- `fee_quote_vs_simulation.integration.test.ts` (anvil): the mocked archiver now reports a real sync point and
  the provider is built against it. Both existing cases stay green, and a new case lands a checkpoint on L1,
  mines past it, and shows the quote unchanged while the archiver has not run a pass, then moving to the new
  fee together with the simulation once the sync point advances. This is what proves pinned `eth_call` with a
  `stateOverride` works against anvil at a recent block.
- `fee_predictor.test.ts` updated to the new `computeState` / `computePredictions` API; the state-caching block
  is gone with the cache.
- `archiver-sync.test.ts` asserts `getL1SyncPoint()` matches the frontier's field after a sync pass;
  `stdlib/src/interfaces/archiver.test.ts` round-trips the new RPC method.

Next PR moves next-block planning and the boundary fee cache out of the simulator.


