### PR TITLE
refactor(pxe): migrate CapsuleStore to BaseStagingStore (backport of aztec-labs-eng/aztec-node#101)

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -397,9 +397,9 @@ describe('Utility Execution test suite', () => {
 
         capsuleStore.getCapsule.mockResolvedValueOnce(capsule);
 
-        utilityExecutionOracle.setCapsule(contractAddress, slot, capsule, scope);
+        await utilityExecutionOracle.setCapsule(contractAddress, slot, capsule, scope);
         await utilityExecutionOracle.getCapsule(contractAddress, slot, capsule.length, scope);
-        utilityExecutionOracle.deleteCapsule(contractAddress, slot, scope);
+        await utilityExecutionOracle.deleteCapsule(contractAddress, slot, scope);
         await utilityExecutionOracle.copyCapsule(contractAddress, srcSlot, dstSlot, 1, scope);
 
         expect(capsuleStore.setCapsule).toHaveBeenCalledWith(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -725,9 +725,9 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-  public setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], scope: AztecAddress): void {
+  public setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], scope: AztecAddress): Promise<void> {
     this.#assertOwnContract(contractAddress);
-    this.capsuleService.setCapsule(contractAddress, slot, capsule, this.changeSetId, scope);
+    return this.capsuleService.setCapsule(contractAddress, slot, capsule, this.changeSetId, scope);
   }
 
   public async getCapsule(
@@ -741,9 +741,9 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return values ? Option.some(values) : Option.none({ length: tSize });
   }
 
-  public deleteCapsule(contractAddress: AztecAddress, slot: Fr, scope: AztecAddress): void {
+  public deleteCapsule(contractAddress: AztecAddress, slot: Fr, scope: AztecAddress): Promise<void> {
     this.#assertOwnContract(contractAddress);
-    this.capsuleService.deleteCapsule(contractAddress, slot, this.changeSetId, scope);
+    return this.capsuleService.deleteCapsule(contractAddress, slot, this.changeSetId, scope);
   }
 
   public copyCapsule(

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -333,7 +333,7 @@ export class PXE {
       readCachedNode,
       store,
       anchorBlockStore,
-      [noteStore, privateEventStore, factStore],
+      [noteStore, privateEventStore, factStore, capsuleStore, recipientTaggingStore],
       l2TipsStore,
       contractSyncService,
       config,

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -129,13 +129,15 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const capsuleStore = new CapsuleStore(kvStore);
 
       const changeSetId = 'fixture-change-set';
+      capsuleStore.beginChangeSet(changeSetId);
+
       const contractAddress = AztecAddress.fromBigIntUnsafe(2n);
       const scope = AztecAddress.fromBigIntUnsafe(3n);
 
       // Three setCapsule calls (2-element, 1-element, 0-element value vector) pin every value-encoding length case.
-      capsuleStore.setCapsule(contractAddress, new Fr(5n), [new Fr(7n), new Fr(11n)], changeSetId, scope);
-      capsuleStore.setCapsule(contractAddress, new Fr(13n), [new Fr(17n)], changeSetId, scope);
-      capsuleStore.setCapsule(contractAddress, new Fr(19n), [], changeSetId, scope);
+      await capsuleStore.setCapsule(contractAddress, new Fr(5n), [new Fr(7n), new Fr(11n)], changeSetId, scope);
+      await capsuleStore.setCapsule(contractAddress, new Fr(13n), [new Fr(17n)], changeSetId, scope);
+      await capsuleStore.setCapsule(contractAddress, new Fr(19n), [], changeSetId, scope);
       await kvStore.transactionAsync(() => capsuleStore.commitChangeSet(changeSetId));
     },
     snapshotStore: async kvStore => ({

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_service.test.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_service.test.ts
@@ -20,6 +20,7 @@ describe('CapsuleService', () => {
     disallowedScope = await AztecAddress.random();
     capsuleStore = new CapsuleStore(await openTmpStore('capsule_service_test'));
     capsuleService = new CapsuleService(capsuleStore, [allowedScope]);
+    capsuleStore.beginChangeSet(changeSetId);
   });
 
   describe('scope enforcement', () => {
@@ -72,15 +73,15 @@ describe('CapsuleService', () => {
       const scope = allowedScope;
 
       // setCapsule + getCapsule
-      capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
+      await capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, slot, changeSetId, scope)).toEqual(capsule);
 
       // deleteCapsule
-      capsuleService.deleteCapsule(contract, slot, changeSetId, scope);
+      await capsuleService.deleteCapsule(contract, slot, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, slot, changeSetId, scope)).toBeNull();
 
       // copyCapsule
-      capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
+      await capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
       await capsuleService.copyCapsule(contract, slot, new Fr(5), 1, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, new Fr(5), changeSetId, scope)).toEqual(capsule);
 
@@ -99,15 +100,15 @@ describe('CapsuleService', () => {
       const scope = AztecAddress.ZERO;
 
       // setCapsule + getCapsule
-      capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
+      await capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, slot, changeSetId, scope)).toEqual(capsule);
 
       // deleteCapsule
-      capsuleService.deleteCapsule(contract, slot, changeSetId, scope);
+      await capsuleService.deleteCapsule(contract, slot, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, slot, changeSetId, scope)).toBeNull();
 
       // copyCapsule
-      capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
+      await capsuleService.setCapsule(contract, slot, capsule, changeSetId, scope);
       await capsuleService.copyCapsule(contract, slot, new Fr(5), 1, changeSetId, scope);
       expect(await capsuleService.getCapsule(contract, new Fr(5), changeSetId, scope)).toEqual(capsule);
 

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_service.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_service.ts
@@ -21,9 +21,15 @@ export class CapsuleService {
     this.allowedScopes = [...allowedScopes, AztecAddress.ZERO];
   }
 
-  setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], changeSetId: ChangeSetId, scope: AztecAddress) {
+  setCapsule(
+    contractAddress: AztecAddress,
+    slot: Fr,
+    capsule: Fr[],
+    changeSetId: ChangeSetId,
+    scope: AztecAddress,
+  ): Promise<void> {
     assertAllowedScope(scope, this.allowedScopes);
-    this.capsuleStore.setCapsule(contractAddress, slot, capsule, changeSetId, scope);
+    return this.capsuleStore.setCapsule(contractAddress, slot, capsule, changeSetId, scope);
   }
 
   async getCapsule(
@@ -46,9 +52,9 @@ export class CapsuleService {
     return maybeTransientCapsule ?? (await this.capsuleStore.getCapsule(contractAddress, slot, changeSetId, scope));
   }
 
-  deleteCapsule(contractAddress: AztecAddress, slot: Fr, changeSetId: ChangeSetId, scope: AztecAddress) {
+  deleteCapsule(contractAddress: AztecAddress, slot: Fr, changeSetId: ChangeSetId, scope: AztecAddress): Promise<void> {
     assertAllowedScope(scope, this.allowedScopes);
-    this.capsuleStore.deleteCapsule(contractAddress, slot, changeSetId, scope);
+    return this.capsuleStore.deleteCapsule(contractAddress, slot, changeSetId, scope);
   }
 
   copyCapsule(

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
@@ -18,6 +18,9 @@ describe('capsule data provider', () => {
     scope = await AztecAddress.random();
     store = await openTmpStore('capsule_store_test');
     capsuleStore = new CapsuleStore(store);
+
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    capsuleStore.beginChangeSet('test');
   });
 
   describe('store and load', () => {
@@ -25,7 +28,7 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values, 'test', scope);
       const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(values);
     });
@@ -34,7 +37,7 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42), new Fr(43), new Fr(44)];
 
-      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values, 'test', scope);
       const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(values);
     });
@@ -44,8 +47,8 @@ describe('capsule data provider', () => {
       const initialValues = [new Fr(42)];
       const newValues = [new Fr(100)];
 
-      capsuleStore.setCapsule(contract, slot, initialValues, 'test', scope);
-      capsuleStore.setCapsule(contract, slot, newValues, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, initialValues, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, newValues, 'test', scope);
 
       const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(newValues);
@@ -57,8 +60,8 @@ describe('capsule data provider', () => {
       const values1 = [new Fr(42)];
       const values2 = [new Fr(100)];
 
-      capsuleStore.setCapsule(contract, slot, values1, 'test', scope);
-      capsuleStore.setCapsule(anotherContract, slot, values2, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values1, 'test', scope);
+      await capsuleStore.setCapsule(anotherContract, slot, values2, 'test', scope);
 
       const result1 = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       const result2 = await capsuleStore.getCapsule(anotherContract, slot, 'test', scope);
@@ -74,8 +77,8 @@ describe('capsule data provider', () => {
       const valuesA = [new Fr(42)];
       const valuesB = [new Fr(100)];
 
-      capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
-      capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
+      await capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
+      await capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
 
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeA)).toEqual(valuesA);
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
@@ -86,7 +89,7 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values, 'test', scope);
 
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toEqual(values);
       expect(await capsuleStore.getCapsule(contract, slot, 'test', AztecAddress.ZERO)).toBeNull();
@@ -104,15 +107,15 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
-      capsuleStore.deleteCapsule(contract, slot, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      await capsuleStore.deleteCapsule(contract, slot, 'test', scope);
 
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toBeNull();
     });
 
     it('deletes an empty slot', async () => {
       const slot = new Fr(1);
-      capsuleStore.deleteCapsule(contract, slot, 'test', scope);
+      await capsuleStore.deleteCapsule(contract, slot, 'test', scope);
 
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toBeNull();
     });
@@ -125,11 +128,11 @@ describe('capsule data provider', () => {
       const valuesB = [Fr.random(), Fr.random(), Fr.random()];
       const globalValues = [Fr.random(), Fr.random(), Fr.random()];
 
-      capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
-      capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
-      capsuleStore.setCapsule(contract, slot, globalValues, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
+      await capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
+      await capsuleStore.setCapsule(contract, slot, globalValues, 'test', scope);
 
-      capsuleStore.deleteCapsule(contract, slot, 'test', scopeA);
+      await capsuleStore.deleteCapsule(contract, slot, 'test', scopeA);
 
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeA)).toBeNull();
       expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
@@ -142,7 +145,7 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      await capsuleStore.setCapsule(contract, slot, values, 'test', scope);
 
       const dstSlot = new Fr(5);
       await capsuleStore.copyCapsule(contract, slot, dstSlot, 1, 'test', scope);
@@ -154,9 +157,9 @@ describe('capsule data provider', () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      await capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(5);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
@@ -170,9 +173,9 @@ describe('capsule data provider', () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      await capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(2);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
@@ -191,9 +194,9 @@ describe('capsule data provider', () => {
       const src = new Fr(5);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      await capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(4);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
@@ -212,9 +215,9 @@ describe('capsule data provider', () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      await capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
       // We skip src[1]
-      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      await capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(5);
       await expect(capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope)).rejects.toThrow(
@@ -228,7 +231,7 @@ describe('capsule data provider', () => {
       const dst = new Fr(5);
       const values = [new Fr(42)];
 
-      capsuleStore.setCapsule(contract, src, values, 'test', scope);
+      await capsuleStore.setCapsule(contract, src, values, 'test', scope);
       await capsuleStore.copyCapsule(contract, src, dst, 1, 'test', scope);
 
       expect(await capsuleStore.getCapsule(contract, dst, 'test', scope)).toEqual(values);
@@ -291,7 +294,7 @@ describe('capsule data provider', () => {
         const baseSlot = new Fr(3);
 
         // Store in the base slot a non-zero value, indicating a non-zero array length
-        capsuleStore.setCapsule(contract, baseSlot, [new Fr(1)], 'test', scope);
+        await capsuleStore.setCapsule(contract, baseSlot, [new Fr(1)], 'test', scope);
 
         // Reading should now fail as some of the capsules in the array are empty
         await expect(capsuleStore.readCapsuleArray(contract, baseSlot, 'test', scope)).rejects.toThrow(
@@ -388,9 +391,7 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
@@ -406,9 +407,7 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
@@ -424,9 +423,7 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
 
         // Append a single element
         await capsuleStore.appendToCapsuleArray(
@@ -437,9 +434,7 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
@@ -455,16 +450,12 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
 
         // We just move the entire thing one slot.
         await capsuleStore.copyCapsule(contract, new Fr(0), new Fr(1), NUMBER_OF_ITEMS, 'test', scope);
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
@@ -480,15 +471,11 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
 
         await capsuleStore.readCapsuleArray(contract, new Fr(0), 'test', scope);
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
@@ -504,121 +491,60 @@ describe('capsule data provider', () => {
           scope,
         );
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
 
         await capsuleStore.setCapsuleArray(contract, new Fr(0), [], 'test', scope);
 
-        await store.transactionAsync(async () => {
-          await capsuleStore.commitChangeSet('test');
-        });
+        await commit();
       },
       TEST_TIMEOUT_MS,
     );
   });
 
   describe('staged writes', () => {
-    it('commit does not hold zombie data', async () => {
-      // This test tries to reproduce a scenario where we fail to clear a change set's data after commit. The effect of
-      // such an incorrect behavior would be perceived if we re-used a changeSetId we had previously committed, which
-      // should not happen given we generate random change set ids, but it's good to keep things clean and consistent.
-      const slot = Fr.random();
-      const committedValues1 = [Fr.random()];
-      const committedValues2 = [Fr.random()];
-
-      capsuleStore.setCapsule(contract, slot, committedValues1, 'change-set-1', scope);
-
-      // After this commit, 'change-set-1' should logically be reset
-      // Any read of contract-slot after this should see committedValues1
-      await capsuleStore.commitChangeSet('change-set-1');
-
-      // Any read of contract-slot should see committedValues2
-      capsuleStore.setCapsule(contract, slot, committedValues2, 'change-set-2', scope);
-      await capsuleStore.commitChangeSet('change-set-2');
-
-      // If we failed to properly dispose 'change-set-1's staged writes on commit, Instead of reading committedValues2
-      // (as we should), we would end up reading committedValues1 (which would be wrong)
-      expect(await capsuleStore.getCapsule(contract, slot, 'change-set-1', scope)).toEqual(committedValues2);
-    });
-
-    it('writes to one change set view are isolated from another change set view', async () => {
-      const slot = Fr.random();
-      const committedValues = [Fr.random()];
-      const stagedValues = [Fr.random()];
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
-      const stagedWrites1: string = 'staged-writes-1';
-      const stagedWrites2: string = 'staged-writes-2';
-
-      // First set a committed capsule (using a different change set that we commit)
-      capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitChangeSet(commitChangeSetId);
-
-      // Then set a staged capsule (not committed)
-      capsuleStore.setCapsule(contract, slot, stagedValues, stagedWrites1, scope);
-
-      // With changeSetId=1, should get staged capsule
-      expect(await capsuleStore.getCapsule(contract, slot, stagedWrites1, scope)).toEqual(stagedValues);
-
-      // With changeSetId=2, should get committed capsule
-      expect(await capsuleStore.getCapsule(contract, slot, stagedWrites2, scope)).toEqual(committedValues);
-    });
-
     it('staged deletions hide committed data', async () => {
       const slot = Fr.random();
       const committedValues = [Fr.random()];
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
-      const stagedWrites1: string = 'staged-writes-1';
-      const stagedWrites2: string = 'staged-writes-2';
+      const deleteChangeSetId: ChangeSetId = 'delete-change-set';
 
       // First set a committed capsule
-      capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitChangeSet(commitChangeSetId);
+      await capsuleStore.setCapsule(contract, slot, committedValues, 'test', scope);
+      await commit();
 
-      // Delete in change set (not committed)
-      capsuleStore.deleteCapsule(contract, slot, stagedWrites1, scope);
+      // Delete in a change set of its own (not committed)
+      capsuleStore.discardChangeSet('test');
+      capsuleStore.beginChangeSet(deleteChangeSetId);
+      await capsuleStore.deleteCapsule(contract, slot, deleteChangeSetId, scope);
 
-      // Without changeSetId=2, should still see committed capsule
-      expect(await capsuleStore.getCapsule(contract, slot, stagedWrites2, scope)).toEqual(committedValues);
+      // The change set that staged the deletion sees null
+      expect(await capsuleStore.getCapsule(contract, slot, deleteChangeSetId, scope)).toBeNull();
 
-      // With changeSetId=1, should see null (deleted in change set)
-      expect(await capsuleStore.getCapsule(contract, slot, stagedWrites1, scope)).toBeNull();
+      // Dropping the staged deletion leaves the committed capsule in place
+      capsuleStore.discardChangeSet(deleteChangeSetId);
+      capsuleStore.beginChangeSet('reader');
+      expect(await capsuleStore.getCapsule(contract, slot, 'reader', scope)).toEqual(committedValues);
     });
 
     it('commit applies staged deletions', async () => {
       const slot = Fr.random();
       const committedValues = [Fr.random()];
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
       const deleteChangeSetId: ChangeSetId = 'delete-change-set';
 
-      capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitChangeSet(commitChangeSetId);
-      capsuleStore.deleteCapsule(contract, slot, deleteChangeSetId, scope);
+      await capsuleStore.setCapsule(contract, slot, committedValues, 'test', scope);
+      await commit();
 
-      await capsuleStore.commitChangeSet(deleteChangeSetId);
+      capsuleStore.discardChangeSet('test');
+      capsuleStore.beginChangeSet(deleteChangeSetId);
+      await capsuleStore.deleteCapsule(contract, slot, deleteChangeSetId, scope);
+      await commit(deleteChangeSetId);
 
-      // Now any change set should see this null (deleted)
-      expect(await capsuleStore.getCapsule(contract, slot, 'any-change-set-sees-this', scope)).toBeNull();
-    });
-
-    it('discardChangeSet removes staged data without affecting main', async () => {
-      const slot = Fr.random();
-      const committedValues = [Fr.random()];
-      const stagedValues = [Fr.random()];
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
-      const stagedChangeSetId: ChangeSetId = 'staged';
-
-      capsuleStore.setCapsule(contract, slot, committedValues, commitChangeSetId, scope);
-      await capsuleStore.commitChangeSet(commitChangeSetId);
-      capsuleStore.setCapsule(contract, slot, stagedValues, stagedChangeSetId, scope);
-
-      capsuleStore.discardChangeSet(stagedChangeSetId);
-
-      // Should still get committed capsule
-      expect(await capsuleStore.getCapsule(contract, slot, 'any-change-set', scope)).toEqual(committedValues);
-
-      // With stagedChangeSetId should fall back to committed since change set was discarded
-      expect(await capsuleStore.getCapsule(contract, slot, stagedChangeSetId, scope)).toEqual(committedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, deleteChangeSetId, scope)).toBeNull();
     });
   });
+
+  // Commits the open change set and opens it again: a commit closes the change set, and every operation needs one open.
+  async function commit(changeSetId: ChangeSetId = 'test') {
+    await store.transactionAsync(() => capsuleStore.commitChangeSet(changeSetId));
+    capsuleStore.beginChangeSet(changeSetId);
+  }
 });

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -1,68 +1,46 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 
-export class CapsuleStore implements StagedStore {
-  readonly storeName = 'capsule';
-
-  #store: AztecAsyncKVStore;
-
-  // Arbitrary data stored by contracts. Key is computed as `${contractAddress}:${scope}:${key}`, using the zero
-  // address for the global scope.
-  #capsules: AztecAsyncMap<string, Buffer>;
-
-  // changeSetId => `${contractAddress}:${scope}:${key}` => capsule data
-  // when `#stagedCapsules.get('some-change-set-id').get('${some-contract-address}:${some-scope}:${some-key}')` is
-  // null, it signals that the capsule was deleted during the change set, so it needs to be deleted on commit
-  #stagedCapsules: Map<ChangeSetId, Map<string, Buffer | null>>;
-
+export class CapsuleStore extends BaseStagingStore<CapsuleStoreChangeSet, CapsuleStoreDb> {
   logger: Logger;
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-
-    this.#capsules = this.#store.openMap('capsules');
-
-    this.#stagedCapsules = new Map();
+    super({
+      storeName: 'capsule',
+      store,
+      buildChangeSet: () => new Map(),
+      buildDb: db => ({
+        capsules: db.openMap('capsules'),
+      }),
+    });
 
     this.logger = createLogger('pxe:capsule-data-provider');
   }
 
   /**
-   * Given a change set denoted by `changeSetId`, it returns the capsules that said change set has interacted with.
-   *
-   * Capsules that haven't been committed to persistence KV storage
-   * are kept in-memory in `#stagedCapsules`, this method provides a convenient
-   * way to access that in-memory collection of data.
-   *
-   * @param changeSetId
-   * @returns
-   */
-  #getStagedCapsules(changeSetId: ChangeSetId): Map<string, Buffer | null> {
-    let stagedCapsules = this.#stagedCapsules.get(changeSetId);
-    if (!stagedCapsules) {
-      stagedCapsules = new Map();
-      this.#stagedCapsules.set(changeSetId, stagedCapsules);
-    }
-    return stagedCapsules;
-  }
-
-  /**
-   * Reads a capsule's slot from the staged version of the data associated to the given changeSetId.
+   * Reads a capsule's slot from the change set's staged data.
    *
    * If it is not there, it reads it from the KV store.
+   * @returns The slot's contents, or `null` when the slot holds no capsule, whether it was never written or was
+   * deleted in the change set.
    */
-  async #getFromStage(changeSetId: ChangeSetId, dbSlotKey: string): Promise<Buffer | null | undefined> {
-    const stagedCapsules = this.#getStagedCapsules(changeSetId);
-    const staged: Buffer | null | undefined = stagedCapsules.get(dbSlotKey);
+  async #readSlot(
+    changeSet: CapsuleStoreChangeSet,
+    db: ReadonlyDb<CapsuleStoreDb>,
+    dbSlotKey: string,
+  ): Promise<Buffer | null> {
+    const staged: Buffer | null | undefined = changeSet.get(dbSlotKey);
 
     // Always issue DB read to keep IndexedDB transaction alive, even if the value is in the staged data. This
     // keeps IndexedDB transactions alive (they auto-commit when a new micro-task starts and there are no pending read
     // requests). The staged value still takes precedence if it exists (including null for deletions).
-    const dbValue = await this.#loadCapsuleFromDb(dbSlotKey);
+    const dbValue = (await db.capsules.getAsync(dbSlotKey)) ?? null;
 
     return staged !== undefined ? staged : dbValue;
   }
@@ -70,55 +48,40 @@ export class CapsuleStore implements StagedStore {
   /**
    * Writes a capsule to the staging area.
    */
-  #setOnStage(changeSetId: ChangeSetId, dbSlotKey: string, capsuleData: Buffer) {
-    this.#getStagedCapsules(changeSetId).set(dbSlotKey, capsuleData);
+  #writeCapsule(
+    changeSet: CapsuleStoreChangeSet,
+    contractAddress: AztecAddress,
+    slot: Fr,
+    capsule: Fr[],
+    scope: AztecAddress,
+  ) {
+    changeSet.set(dbSlotToKey(contractAddress, slot, scope), packCapsule(capsule));
   }
 
   /**
    * Deletes a capsule on the staging area. Note the capsule will still
    * exist in storage until the change set is committed.
    */
-  #deleteOnStage(changeSetId: ChangeSetId, dbSlotKey: string) {
-    this.#getStagedCapsules(changeSetId).set(dbSlotKey, null);
+  #deleteCapsule(changeSet: CapsuleStoreChangeSet, contractAddress: AztecAddress, slot: Fr, scope: AztecAddress) {
+    changeSet.set(dbSlotToKey(contractAddress, slot, scope), null);
   }
 
-  async #loadCapsuleFromDb(dbSlotKey: string): Promise<Buffer | null> {
-    const dataBuffer = await this.#capsules.getAsync(dbSlotKey);
-    if (!dataBuffer) {
-      return null;
-    }
-
-    return dataBuffer;
-  }
-
-  /**
-   * Commits staged data to main storage. Called by StagedWriteCoordinator when an operation completes successfully.
-   * Note: StagedWriteCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync
-   * here (and using one would deadlock on IndexedDB).
-   * @param changeSetId - The changeSetId identifying which staged data to commit
-   */
-  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
-    const stagedCapsules = this.#getStagedCapsules(changeSetId);
-
-    for (const [key, value] of stagedCapsules) {
+  protected async flushChangeSet(changeSet: CapsuleStoreChangeSet, db: CapsuleStoreDb): Promise<void> {
+    for (const [key, value] of changeSet) {
       // In the write stage, we represent deleted capsules with null
       // (as opposed to undefined, which denotes there was never a capsule there to begin with).
       // So we delete from actual KV store here.
       if (value === null) {
-        await this.#capsules.delete(key);
+        await db.capsules.delete(key);
       } else {
-        await this.#capsules.set(key, value);
+        await db.capsules.set(key, value);
       }
     }
-
-    this.#stagedCapsules.delete(changeSetId);
   }
 
-  /**
-   * Discards staged data without committing.
-   */
-  discardChangeSet(changeSetId: ChangeSetId): void {
-    this.#stagedCapsules.delete(changeSetId);
+  /** No-op: capsules are not anchored to a block, so a prune cannot orphan any of them. */
+  protected applyRollback(): Promise<void> {
+    return Promise.resolve();
   }
 
   /**
@@ -133,11 +96,17 @@ export class CapsuleStore implements StagedStore {
    * to public contract storage in that it's indexed by the contract address and storage slot but instead of the global
    * network state it's backed by local PXE db.
    */
-  setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], changeSetId: ChangeSetId, scope: AztecAddress) {
-    const dbSlotKey = dbSlotToKey(contractAddress, slot, scope);
-
+  setCapsule(
+    contractAddress: AztecAddress,
+    slot: Fr,
+    capsule: Fr[],
+    changeSetId: ChangeSetId,
+    scope: AztecAddress,
+  ): Promise<void> {
     // A store overrides any pre-existing data on the slot
-    this.#setOnStage(changeSetId, dbSlotKey, Buffer.concat(capsule.map(value => value.toBuffer())));
+    return this.withChangeSet(changeSetId, changeSet => {
+      this.#writeCapsule(changeSet, contractAddress, slot, capsule, scope);
+    });
   }
 
   /**
@@ -152,26 +121,25 @@ export class CapsuleStore implements StagedStore {
     changeSetId: ChangeSetId,
     scope: AztecAddress,
   ): Promise<Fr[] | null> {
-    return this.#store.transactionAsync(() => this.#getCapsuleInternal(contractAddress, slot, changeSetId, scope));
+    return this.withChangeSetAndDb(changeSetId, (changeSet, db) =>
+      this.#readCapsule(changeSet, db, contractAddress, slot, scope),
+    );
   }
 
-  /** Same as getCapsule but without its own transaction, for use inside an existing transactionAsync. */
-  async #getCapsuleInternal(
+  /** Same as getCapsule but operating on an already entered change set, for use by the other operations. */
+  async #readCapsule(
+    changeSet: CapsuleStoreChangeSet,
+    db: ReadonlyDb<CapsuleStoreDb>,
     contractAddress: AztecAddress,
     slot: Fr,
-    changeSetId: ChangeSetId,
     scope: AztecAddress,
   ): Promise<Fr[] | null> {
-    const dataBuffer = await this.#getFromStage(changeSetId, dbSlotToKey(contractAddress, slot, scope));
+    const dataBuffer = await this.#readSlot(changeSet, db, dbSlotToKey(contractAddress, slot, scope));
     if (!dataBuffer) {
       this.logger.trace(`Data not found for contract ${contractAddress.toString()} and slot ${slot.toString()}`);
       return null;
     }
-    const capsule: Fr[] = [];
-    for (let i = 0; i < dataBuffer.length; i += Fr.SIZE_IN_BYTES) {
-      capsule.push(Fr.fromBuffer(dataBuffer.subarray(i, i + Fr.SIZE_IN_BYTES)));
-    }
-    return capsule;
+    return BufferReader.asReader(dataBuffer).readArray(dataBuffer.length / Fr.SIZE_IN_BYTES, Fr);
   }
 
   /**
@@ -179,9 +147,11 @@ export class CapsuleStore implements StagedStore {
    * @param contractAddress - The contract address under which the data is scoped.
    * @param slot - The slot in the database to delete.
    */
-  deleteCapsule(contractAddress: AztecAddress, slot: Fr, changeSetId: ChangeSetId, scope: AztecAddress) {
+  deleteCapsule(contractAddress: AztecAddress, slot: Fr, changeSetId: ChangeSetId, scope: AztecAddress): Promise<void> {
     // When we commit this, we will interpret null as a deletion, so we'll propagate the delete to the KV store
-    this.#deleteOnStage(changeSetId, dbSlotToKey(contractAddress, slot, scope));
+    return this.withChangeSet(changeSetId, changeSet => {
+      this.#deleteCapsule(changeSet, contractAddress, slot, scope);
+    });
   }
 
   /**
@@ -203,11 +173,7 @@ export class CapsuleStore implements StagedStore {
     changeSetId: ChangeSetId,
     scope: AztecAddress,
   ): Promise<void> {
-    // This transactional context gives us "copy atomicity":
-    // there shouldn't be concurrent writes to what's being copied here.
-    // Equally important: this in practice is expected to perform thousands of DB operations
-    // and not using a transaction here would heavily impact performance.
-    return this.#store.transactionAsync(async () => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       // In order to support overlapping source and destination regions, we need to check the relative positions of source
       // and destination. If destination is ahead of source, then by the time we overwrite source elements using forward
       // indexes we'll have already read those. On the contrary, if source is ahead of destination we need to use backward
@@ -221,12 +187,12 @@ export class CapsuleStore implements StagedStore {
         const currentSrcSlot = dbSlotToKey(contractAddress, srcSlot.add(new Fr(i)), scope);
         const currentDstSlot = dbSlotToKey(contractAddress, dstSlot.add(new Fr(i)), scope);
 
-        const toCopy = await this.#getFromStage(changeSetId, currentSrcSlot);
+        const toCopy = await this.#readSlot(changeSet, db, currentSrcSlot);
         if (!toCopy) {
           throw new Error(`Attempted to copy empty slot ${currentSrcSlot} for contract ${contractAddress.toString()}`);
         }
 
-        this.#setOnStage(changeSetId, currentDstSlot, toCopy);
+        changeSet.set(currentDstSlot, toCopy);
       }
     });
   }
@@ -234,7 +200,6 @@ export class CapsuleStore implements StagedStore {
   /**
    * Appends multiple capsules to a capsule array stored at the base slot.
    * The array length is stored at the base slot, and elements are stored in consecutive slots after it.
-   * All operations are performed in a single transaction.
    * @param contractAddress - The contract address that owns the capsule array
    * @param baseSlot - The slot where the array length is stored
    * @param content - Array of capsule data to append
@@ -246,25 +211,20 @@ export class CapsuleStore implements StagedStore {
     changeSetId: ChangeSetId,
     scope: AztecAddress,
   ): Promise<void> {
-    // We wrap this in a transaction to serialize concurrent calls from allToCompletion.
-    // Without this, concurrent appends to the same array could race: both read length=0,
-    // both write at the same slots, one overwrites the other.
-    // Equally important: this in practice is expected to perform thousands of DB operations
-    // and not using a transaction here would heavily impact performance.
-    return this.#store.transactionAsync(async () => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       // Load current length, defaulting to 0 if not found
-      const lengthData = await this.#getCapsuleInternal(contractAddress, baseSlot, changeSetId, scope);
+      const lengthData = await this.#readCapsule(changeSet, db, contractAddress, baseSlot, scope);
       const currentLength = lengthData ? lengthData[0].toNumber() : 0;
 
       // Store each capsule at consecutive slots after baseSlot + 1 + currentLength
       for (let i = 0; i < content.length; i++) {
         const nextSlot = arraySlot(baseSlot, currentLength + i);
-        this.setCapsule(contractAddress, nextSlot, content[i], changeSetId, scope);
+        this.#writeCapsule(changeSet, contractAddress, nextSlot, content[i], scope);
       }
 
       // Update length to include all new capsules
       const newLength = currentLength + content.length;
-      this.setCapsule(contractAddress, baseSlot, [new Fr(newLength)], changeSetId, scope);
+      this.#writeCapsule(changeSet, contractAddress, baseSlot, [new Fr(newLength)], scope);
     });
   }
 
@@ -274,25 +234,16 @@ export class CapsuleStore implements StagedStore {
     changeSetId: ChangeSetId,
     scope: AztecAddress,
   ): Promise<Fr[][]> {
-    // I'm leaving this transactional context here though because I'm assuming this gives us "read array atomicity":
-    // there shouldn't be concurrent writes to what's being copied here. This is one point we should revisit in the
-    // future if we want to relax the concurrency of change sets: different calls running concurrently on the same
-    // contract may cause trouble.
-    return this.#store.transactionAsync(async () => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       // Load length, defaulting to 0 if not found
-      const maybeLength = await this.#getCapsuleInternal(contractAddress, baseSlot, changeSetId, scope);
+      const maybeLength = await this.#readCapsule(changeSet, db, contractAddress, baseSlot, scope);
       const length = maybeLength ? maybeLength[0].toBigInt() : 0n;
 
       const values: Fr[][] = [];
 
       // Read each capsule at consecutive slots after baseSlot
       for (let i = 0; i < length; i++) {
-        const currentValue = await this.#getCapsuleInternal(
-          contractAddress,
-          arraySlot(baseSlot, i),
-          changeSetId,
-          scope,
-        );
+        const currentValue = await this.#readCapsule(changeSet, db, contractAddress, arraySlot(baseSlot, i), scope);
         if (currentValue == undefined) {
           throw new Error(
             `Expected non-empty value at capsule array in base slot ${baseSlot} at index ${i} for contract ${contractAddress}`,
@@ -312,29 +263,23 @@ export class CapsuleStore implements StagedStore {
     content: Fr[][],
     changeSetId: ChangeSetId,
     scope: AztecAddress,
-  ) {
-    // This transactional context in theory isn't so critical now because we aren't writing to DB so if there's
-    // exceptions midway and it blows up, no visible impact to persistent storage will happen. I'm leaving this
-    // transactional context here though because I'm assuming this gives us "write array atomicity": there shouldn't be
-    // concurrent writes to what's being copied here. This is one point we should revisit in the future if we want to
-    // relax the concurrency of change sets: different calls running concurrently on the same contract may cause
-    // trouble.
-    return this.#store.transactionAsync(async () => {
+  ): Promise<void> {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       // Load current length, defaulting to 0 if not found
-      const maybeLength = await this.#getCapsuleInternal(contractAddress, baseSlot, changeSetId, scope);
+      const maybeLength = await this.#readCapsule(changeSet, db, contractAddress, baseSlot, scope);
       const originalLength = maybeLength ? maybeLength[0].toNumber() : 0;
 
       // Set the new length
-      this.setCapsule(contractAddress, baseSlot, [new Fr(content.length)], changeSetId, scope);
+      this.#writeCapsule(changeSet, contractAddress, baseSlot, [new Fr(content.length)], scope);
 
       // Store the new content, possibly overwriting existing values
       for (let i = 0; i < content.length; i++) {
-        this.setCapsule(contractAddress, arraySlot(baseSlot, i), content[i], changeSetId, scope);
+        this.#writeCapsule(changeSet, contractAddress, arraySlot(baseSlot, i), content[i], scope);
       }
 
       // Clear any stragglers
       for (let i = content.length; i < originalLength; i++) {
-        this.deleteCapsule(contractAddress, arraySlot(baseSlot, i), changeSetId, scope);
+        this.#deleteCapsule(changeSet, contractAddress, arraySlot(baseSlot, i), scope);
       }
     });
   }
@@ -347,3 +292,19 @@ function dbSlotToKey(contractAddress: AztecAddress, slot: Fr, scope: AztecAddres
 function arraySlot(baseSlot: Fr, index: number) {
   return baseSlot.add(new Fr(1)).add(new Fr(index));
 }
+
+function packCapsule(capsule: Fr[]): Buffer {
+  return serializeToBuffer(capsule);
+}
+
+/**
+ * A change set's staged capsules, keyed as `${contractAddress}:${scope}:${slot}`. A `null` value signals that the
+ * capsule was deleted during the change set, so it needs to be deleted on commit.
+ */
+type CapsuleStoreChangeSet = Map<string, Buffer | null>;
+
+type CapsuleStoreDb = {
+  // Arbitrary data stored by contracts. Key is computed as `${contractAddress}:${scope}:${slot}`, using the zero
+  // address for the global scope.
+  capsules: AztecAsyncMap<string, Buffer>;
+};


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/101 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `ff9545903b2592201515ff7d3af9e92587f15b6e`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff ff9545903b^..ff9545903b origin/nico/port-node-101-capsule-store-staging^..origin/nico/port-node-101-capsule-store-staging
   ```

   Expected: the `(cherry picked from commit …)` trailer and exactly one patch-level difference, in `yarn-project/pxe/src/storage/capsule_store/capsule_store.ts`:

   ```
   -+import { BufferReader, serializeToBuffer } from '@aztec-labs/foundation/serialize';
   ++import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
   ```

   Same added import on both sides; the scope differs because upstream renamed its packages to `@aztec-labs/*` (aztec-labs-eng/aztec-node#93) and this repo keeps `@aztec/*`. Surrounding import lines show as context-only differences (single `-`/`+` followed by a space) for the same reason. No other file differs.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.
4. Confirm upstream's package-scope renames leaked nothing into this repo: `git grep -cE '@aztec-labs|@aztec-foundation' -- yarn-project` on this PR's head must return no matches.

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#98 (branch `nico/port-node-98-fact-store-staging`, PR #25368); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 → #101 → #108 → #110 (aztec-node numbers).
