### PR TITLE
refactor(ipc-codegen): keep the generator to erasable TypeScript

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/avm/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE IPC_CODEGEN_SRC
 )
 add_custom_command(
     OUTPUT ${AVM_GEN_OUTPUTS}
-    COMMAND node --experimental-strip-types --experimental-transform-types --no-warnings
+    COMMAND node --experimental-strip-types --no-warnings
             ${IPC_CODEGEN_DIR}/src/generate.ts
             --schema ${AVM_SCHEMA}
             --lang cpp

--- a/barretenberg/cpp/src/barretenberg/cdb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/cdb/CMakeLists.txt
@@ -15,7 +15,7 @@ file(GLOB_RECURSE IPC_CODEGEN_SRC
 )
 add_custom_command(
     OUTPUT ${CDB_GEN_OUTPUTS}
-    COMMAND node --experimental-strip-types --experimental-transform-types --no-warnings
+    COMMAND node --experimental-strip-types --no-warnings
             ${IPC_CODEGEN_DIR}/src/generate.ts
             --schema ${CDB_SCHEMA}
             --lang cpp

--- a/barretenberg/cpp/src/barretenberg/wsdb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/wsdb/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB_RECURSE IPC_CODEGEN_SRC
 )
 add_custom_command(
     OUTPUT ${WSDB_GEN_OUTPUTS}
-    COMMAND node --experimental-strip-types --experimental-transform-types --no-warnings
+    COMMAND node --experimental-strip-types --no-warnings
             ${IPC_CODEGEN_DIR}/src/generate.ts
             --schema ${WSDB_SCHEMA}
             --lang cpp

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -15,7 +15,7 @@ hash=$(hash_str \
   $(semver check $REF_NAME && echo 1 || echo 0))
 
 function generate_bb_avm_sim_package {
-  node --experimental-strip-types --experimental-transform-types --no-warnings \
+  node --experimental-strip-types --no-warnings \
     "$ROOT/ipc-codegen/src/generate.ts" \
     --schema "$ROOT/barretenberg/cpp/src/barretenberg/avm/avm_schema.json" \
     --lang ts \
@@ -33,7 +33,7 @@ function generate_bb_avm_sim_package {
 # Server binding package for the AVM CDB protocol: generated wire types +
 # Handler/dispatch + the schema itself. Pure TS — no binary, no arch packages.
 function generate_cdb_package {
-  node --experimental-strip-types --experimental-transform-types --no-warnings \
+  node --experimental-strip-types --no-warnings \
     "$ROOT/ipc-codegen/src/generate.ts" \
     --schema "$ROOT/barretenberg/cpp/src/barretenberg/cdb/cdb_schema.json" \
     --lang ts \

--- a/ipc-codegen/README.md
+++ b/ipc-codegen/README.md
@@ -84,7 +84,7 @@ Invoked once per (schema, language) pair. Run directly with
 `node --experimental-strip-types`, or via `bootstrap.sh`.
 
 ```
-node --experimental-strip-types --experimental-transform-types --no-warnings \
+node --experimental-strip-types --no-warnings \
   src/generate.ts --schema <file> --lang <ts|cpp|rust|zig> --out <dir> [flags]
 ```
 

--- a/ipc-codegen/bootstrap.sh
+++ b/ipc-codegen/bootstrap.sh
@@ -49,6 +49,9 @@ function test_cmds {
   # Generator unit tests (schema validation).
   echo "$prefix node --experimental-strip-types --no-warnings ipc-codegen/test/schema_visitor.test.ts"
 
+  # The generator itself must load under type stripping alone (no transform step).
+  echo "$prefix ipc-codegen/scripts/strip_only_test.sh"
+
   # Golden tests (each language verifies it can deserialize the goldens
   # baked by build(), and re-encode them byte-identically).
   echo "$prefix $script golden rust"

--- a/ipc-codegen/echo_example/cpp/bootstrap.sh
+++ b/ipc-codegen/echo_example/cpp/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 CODEGEN="$(cd "$DIR/../.." && pwd)"
-NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+NODE="node --experimental-strip-types --no-warnings"
 
 $NODE "$CODEGEN/src/generate.ts" \
   --schema "$DIR/../schema/schema.jsonc" \

--- a/ipc-codegen/echo_example/rust/bootstrap.sh
+++ b/ipc-codegen/echo_example/rust/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 CODEGEN="$(cd "$DIR/../.." && pwd)"
-NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+NODE="node --experimental-strip-types --no-warnings"
 
 $NODE "$CODEGEN/src/generate.ts" \
   --schema "$DIR/../schema/schema.jsonc" \

--- a/ipc-codegen/echo_example/ts/bootstrap.sh
+++ b/ipc-codegen/echo_example/ts/bootstrap.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 CODEGEN="$(cd "$DIR/../.." && pwd)"
 REPO_ROOT="$(cd "$CODEGEN/.." && pwd)"
-NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+NODE="node --experimental-strip-types --no-warnings"
 
 $NODE "$CODEGEN/src/generate.ts" \
   --schema "$DIR/../schema/schema.jsonc" \

--- a/ipc-codegen/echo_example/ts_package/bootstrap.sh
+++ b/ipc-codegen/echo_example/ts_package/bootstrap.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 CODEGEN="$(cd "$DIR/../.." && pwd)"
 REPO_ROOT="$(cd "$CODEGEN/.." && pwd)"
-NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+NODE="node --experimental-strip-types --no-warnings"
 
 $NODE "$CODEGEN/src/generate.ts" \
   --schema "$DIR/../schema/schema.jsonc" \

--- a/ipc-codegen/echo_example/zig/bootstrap.sh
+++ b/ipc-codegen/echo_example/zig/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 CODEGEN="$(cd "$DIR/../.." && pwd)"
-NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+NODE="node --experimental-strip-types --no-warnings"
 
 $NODE "$CODEGEN/src/generate.ts" \
   --schema "$DIR/../schema/schema.jsonc" \

--- a/ipc-codegen/scripts/strip_only_test.sh
+++ b/ipc-codegen/scripts/strip_only_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# The generator must run under Node's type stripping alone, with no transform
+# step: only erasable TypeScript, so no parameter properties, enums, namespaces
+# or decorators in ipc-codegen/src. Node reports those as
+# ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX at module load, which takes out every
+# --lang at once, so generate one of each here rather than trusting the callers
+# to notice.
+source $(git rev-parse --show-toplevel)/ci3/source
+
+schema="$root/ipc-codegen/echo_example/schema/schema.jsonc"
+out=$(mktemp -d)
+trap "rm -rf $out" EXIT
+
+for lang in rust ts zig cpp; do
+  node --experimental-strip-types --no-warnings "$root/ipc-codegen/src/generate.ts" \
+    --schema "$schema" --lang "$lang" --out "$out/$lang" --server --client >/dev/null
+done
+
+echo "generate.ts runs strip-only for rust, ts, zig and cpp."

--- a/ipc-codegen/src/cpp_codegen.ts
+++ b/ipc-codegen/src/cpp_codegen.ts
@@ -41,7 +41,11 @@ export interface CppCodegenOptions {
 }
 
 export class CppCodegen {
-  constructor(private opts: CppCodegenOptions) {}
+  private opts: CppCodegenOptions;
+
+  constructor(opts: CppCodegenOptions) {
+    this.opts = opts;
+  }
 
   private primitiveType(type: import("./schema_visitor.ts").Type): string {
     switch (type.primitive) {

--- a/ipc-codegen/src/typescript_package_codegen.ts
+++ b/ipc-codegen/src/typescript_package_codegen.ts
@@ -100,7 +100,11 @@ export interface TypeScriptServerPackageOptions {
  * from @aztec-foundation/ipc-runtime).
  */
 export class TypeScriptServerPackageCodegen {
-  constructor(private opts: TypeScriptServerPackageOptions) {}
+  private opts: TypeScriptServerPackageOptions;
+
+  constructor(opts: TypeScriptServerPackageOptions) {
+    this.opts = opts;
+  }
 
   generatePackageJson(): string {
     const pkg = {
@@ -175,7 +179,11 @@ runs \`yarn build\`.
 }
 
 export class TypeScriptPackageCodegen {
-  constructor(private opts: TypeScriptPackageOptions) {}
+  private opts: TypeScriptPackageOptions;
+
+  constructor(opts: TypeScriptPackageOptions) {
+    this.opts = opts;
+  }
 
   generatePackageJson(): string {
     const archPackages = archPackageNames(this.opts.packageName);

--- a/wsdb/bootstrap.sh
+++ b/wsdb/bootstrap.sh
@@ -10,7 +10,7 @@ hash=$(hash_str \
   $(cache_content_hash .rebuild_patterns))
 
 function generate_ts_package {
-  node --experimental-strip-types --experimental-transform-types --no-warnings \
+  node --experimental-strip-types --no-warnings \
     "$ROOT/ipc-codegen/src/generate.ts" \
     --schema "$ROOT/barretenberg/cpp/src/barretenberg/wsdb/wsdb_schema.jsonc" \
     --lang ts \


### PR DESCRIPTION
## Problem

`ipc-codegen/src/generate.ts` says:

```
* Zero npm dependencies — runs with Node.js 22+ via --experimental-strip-types.
```

It could not. Three parameter properties made Node reject the module at load:

```
$ node --experimental-strip-types ipc-codegen/src/generate.ts --lang rust ...
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
```

`generate.ts` imports `typescript_package_codegen.ts` unconditionally, so this broke **every** `--lang`, not just `ts`.

Nothing noticed because all eleven call sites also pass `--experimental-transform-types`, which compiles parameter properties. The documented invocation was never exercised: the only test that runs strip-only is `schema_visitor.test.ts`, whose sole local import is `schema_visitor.ts` — it never reaches `generate.ts`.

## Change

Expanded the three into an explicit field plus an assignment in the constructor body — what the transform emitted anyway:

```diff
-  constructor(private opts: CppCodegenOptions) {}
+  private opts: CppCodegenOptions;
+
+  constructor(opts: CppCodegenOptions) {
+    this.opts = opts;
+  }
```

That makes the source erasable, so `--experimental-transform-types` comes off all eleven call sites (3 CMakeLists, `barretenberg/ts/bootstrap.sh`, `wsdb/bootstrap.sh`, 5 echo_example bootstraps, the README). The generator now runs under the type stripping Node 23.6+ does by default.

`--experimental-strip-types` is kept: it is a no-op on the pinned Node (`.nvmrc` is `v24.15.0`) but is still required by the Node 22 the header mentions.

A fourth parameter property at `typescript_package_codegen.ts:332` is inside a template literal — emitted code, not source — so it is untouched.

## Verification

- **Generated output is byte-identical** for all four languages, diffed against the previous invocation (`--experimental-strip-types --experimental-transform-types`) over `bb_schema.json`. This is a no-op for consumers.
- All four `--lang` values generate with the transform flag gone.
- `ipc-codegen/test/schema_visitor.test.ts` passes; `echo_example/rust/bootstrap.sh` (a real modified call site) generates fine.
- Probed which constructs strip-only actually rejects, so the constraint is stated from measurement rather than memory: parameter properties, `enum`, `const enum`, and `namespace` are rejected; interfaces, type aliases, annotations, generics and `import type` are fine.

## Guard

The failure mode is invisible while any caller passes the transform flag, so the property needs a test. `ipc-codegen/scripts/strip_only_test.sh` generates one of each `--lang` strip-only and is wired into `test_cmds`. Red/green checked — reintroducing a parameter property fails it:

```
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
exit=1
```

The stronger guard would be `erasableSyntaxOnly` in a tsconfig, which fails at typecheck rather than at load. Not done here: `ipc-codegen` has no `tsconfig.json` or `package.json` (the "zero npm dependencies" claim is literal), and the repo pins TypeScript `^5.3.3` while that flag landed in 5.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016einpgfthfjLYGwCB3iQqD