### PR TITLE
fix(fast-inbox): replay published blocks by message count

### DIFF
--- a/yarn-project/archiver/src/errors.ts
+++ b/yarn-project/archiver/src/errors.ts
@@ -114,13 +114,20 @@ export class InboxBucketNotSyncedError extends Error {
 }
 
 /**
- * Thrown when a cumulative Inbox message count does not resolve to a bucket boundary this archiver has synced, either
- * because the count sits inside a bucket or because the bucket is not synced yet.
+ * Thrown when a cumulative Inbox message-count range is not fully backed by the messages this archiver has synced,
+ * either because it reaches past the synced tip or because the store is missing an index inside it.
  */
-export class InboxBucketBoundaryNotSyncedError extends Error {
-  constructor(public readonly totalMsgCount: bigint) {
-    super(`No synced Inbox bucket ends at cumulative message count ${totalMsgCount}`);
-    this.name = 'InboxBucketBoundaryNotSyncedError';
+export class InboxMessageRangeNotSyncedError extends Error {
+  constructor(
+    public readonly startLeafCount: bigint,
+    public readonly endLeafCount: bigint,
+    public readonly actualCount: bigint,
+  ) {
+    super(
+      `Inbox message range [${startLeafCount}, ${endLeafCount}) is not fully synced ` +
+        `(got ${actualCount} of ${endLeafCount - startLeafCount} messages)`,
+    );
+    this.name = 'InboxMessageRangeNotSyncedError';
   }
 }
 

--- a/yarn-project/archiver/src/store/message_store.test.ts
+++ b/yarn-project/archiver/src/store/message_store.test.ts
@@ -2,12 +2,13 @@ import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { Checkpoint, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { updateInboxRollingHash } from '@aztec/stdlib/messaging';
 import '@aztec/stdlib/testing/jest';
 
-import { InboxBucketBoundaryNotSyncedError, InboxBucketNotSyncedError } from '../errors.js';
+import { InboxBucketNotSyncedError, InboxMessageRangeNotSyncedError } from '../errors.js';
 import type { InboxMessage } from '../structs/inbox_message.js';
 import {
   makeInboxMessage,
@@ -23,6 +24,7 @@ import { type ArchiverL1SynchPoint, getArchiverSynchPoint } from './data_stores.
 import { MessageStore, MessageStoreError } from './message_store.js';
 
 describe('MessageStore', () => {
+  let db: AztecAsyncKVStore;
   let blockStore: BlockStore;
   let messageStore: MessageStore;
   let publishedCheckpoints: PublishedCheckpoint[];
@@ -40,7 +42,7 @@ describe('MessageStore', () => {
     });
 
   beforeEach(async () => {
-    const db = await openTmpStore('message_store_test');
+    db = await openTmpStore('message_store_test');
     blockStore = new BlockStore(db);
     messageStore = new MessageStore(db);
     // Create checkpoints sequentially to ensure archive roots are chained properly.
@@ -552,23 +554,61 @@ describe('MessageStore', () => {
       expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(0n, 0n)).toEqual([]);
     });
 
-    it('throws when a leaf count does not land on a synced bucket boundary', async () => {
+    it('returns messages between leaf counts interior to the bucket partition', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+      const leaves = msgs.map(m => m.leaf);
+
+      // Counts 1, 2 and 4 sit inside a bucket. A published block commits to a leaf count, and a reorg can merge away
+      // the bucket that ended there, so the range is addressed by message index alone.
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(1n, 6n)).toEqual(leaves.slice(1));
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(0n, 4n)).toEqual(leaves.slice(0, 4));
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(1n, 4n)).toEqual(leaves.slice(1, 4));
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(4n, 6n)).toEqual(leaves.slice(4));
+      // An empty range at an interior count consumes nothing rather than failing.
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(4n, 4n)).toEqual([]);
+    });
+
+    it('throws on an invalid or unsynced leaf count range', async () => {
       const msgs = makeBucketedMessages(threeBucketSpec);
       await messageStore.addL1ToL2MessageBuckets(msgs);
 
-      // Counts inside a bucket and past the last synced bucket both fail rather than returning a partial range.
-      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(0n, 4n)).rejects.toThrow(
-        InboxBucketBoundaryNotSyncedError,
-      );
-      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(4n, 6n)).rejects.toThrow(
-        InboxBucketBoundaryNotSyncedError,
-      );
+      // Ranges reaching past the synced tip fail rather than returning a partial range, empty ones included.
       await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(3n, 9n)).rejects.toThrow(
-        InboxBucketBoundaryNotSyncedError,
+        InboxMessageRangeNotSyncedError,
       );
+      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(7n, 7n)).rejects.toThrow(
+        InboxMessageRangeNotSyncedError,
+      );
+      // Reversed and negative bounds are caller errors, reported like every other failure of this API: as a
+      // rejection, so remote callers behind the archiver RPC see them the same way.
       await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(5n, 3n)).rejects.toThrow(
         /Invalid Inbox leaf count range/,
       );
+      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(-1n, 3n)).rejects.toThrow(
+        /Invalid Inbox leaf count range/,
+      );
+      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(0n, -1n)).rejects.toThrow(
+        /Invalid Inbox leaf count range/,
+      );
+    });
+
+    it('throws when the leaf count range has a hole', async () => {
+      const msgs = makeBucketedMessages(threeBucketSpec);
+      await messageStore.addL1ToL2MessageBuckets(msgs);
+
+      // Defense in depth: insertion is contiguity-checked and removal only ever drops a suffix, so no caller can put
+      // a hole in the middle of the log. Punch one straight into the map to prove a short read is never returned.
+      await db.openMap<number, Buffer>('archiver_l1_to_l2_messages').delete(2);
+
+      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(0n, 6n)).rejects.toThrow(
+        InboxMessageRangeNotSyncedError,
+      );
+      await expect(messageStore.getL1ToL2MessagesBetweenLeafCounts(2n, 3n)).rejects.toThrow(
+        InboxMessageRangeNotSyncedError,
+      );
+      // Ranges that do not cover the hole are unaffected.
+      expect(await messageStore.getL1ToL2MessagesBetweenLeafCounts(3n, 6n)).toEqual(msgs.slice(3).map(m => m.leaf));
     });
 
     it('rewinds buckets when messages are removed', async () => {

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -14,7 +14,7 @@ import {
 } from '@aztec/kv-store';
 import { type InboxBucket, updateInboxRollingHash } from '@aztec/stdlib/messaging';
 
-import { InboxBucketBoundaryNotSyncedError, InboxBucketNotSyncedError } from '../errors.js';
+import { InboxBucketNotSyncedError, InboxMessageRangeNotSyncedError } from '../errors.js';
 import { type InboxMessage, deserializeInboxMessage, serializeInboxMessage } from '../structs/inbox_message.js';
 
 /**
@@ -602,27 +602,37 @@ export class MessageStore {
 
   /**
    * Returns the message leaves in the cumulative Inbox message-count range `[startLeafCount, endLeafCount)`, in
-   * insertion order. The bounds are compact L1-to-L2 tree leaf counts, which every block header
-   * carries, so consumers can ask for the messages a block or checkpoint consumed without resolving buckets
-   * themselves. Both bounds must land on a bucket boundary this archiver has synced; it throws otherwise, since a
-   * caller asking for a range always expects the messages in it.
+   * insertion order. The bounds are compact L1-to-L2 tree leaf counts, which every block header carries, so consumers
+   * can ask for the messages a block or checkpoint consumed without resolving buckets themselves.
+   *
+   * The bounds address canonical compact message indices and need not land on a bucket boundary of the partition this
+   * archiver currently holds: a published block commits to a leaf count, while an L1 reorg can merge away the bucket
+   * that once ended there. An invalid range, one reaching past the synced tip, or one the store cannot serve whole
+   * throws, since a caller asking for a range always expects every message in it.
    */
   public async getL1ToL2MessagesBetweenLeafCounts(startLeafCount: bigint, endLeafCount: bigint): Promise<Fr[]> {
-    if (startLeafCount > endLeafCount) {
+    if (startLeafCount < 0n || endLeafCount < 0n || startLeafCount > endLeafCount) {
       throw new Error(`Invalid Inbox leaf count range [${startLeafCount}, ${endLeafCount})`);
     }
-    const startBucket = await this.getBucketAtBoundary(startLeafCount);
-    const endBucket = await this.getBucketAtBoundary(endLeafCount);
-    return this.getL1ToL2MessagesBetweenBuckets(startBucket.seq, endBucket.seq);
-  }
-
-  /** Resolves the bucket ending at the given cumulative message count, failing loudly if there is none. */
-  private async getBucketAtBoundary(totalMsgCount: bigint): Promise<InboxBucket> {
-    const bucket = await this.getInboxBucketByTotalMsgCount(totalMsgCount);
-    if (bucket === undefined) {
-      throw new InboxBucketBoundaryNotSyncedError(totalMsgCount);
-    }
-    return bucket;
+    // The synced total and the leaves are read together so a concurrent suffix removal cannot land between them and
+    // turn a range this store holds whole into a spurious incomplete one.
+    return await this.db.transactionAsync(async () => {
+      const syncedTotal = await this.getTotalL1ToL2MessageCount();
+      if (endLeafCount > syncedTotal) {
+        const available = syncedTotal > startLeafCount ? syncedTotal - startLeafCount : 0n;
+        throw new InboxMessageRangeNotSyncedError(startLeafCount, endLeafCount, available);
+      }
+      if (startLeafCount === endLeafCount) {
+        return [];
+      }
+      const leaves = await this.getMessageLeavesInIndexRange(startLeafCount, endLeafCount);
+      // The map holds at most one entry per index, so a short read is the only way a hole inside the range can show
+      // up, and the count catches every one of them.
+      if (BigInt(leaves.length) !== endLeafCount - startLeafCount) {
+        throw new InboxMessageRangeNotSyncedError(startLeafCount, endLeafCount, BigInt(leaves.length));
+      }
+      return leaves;
+    });
   }
 
   /**

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -18,6 +18,10 @@ export class MockArchiver extends MockL2BlockSource implements L2BlockSource, L1
     this.messageSource.setInboxBucket(bucket, msgs);
   }
 
+  public replaceInboxBuckets(buckets: { bucket: InboxBucket; msgs: Fr[] }[]) {
+    this.messageSource.replaceInboxBuckets(buckets);
+  }
+
   getL1ToL2MessageIndex(_l1ToL2Message: Fr): Promise<bigint | undefined> {
     return this.messageSource.getL1ToL2MessageIndex(_l1ToL2Message);
   }

--- a/yarn-project/archiver/src/test/mock_l1_to_l2_message_source.ts
+++ b/yarn-project/archiver/src/test/mock_l1_to_l2_message_source.ts
@@ -9,12 +9,34 @@ import type { InboxBucket, L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 export class MockL1ToL2MessageSource implements L1ToL2MessageSource {
   private buckets = new Map<bigint, InboxBucket>();
   private messagesPerBucket = new Map<bigint, Fr[]>();
+  /**
+   * The canonical message log, keyed by compact global index. Kept apart from the bucket partition so a test can
+   * repartition the buckets (as an L1 reorg does) while the indexed leaves stay exactly as they were.
+   */
+  private leavesByIndex = new Map<bigint, Fr>();
 
   constructor(private blockNumber: number) {}
 
   public setInboxBucket(bucket: InboxBucket, msgs: Fr[] = []) {
     this.buckets.set(bucket.seq, bucket);
     this.messagesPerBucket.set(bucket.seq, msgs);
+    // Index from the bucket's own cumulative total rather than call order, so re-registering a bucket or setting them
+    // out of order keeps every leaf at the index the archiver would give it.
+    const firstIndex = bucket.totalMsgCount - BigInt(msgs.length);
+    msgs.forEach((msg, i) => this.leavesByIndex.set(firstIndex + BigInt(i), msg));
+  }
+
+  /**
+   * Replaces the current bucket partition without touching the indexed leaf log, modelling an L1 reorg that re-mines
+   * the same messages under different bucket boundaries.
+   */
+  public replaceInboxBuckets(buckets: { bucket: InboxBucket; msgs: Fr[] }[]) {
+    this.buckets = new Map();
+    this.messagesPerBucket = new Map();
+    for (const { bucket, msgs } of buckets) {
+      this.buckets.set(bucket.seq, bucket);
+      this.messagesPerBucket.set(bucket.seq, msgs);
+    }
   }
 
   public setBlockNumber(blockNumber: number) {
@@ -57,13 +79,27 @@ export class MockL1ToL2MessageSource implements L1ToL2MessageSource {
     return Promise.resolve(seqs.flatMap(seq => this.messagesPerBucket.get(seq) ?? []));
   }
 
-  async getL1ToL2MessagesBetweenLeafCounts(startLeafCount: bigint, endLeafCount: bigint): Promise<Fr[]> {
-    const startBucket = await this.getInboxBucketByTotalMsgCount(startLeafCount);
-    const endBucket = await this.getInboxBucketByTotalMsgCount(endLeafCount);
-    if (startBucket === undefined || endBucket === undefined) {
-      throw new Error(`No mocked Inbox bucket boundary at ${startLeafCount} or ${endLeafCount}`);
+  /**
+   * Slices the indexed leaf log, enforcing the same range contract as the archiver's message store. Every failure is
+   * a rejection rather than a synchronous throw, so callers see this stand-in behave like the async source it mocks.
+   */
+  getL1ToL2MessagesBetweenLeafCounts(startLeafCount: bigint, endLeafCount: bigint): Promise<Fr[]> {
+    if (startLeafCount < 0n || endLeafCount < 0n || startLeafCount > endLeafCount) {
+      return Promise.reject(new Error(`Invalid Inbox leaf count range [${startLeafCount}, ${endLeafCount})`));
     }
-    return this.getL1ToL2MessagesBetweenBuckets(startBucket.seq, endBucket.seq);
+    const leaves: Fr[] = [];
+    for (let index = startLeafCount; index < endLeafCount; index++) {
+      const leaf = this.leavesByIndex.get(index);
+      if (leaf === undefined) {
+        return Promise.reject(
+          new Error(
+            `Inbox message range [${startLeafCount}, ${endLeafCount}) is not fully mocked (missing index ${index})`,
+          ),
+        );
+      }
+      leaves.push(leaf);
+    }
+    return Promise.resolve(leaves);
   }
 
   getBlockNumber() {

--- a/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
+++ b/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
@@ -63,9 +63,13 @@ export interface L1ToL2MessageSource {
 
   /**
    * Returns the message leaves in the cumulative Inbox message-count range `[startLeafCount, endLeafCount)`, in
-   * insertion order. The bounds are compact L1-to-L2 tree leaf counts, which every block header
-   * carries, so a consumer can ask for the messages a block or checkpoint consumed without resolving Inbox buckets
-   * itself. Both bounds must land on a bucket boundary the source has synced; it throws otherwise.
+   * insertion order. The bounds are compact L1-to-L2 tree leaf counts, which every block header carries, so a
+   * consumer can ask for the messages a block or checkpoint consumed without resolving Inbox buckets itself.
+   *
+   * The bounds address canonical compact message indices and need not land on a boundary of the bucket partition the
+   * source currently holds, so a published block's committed leaf counts stay resolvable after an L1 reorg has merged
+   * the bucket that ended at one of them. An invalid range, one past the synced tip, or one the source cannot serve
+   * whole throws, so an empty result always means the range holds no messages.
    * @param startLeafCount - The cumulative Inbox message count the range starts at, inclusive.
    * @param endLeafCount - The cumulative Inbox message count the range ends at, exclusive.
    */

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -593,6 +593,74 @@ describe('ProposalHandler checkpoint validation', () => {
       return makeHeader({ epochOutHash, ...overrides });
     }
 
+    // An L1 reorg can merge the bucket a checkpointed block consumed through into a later one. The archiver never
+    // prunes a checkpointed block, so that block's committed count stays interior to the current partition forever;
+    // reading the consumed range by count keeps the parent position resolvable, where resolving it as a bucket would
+    // derive an empty bundle and make this node decline a valid checkpoint.
+    it('derives the consumed bundle from a checkpoint-start count interior to the current buckets', async () => {
+      const header = makeHeader();
+      const consumedMessages = [new Fr(1000), new Fr(1001), new Fr(1002), new Fr(1003)];
+      setupDeepValidationMocks({ header });
+
+      const firstBlockNumber = 5;
+      const block = {
+        archive: new AppendOnlyTreeSnapshot(archiveRoot, 1),
+        number: firstBlockNumber,
+        checkpointNumber: CheckpointNumber(1),
+        header: {
+          globalVariables: GlobalVariables.empty({ slotNumber: SlotNumber(1) }),
+          state: { l1ToL2MessageTree: { nextAvailableLeafIndex: 7 } },
+        },
+      } as unknown as L2Block;
+      blockSource.getBlocksForSlot.mockResolvedValue([block]);
+      blockSource.getBlockData.mockImplementation(query =>
+        Promise.resolve(
+          'number' in query && query.number === firstBlockNumber - 1
+            ? ({
+                header: { state: { l1ToL2MessageTree: { nextAvailableLeafIndex: 3 } } },
+              } as unknown as BlockData)
+            : ({ header: makeBlockHeader() } as BlockData),
+        ),
+      );
+
+      // The checkpoint's final position is still a live bucket boundary; only the parent's is gone.
+      l1ToL2MessageSource.getInboxBucketByTotalMsgCount.mockImplementation(total =>
+        Promise.resolve(
+          total === 7n
+            ? ({
+                seq: 1n,
+                inboxRollingHash: Fr.random(),
+                totalMsgCount: 7n,
+                timestamp: 10n,
+                msgCount: 7,
+                lastMessageIndex: 6n,
+                l1BlockNumber: 10n,
+                l1BlockHash: Buffer32.fromBigInt(10n),
+              } satisfies InboxBucket)
+            : undefined,
+        ),
+      );
+      l1ToL2MessageSource.getL1ToL2MessagesBetweenLeafCounts.mockResolvedValue(consumedMessages);
+
+      await handler.handleCheckpointProposal(
+        await makeProposal({ archiveRoot, checkpointHeader: header }),
+        proposalInfo,
+      );
+
+      expect(l1ToL2MessageSource.getL1ToL2MessagesBetweenLeafCounts).toHaveBeenCalledWith(3n, 7n);
+      expect(checkpointsBuilder.openCheckpoint).toHaveBeenCalledWith(
+        CheckpointNumber(1),
+        expect.anything(),
+        expect.anything(),
+        consumedMessages,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        [block],
+        expect.anything(),
+      );
+    });
+
     it('returns checkpoint_header_mismatch when headers differ', async () => {
       const proposalHeader = makeHeader();
       const computedHeader = makeHeader({ totalManaUsed: new Fr(999) });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -1132,9 +1132,14 @@ export class ProposalHandler {
   }
 
   /**
-   * Derives the ordered list of L1-to-L2 messages a checkpoint consumed across its blocks, from the Inbox buckets
-   * between the parent checkpoint's consumed position and the checkpoint's last block. Empty when
-   * the checkpoint consumed nothing or its consumption cannot be resolved against the local Inbox view.
+   * Derives the ordered list of L1-to-L2 messages a checkpoint consumed across its blocks: the compact message-count
+   * range between the parent checkpoint's consumed position and the checkpoint's last block. Empty when the
+   * checkpoint consumed nothing or its final consumption position does not resolve to a current Inbox bucket.
+   *
+   * Only the final position is resolved as a bucket, which is the live rule this proposal must satisfy. The start
+   * position is a count committed by an already checkpointed block, which the archiver never prunes, so an L1 reorg
+   * that merges buckets can leave it permanently interior to the current partition; reading the range by count keeps
+   * that historical bound resolvable instead of silently deriving an empty bundle for a valid proposal.
    */
   private async deriveCheckpointConsumedMessages(blocks: L2Block[]): Promise<Fr[]> {
     const checkpointStartTotal = await this.getPreBlockConsumedTotal(blocks[0].number);
@@ -1142,12 +1147,11 @@ export class ProposalHandler {
     if (checkpointStartTotal === undefined || lastBlockTotal <= checkpointStartTotal) {
       return [];
     }
-    const startBucket = await this.l1ToL2MessageSource.getInboxBucketByTotalMsgCount(checkpointStartTotal);
     const endBucket = await this.l1ToL2MessageSource.getInboxBucketByTotalMsgCount(lastBlockTotal);
-    if (startBucket === undefined || endBucket === undefined) {
+    if (endBucket === undefined) {
       return [];
     }
-    return this.l1ToL2MessageSource.getL1ToL2MessagesBetweenBuckets(startBucket.seq, endBucket.seq);
+    return this.l1ToL2MessageSource.getL1ToL2MessagesBetweenLeafCounts(checkpointStartTotal, endBucket.totalMsgCount);
   }
 
   async reexecuteTransactions(

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -51,6 +51,21 @@ describe('ServerWorldStateSynchronizer', () => {
   beforeEach(() => {
     blockAndMessagesSource = mock<L2BlockSource & L1ToL2MessageSource>();
     blockAndMessagesSource.getBlockNumber.mockResolvedValue(BlockNumber(LATEST_BLOCK_NUMBER));
+    // Published-block replay reads the parent block's leaf count and then the messages in the range it opens, so the
+    // source answers both like an archiver holding the whole mock chain.
+    blockAndMessagesSource.getBlockData.mockImplementation(async query => {
+      const block = allBlocks().find(b => 'number' in query && b.number === query.number);
+      return block === undefined
+        ? undefined
+        : {
+            header: block.header,
+            archive: block.archive,
+            blockHash: await block.hash(),
+            checkpointNumber: block.checkpointNumber,
+            indexWithinCheckpoint: block.indexWithinCheckpoint,
+          };
+    });
+    blockAndMessagesSource.getL1ToL2MessagesBetweenLeafCounts.mockResolvedValue([]);
 
     merkleTreeRead = mock<MerkleTreeReadOperations>();
     merkleTreeRead.getInitialHeader.mockReturnValue({
@@ -88,8 +103,10 @@ describe('ServerWorldStateSynchronizer', () => {
     await server.stop();
   });
 
+  const allBlocks = () => checkpoints.flatMap(c => c.checkpoint.blocks);
+
   const pushBlocks = async (from: number, to: number) => {
-    const blocks = checkpoints.flatMap(c => c.checkpoint.blocks).filter(b => b.number >= from && b.number <= to);
+    const blocks = allBlocks().filter(b => b.number >= from && b.number <= to);
     await server.handleBlockStreamEvent({
       type: 'blocks-added',
       blocks,
@@ -246,6 +263,88 @@ describe('ServerWorldStateSynchronizer', () => {
     void server.start();
     merkleTreeDb.handleL2BlockAndMessages.mockRejectedValue(new Error('Test error'));
     await expect(pushBlocks(1, 5)).rejects.toThrow(/Test error/i);
+  });
+
+  describe('L1 to L2 message replay', () => {
+    // Blocks with a strictly growing leaf count, so each one opens a non-empty range over the one before it.
+    const blockLeafCounts = [3, 3, 7];
+
+    let messagesByRange: Map<string, Fr[]>;
+    let originalLeafCounts: number[];
+
+    afterEach(() => {
+      const blocks = allBlocks();
+      originalLeafCounts.forEach(
+        (count, i) => (blocks[i].header.state.l1ToL2MessageTree.nextAvailableLeafIndex = count),
+      );
+    });
+
+    beforeEach(() => {
+      const blocks = allBlocks();
+      originalLeafCounts = blockLeafCounts.map(
+        (_, i) => blocks[i].header.state.l1ToL2MessageTree.nextAvailableLeafIndex,
+      );
+      blockLeafCounts.forEach((count, i) => (blocks[i].header.state.l1ToL2MessageTree.nextAvailableLeafIndex = count));
+
+      // Historical replay addresses canonical message indices: resolving a count as a bucket of the current
+      // partition is exactly what a reorg can make impossible, so it must not happen here.
+      blockAndMessagesSource.getInboxBucketByTotalMsgCount.mockImplementation(() => {
+        throw new Error('Published-block replay must not resolve leaf counts as buckets');
+      });
+      blockAndMessagesSource.getL1ToL2MessagesBetweenBuckets.mockImplementation(() => {
+        throw new Error('Published-block replay must not read messages by bucket');
+      });
+
+      messagesByRange = new Map([
+        ['0-3', [new Fr(10n), new Fr(11n), new Fr(12n)]],
+        ['3-7', [new Fr(13n), new Fr(14n), new Fr(15n), new Fr(16n)]],
+      ]);
+      blockAndMessagesSource.getL1ToL2MessagesBetweenLeafCounts.mockImplementation((start, end) => {
+        const messages = messagesByRange.get(`${start}-${end}`);
+        return messages === undefined
+          ? Promise.reject(new Error(`Unexpected leaf count range [${start}, ${end})`))
+          : Promise.resolve(messages);
+      });
+    });
+
+    it('replays each block from the leaf count range it committed to', async () => {
+      void server.start();
+      await pushBlocks(1, 3);
+
+      const blocks = allBlocks();
+      expect(merkleTreeDb.handleL2BlockAndMessages.mock.calls).toEqual([
+        [blocks[0], messagesByRange.get('0-3')],
+        // The second block consumed nothing, so its range is empty and needs no query at all.
+        [blocks[1], []],
+        [blocks[2], messagesByRange.get('3-7')],
+      ]);
+      expect(blockAndMessagesSource.getL1ToL2MessagesBetweenLeafCounts.mock.calls).toEqual([
+        [0n, 3n],
+        [3n, 7n],
+      ]);
+    });
+
+    it('applies the blocks before an unavailable range and stops there', async () => {
+      void server.start();
+      messagesByRange.delete('3-7');
+
+      await expect(pushBlocks(1, 3)).rejects.toThrow(/Unexpected leaf count range \[3, 7\)/);
+
+      // The unavailable range fails the sync instead of silently applying the block with no messages, and the blocks
+      // already applied are kept so the retry resumes from there.
+      expect(merkleTreeDb.handleL2BlockAndMessages.mock.calls).toEqual([
+        [allBlocks()[0], messagesByRange.get('0-3')],
+        [allBlocks()[1], []],
+      ]);
+    });
+
+    it('fails instead of replaying a whole message history when the parent block is missing', async () => {
+      void server.start();
+      blockAndMessagesSource.getBlockData.mockResolvedValue(undefined);
+
+      await expect(pushBlocks(2, 3)).rejects.toThrow(/block 1 is unavailable/);
+      expect(merkleTreeDb.handleL2BlockAndMessages).not.toHaveBeenCalled();
+    });
   });
 
   describe('getVerifiedSnapshot', () => {

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -369,31 +369,22 @@ export class ServerWorldStateSynchronizer
   private async handleL2Blocks(l2Blocks: L2Block[]) {
     this.log.debug(`Handling L2 blocks ${l2Blocks[0].number} to ${l2Blocks.at(-1)!.number}`);
 
-    // Derive each block's real L1-to-L2 message bundle from the compact leaf-index range it inserted:
-    // the messages between the parent block's L1-to-L2 tree leaf count and this block's, resolved via the
-    // Inbox buckets. Blocks in a batch are consecutive, so we track the running leaf count.
-    const messagesForBlocks = new Map<BlockNumber, Fr[]>();
+    // Each block's real L1-to-L2 message bundle is the compact leaf-index range it inserted: the messages between the
+    // parent block's L1-to-L2 tree leaf count and this block's. The range addresses canonical message indices, so it
+    // is served whole even after an L1 reorg merged away the bucket that once ended at the parent's count. Blocks in
+    // a batch are consecutive, so we track the running leaf count; each block is fetched and applied before the next
+    // one is read, so a range the archiver cannot serve yet does not discard the blocks already applied.
     let prevLeafCount = await this.getL1ToL2LeafCountBefore(l2Blocks[0].number);
-    for (const block of l2Blocks) {
-      const blockLeafCount = BigInt(block.header.state.l1ToL2MessageTree.nextAvailableLeafIndex);
-      if (blockLeafCount > prevLeafCount) {
-        const startBucket = await this.l2BlockSource.getInboxBucketByTotalMsgCount(prevLeafCount);
-        const endBucket = await this.l2BlockSource.getInboxBucketByTotalMsgCount(blockLeafCount);
-        if (startBucket !== undefined && endBucket !== undefined) {
-          messagesForBlocks.set(
-            block.number,
-            await this.l2BlockSource.getL1ToL2MessagesBetweenBuckets(startBucket.seq, endBucket.seq),
-          );
-        }
-      }
-      prevLeafCount = blockLeafCount;
-    }
-
     let updateStatus: WorldStateStatusFull | undefined = undefined;
     for (const block of l2Blocks) {
-      const [duration, result] = await elapsed(() =>
-        this.handleL2Block(block, messagesForBlocks.get(block.number) ?? []),
-      );
+      const blockLeafCount = BigInt(block.header.state.l1ToL2MessageTree.nextAvailableLeafIndex);
+      const messages =
+        blockLeafCount > prevLeafCount
+          ? await this.l2BlockSource.getL1ToL2MessagesBetweenLeafCounts(prevLeafCount, blockLeafCount)
+          : [];
+      prevLeafCount = blockLeafCount;
+
+      const [duration, result] = await elapsed(() => this.handleL2Block(block, messages));
       this.log.info(`World state updated with L2 block ${block.number}`, {
         eventName: 'l2-block-handled',
         duration,
@@ -410,14 +401,21 @@ export class ServerWorldStateSynchronizer
     this.instrumentation.updateWorldStateMetrics(updateStatus);
   }
 
-  /** The L1-to-L2 message tree leaf count as of the block before `blockNumber` (0 if that block is genesis). */
+  /**
+   * The L1-to-L2 message tree leaf count as of the block before `blockNumber` (0 if that block is genesis). Throws
+   * when a non-genesis parent is unavailable: treating it as zero would ask for every message ever received as the
+   * next block's bundle.
+   */
   private async getL1ToL2LeafCountBefore(blockNumber: BlockNumber): Promise<bigint> {
     const parentNumber = blockNumber - 1;
     if (parentNumber < INITIAL_L2_BLOCK_NUM) {
       return 0n;
     }
     const parentBlock = await this.l2BlockSource.getBlockData({ number: BlockNumber(parentNumber) });
-    return parentBlock === undefined ? 0n : BigInt(parentBlock.header.state.l1ToL2MessageTree.nextAvailableLeafIndex);
+    if (parentBlock === undefined) {
+      throw new Error(`Cannot derive L1 to L2 messages for block ${blockNumber}: block ${parentNumber} is unavailable`);
+    }
+    return BigInt(parentBlock.header.state.l1ToL2MessageTree.nextAvailableLeafIndex);
   }
 
   /**

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -1,6 +1,7 @@
 import { MockPrefilledArchiver } from '@aztec/archiver/test';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { timesAsync } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -161,6 +162,71 @@ describe('world-state integration', () => {
       await archiver.createBlocks(4);
       await awaitSync(12);
       await expectSynchedToBlock(12);
+    });
+  });
+
+  describe('Inbox bucket repartitioning', () => {
+    // Rebuilds the current bucket partition as a single bucket holding every message the given blocks consumed, as an
+    // L1 reorg that re-mines the same messages under merged boundaries leaves it. The indexed leaves are unchanged,
+    // but the boundary each published block consumed through is gone from the current partition.
+    const mergeInboxBuckets = (blockCount: number) => {
+      const messages = checkpoints.slice(0, blockCount).flatMap(c => c.messages);
+      archiver.replaceInboxBuckets([
+        {
+          bucket: {
+            seq: 0n,
+            inboxRollingHash: Fr.ZERO,
+            totalMsgCount: 0n,
+            timestamp: 0n,
+            msgCount: 0,
+            lastMessageIndex: 0n,
+            l1BlockNumber: 0n,
+            l1BlockHash: Buffer32.ZERO,
+          },
+          msgs: [],
+        },
+        {
+          bucket: {
+            seq: 1n,
+            inboxRollingHash: Fr.ZERO,
+            totalMsgCount: BigInt(messages.length),
+            timestamp: 1n,
+            msgCount: messages.length,
+            lastMessageIndex: BigInt(messages.length) - 1n,
+            l1BlockNumber: 1n,
+            l1BlockHash: Buffer32.ZERO,
+          },
+          msgs: messages,
+        },
+      ]);
+    };
+
+    it('replays published blocks whose consumed boundary the current partition no longer has', async () => {
+      const blockCount = 3;
+      await archiver.createBlocks(blockCount);
+      mergeInboxBuckets(blockCount);
+
+      // Driven directly rather than through the block stream, which swallows and retries the archive-root divergence
+      // a wrong message bundle causes.
+      const blocks = checkpoints.slice(0, blockCount).flatMap(c => c.checkpoint.blocks);
+      await synchronizer.handleBlockStreamEvent({ type: 'blocks-added', blocks });
+
+      for (let blockNumber = 1; blockNumber <= blockCount; blockNumber++) {
+        await expectSynchedBlockHashMatches(blockNumber);
+      }
+      const lastBlockState = blocks.at(-1)!.header.state;
+      const messageTree = await db.getCommitted().getTreeInfo(MerkleTreeId.L1_TO_L2_MESSAGE_TREE);
+      expect(messageTree.root).toEqual(lastBlockState.l1ToL2MessageTree.root.toBuffer());
+      expect(messageTree.size).toEqual(BigInt(lastBlockState.l1ToL2MessageTree.nextAvailableLeafIndex));
+    });
+
+    it('syncs the whole chain through the block stream under a merged partition', async () => {
+      const blockCount = 3;
+      await archiver.createBlocks(blockCount);
+      mergeInboxBuckets(blockCount);
+
+      await synchronizer.start();
+      await expectSynchedToBlock(blockCount);
     });
   });
 


### PR DESCRIPTION
## Context

The message-only Inbox rolling hash survives an L1 reorg that re-mines the same ordered leaves under different bucket boundaries. An already-published block remains valid in that case, but a fresh node could not replay it when an intermediate committed leaf count was no longer a boundary in the current Inbox partition.

## Approach

Historical message retrieval now reads exact compact leaf-count ranges directly from the archiver's indexed message log, validates that each range is fully synced, and no longer resolves its bounds through current bucket metadata. World-state applies those ranges block by block without a silent empty fallback, and validator checkpoint reconstruction uses the same count-addressed semantics for its historical start while retaining the current-bucket requirement at the final endpoint.

The shared archiver mocks now keep indexed leaves separate from replaceable bucket metadata, enabling a fresh-world-state regression that replays published blocks after a same-message bucket merge. Live bucket-range selection and proposal validation remain unchanged.

Stacked on #25398

Fixes A-1924
