### PR TITLE
chore(ci): correct the comments about private releases

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -128,8 +128,9 @@ function main {
     ci_mode="skip"
   elif has_label "ci-release-pr"; then
     # Release-PR mode creates and pushes a release tag for this PR's head (ci3.sh::handle_release_pr).
-    # In the private repo that tag triggers a private release via the safety gate below — this is the
-    # manual way to cut a private release from a PR, alongside the nightly tag cron.
+    # In the private repo that tag triggers a private release via the safety gate below. It is the only
+    # way a private release is cut: there are no private nightlies (nightly-release-tag.yml runs in the
+    # public repo alone, by design).
     ci_mode="release-pr"
   elif has_label "ci-full"; then
     ci_mode="full"
@@ -142,9 +143,10 @@ function main {
   elif has_label "ci-barretenberg" || [ "$target_branch" == "merge-train/barretenberg" ]; then
     ci_mode="barretenberg"
   elif [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
-    # A pushed semver tag is a release; REF_NAME is the tag (see ci3/source_refname). In the private
-    # repo this is the nightly path (nightly-release-tag*.yml push v<ver>-nightly.<date> tags on next and
-    # v5-next); the private-repo safety gate below routes it to the internal Artifact Registry.
+    # A pushed semver tag is a release; REF_NAME is the tag (see ci3/source_refname). In the public repo
+    # nightly-release-tag.yml pushes v<ver>-nightly.<date> tags on next and v5-next; in the private repo
+    # the only tags are the ones ci-release-pr creates, and the safety gate below routes them to the
+    # internal Artifact Registry.
     ci_mode="release"
   else
     ci_mode="fast"

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   nightly-release-tag:
+    # Public repo only: forks and the private mirror carry this file too. The private repo deliberately
+    # cuts no nightlies; a private release is cut on demand with the ci-release-pr label
+    # (bootstrap.sh::private_release).
     if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
     runs-on: ubuntu-latest
     strategy:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -643,9 +643,10 @@ function release_dryrun {
 }
 
 function private_release {
-  # Release flow for the private repo, run for any v* tag pushed there — routinely the nightly
-  # v<ver>-nightly.<date> tags (see ci3_labels_to_env.sh, which forces PRIVATE_RELEASE=1 for every
-  # release in that repo). We publish only our foundation npm packages (barretenberg/ts, noir,
+  # Release flow for the private repo, run for any v* tag pushed there: the v0.0.1-commit.<sha> tag a
+  # ci-release-pr label creates, on demand. There are no private nightlies by design
+  # (nightly-release-tag.yml runs in the public repo alone). ci3_labels_to_env.sh forces
+  # PRIVATE_RELEASE=1 for every release in that repo. We publish only our foundation npm packages (barretenberg/ts, noir,
   # ipc-runtime, wsdb, protocol/constants-codegen, l1-contracts' l1-artifacts, the noir-projects/fnd
   # artifacts packages) to the INTERNAL_NPM_REGISTRY npm repo in our internal GCP Artifact Registry.
   # We run the release step for real on exactly those components and do not invoke the others — the
@@ -973,7 +974,7 @@ case "$cmd" in
   "ci-private-release")
     # Local/dev entrypoint for the PRIVATE_RELEASE flow (see private_release): publish the foundation
     # npm packages to the internal GCP Artifact Registry.
-    # Same publishing path the private-release.yml workflow runs, minus EC2 and the compat-e2e gating.
+    # Same publishing path a release run in the private repo takes (ci3.yml on a tag), minus EC2.
     # Build first so the artifacts the publishes pack exist; set SKIP_BUILD=1 to reuse an existing
     # build. Requires GCP creds (GCP_PRIVATE_NPM_DEPLOY_KEY or GOOGLE_APPLICATION_CREDENTIALS) in the environment.
     export CI=${CI:-1}


### PR DESCRIPTION
Comment-only. The private repo cuts no nightly tags: `nightly-release-tag.yml` is gated to the public repo and the private mirror carries the same file, so there are no private nightlies, by decision. Four comments claimed the opposite (`ci3_labels_to_env.sh` twice, `bootstrap.sh::private_release`) and the `ci-private-release` entry named a `private-release.yml` workflow that does not exist. A private release is cut on demand with the `ci-release-pr` label.