### PR TITLE
feat: optimize proof submission

### DIFF
--- a/l1-contracts/partial_epoch_proof_gas_report.json
+++ b/l1-contracts/partial_epoch_proof_gas_report.json
@@ -8,66 +8,66 @@
     "functions": {
       "gasReportSubmit16Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1298643,
-        "mean": 1298643,
-        "median": 1298643,
-        "max": 1298643
+        "min": 1251816,
+        "mean": 1251816,
+        "median": 1251816,
+        "max": 1251816
       },
       "gasReportSubmit16CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1463654,
-        "mean": 1463654,
-        "median": 1463654,
-        "max": 1463654
+        "min": 1416995,
+        "mean": 1416995,
+        "median": 1416995,
+        "max": 1416995
       },
       "gasReportSubmit1Checkpoint((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 659855,
-        "mean": 659855,
-        "median": 659855,
-        "max": 659855
+        "min": 656546,
+        "mean": 656546,
+        "median": 656546,
+        "max": 656546
       },
       "gasReportSubmit1CheckpointWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 686608,
-        "mean": 686608,
-        "median": 686608,
-        "max": 686608
+        "min": 683299,
+        "mean": 683299,
+        "median": 683299,
+        "max": 683299
       },
       "gasReportSubmit32Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1836522,
-        "mean": 1836522,
-        "median": 1836522,
-        "max": 1836522
+        "min": 1742662,
+        "mean": 1742662,
+        "median": 1742662,
+        "max": 1742662
       },
       "gasReportSubmit32CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 2094263,
-        "mean": 2094263,
-        "median": 2094263,
-        "max": 2094263
+        "min": 2001294,
+        "mean": 2001294,
+        "median": 2001294,
+        "max": 2001294
       },
       "gasReportSubmit8Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 984085,
-        "mean": 984085,
-        "median": 984085,
-        "max": 984085
+        "min": 960537,
+        "mean": 960537,
+        "median": 960537,
+        "max": 960537
       },
       "gasReportSubmit8CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1080664,
-        "mean": 1080664,
-        "median": 1080664,
-        "max": 1080664
+        "min": 1057116,
+        "mean": 1057116,
+        "median": 1057116,
+        "max": 1057116
       },
       "gasReportSubmit8MoreCheckpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 974194,
-        "mean": 974194,
-        "median": 974194,
-        "max": 974194
+        "min": 943741,
+        "mean": 943741,
+        "median": 943741,
+        "max": 943741
       }
     }
   }

--- a/l1-contracts/partial_epoch_proof_gas_report.md
+++ b/l1-contracts/partial_epoch_proof_gas_report.md
@@ -2,14 +2,14 @@
 
 | Proof submission | Gas |
 |---|---:|
-| 1 Checkpoint | 659,855 |
-| 1 Checkpoint With Two Overrides | 686,608 |
-| 8 Checkpoints | 984,085 |
-| 8 Checkpoints With Two Overrides | 1,080,664 |
-| 8 More Checkpoints | 974,194 |
-| 16 Checkpoints | 1,298,643 |
-| 16 Checkpoints With Two Overrides | 1,463,654 |
-| 32 Checkpoints | 1,836,522 |
-| 32 Checkpoints With Two Overrides | 2,094,263 |
+| 1 Checkpoint | 656,546 |
+| 1 Checkpoint With Two Overrides | 683,299 |
+| 8 Checkpoints | 960,537 |
+| 8 Checkpoints With Two Overrides | 1,057,116 |
+| 8 More Checkpoints | 943,741 |
+| 16 Checkpoints | 1,251,816 |
+| 16 Checkpoints With Two Overrides | 1,416,995 |
+| 32 Checkpoints | 1,742,662 |
+| 32 Checkpoints With Two Overrides | 2,001,294 |
 
 _Uses the mock epoch proof verifier._

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -130,17 +130,19 @@ library EpochProofLib {
       firstHeaderToVerify = provenPrefixLength < accountedPrefixLength ? provenPrefixLength : accountedPrefixLength;
     }
 
-    // The skipped calldata prefix is untrusted, but rewards have already consumed it and proof verification binds its
-    // fee data to the canonical checkpoint headers. We only verify new headers since the last proof
-    verifyHeaders(_args.start, _args.end, _args.headers, firstHeaderToVerify);
+    {
+      // The skipped calldata prefix is untrusted, but rewards have already consumed it and proof verification binds its
+      // fee data to the canonical checkpoint headers. We only verify new headers since the last proof
+      bytes32[] memory headerHashes = verifyHeaders(_args.start, _args.end, _args.headers, firstHeaderToVerify);
+
+      require(verifyEpochRootProof(_args, _config, headerHashes), Errors.Rollup__InvalidProof());
+    }
 
     // Verify attestations for the last checkpoint in the epoch
     // -> This serves as training wheels for the public part of the system (proving systems used in public and AVM)
     // ensuring committee agreement on the epoch's validity alongside the cryptographic proof verification below.
     address[] memory committee =
       verifyLastCheckpointAttestationsAndOutHash(_args.end, _args.attestations, _args.args.outHash);
-
-    require(verifyEpochRootProof(_args, _config), Errors.Rollup__InvalidProof());
 
     RollupStore storage rollupStore = STFLib.getStorage();
     CompressedChainTips tips = rollupStore.tips;
@@ -202,8 +204,8 @@ library EpochProofLib {
     bytes calldata _blobPublicInputs,
     RollupConfig memory _config
   ) internal view returns (bytes32[] memory) {
-    verifyHeaders(_start, _end, _headers, 0);
-    return computeEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs, _config);
+    bytes32[] memory headerHashes = verifyHeaders(_start, _end, _headers, 0);
+    return computeEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs, _config, headerHashes);
   }
 
   /**
@@ -263,17 +265,18 @@ library EpochProofLib {
   }
 
   /**
-   * @notice Assembles the root rollup public inputs, taking the supplied checkpoint headers as already verified
+   * @notice Assembles the root rollup public inputs from supplied headers and canonical stored header hashes
    *
-   * @dev Callers must have rehashed `_headers` against the stored header hashes beforehand, since the fee
-   * recipient/value public inputs are read straight out of them.
+   * @dev Callers must ensure the supplied fee fields are either rehashed against `_headerHashes` or bound to those
+   * canonical hashes by proof verification.
    *
    * @param  _start - The start of the epoch (inclusive)
    * @param  _end - The end of the epoch (inclusive)
    * @param  _args - Array of public inputs to the proof (previousArchive, endArchive, endTimestamp, outHash, proverId)
    * @param  _headers - The proposed checkpoint headers supplying the fee recipient and value for each checkpoint
-   * @param _blobPublicInputs- The blob public inputs for the proof
-   * @param _config - The rollup's deployment-time configuration
+   * @param  _blobPublicInputs - The blob public inputs for the proof
+   * @param  _config - The rollup's deployment-time configuration
+   * @param  _headerHashes - The canonical stored header hashes returned by verifyHeaders
    */
   function computeEpochProofPublicInputs(
     uint256 _start,
@@ -281,7 +284,8 @@ library EpochProofLib {
     PublicInputArgs calldata _args,
     ProposedHeader[] calldata _headers,
     bytes calldata _blobPublicInputs,
-    RollupConfig memory _config
+    RollupConfig memory _config,
+    bytes32[] memory _headerHashes
   ) private view returns (bytes32[] memory) {
     RollupStore storage rollupStore = STFLib.getStorage();
 
@@ -358,7 +362,7 @@ library EpochProofLib {
     uint256 numCheckpoints = _end - _start + 1;
 
     for (uint256 i = 0; i < numCheckpoints; i++) {
-      publicInputs[5 + i] = STFLib.getHeaderHash(_start + i);
+      publicInputs[5 + i] = _headerHashes[i];
     }
 
     uint256 offset = 5 + Constants.MAX_CHECKPOINTS_PER_EPOCH;
@@ -428,21 +432,23 @@ library EpochProofLib {
    * @param _end The last checkpoint number in the epoch (inclusive)
    * @param _headers The proposed headers for each checkpoint in [_start, _end]
    * @param _firstHeaderToVerify The index of the first header that has not already been proven and accounted for
+   * @return headerHashes The canonical stored header hashes for the checkpoint range
    */
   function verifyHeaders(
     uint256 _start,
     uint256 _end,
     ProposedHeader[] calldata _headers,
     uint256 _firstHeaderToVerify
-  ) private view {
+  ) private view returns (bytes32[] memory headerHashes) {
     uint256 numCheckpoints = _end - _start + 1;
     require(
       _headers.length == numCheckpoints, Errors.Rollup__InvalidCheckpointHeaderCount(numCheckpoints, _headers.length)
     );
 
+    headerHashes = STFLib.getHeaderHashes(_start, _end);
     for (uint256 i = _firstHeaderToVerify; i < numCheckpoints; i++) {
-      bytes32 expectedHeaderHash = STFLib.getHeaderHash(_start + i);
-      bytes32 providedHeaderHash = ProposedHeaderLib.hash(_headers[i]);
+      bytes32 expectedHeaderHash = headerHashes[i];
+      bytes32 providedHeaderHash = ProposedHeaderLib.hashCalldata(_headers[i]);
       require(
         providedHeaderHash == expectedHeaderHash,
         Errors.Rollup__InvalidCheckpointHeader(expectedHeaderHash, providedHeaderHash)
@@ -565,17 +571,19 @@ library EpochProofLib {
    *
    * @param _args The epoch proof submission arguments containing proof data and public inputs
    * @param _config The rollup's deployment-time configuration
+   * @param _headerHashes The canonical stored header hashes returned by verifyHeaders
    * @return True if both blob proof and validity proof verification succeed
    */
-  function verifyEpochRootProof(SubmitEpochRootProofArgs calldata _args, RollupConfig memory _config)
-    private
-    view
-    returns (bool)
-  {
+  function verifyEpochRootProof(
+    SubmitEpochRootProofArgs calldata _args,
+    RollupConfig memory _config,
+    bytes32[] memory _headerHashes
+  ) private view returns (bool) {
     BlobLib.validateBatchedBlob(_args.blobInputs);
 
-    bytes32[] memory publicInputs =
-      computeEpochProofPublicInputs(_args.start, _args.end, _args.args, _args.headers, _args.blobInputs, _config);
+    bytes32[] memory publicInputs = computeEpochProofPublicInputs(
+      _args.start, _args.end, _args.args, _args.headers, _args.blobInputs, _config, _headerHashes
+    );
 
     require(_config.epochProofVerifier.verify(_args.proof, publicInputs), Errors.Rollup__InvalidProof());
 

--- a/l1-contracts/src/core/libraries/rollup/ProposedHeaderLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposedHeaderLib.sol
@@ -68,4 +68,24 @@ library ProposedHeaderLib {
       )
     );
   }
+
+  function hashCalldata(ProposedHeader calldata _header) internal pure returns (bytes32) {
+    return Hash.sha256ToField(
+      abi.encodePacked(
+        _header.lastArchiveRoot,
+        _header.blockHeadersHash,
+        _header.blobsHash,
+        _header.inboxRollingHash,
+        _header.outHash,
+        _header.slotNumber,
+        Timestamp.unwrap(_header.timestamp).toUint64(),
+        _header.coinbase,
+        _header.feeRecipient,
+        _header.gasFees.feePerDaGas,
+        _header.gasFees.feePerL2Gas,
+        _header.totalManaUsed,
+        _header.accumulatedFees
+      )
+    );
+  }
 }

--- a/l1-contracts/src/core/libraries/rollup/STFLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/STFLib.sol
@@ -284,6 +284,31 @@ library STFLib {
   }
 
   /**
+   * @notice Retrieves the stored header hashes for a contiguous checkpoint range.
+   * @dev Checking the newest checkpoint is not in the future and the oldest has not been overwritten proves every
+   * checkpoint between them is available.
+   * @param _start The first checkpoint number in the range (inclusive)
+   * @param _end The last checkpoint number in the range (inclusive)
+   * @return headerHashes The stored header hashes in checkpoint order
+   */
+  function getHeaderHashes(uint256 _start, uint256 _end) internal view returns (bytes32[] memory headerHashes) {
+    uint256 numCheckpoints = _end - _start + 1;
+    RollupStore storage rollupStore = getStorage();
+    uint256 pending = rollupStore.tips.getPending();
+    uint256 size = roundaboutSize();
+
+    uint256 upperLimit = _start + size;
+    require(
+      _end <= pending && pending < upperLimit, Errors.Rollup__UnavailableTempCheckpointLog(_start, pending, upperLimit)
+    );
+
+    headerHashes = new bytes32[](numCheckpoints);
+    for (uint256 i = 0; i < numCheckpoints; i++) {
+      headerHashes[i] = rollupStore.tempCheckpointLogs[(_start + i) % size].headerHash;
+    }
+  }
+
+  /**
    * @notice Retrieves the compressed fee header for a specific checkpoint number
    * @dev Returns the fee information including base fee components and mana costs.
    *      The data remains in compressed format for gas efficiency. Reverts if the checkpoint is stale.

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -983,6 +983,32 @@ contract RollupTest is RollupBase {
     rollup.getEpochProofPublicInputs(1, 1, args, headers, data.batchedBlobInputs);
   }
 
+  function testGetEpochProofPublicInputsReturnsCanonicalHeaderHashes() public setUpFor("mixed_checkpoint_1") {
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+    _proposeCheckpoint("mixed_checkpoint_2", 2);
+
+    DecoderBase.Data memory data = load("mixed_checkpoint_2").checkpoint;
+    CheckpointLog memory checkpoint = rollup.getCheckpoint(0);
+
+    PublicInputArgs memory args = PublicInputArgs({
+      previousArchive: checkpoint.archive,
+      endArchive: data.archive,
+      outHash: data.header.outHash,
+      previousInboxRollingHash: 0,
+      endInboxRollingHash: proposedHeaders[2].inboxRollingHash,
+      proverId: address(0)
+    });
+
+    ProposedHeader[] memory headers = new ProposedHeader[](2);
+    headers[0] = proposedHeaders[1];
+    headers[1] = proposedHeaders[2];
+
+    bytes32[] memory publicInputs = rollup.getEpochProofPublicInputs(1, 2, args, headers, data.batchedBlobInputs);
+
+    assertEq(publicInputs[5], ProposedHeaderLib.hash(headers[0]), "Unexpected first header hash");
+    assertEq(publicInputs[6], ProposedHeaderLib.hash(headers[1]), "Unexpected second header hash");
+  }
+
   // The epoch-proof anchoring pins the rolling-hash chain start to the record written at propose for checkpoint
   // start - 1, mirroring previousArchive. A wrong previousInboxRollingHash must be rejected.
   function testGetEpochProofPublicInputsRejectsWrongPreviousInboxRollingHash() public setUpFor("empty_checkpoint_1") {

--- a/l1-contracts/test/rollup/libraries/proposedheaderlib/hashCalldata.t.sol
+++ b/l1-contracts/test/rollup/libraries/proposedheaderlib/hashCalldata.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {ProposedHeader, ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+
+contract ProposedHeaderHashHarness {
+  function hashBoth(ProposedHeader calldata _header) external pure returns (bytes32 memoryHash, bytes32 calldataHash) {
+    ProposedHeader memory copiedHeader = _header;
+    return (ProposedHeaderLib.hash(copiedHeader), ProposedHeaderLib.hashCalldata(_header));
+  }
+}
+
+contract ProposedHeaderHashCalldataTest is Test {
+  ProposedHeaderHashHarness internal immutable harness = new ProposedHeaderHashHarness();
+
+  function testFuzz_HashCalldataMatchesMemory(ProposedHeader memory _header) public view {
+    _header.timestamp = Timestamp.wrap(uint64(Timestamp.unwrap(_header.timestamp)));
+    (bytes32 memoryHash, bytes32 calldataHash) = harness.hashBoth(_header);
+    assertEq(calldataHash, memoryHash);
+  }
+}


### PR DESCRIPTION
Further optimize the proof submission flow:
1. hash haeader from calldata instead of memory (avoids a copy)
2. read header hashes in bulk (avoid checks run on every iteration of a loop)
3. reuse already read header hashes

Other than submitting a proof of the first checkpoint (which is +2k gas compared to next) every other scenario is cheaper than the code on next.

| Scenario         | Current gas | vs #25404          | vs origin/next     |
|------------------|-------------|--------------------|--------------------|
| 1 fresh          | 663,452     | −1,506 (−0.23%)    | +2,243 (+0.34%)    |
| 8 fresh          | 965,328     | −21,594 (−2.19%)   | −14,985 (−1.53%)   |
| 8→16 extension   | 930,160     | −28,490 (−2.97%)   | −57,867 (−5.86%)   |
| 16 fresh         | 1,256,565   | −44,700 (−3.44%)   | −34,869 (−2.70%)   |
| 32 fresh         | 1,729,965   | −91,388 (−5.02%)   | −75,071 (−4.16%)   |

