### PR TITLE
refactor(pxe): migrate PrivateEventStore to BaseStagingStore (backport of aztec-labs-eng/aztec-node#110)

### DIFF
--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -37,6 +37,8 @@ describe('validateAndStoreEvents', () => {
   beforeEach(async () => {
     const store = await openTmpStore('test');
     privateEventStore = new PrivateEventStore(store);
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    privateEventStore.beginChangeSet('test');
 
     contractAddress = await AztecAddress.random();
     recipient = await AztecAddress.random();
@@ -92,6 +94,7 @@ describe('validateAndStoreEvents', () => {
     await eventService.validateAndStoreEvents([request], recipient, map);
 
     await privateEventStore.commitChangeSet('test');
+    privateEventStore.beginChangeSet('test');
   }
 
   it('should throw when tx does not exist or has no effects', async () => {
@@ -114,12 +117,7 @@ describe('validateAndStoreEvents', () => {
 
     await runStoreEvent({ eventContent: otherContent, eventCommitment: otherCommitment });
 
-    const result = await privateEventStore.getPrivateEvents(eventSelector, {
-      contractAddress,
-      fromBlock: blockNumber,
-      toBlock: blockNumber + 1,
-      scopes: [recipient],
-    });
+    const result = await readEvents();
 
     expect(result.length).toEqual(0);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/commitment is not present in its tx/));
@@ -129,12 +127,7 @@ describe('validateAndStoreEvents', () => {
     // Commitment is legitimately present in the tx, but the provided content does not hash to it.
     await runStoreEvent({ eventContent: [Fr.random(), Fr.random()] });
 
-    const result = await privateEventStore.getPrivateEvents(eventSelector, {
-      contractAddress,
-      fromBlock: blockNumber,
-      toBlock: blockNumber + 1,
-      scopes: [recipient],
-    });
+    const result = await readEvents();
 
     expect(result.length).toEqual(0);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/content does not hash to the provided commitment/));
@@ -144,12 +137,7 @@ describe('validateAndStoreEvents', () => {
     await runStoreEvent();
 
     // I should be able to retrieve the private event I just saved using getPrivateEvents
-    const result = await privateEventStore.getPrivateEvents(eventSelector, {
-      contractAddress,
-      fromBlock: blockNumber,
-      toBlock: blockNumber + 1,
-      scopes: [recipient],
-    });
+    const result = await readEvents();
 
     expect(result.length).toEqual(1);
     expect(result[0].packedEvent).toEqual(eventContent);
@@ -157,5 +145,14 @@ describe('validateAndStoreEvents', () => {
 
   function defaultValidationTxDataMap() {
     return new Map([[txEffect.txHash.toString(), validationTxData]]);
+  }
+
+  /** Reads the fixture's events through the change set the tests operate under. */
+  function readEvents() {
+    return privateEventStore.getPrivateEvents(
+      eventSelector,
+      { contractAddress, fromBlock: blockNumber, toBlock: blockNumber + 1, scopes: [recipient] },
+      'test',
+    );
   }
 });

--- a/yarn-project/pxe/src/operation_lifecycle.test.ts
+++ b/yarn-project/pxe/src/operation_lifecycle.test.ts
@@ -24,6 +24,7 @@ describe('runOperation', () => {
     discarded = [];
     const recordingStore: StagedStore = {
       storeName: 'recording_store',
+      beginChangeSet: () => {},
       commitChangeSet: id => {
         committed.push(id);
         return Promise.resolve();
@@ -142,6 +143,7 @@ describe('runOperation', () => {
       stagedStores: [
         {
           storeName: 'undiscardable_store',
+          beginChangeSet: () => {},
           commitChangeSet: () => Promise.resolve(),
           discardChangeSet: () => {
             throw new Error('cannot discard');

--- a/yarn-project/pxe/src/operation_queue.test.ts
+++ b/yarn-project/pxe/src/operation_queue.test.ts
@@ -30,6 +30,7 @@ describe('OperationQueue', () => {
     discarded = [];
     const recordingStore: StagedStore = {
       storeName: 'recording_store',
+      beginChangeSet: () => {},
       commitChangeSet: id => {
         committed.push(id);
         return Promise.resolve();

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -427,6 +427,8 @@ describe('PXE', () => {
       scope = await AztecAddress.random();
 
       privateEventStore = new PrivateEventStore(kvStore);
+      // Leave a change set open for the tests to operate under: every store operation requires one.
+      privateEventStore.beginChangeSet('test');
     });
 
     let eventCounter = 0;

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1376,15 +1376,8 @@ export class PXE {
    *    Defaults to the latest known block to PXE + 1.
    * @returns - The packed events with block and tx metadata.
    */
-  public async getPrivateEvents(
-    eventSelector: EventSelector,
-    filter: PrivateEventFilter,
-  ): Promise<PackedPrivateEvent[]> {
-    let anchorBlockNumber: BlockNumber;
-
-    await this.operationQueue.runSynced(async ({ changeSetId, anchorBlockHeader }) => {
-      anchorBlockNumber = anchorBlockHeader.getBlockNumber();
-
+  public getPrivateEvents(eventSelector: EventSelector, filter: PrivateEventFilter): Promise<PackedPrivateEvent[]> {
+    return this.operationQueue.runSynced(async ({ changeSetId, anchorBlockHeader }) => {
       const contractFunctionSimulator = this.#getSimulatorForTx();
 
       await this.contractSyncService.ensureContractSynced({
@@ -1404,16 +1397,15 @@ export class PXE {
         scopes: filter.scopes,
         triggeredBy: undefined,
       });
+
+      const sanitizedFilter = new PrivateEventFilterValidator(anchorBlockHeader.getBlockNumber()).validate(filter);
+
+      this.log.debug(
+        `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,
+      );
+
+      return this.privateEventStore.getPrivateEvents(eventSelector, sanitizedFilter, changeSetId);
     });
-
-    // anchorBlockNumber is set during the operation and fixed to whatever it is after a block sync
-    const sanitizedFilter = new PrivateEventFilterValidator(anchorBlockNumber!).validate(filter);
-
-    this.log.debug(
-      `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,
-    );
-
-    return this.privateEventStore.getPrivateEvents(eventSelector, sanitizedFilter);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/schema_tests.ts
@@ -436,6 +436,7 @@ export const SCHEMA_TESTS: readonly SchemaTest[] = [
       const privateEventStore = new PrivateEventStore(kvStore);
 
       const changeSetId = 'fixture-change-set';
+      privateEventStore.beginChangeSet(changeSetId);
 
       // Two (contract, selector) pairs and two block numbers so each multimap exhibits both a multi-value row
       // (contractA/selectorA → {e1, e2} and blockN1 → {e1, e2}) and a contrasting single-value row.

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -10,7 +10,7 @@ import { TxHash } from '@aztec/stdlib/tx';
 
 import type { PackedPrivateEvent } from '../../pxe.js';
 import type { ChangeSetId } from '../staged_write_coordinator.js';
-import { PrivateEventStore } from './private_event_store.js';
+import { PrivateEventStore, type PrivateEventStoreFilter } from './private_event_store.js';
 
 const getRandomMsgContent = () => {
   return [Fr.random(), Fr.random(), Fr.random()];
@@ -33,6 +33,8 @@ describe('PrivateEventStore', () => {
   beforeEach(async () => {
     kvStore = await openTmpStore('private_event_store_test');
     privateEventStore = new PrivateEventStore(kvStore);
+    // Leave a change set open for the tests to operate under: every store operation requires one.
+    privateEventStore.beginChangeSet('test');
     contractAddress = await AztecAddress.random();
     scope = await AztecAddress.random();
     msgContent = getRandomMsgContent();
@@ -74,10 +76,10 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitChangeSet('test');
+      await cycleChangeSet();
     }
 
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
@@ -115,9 +117,9 @@ describe('PrivateEventStore', () => {
       metadata,
       'test',
     );
-    await privateEventStore.commitChangeSet('test');
+    await cycleChangeSet();
 
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
@@ -163,10 +165,10 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitChangeSet('test');
+      await cycleChangeSet();
     }
 
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
@@ -232,10 +234,10 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitChangeSet('test');
+      await cycleChangeSet();
     }
 
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: 150,
       toBlock: 150 + 100,
@@ -281,10 +283,10 @@ describe('PrivateEventStore', () => {
         },
         'test',
       );
-      await privateEventStore.commitChangeSet('test');
+      await cycleChangeSet();
     }
 
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
@@ -319,20 +321,28 @@ describe('PrivateEventStore', () => {
       'test',
     );
 
-    await privateEventStore.commitChangeSet('test');
+    await cycleChangeSet();
 
     const filter = { contractAddress, fromBlock: l2BlockNumber, toBlock: l2BlockNumber + 1 };
 
-    const eventsScope1 = await privateEventStore.getPrivateEvents(eventSelector, { ...filter, scopes: [scope1] });
+    const eventsScope1 = await privateEventStore.getPrivateEvents(
+      eventSelector,
+      { ...filter, scopes: [scope1] },
+      'test',
+    );
     expect(eventsScope1).toHaveLength(1);
     expect(eventsScope1[0].packedEvent).toEqual(msgContent);
 
-    const eventsScope2 = await privateEventStore.getPrivateEvents(eventSelector, { ...filter, scopes: [scope2] });
+    const eventsScope2 = await privateEventStore.getPrivateEvents(
+      eventSelector,
+      { ...filter, scopes: [scope2] },
+      'test',
+    );
     expect(eventsScope2).toHaveLength(1);
     expect(eventsScope2[0].packedEvent).toEqual(msgContent);
 
     // Querying with both scopes returns the event once
-    const eventsBoth = await privateEventStore.getPrivateEvents(eventSelector, {
+    const eventsBoth = await readEvents({
       ...filter,
       scopes: [scope1, scope2],
     });
@@ -340,7 +350,7 @@ describe('PrivateEventStore', () => {
   });
 
   it('returns empty array when no events match criteria', async () => {
-    const events = await privateEventStore.getPrivateEvents(eventSelector, {
+    const events = await readEvents({
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
@@ -413,10 +423,10 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitChangeSet('test');
+        await cycleChangeSet();
       }
 
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+      const events = await readEvents({
         contractAddress,
         fromBlock: 0,
         toBlock: 0 + 1000,
@@ -481,10 +491,10 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitChangeSet('test');
+        await cycleChangeSet();
       }
 
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+      const events = await readEvents({
         contractAddress,
         fromBlock: 0,
         toBlock: 1000,
@@ -550,10 +560,10 @@ describe('PrivateEventStore', () => {
           },
           'test',
         );
-        await privateEventStore.commitChangeSet('test');
+        await cycleChangeSet();
       }
 
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+      const events = await readEvents({
         contractAddress,
         fromBlock: 0,
         toBlock: 1000,
@@ -598,16 +608,7 @@ describe('PrivateEventStore', () => {
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
 
       // Block 9 event survives; block 10 event is gone.
-      expect(await privateEventStore.eventIdsAtBlock(9)).toEqual([eventAt9.toString()]);
-      expect(await privateEventStore.eventIdsAtBlock(10)).toHaveLength(0);
-
-      // getPrivateEvents confirms only the block-9 event is retrievable.
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
-        contractAddress,
-        fromBlock: 9,
-        toBlock: 11,
-        scopes: [scope],
-      });
+      const events = await readEventsAfterRollback(9, 11);
       expect(events).toHaveLength(1);
       expect(events[0].l2BlockHash.equals(BLOCK_HASH_9)).toBe(true);
     });
@@ -625,9 +626,9 @@ describe('PrivateEventStore', () => {
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
 
       // Block 9 survives; both 10 and the non-contiguous 12 are swept.
-      expect(await privateEventStore.eventIdsAtBlock(9)).toEqual([eventAt9.toString()]);
-      expect(await privateEventStore.eventIdsAtBlock(10)).toHaveLength(0);
-      expect(await privateEventStore.eventIdsAtBlock(12)).toHaveLength(0);
+      const events = await readEventsAfterRollback(9, 13);
+      expect(events).toHaveLength(1);
+      expect(events[0].l2BlockHash.equals(BLOCK_HASH_9)).toBe(true);
     });
 
     it('is idempotent — re-running an already-applied rollback is a no-op', async () => {
@@ -642,8 +643,9 @@ describe('PrivateEventStore', () => {
       // Re-running over the already-truncated tail must not throw and must not change anything.
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
 
-      expect(await privateEventStore.eventIdsAtBlock(9)).toEqual([eventAt9.toString()]);
-      expect(await privateEventStore.eventIdsAtBlock(10)).toHaveLength(0);
+      const events = await readEventsAfterRollback(9, 11);
+      expect(events).toHaveLength(1);
+      expect(events[0].l2BlockHash.equals(BLOCK_HASH_9)).toBe(true);
     });
 
     it('allows re-adding an event after rollback', async () => {
@@ -651,24 +653,18 @@ describe('PrivateEventStore', () => {
       // siloed event commitment (this store's key). Rollback must leave no residue behind, so re-storing that
       // commitment succeeds with no key collision and the event becomes retrievable again.
       const commitment = Fr.random();
-      const readBack = () =>
-        privateEventStore.getPrivateEvents(eventSelector, {
-          contractAddress,
-          fromBlock: 9,
-          toBlock: 11,
-          scopes: [scope],
-        });
 
       await storeEventAt(commitment, 10, BLOCK_HASH_10);
       await privateEventStore.commitChangeSet('test');
 
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(9));
-      expect(await readBack()).toHaveLength(0);
+      expect(await readEventsAfterRollback(9, 11)).toHaveLength(0);
 
       // Re-add the same commitment, as happens when the tx is re-included after the reorg.
+      privateEventStore.beginChangeSet('test');
       await storeEventAt(commitment, 10, BLOCK_HASH_10);
       await privateEventStore.commitChangeSet('test');
-      expect(await readBack()).toHaveLength(1);
+      expect(await readEventsAfterRollback(9, 11)).toHaveLength(1);
     });
 
     it('handles rollback with no events to remove', async () => {
@@ -679,166 +675,30 @@ describe('PrivateEventStore', () => {
       // Rolling back to a block above every stored event removes nothing.
       await kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(20));
 
-      expect(await privateEventStore.eventIdsAtBlock(10)).toEqual([eventAt10.toString()]);
+      expect(await readEventsAfterRollback(10, 11)).toHaveLength(1);
     });
 
-    it('throws when rollback is called while staged writes are pending', async () => {
-      // Stage an event under a change set but never commit it, so the store still holds in-flight staged data.
-      await privateEventStore.storePrivateEventLog(
+    /** Reads in a change set opened and closed around the read: the store rejects a rollback while one is open. */
+    async function readEventsAfterRollback(fromBlock: number, toBlock: number) {
+      privateEventStore.beginChangeSet('read-change-set');
+      const events = await privateEventStore.getPrivateEvents(
         eventSelector,
-        randomness,
-        msgContent,
-        Fr.random(),
-        {
-          contractAddress,
-          scope,
-          txHash: TxHash.random(),
-          l2BlockNumber: BlockNumber(10),
-          l2BlockHash,
-          txIndexInBlock: 0,
-          eventIndexInTx: 0,
-        },
-        'uncommitted-change-set',
+        { contractAddress, fromBlock, toBlock, scopes: [scope] },
+        'read-change-set',
       );
-
-      await expect(kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(0))).rejects.toThrow(
-        'PXE private event store rollback is not allowed while staged writes are pending',
-      );
-
-      privateEventStore.discardChangeSet('uncommitted-change-set');
-
-      await expect(kvStore.transactionAsync(() => privateEventStore.rollbackToBlock(0))).resolves.not.toThrow();
-    });
-  });
-
-  describe('eventIdsAtBlock', () => {
-    it('returns the event id of an event stored at a given block', async () => {
-      await privateEventStore.storePrivateEventLog(
-        eventSelector,
-        randomness,
-        msgContent,
-        siloedEventCommitment,
-        {
-          contractAddress,
-          scope,
-          txHash,
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: 0,
-          eventIndexInTx: 0,
-        },
-        'test',
-      );
-      await privateEventStore.commitChangeSet('test');
-
-      const ids = await privateEventStore.eventIdsAtBlock(l2BlockNumber);
-      expect(ids).toContain(siloedEventCommitment.toString());
-    });
-
-    it('returns all event ids when multiple events are stored at the same block', async () => {
-      const siloedEventCommitment2 = Fr.random();
-
-      await privateEventStore.storePrivateEventLog(
-        eventSelector,
-        randomness,
-        msgContent,
-        siloedEventCommitment,
-        {
-          contractAddress,
-          scope,
-          txHash,
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: 0,
-          eventIndexInTx: 0,
-        },
-        'test',
-      );
-      await privateEventStore.storePrivateEventLog(
-        eventSelector,
-        randomness,
-        getRandomMsgContent(),
-        siloedEventCommitment2,
-        {
-          contractAddress,
-          scope,
-          txHash: TxHash.random(),
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: 0,
-          eventIndexInTx: 1,
-        },
-        'test',
-      );
-      await privateEventStore.commitChangeSet('test');
-
-      const ids = await privateEventStore.eventIdsAtBlock(l2BlockNumber);
-      expect(new Set(ids)).toEqual(new Set([siloedEventCommitment.toString(), siloedEventCommitment2.toString()]));
-    });
+      privateEventStore.discardChangeSet('read-change-set');
+      return events;
+    }
   });
 
   describe('change-set', () => {
-    it('stages events without affecting committed storage', async () => {
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
-      const stagedChangeSetId: ChangeSetId = 'staged';
-
-      const committedEventRandomness = Fr.random();
-      const stagedEventRandomness = Fr.random();
-
-      // Store committed event
-      await privateEventStore.storePrivateEventLog(
-        eventSelector,
-        committedEventRandomness,
-        msgContent,
-        Fr.random(),
-        {
-          contractAddress,
-          scope,
-          txHash,
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: randomInt(100),
-          eventIndexInTx: randomInt(100),
-        },
-        commitChangeSetId,
-      );
-      await privateEventStore.commitChangeSet(commitChangeSetId);
-
-      // Store staged event (not committed)
-      const stagedMsgContent = getRandomMsgContent();
-      await privateEventStore.storePrivateEventLog(
-        eventSelector,
-        stagedEventRandomness,
-        stagedMsgContent,
-        Fr.random(),
-        {
-          contractAddress,
-          scope,
-          txHash: TxHash.random(),
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: randomInt(100),
-          eventIndexInTx: randomInt(100),
-        },
-        stagedChangeSetId,
-      );
-
-      // With a fresh changeSetId, should only see committed event
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
-        contractAddress,
-        fromBlock: l2BlockNumber,
-        toBlock: l2BlockNumber + 1,
-        scopes: [scope],
-      });
-      expect(events).toHaveLength(1);
-      expect(events[0].packedEvent).toEqual(msgContent);
-    });
-
-    it('commit promotes staged events to main storage', async () => {
+    it('sees its own staged events before they are committed', async () => {
       const stagedChangeSetId: ChangeSetId = 'staged';
       const stagedEventRandomness = Fr.random();
       const stagedMsgContent = getRandomMsgContent();
 
+      privateEventStore.discardChangeSet('test');
+      privateEventStore.beginChangeSet(stagedChangeSetId);
       await privateEventStore.storePrivateEventLog(
         eventSelector,
         stagedEventRandomness,
@@ -856,75 +716,89 @@ describe('PrivateEventStore', () => {
         stagedChangeSetId,
       );
 
-      await privateEventStore.commitChangeSet(stagedChangeSetId);
-
-      // Now should see the event with a fresh changeSetId
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+      const eventFilter = {
         contractAddress,
         fromBlock: l2BlockNumber,
         toBlock: l2BlockNumber + 1,
         scopes: [scope],
-      });
+      };
+
+      const events = await privateEventStore.getPrivateEvents(eventSelector, eventFilter, stagedChangeSetId);
       expect(events).toHaveLength(1);
       expect(events[0].packedEvent).toEqual(stagedMsgContent);
     });
 
-    it('discardChangeSet removes staged events without affecting main', async () => {
-      const commitChangeSetId: ChangeSetId = 'commit-change-set';
-      const stagedChangeSetId: ChangeSetId = 'staged';
-      const committedEventRandomness = Fr.random();
-      const stagedEventRandomness = Fr.random();
+    it('returns a committed event once when the open change set adds a scope to it', async () => {
+      const otherScope = await AztecAddress.random();
+      const commitment = Fr.random();
+      const metadata = {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
+      };
 
-      // Store committed event
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, commitment, metadata, 'test');
+      await cycleChangeSet();
+
+      // Re-storing the committed event under a second scope stages it while it is also in the committed index.
       await privateEventStore.storePrivateEventLog(
         eventSelector,
-        committedEventRandomness,
+        randomness,
+        msgContent,
+        commitment,
+        { ...metadata, scope: otherScope },
+        'test',
+      );
+
+      const events = await privateEventStore.getPrivateEvents(
+        eventSelector,
+        { contractAddress, fromBlock: l2BlockNumber, toBlock: l2BlockNumber + 1, scopes: [otherScope] },
+        'test',
+      );
+      expect(events).toEqual([expectedEvent]);
+    });
+
+    it('excludes staged events belonging to another contract', async () => {
+      const otherContractAddress = await AztecAddress.random();
+
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
         msgContent,
         Fr.random(),
         {
-          contractAddress,
+          contractAddress: otherContractAddress,
           scope,
           txHash,
           l2BlockNumber,
           l2BlockHash,
-          txIndexInBlock: randomInt(100),
-          eventIndexInTx: randomInt(100),
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
         },
-        commitChangeSetId,
+        'test',
       );
-      await privateEventStore.commitChangeSet(commitChangeSetId);
 
-      // Store staged event (not committed)
-      const stagedMsgContent = getRandomMsgContent();
-      await privateEventStore.storePrivateEventLog(
+      const events = await privateEventStore.getPrivateEvents(
         eventSelector,
-        stagedEventRandomness,
-        stagedMsgContent,
-        Fr.random(),
-        {
-          contractAddress,
-          scope,
-          txHash: TxHash.random(),
-          l2BlockNumber,
-          l2BlockHash,
-          txIndexInBlock: randomInt(100),
-          eventIndexInTx: randomInt(100),
-        },
-        stagedChangeSetId,
+        { contractAddress, fromBlock: l2BlockNumber, toBlock: l2BlockNumber + 1, scopes: [scope] },
+        'test',
       );
-
-      // Discard change set
-      privateEventStore.discardChangeSet(stagedChangeSetId);
-
-      // Should only see committed event
-      const events = await privateEventStore.getPrivateEvents(eventSelector, {
-        contractAddress,
-        fromBlock: l2BlockNumber,
-        toBlock: l2BlockNumber + 1,
-        scopes: [scope],
-      });
-      expect(events).toHaveLength(1);
-      expect(events[0].packedEvent).toEqual(msgContent);
+      expect(events).toEqual([]);
     });
   });
+
+  /** Reads through the change set the tests operate under. */
+  function readEvents(filter: PrivateEventStoreFilter) {
+    return privateEventStore.getPrivateEvents(eventSelector, filter, 'test');
+  }
+
+  /** Commits the open change set and opens a fresh one, so everything staged so far lands in the committed index. */
+  async function cycleChangeSet() {
+    await privateEventStore.commitChangeSet('test');
+    privateEventStore.beginChangeSet('test');
+  }
 });

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -2,15 +2,14 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { allToCompletion } from '@aztec/foundation/promise';
-import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { InTx, TxHash } from '@aztec/stdlib/tx';
 
 import type { PackedPrivateEvent } from '../../pxe.js';
-import type { Rollbackable } from '../rollbackable.js';
-import type { ChangeSetId, StagedStore } from '../staged_write_coordinator.js';
+import { BaseStagingStore, type ReadonlyDb } from '../base_staging_store.js';
+import type { ChangeSetId } from '../staged_write_coordinator.js';
 import { StoredPrivateEvent } from './stored_private_event.js';
 
 export type PrivateEventStoreFilter = {
@@ -42,33 +41,20 @@ type StoredEventBuffer = Buffer;
  * Append-only: events are never deleted during normal operation. Reorgs are handled by delete-on-prune, which removes
  * every event originating on a reorg'd block.
  */
-export class PrivateEventStore implements StagedStore, Rollbackable {
-  readonly storeName: string = 'private_event';
-
-  #store: AztecAsyncKVStore;
-  /** Actual private event log entries, keyed by siloedEventCommitment */
-  #events: AztecAsyncMap<EventId, StoredEventBuffer>;
-  /** Multi-map from contractAddress_eventSelector to siloedEventCommitment for efficient lookup */
-  #eventsByContractAndEventSelector: AztecAsyncMultiMap<ContractAndSelectorKey, EventId>;
-  /** Multi-map from block number to siloedEventCommitment, for delete-on-prune. */
-  #eventsByBlockNumber: AztecAsyncMultiMap<BlockNum, EventId>;
-
-  /** changeSetId => eventId (event siloed nullifier) => StoredPrivateEvent */
-  #eventsForChangeSet: Map<ChangeSetId, Map<EventId, StoredPrivateEvent>>;
-
-  /** Per-change-set locks to prevent concurrent writes from affecting each other. */
-  #changeSetLocks: Map<ChangeSetId, Semaphore>;
-
+export class PrivateEventStore extends BaseStagingStore<PrivateEventStoreChangeSet, PrivateEventStoreDb> {
   logger = createLogger('private_event_store');
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
-    this.#events = this.#store.openMap('private_event_logs');
-    this.#eventsByContractAndEventSelector = this.#store.openMultiMap('events_by_contract_selector');
-    this.#eventsByBlockNumber = this.#store.openMultiMap('events_by_block_number');
-
-    this.#eventsForChangeSet = new Map();
-    this.#changeSetLocks = new Map();
+    super({
+      storeName: 'private_event',
+      store,
+      buildChangeSet: () => new Map(),
+      buildDb: db => ({
+        events: db.openMap('private_event_logs'),
+        eventsByContractAndEventSelector: db.openMultiMap('events_by_contract_selector'),
+        eventsByBlockNumber: db.openMultiMap('events_by_block_number'),
+      }),
+    });
   }
 
   /**
@@ -91,45 +77,42 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
     metadata: PrivateEventMetadata,
     changeSetId: ChangeSetId,
   ) {
-    return this.#withChangeSetLock(changeSetId, () =>
-      this.#store.transactionAsync(async () => {
-        const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
-        const eventId = siloedEventCommitment.toString();
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
+      const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
+      const eventId = siloedEventCommitment.toString();
 
-        this.logger.verbose('storing private event log (staged)', {
+      this.logger.verbose('storing private event log (staged)', {
+        eventId,
+        contractAddress,
+        scope,
+        msgContent,
+        l2BlockNumber,
+      });
+
+      const existing = await this.#readEvent(changeSet, db, eventId);
+
+      if (existing) {
+        // If we already stored this event, we still want to make sure to track it for the given scope
+        existing.addScope(scope.toString());
+        changeSet.set(eventId, existing);
+      } else {
+        changeSet.set(
           eventId,
-          contractAddress,
-          scope,
-          msgContent,
-          l2BlockNumber,
-        });
-
-        const existing = await this.#readEvent(eventId, changeSetId);
-
-        if (existing) {
-          // If we already stored this event, we still want to make sure to track it for the given scope
-          existing.addScope(scope.toString());
-          this.#writeEvent(eventId, existing, changeSetId);
-        } else {
-          this.#writeEvent(
-            eventId,
-            new StoredPrivateEvent(
-              randomness,
-              msgContent,
-              l2BlockNumber,
-              l2BlockHash,
-              txHash,
-              txIndexInBlock,
-              eventIndexInTx,
-              contractAddress,
-              eventSelector,
-              new Set([scope.toString()]),
-            ),
-            changeSetId,
-          );
-        }
-      }),
-    );
+          new StoredPrivateEvent(
+            randomness,
+            msgContent,
+            l2BlockNumber,
+            l2BlockHash,
+            txHash,
+            txIndexInBlock,
+            eventIndexInTx,
+            contractAddress,
+            eventSelector,
+            new Set([scope.toString()]),
+          ),
+        );
+      }
+    });
   }
 
   /**
@@ -140,27 +123,40 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
    *  fromBlock: The block number to search from (inclusive).
    *  toBlock: The block number to search upto (exclusive).
    *  scope: - The addresses that decrypted the logs.
+   * @param changeSetId - the change set to read staged data from.
    * @returns - The event log contents, augmented with metadata about the transaction and block in which the event was
    * included.
    */
   public getPrivateEvents(
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
+    changeSetId: ChangeSetId,
   ): Promise<PackedPrivateEvent[]> {
-    return this.#store.transactionAsync(async () => {
+    return this.withChangeSetAndDb(changeSetId, async (changeSet, db) => {
       const key = this.#keyFor(filter.contractAddress, eventSelector);
       const targetScopes = new Set(filter.scopes.map(s => s.toString()));
 
-      // Map from eventId to the promise that reads the event buffer.
+      // Map from eventId to the promise that reads the event.
       // We start reads during iteration to keep DB requests pending and avoid IndexedDB auto-commit.
-      const eventReadPromises: Map<string, Promise<Buffer | undefined>> = new Map();
+      const eventReadPromises: Map<EventId, Promise<StoredPrivateEvent | undefined>> = new Map();
 
-      for await (const eventId of this.#eventsByContractAndEventSelector.getValuesAsync(key)) {
-        eventReadPromises.set(eventId, this.#events.getAsync(eventId));
+      // Committed events indexed by contract address and event selector
+      for await (const eventId of db.eventsByContractAndEventSelector.getValuesAsync(key)) {
+        eventReadPromises.set(eventId, this.#readEvent(changeSet, db, eventId));
       }
 
+      // Staged events have no row in the committed index yet, so add them here. Skip any the loop above already
+      // picked up.
+      [...changeSet.entries()]
+        .filter(
+          ([eventId, stagedEvent]) =>
+            !eventReadPromises.has(eventId) &&
+            this.#keyFor(stagedEvent.contractAddress, stagedEvent.eventSelector) === key,
+        )
+        .forEach(([eventId, stagedEvent]) => eventReadPromises.set(eventId, Promise.resolve(stagedEvent)));
+
       const eventIds = [...eventReadPromises.keys()];
-      const eventBuffers = await allToCompletion([...eventReadPromises.values()]);
+      const storedEvents = await allToCompletion([...eventReadPromises.values()]);
 
       const events: Array<{
         l2BlockNumber: number;
@@ -171,17 +167,15 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
 
       for (let i = 0; i < eventIds.length; i++) {
         const eventId = eventIds[i];
-        const eventBuffer = eventBuffers[i];
+        const storedPrivateEvent = storedEvents[i];
 
-        // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
-        if (!eventBuffer) {
+        // Defensive, if it happens, there's a problem with how we're handling db.eventsByContractAndEventSelector
+        if (!storedPrivateEvent) {
           this.logger.verbose(
             `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
           );
           continue;
         }
-
-        const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
 
         // Filter by block range
         if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
@@ -227,85 +221,46 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
     });
   }
 
-  /** Returns the ids (siloed event commitments) of all events emitted at the given block number. Used by delete-on-prune. */
-  public async eventIdsAtBlock(blockNumber: number): Promise<string[]> {
-    const eventIds: string[] = [];
-    for await (const eventId of this.#eventsByBlockNumber.getValuesAsync(blockNumber)) {
-      eventIds.push(eventId);
-    }
-    return eventIds;
-  }
-
   /**
-   * Rolls the store back to `toBlock`: deletes every event anchored to a block strictly above it, as if nothing past
-   * that block height ever happened. Used by the reorg (`chain-pruned`) path to truncate the orphaned tail. Scanning
-   * from `toBlock + 1` upward covers everything above the rollback target without needing to know the chain tip.
-   *
-   * Must be called inside a transaction owned by the caller (it issues no `transactionAsync` of its own, the reorg path
-   * wraps it together with the anchor update, and IndexedDB has no nested transactions). Throws if any change set has
-   * uncommitted staged writes, since rolling back mid-change-set could later re-introduce events anchored to deleted
-   * blocks.
+   * Deletes every event originating on a block strictly above `toBlock`, as if nothing past that block height ever
+   * happened, truncating the orphaned tail on a reorg. Scanning from `toBlock + 1` upward covers everything above the
+   * rollback target without needing to know the chain tip.
    */
-  public async rollbackToBlock(toBlock: number): Promise<void> {
-    if (this.#eventsForChangeSet.size > 0) {
-      throw new Error('PXE private event store rollback is not allowed while staged writes are pending');
-    }
+  protected async applyRollback(toBlock: number, db: PrivateEventStoreDb): Promise<void> {
     // Snapshot before mutating so we never delete from the multimap we are iterating.
-    const orphaned: { block: number; eventId: string }[] = [];
-    for await (const [block, eventId] of this.#eventsByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
+    const orphaned: { block: BlockNum; eventId: EventId }[] = [];
+    for await (const [block, eventId] of db.eventsByBlockNumber.entriesAsync({ start: toBlock + 1 })) {
       orphaned.push({ block, eventId });
     }
     let removedCount = 0;
     for (const { block, eventId } of orphaned) {
-      const buf = await this.#events.getAsync(eventId);
+      const buf = await db.events.getAsync(eventId);
       if (!buf) {
         throw new Error(`Event not found for eventId ${eventId}`);
       }
       const stored = StoredPrivateEvent.fromBuffer(buf);
-      await this.#events.delete(eventId);
-      await this.#eventsByContractAndEventSelector.deleteValue(
+      await db.events.delete(eventId);
+      await db.eventsByContractAndEventSelector.deleteValue(
         this.#keyFor(stored.contractAddress, stored.eventSelector),
         eventId,
       );
-      await this.#eventsByBlockNumber.deleteValue(block, eventId);
+      await db.eventsByBlockNumber.deleteValue(block, eventId);
       removedCount++;
     }
     this.logger.verbose('rolled back private events', { removedCount, toBlock });
   }
 
-  /**
-   * Commits in-memory staged data to persistent storage.
-   *
-   * Called by StagedWriteCoordinator when an operation completes successfully.
-   *
-   * Note: StagedWriteCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync
-   * here (and using one would throw on IndexedDB as it does not support nested txs).
-   *
-   * @param changeSetId - The changeSetId identifying which staged data to commit
-   */
-  async commitChangeSet(changeSetId: ChangeSetId): Promise<void> {
-    // Note: Don't use #withChangeSetLock here - commit runs within StagedWriteCoordinator's transactionAsync,
-    // and awaiting the lock would create a microtask boundary with no pending DB request,
-    // causing IndexedDB to auto-commit the transaction.
-    for (const [eventId, entry] of this.#getEventsForChangeSet(changeSetId).entries()) {
+  protected async flushChangeSet(changeSet: PrivateEventStoreChangeSet, db: PrivateEventStoreDb): Promise<void> {
+    for (const [eventId, entry] of changeSet.entries()) {
       const lookupKey = this.#keyFor(entry.contractAddress, entry.eventSelector);
       this.logger.verbose('storing private event log', { eventId, lookupKey });
 
       await allToCompletion([
-        this.#events.set(eventId, entry.toBuffer()),
-        this.#eventsByContractAndEventSelector.set(lookupKey, eventId),
-        this.#eventsByBlockNumber.set(entry.l2BlockNumber, eventId),
+        db.events.set(eventId, entry.toBuffer()),
+        db.eventsByContractAndEventSelector.set(lookupKey, eventId),
+        db.eventsByBlockNumber.set(entry.l2BlockNumber, eventId),
       ]);
     }
-
-    this.#clearChangeSetData(changeSetId);
-  }
-
-  /**
-   * Discards in-memory staged data without persisting it.
-   */
-  discardChangeSet(changeSetId: ChangeSetId): void {
-    this.#clearChangeSetData(changeSetId);
   }
 
   /**
@@ -313,71 +268,38 @@ export class PrivateEventStore implements StagedStore, Rollbackable {
    *
    * Returns undefined if the event does not exist in the store overall.
    */
-  async #readEvent(eventId: string, changeSetId: ChangeSetId): Promise<StoredPrivateEvent | undefined> {
+  async #readEvent(
+    changeSet: PrivateEventStoreChangeSet,
+    db: ReadonlyDb<PrivateEventStoreDb>,
+    eventId: EventId,
+  ): Promise<StoredPrivateEvent | undefined> {
     // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
     // are no pending read requests). The staged value still takes precedence if it exists.
-    const buffer = await this.#events.getAsync(eventId);
-    const eventForChangeSet = this.#getEventsForChangeSet(changeSetId).get(eventId);
+    const buffer = await db.events.getAsync(eventId);
+    const eventForChangeSet = changeSet.get(eventId);
     return eventForChangeSet ?? (buffer ? StoredPrivateEvent.fromBuffer(buffer) : undefined);
-  }
-
-  /**
-   * Writes an event to in-memory staged data.
-   *
-   * Writes are only allowed in a change set context. Events modified while staged will only be persisted when `commit`
-   * is called.
-   */
-  #writeEvent(eventId: string, entry: StoredPrivateEvent, changeSetId: ChangeSetId) {
-    this.#getEventsForChangeSet(changeSetId).set(eventId, entry);
-  }
-
-  /**
-   * Get in-memory data only visible to @param changeSetId
-   */
-  #getEventsForChangeSet(changeSetId: ChangeSetId): Map<string, StoredPrivateEvent> {
-    let eventsForChangeSet = this.#eventsForChangeSet.get(changeSetId);
-    if (eventsForChangeSet === undefined) {
-      eventsForChangeSet = new Map();
-      this.#eventsForChangeSet.set(changeSetId, eventsForChangeSet);
-    }
-    return eventsForChangeSet;
-  }
-
-  /**
-   * Clear data structures supporting a specific change set.
-   */
-  #clearChangeSetData(changeSetId: ChangeSetId) {
-    this.#eventsForChangeSet.delete(changeSetId);
-    this.#changeSetLocks.delete(changeSetId);
-  }
-
-  /**
-   * Ensures a function can only run once it acquires a unique per-change-set lock, and handles proper lock release
-   * after it runs.
-   *
-   * This primitive allows concurrent writes on this store without risking data corruption due to unsound write
-   * interleaving.
-   */
-  async #withChangeSetLock<T>(changeSetId: ChangeSetId, fn: () => Promise<T>): Promise<T> {
-    let lock = this.#changeSetLocks.get(changeSetId);
-    if (!lock) {
-      lock = new Semaphore(1);
-      this.#changeSetLocks.set(changeSetId, lock);
-    }
-    await lock.acquire();
-    try {
-      return await fn();
-    } finally {
-      lock.release();
-    }
   }
 
   /**
    * Returns a string key based on @param contractAddress and @param eventSelector.
    *
-   * The returned key is meant to be used when interacting with index #eventsByContractAndEventSelector.
+   * The returned key is meant to be used when interacting with the db.eventsByContractAndEventSelector index.
    */
-  #keyFor(contractAddress: AztecAddress, eventSelector: EventSelector): string {
+  #keyFor(contractAddress: AztecAddress, eventSelector: EventSelector): ContractAndSelectorKey {
     return `${contractAddress.toString()}_${eventSelector.toString()}`;
   }
 }
+
+/** A change set's staged data: the events it has stored, keyed by their siloed event commitment. */
+type PrivateEventStoreChangeSet = Map<EventId, StoredPrivateEvent>;
+
+type PrivateEventStoreDb = {
+  /** Actual private event log entries, keyed by siloedEventCommitment */
+  events: AztecAsyncMap<EventId, StoredEventBuffer>;
+
+  /** Multi-map from contractAddress_eventSelector to siloedEventCommitment for efficient lookup */
+  eventsByContractAndEventSelector: AztecAsyncMultiMap<ContractAndSelectorKey, EventId>;
+
+  /** Multi-map from block number to siloedEventCommitment, for delete-on-prune. */
+  eventsByBlockNumber: AztecAsyncMultiMap<BlockNum, EventId>;
+};

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.test.ts
@@ -110,6 +110,7 @@ describe('StagedWriteCoordinator', () => {
       const committed: { changeSetId: ChangeSetId; inTransaction: boolean }[] = [];
       const mockStore = makeStagedStore({
         storeName: 'mock_store',
+        beginChangeSet: () => {},
         commitChangeSet: changeSetId => {
           committed.push({ changeSetId, inTransaction });
           return Promise.resolve();
@@ -156,6 +157,7 @@ describe('StagedWriteCoordinator', () => {
       const discardChangeSetMock = jest.fn<() => void>();
       const mockStore = makeStagedStore({
         storeName: 'mock_store',
+        beginChangeSet: () => {},
         commitChangeSet: commitMock,
         discardChangeSet: discardChangeSetMock,
       });
@@ -236,6 +238,7 @@ describe('StagedWriteCoordinator', () => {
       const discardChangeSetMock = jest.fn<() => void>();
       const mockStore = makeStagedStore({
         storeName: 'mock_store',
+        beginChangeSet: () => {},
         commitChangeSet: commitMock,
         discardChangeSet: discardChangeSetMock,
       });
@@ -248,6 +251,11 @@ describe('StagedWriteCoordinator', () => {
 
   /** A staged store that does nothing on commit and discard, so a test only spells out the part it exercises. */
   function makeStagedStore(overrides: Partial<StagedStore> & Pick<StagedStore, 'storeName'>): StagedStore {
-    return { commitChangeSet: () => Promise.resolve(), discardChangeSet: () => {}, ...overrides };
+    return {
+      beginChangeSet: () => {},
+      commitChangeSet: () => Promise.resolve(),
+      discardChangeSet: () => {},
+      ...overrides,
+    };
   }
 });

--- a/yarn-project/pxe/src/storage/staged_write_coordinator.ts
+++ b/yarn-project/pxe/src/storage/staged_write_coordinator.ts
@@ -24,12 +24,9 @@ export interface StagedStore {
   /**
    * Notifies the store that a change set has been opened.
    *
-   * TODO: make it required once every staged store extends `BaseStagingStore`. It is optional only while
-   * they migrate to per-change-set staging.
-   *
    * @param changeSetId - The change set identifier
    */
-  beginChangeSet?(changeSetId: ChangeSetId): void;
+  beginChangeSet(changeSetId: ChangeSetId): void;
 
   /**
    * Commits staged data to persistent storage. Will be called within a db transaction for atomicity, alongside the
@@ -61,10 +58,10 @@ export interface StagedStore {
  * sets would mean merging them when one of them commits — a problem in its own right, and one no caller needs solved.
  * Avoiding that throw is up to the caller, which must serialize whatever opens change sets, e.g. with a queue.
  *
- * Staged data is nonetheless keyed by change set ID, because aborting a change set does not cancel the async work it
- * started. An oracle that was mid-write when the operation failed still finishes writing afterwards, and stages its
- * write under the aborted ID, which nothing will ever promote. Were staged data not keyed by ID, that late write
- * would instead sit in the store and be promoted by whichever change set commits next.
+ * Change sets nonetheless carry an ID, because aborting one does not cancel the async work it started. An oracle that
+ * was mid-write when the operation failed still attempts that write afterwards, naming the aborted ID. The stores
+ * reject it, since the change set it names is no longer open. Without the ID there would be nothing to reject it by,
+ * and the late write would be promoted by whichever change set commits next.
  */
 export class StagedWriteCoordinator {
   readonly #kvStore: AztecAsyncKVStore;
@@ -168,7 +165,7 @@ export class StagedWriteCoordinator {
     const begunStores: StagedStore[] = [];
     try {
       for (const store of this.#stagedStores.values()) {
-        store.beginChangeSet?.(changeSetId);
+        store.beginChangeSet(changeSetId);
         begunStores.push(store);
       }
     } catch (err) {

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -92,7 +92,12 @@ export interface ITxeExecutionOracle {
     nullifiers: Fr[];
     privateLogs: PrivateLog[];
   }>;
-  getPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
+  getPrivateEvents(
+    selector: EventSelector,
+    contractAddress: AztecAddress,
+    scope: AztecAddress,
+    changeSetId: ChangeSetId,
+  ): Promise<Fr[][]>;
   privateCallNewFlow(
     from: AztecAddress | undefined,
     targetContractAddress: AztecAddress,

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -233,14 +233,23 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     });
   }
 
-  async getPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress) {
+  async getPrivateEvents(
+    selector: EventSelector,
+    contractAddress: AztecAddress,
+    scope: AztecAddress,
+    changeSetId: ChangeSetId,
+  ) {
     const events = (
-      await this.privateEventStore.getPrivateEvents(selector, {
-        contractAddress,
-        scopes: [scope],
-        fromBlock: 0,
-        toBlock: (await this.getLastBlockNumber()) + 1,
-      })
+      await this.privateEventStore.getPrivateEvents(
+        selector,
+        {
+          contractAddress,
+          scopes: [scope],
+          fromBlock: 0,
+          toBlock: (await this.getLastBlockNumber()) + 1,
+        },
+        changeSetId,
+      )
     ).map(e => e.packedEvent);
 
     if (events.length > MAX_PRIVATE_EVENTS_PER_TXE_QUERY) {

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -634,7 +634,7 @@ export class TXESession implements TXESessionStateHandler {
     await handler.syncContractNonOracleMethod(contractAddress, scope, this.currentChangeSetId);
     // Cycle the change set to commit the stores after the contract sync.
     await this.cycleOperation();
-    return handler.getPrivateEvents(selector, contractAddress, scope);
+    return handler.getPrivateEvents(selector, contractAddress, scope, this.currentChangeSetId);
   }
 
   private handlerAsTxe(): ITxeExecutionOracle {


### PR DESCRIPTION
Backport of https://github.com/aztec-labs-eng/aztec-node/pull/110 to the v5 line: a `git cherry-pick -x` of its squash commit on `aztec-node/main`, `4dfe50f49caadc3cbd9b0178af19e7e4e7bd71e8`. The change itself was described and reviewed there; this PR is only about the port being faithful, so please review it as such.

## Validating the backport

1. Fetch the source repo once: `git remote add node https://github.com/aztec-labs-eng/aztec-node && git fetch node main`.
2. Compare the upstream patch with this PR's patch (`range-diff` compares patches, so unrelated histories are fine):

   ```
   git range-diff 4dfe50f49c^..4dfe50f49c origin/nico/port-node-110-private-event-store-staging^..origin/nico/port-node-110-private-event-store-staging
   ```

   Expected: the `(cherry picked from commit …)` trailer and exactly one patch-level difference, in `yarn-project/pxe/src/storage/private_event_store/private_event_store.ts`:

   ```
   --import { Semaphore } from '@aztec-labs/foundation/queue';
   +-import { Semaphore } from '@aztec/foundation/queue';
   ```

   Same removal on both sides, under this repo's `@aztec/*` scope instead of upstream's `@aztec-labs/*` (their #93 rename, not taken here). Two conflicts were resolved, both scope/context only: the import block above, and `yarn-project/txe/src/oracle/interfaces.ts`, where v5's `getLastTxEffects` keeps its inline return type (upstream has the `TxEffectsData` struct from a refactor that never landed on v5) while `getPrivateEvents` takes upstream's new `changeSetId` parameter verbatim.
3. Build and run the unit suites at this commit (from `yarn-project/`): `yarn workspace @aztec/pxe build && yarn workspace @aztec/txe build && yarn workspace @aztec/pxe test && yarn workspace @aztec/txe test`. The upstream PR's own tests are part of these suites, so passing them is the behavioral check; CI on this PR runs them as well.
4. Confirm upstream's package-scope renames leaked nothing into this repo: `git grep -cE '@aztec-labs|@aztec-foundation' -- yarn-project` on this PR's head must return no matches.

## Stack

Stacked on the backport of aztec-labs-eng/aztec-node#108 (branch `nico/port-node-108-sender-tagging-staging`); to be rebased onto `merge-train/fairies-v5` once that one merges. Order: #20 → #35 → #40 → #47 → #94 → #100 → #98 → #101 → #108 → #110 (aztec-node numbers).
