### PR TITLE
feat: lead the fee quote with the fee the next block will charge

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,12 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec Node] `getPredictedMinFees` leads with the fee the next block will charge
+
+The first entry of `getPredictedMinFees` is now the fee the node's public simulation would charge for the next block: the fee frozen into an in-progress checkpoint when the next block continues one, or the price of the slot the next block opens. The remaining entries are the L1 projections for the current slot and the following ones, unchanged. The node omits the leading entry when it cannot price the next block (for example during an L1 outage), in which case only the projections are returned.
+
+Clients that reduce the list with `max` (the wallet SDK's `getMinFees`, the CLI) are unaffected, and now quote a fee the node's simulation accepts even mid-checkpoint. A client that reads `fees[0]` as "the current min fee" should call `getCurrentMinFees` instead.
+
 ### [Aztec.js] Protocol contracts removed from `@aztec/noir-contracts.js`
 
 `@aztec/noir-contracts.js` no longer includes the protocol contracts: the `FeeJuice`, `ContractClassRegistry`, and `ContractInstanceRegistry` artifacts and typed wrappers have been removed from the package, so imports such as `@aztec/noir-contracts.js/FeeJuice` no longer resolve. These names are also no longer available to the `aztec` CLI's contract-name lookup (e.g. in `aztec example-contracts`).

--- a/yarn-project/aztec-node/src/aztec-node/fee_quote_vs_simulation.integration.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/fee_quote_vs_simulation.integration.test.ts
@@ -30,6 +30,7 @@ import type { L2LogsSource, WorldStateSynchronizer } from '@aztec/stdlib/interfa
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { mockTx } from '@aztec/stdlib/testing';
+import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { BlockHeader, GlobalVariables, type Tx } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 import { NativeWorldStateService } from '@aztec/world-state';
@@ -157,6 +158,21 @@ describe('fee quote vs public simulation', () => {
     blockHash: blockHashOf(blockNumber),
     checkpointNumber: PENDING_CHECKPOINT,
     indexWithinCheckpoint: IndexWithinCheckpoint(0),
+  });
+
+  const makeProposedCheckpointData = (args: {
+    checkpointNumber: CheckpointNumber;
+    startBlock: BlockNumber;
+    slotNumber: SlotNumber;
+  }): ProposedCheckpointData => ({
+    checkpointNumber: args.checkpointNumber,
+    header: CheckpointHeader.empty({ slotNumber: args.slotNumber }),
+    startBlock: args.startBlock,
+    blockCount: 1,
+    totalManaUsed: 0n,
+    feeAssetPriceModifier: 0n,
+    archive: AppendOnlyTreeSnapshot.empty(),
+    checkpointOutHash: Fr.ZERO,
   });
 
   const makeTx = (seed: number, maxFeesPerGas: GasFees): Promise<Tx> =>
@@ -401,6 +417,35 @@ describe('fee quote vs public simulation', () => {
     expect(output.globalVariables.gasFees.feePerL2Gas).toEqual(fees[0].feePerL2Gas);
   }, 120_000);
 
+  it('quotes the frozen checkpoint fee the simulation charges mid-checkpoint', async () => {
+    await startNodeAt(tsOf(changeSlot));
+
+    // Checkpoint 2 is proposed and terminates at block 2, but block 3 already extends it, so the next block
+    // continues the in-progress checkpoint and inherits the (pre-step, high) fee frozen into its header. No
+    // forward-looking L1 projection can see that fee: it was priced at a slot L1 has already moved past.
+    mockL2Frontier({
+      proposed: BlockNumber(3),
+      checkpointedBlock: BlockNumber(1),
+      checkpointedTipSlot: SlotNumber(changeSlot - 1),
+      proposedCheckpoint: makeProposedCheckpointData({
+        checkpointNumber: CheckpointNumber(2),
+        startBlock: BlockNumber(2),
+        slotNumber: SlotNumber(changeSlot - 1),
+      }),
+      latestBlockGlobals: { slotNumber: SlotNumber(changeSlot - 1), gasFees: new GasFees(0, highFee) },
+    });
+
+    const fees = await node.getPredictedMinFees(ManaUsageEstimate.Limit);
+    expect(fees[0].feePerL2Gas).toEqual(highFee);
+
+    const output = await node.simulatePublicCalls(await makeTx(0x20000, walletCap(fees)));
+
+    expect(output.globalVariables.slotNumber).toEqual(SlotNumber(changeSlot - 1));
+    expect(output.globalVariables.gasFees.feePerL2Gas).toEqual(highFee);
+    // What the wallet would actually quote covers what the simulation charges.
+    expect(walletCap(fees).feePerL2Gas).toBeGreaterThanOrEqual(output.globalVariables.gasFees.feePerL2Gas);
+  }, 120_000);
+
   it('quotes the same fee the simulation charges when nothing is lagging', async () => {
     await startNodeAt(tsOf(changeSlot));
 
@@ -418,6 +463,7 @@ describe('fee quote vs public simulation', () => {
 
     expect(output.globalVariables.slotNumber).toEqual(SlotNumber(changeSlot + 1));
     expect(output.globalVariables.gasFees.feePerL2Gas).toEqual(lowFee);
+    expect(output.globalVariables.gasFees).toEqual(fees[0]);
   }, 120_000);
 
   it('reuses the cached boundary fee across simulations instead of asking L1 again', async () => {

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -8,6 +8,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { BadRequestError } from '@aztec/foundation/json-rpc';
@@ -29,6 +30,7 @@ import {
   BlockHash,
   type BlockParameter,
   type BlockQuery,
+  type L1SyncPoint,
   L2Block,
   type L2BlockSource,
   type L2BlockSourceEventEmitter,
@@ -84,7 +86,7 @@ import { join } from 'path';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { type AztecNodeConfig, getConfigEnvVars } from './config.js';
-import { NextBlockPredictor } from './next_block/index.js';
+import { NextBlockPredictor, QUOTE_MAX_WAIT_MS } from './next_block/index.js';
 import { AztecNodeService } from './server.js';
 
 // Arbitrary fixed timestamp for the mock date provider. DateProvider.now() returns milliseconds but ExpirationTimestamp
@@ -449,6 +451,65 @@ describe('aztec node', () => {
 
       await node.sendTx(tx);
       expect(p2p.sendTx).toHaveBeenCalledWith(tx);
+    });
+  });
+
+  describe('min fee quotes', () => {
+    const l1SyncPoint: L1SyncPoint = { blockNumber: 42n, blockHash: Buffer32.random() };
+    const headFees = new GasFees(3, 3000);
+    /** The provider answers differently per L1 view, so which view the node asked for is visible in the result. */
+    const projectionsAtLatest = [new GasFees(1, 100), new GasFees(1, 110)];
+    const projectionsAtSyncPoint = [new GasFees(2, 200), new GasFees(2, 210)];
+
+    let quoteMinFees: jest.SpiedFunction<NextBlockPredictor['quoteMinFees']>;
+
+    beforeEach(() => {
+      feeProvider.getPredictedMinFees.mockImplementation((_manaUsage, asOf) =>
+        Promise.resolve(
+          asOf?.blockNumber === l1SyncPoint.blockNumber &&
+            asOf.maxWaitMs !== undefined &&
+            asOf.maxWaitMs <= QUOTE_MAX_WAIT_MS
+            ? projectionsAtSyncPoint
+            : projectionsAtLatest,
+        ),
+      );
+      quoteMinFees = jest.spyOn(node['nextBlockPredictor'], 'quoteMinFees');
+    });
+
+    it('leads with the next-block fee and prices the projections at the same L1 block', async () => {
+      quoteMinFees.mockResolvedValue({ fees: headFees, l1SyncPoint });
+
+      expect(await node.getPredictedMinFees()).toEqual([headFees, ...projectionsAtSyncPoint]);
+    });
+
+    it('leaves the projections untagged when the next-block fee carries no L1 sync point', async () => {
+      quoteMinFees.mockResolvedValue({ fees: headFees, l1SyncPoint: undefined });
+
+      expect(await node.getPredictedMinFees()).toEqual([headFees, ...projectionsAtLatest]);
+    });
+
+    it('serves the projections alone when the node cannot price the next block', async () => {
+      quoteMinFees.mockResolvedValue(undefined);
+
+      expect(await node.getPredictedMinFees()).toEqual(projectionsAtLatest);
+    });
+
+    it('serves the projections alone and warns when pricing the next block throws', async () => {
+      const warn = jest.spyOn(node['log'], 'warn');
+      quoteMinFees.mockRejectedValue(new Error('l1 is down'));
+
+      expect(await node.getPredictedMinFees()).toEqual(projectionsAtLatest);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('next-block min fee'), expect.any(Error));
+    });
+
+    it('does not fold the next-block fee into the current min fees or tx admission', async () => {
+      quoteMinFees.mockResolvedValue({ fees: headFees, l1SyncPoint });
+      const currentFees = new GasFees(0, 0);
+      feeProvider.getCurrentMinFees.mockResolvedValue(currentFees);
+
+      expect(await node.getCurrentMinFees()).toEqual(currentFees);
+      // A tx priced at the current min fees stays admissible even though the quote's head is far above them.
+      expect(await node.isValidTx(await mockTxForRollup(0x10000))).toEqual({ result: 'valid' });
     });
   });
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -114,7 +114,7 @@ import { NodeWorldStateQueries } from '../modules/node_world_state_queries.js';
 import { UnseenBlockHoldOff } from '../modules/unseen_block_hold_off.js';
 import { Sentinel } from '../sentinel/sentinel.js';
 import type { AztecNodeConfig } from './config.js';
-import type { NextBlockPredictor } from './next_block/index.js';
+import { type NextBlockPredictor, QUOTE_MAX_WAIT_MS } from './next_block/index.js';
 import { NodeMetrics } from './node_metrics.js';
 import { NodePublicCallsSimulator } from './node_public_calls_simulator.js';
 
@@ -461,9 +461,33 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     return await this.feeProvider.getCurrentMinFees();
   }
 
-  /** Returns predicted min fees for the current slot and next N slots. */
+  /**
+   * Returns the min fees a transaction submitted now may have to pay, worst entry first in intent: the list
+   * leads with the fee this node's public simulation would charge the next block right now, followed by the
+   * fee provider's projections for the current slot and the next N slots. Clients pad the worst entry, so a
+   * quoted transaction clears the simulation's fee check whether the difference comes from a frozen
+   * mid-checkpoint fee, a lagging clock, or L1 lag.
+   *
+   * The head normally comes from memory: the plan from the archiver's in-memory frontier and the boundary fee
+   * from the background-refreshed cache. At a boundary the cache has not priced yet, the request joins the
+   * shared refresh for at most {@link QUOTE_MAX_WAIT_MS}, a budget the projections' wait shares so the whole
+   * quote stays under that bound. The head is omitted when the node cannot produce it in time — an L1 outage
+   * that outlasts the cache's cutoff, or a frontier with no header for its proposed tip — in which case the
+   * projections alone are returned, as before this method grew a head.
+   */
   public async getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]> {
-    return await this.feeProvider.getPredictedMinFees(manaUsage);
+    const timer = new Timer();
+    const head = await this.nextBlockPredictor.quoteMinFees().catch((err: Error) => {
+      this.log.warn(`Failed to compute the next-block min fee for a quote, serving L1 projections only`, err);
+      return undefined;
+    });
+    // Tagging the projections with the head's L1 sync point keeps both halves of the answer on one L1 block.
+    const asOf = head?.l1SyncPoint && {
+      blockNumber: head.l1SyncPoint.blockNumber,
+      maxWaitMs: Math.max(0, QUOTE_MAX_WAIT_MS - timer.ms()),
+    };
+    const projections = await this.feeProvider.getPredictedMinFees(manaUsage, asOf);
+    return head ? [head.fees, ...projections] : projections;
   }
 
   public async getMaxPriorityFees(): Promise<GasFees> {

--- a/yarn-project/ethereum/src/test/start_anvil.test.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.test.ts
@@ -2,6 +2,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 
+import { type AddressInfo, createServer } from 'node:net';
 import { createPublicClient, http, parseAbiItem } from 'viem';
 
 import type { Anvil } from './start_anvil.js';
@@ -38,6 +39,18 @@ describe('start_anvil', () => {
     await anvil.stop().catch(err => createLogger('cleanup').error(err));
     expect(anvil.status).toEqual('idle');
   });
+
+  it('rejects instead of hanging when anvil cannot bind its port', async () => {
+    const blocker = createServer();
+    await new Promise<void>(resolve => blocker.listen(0, '127.0.0.1', () => resolve()));
+    const port = (blocker.address() as AddressInfo).port;
+
+    try {
+      await expect(startAnvil({ port })).rejects.toThrow(/before listening/);
+    } finally {
+      await new Promise<void>(resolve => blocker.close(() => resolve()));
+    }
+  }, 120_000);
 
   it('ignores errors uninstalling filters during teardown', async () => {
     const publicClient = createPublicClient({ transport: http(rpcUrl, { batch: false }) });

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -28,6 +28,11 @@ export interface Anvil {
 // so trapping the kill directly on TERM would leave the poll loop running and the caller's teardown
 // hanging until its SIGKILL escalation. `sleep & wait` makes the poll interruptible, so INT/TERM are
 // handled immediately rather than after the current `sleep` returns.
+//
+// The loop also stops once anvil itself is gone. Anvil's stdio is inherited by the supervisor, so a
+// supervisor that outlives a dead anvil holds the pipes open: the caller below sees neither a
+// "Listening on" line nor a `close` event, and waits forever. Watching the child means an anvil that
+// dies on startup (a port already in use, say) closes the supervisor and surfaces as an error.
 const ANVIL_WATCHDOG = `
 set -u
 parent=$PPID
@@ -35,8 +40,12 @@ parent=$PPID
 anvil_pid=$!
 trap 'kill "$anvil_pid" 2>/dev/null' EXIT
 trap 'exit 0' INT TERM
-while kill -0 "$parent" 2>/dev/null; do sleep 1 & wait $!; done
+while kill -0 "$parent" 2>/dev/null && kill -0 "$anvil_pid" 2>/dev/null; do sleep 1 & wait $!; done
 `;
+
+// How long to wait for anvil's "Listening on" banner before giving up on a spawn. Anvil normally
+// prints it in well under a second, so this only bounds a start that neither listens nor exits.
+const ANVIL_STARTUP_TIMEOUT_MS = 30_000;
 
 /**
  * Ensures there's a running Anvil instance and returns the RPC URL.
@@ -105,12 +114,26 @@ export async function startAnvil(
         env: { ...process.env, ANVIL_BIN: anvilBinary, RAYON_NUM_THREADS: '1' },
       });
 
-      // Wait for "Listening on" or an early exit.
+      // Wait for "Listening on", an early exit, or the startup budget running out. Both streams are
+      // collected so the rejection carries whatever anvil managed to say about why it did not start:
+      // it reports a refused bind on stdout, and `retry` only logs the error it is handed.
       await new Promise<void>((resolve, reject) => {
-        let stderr = '';
+        let output = '';
+        let startupTimer: NodeJS.Timeout | undefined;
+
+        const stopListening = () => {
+          if (startupTimer !== undefined) {
+            clearTimeout(startupTimer);
+            startupTimer = undefined;
+          }
+          child.stdout?.removeListener('data', onStdout);
+          child.stderr?.removeListener('data', onStderr);
+          child.removeListener('close', onClose);
+        };
 
         const onStdout = (data: Buffer) => {
           const text = data.toString();
+          output += text;
           logger?.debug(text.trim());
           methodCalls?.push(...(text.match(/eth_[^\s]+/g) || []));
 
@@ -121,27 +144,35 @@ export async function startAnvil(
             }
           }
           if (detectedPort !== undefined) {
-            child.stdout?.removeListener('data', onStdout);
-            child.stderr?.removeListener('data', onStderr);
-            child.removeListener('close', onClose);
+            stopListening();
             resolve();
           }
         };
 
         const onStderr = (data: Buffer) => {
-          stderr += data.toString();
-          logger?.debug(data.toString().trim());
+          const text = data.toString();
+          output += text;
+          logger?.debug(text.trim());
         };
 
         const onClose = (code: number | null) => {
-          child.stdout?.removeListener('data', onStdout);
-          child.stderr?.removeListener('data', onStderr);
-          reject(new Error(`Anvil exited with code ${code} before listening. stderr: ${stderr}`));
+          stopListening();
+          reject(new Error(`Anvil exited with code ${code} before listening. Output: ${output}`));
         };
 
         child.stdout?.on('data', onStdout);
         child.stderr?.on('data', onStderr);
         child.once('close', onClose);
+
+        startupTimer = setTimeout(() => {
+          stopListening();
+          // Tear the spawn down before retrying, so a stuck anvil does not keep holding the port.
+          void killChild(child).finally(() =>
+            reject(
+              new Error(`Anvil did not listen within ${ANVIL_STARTUP_TIMEOUT_MS}ms of starting. Output: ${output}`),
+            ),
+          );
+        }, ANVIL_STARTUP_TIMEOUT_MS);
       });
 
       // Continue piping for logging, method-call capture, and/or dateProvider sync after startup.

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -218,9 +218,10 @@ describe('L1Publisher integration', () => {
       getNextL1SlotTimestamp(dateProvider.nowInSeconds(), l1Constants) + BigInt(config.aztecSlotDuration),
     );
 
-  let port = 8545; // We increase the port for each test to avoid anvil conflicts
   const setup = async (deployL1ContractsArgs: Partial<DeployAztecL1ContractsArgs> = {}) => {
-    ({ rpcUrl, anvil } = await startAnvil({ port: port++ }));
+    // Port 0 lets the OS pick a free port, so neither the tests in this file nor other suites sharing
+    // the CI host can collide on it.
+    ({ rpcUrl, anvil } = await startAnvil({ port: 0 }));
     config.l1RpcUrls = [rpcUrl];
 
     deployerAccount = privateKeyToAccount(deployerPK);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -347,11 +347,12 @@ export interface AztecNode {
   getCurrentMinFees(): Promise<GasFees>;
 
   /**
-   * Returns predicted min fees for the current slot and next N slots.
-   * Each entry accounts for the L1 gas oracle transition and congestion growth based on the
-   * given mana usage estimate. Defaults to target usage (steady state).
+   * Returns min fees a transaction submitted now may have to pay. When the node can compute it, the list
+   * leads with the fee its public simulation would charge right now; the rest are the predicted min fees for
+   * the current slot and next N slots, each accounting for the L1 gas oracle transition and congestion growth
+   * based on the given mana usage estimate. Defaults to target usage (steady state).
    * @param manaUsage - Expected mana usage per checkpoint (none, target, or limit).
-   * @returns An array of GasFees with current min fees first, followed by one entry per predicted slot.
+   * @returns An array of GasFees whose worst entry is the fee a client should pad and quote.
    */
   getPredictedMinFees(manaUsage?: ManaUsageEstimate): Promise<GasFees[]>;
 


### PR DESCRIPTION
Fixes A-1906. Part of A-1903.
Design: https://claude.ai/code/artifact/e9b78bd2-501d-4c30-a81a-5a10cbeed392

Last of the fee-quote series, stacked on #25393. Fixes Bug 2 of #25344 / A-1885: the fee frozen into an in-progress checkpoint is invisible to a quote built only from forward-looking L1 projections.

## The bug

Every block in a checkpoint carries the fee frozen into the checkpoint's first block. The public simulation honours that; the fee quote did not — it only asked the L1 fee provider what a *future* slot would cost.

Worked example, with the L1 gas oracle stepping down between two slots:

- A checkpoint opens at slot 22 and freezes a mana min fee of 3,415 into its first block.
- The oracle steps down, so slot 23 onwards prices at 920.
- A wallet asks for a quote while that checkpoint is still in progress. The projections answer 920; the wallet's default 1.5x padding takes it to 1,380.
- The next block continues the checkpoint, so it charges 3,415. The transaction is rejected for paying too little, on a fee the node itself quoted.

## The fix

`AztecNodeService.getPredictedMinFees` now asks the next-block predictor for the fee the next block will actually charge and puts it first:

- Mid-checkpoint that fee is copied from the in-progress checkpoint's header — no L1 involved.
- At a checkpoint boundary it is the background-refreshed boundary fee.
- The projections are then requested `asOf` the same L1 sync point the head was derived from, so both halves of the answer describe one L1 block instead of two independently polled views.

Wallets already reduce the list with `max` (wallet SDK `getMinFees`, the CLI, the e2e fixture), so they pick up the head automatically and a quoted transaction clears the simulation's fee check.

## Why the quote waits at a transition

At a boundary the head can miss the shared fee cache and waits up to `QUOTE_MAX_WAIT_MS` (5s) for the refresh — the same L1 call the background loop was about to make, moved earlier and single-flighted, so a burst of quotes during a transition costs one round trip. The projections' tagged wait shares that budget (it gets whatever the head left of the 5s), so the whole quote is bounded by 5s rather than 10s.

Skipping the head instead would be wrong, because fees go up as well as down. The head is priced with the pipelining overrides, which include the proposed parent's real mana usage; the projections only approximate that with an assumed usage. When the parent ran hot the head exceeds every projection, and omitting it would underquote.

## Degraded path

If `quoteMinFees` cannot price the next block in time (an L1 outage past the cache's staleness cutoff, a refresh that outlasts the 5s budget, or a frontier with no header for its proposed tip) the node serves the projections alone, untagged — exactly the answer it gave before this change. The predictor logs the cause (a warning for a missing header, debug for a timed-out refresh); an outright throw from the predictor is logged as a warning here.

## API note for consumers

The first entry of `getPredictedMinFees` is now the fee the node's public simulation would charge for the next block, not "the current min fee". Clients that reduce the list with `max` are unaffected. A client that read `fees[0]` as the current fee should call `getCurrentMinFees` instead. `getCurrentMinFees` and tx admission (`isValidTx`) are unchanged. Documented in the migration notes.

## Tests

- Restored the frozen-fee integration case in `fee_quote_vs_simulation.integration.test.ts`: mid-checkpoint, the quote's first entry equals the frozen header fee, the simulation charges the same fee, and the padded quote covers it. Verified red on #25393 (quote head absent, quote 360,947,600,000 vs frozen 360,937,510,100,000) and green here.
- The remaining integration cases (lagging clock, nothing lagging, cached boundary fee, checkpoint landing) stay green; the "nothing lagging" case now also asserts the quote head equals the fee the simulation charges.
- Server unit tests for the head being prepended and the projections tagged with the head's sync point, the untagged path when there is no sync point, the projections-only paths when the head is undefined or throws, and that `getCurrentMinFees` and `isValidTx` do not see the head.


