### PR TITLE
feat: submitProof takes only new headers

### DIFF
--- a/l1-contracts/l1-artifacts/scripts/generate-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/generate-artifacts.sh
@@ -16,6 +16,7 @@ contracts=(
   "SlashingProposer"
   "EmpireBase"
   "RollupOperationsExtLib"
+  "EpochProofExtLib"
   "ValidatorOperationsExtLib"
   "RewardExtLib"
   "SlasherDeploymentExtLib"

--- a/l1-contracts/partial_epoch_proof_gas_report.json
+++ b/l1-contracts/partial_epoch_proof_gas_report.json
@@ -3,71 +3,71 @@
     "contract": "test/RollupWithPreheating.sol:RollupWithPreheating",
     "deployment": {
       "gas": 0,
-      "size": 44750
+      "size": 44946
     },
     "functions": {
-      "gasReportSubmit16Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit16Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1251816,
-        "mean": 1251816,
-        "median": 1251816,
-        "max": 1251816
+        "min": 1255881,
+        "mean": 1255881,
+        "median": 1255881,
+        "max": 1255881
       },
-      "gasReportSubmit16CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit16CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1416995,
-        "mean": 1416995,
-        "median": 1416995,
-        "max": 1416995
+        "min": 1421159,
+        "mean": 1421159,
+        "median": 1421159,
+        "max": 1421159
       },
-      "gasReportSubmit1Checkpoint((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit1Checkpoint((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 656546,
-        "mean": 656546,
-        "median": 656546,
-        "max": 656546
+        "min": 658412,
+        "mean": 658412,
+        "median": 658412,
+        "max": 658412
       },
-      "gasReportSubmit1CheckpointWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit1CheckpointWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 683299,
-        "mean": 683299,
-        "median": 683299,
-        "max": 683299
+        "min": 685559,
+        "mean": 685559,
+        "median": 685559,
+        "max": 685559
       },
-      "gasReportSubmit32Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit32Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1742662,
-        "mean": 1742662,
-        "median": 1742662,
-        "max": 1742662
+        "min": 1748763,
+        "mean": 1748763,
+        "median": 1748763,
+        "max": 1748763
       },
-      "gasReportSubmit32CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit32CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 2001294,
-        "mean": 2001294,
-        "median": 2001294,
-        "max": 2001294
+        "min": 2007827,
+        "mean": 2007827,
+        "median": 2007827,
+        "max": 2007827
       },
-      "gasReportSubmit8Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit8Checkpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 960537,
-        "mean": 960537,
-        "median": 960537,
-        "max": 960537
+        "min": 963262,
+        "mean": 963262,
+        "median": 963262,
+        "max": 963262
       },
-      "gasReportSubmit8CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit8CheckpointsWithTwoOverrides((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 1057116,
-        "mean": 1057116,
-        "median": 1057116,
-        "max": 1057116
+        "min": 1060278,
+        "mean": 1060278,
+        "median": 1060278,
+        "max": 1060278
       },
-      "gasReportSubmit8MoreCheckpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
+      "gasReportSubmit8MoreCheckpoints((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(address,uint256)[],(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
         "calls": 1,
-        "min": 943741,
-        "mean": 943741,
-        "median": 943741,
-        "max": 943741
+        "min": 916794,
+        "mean": 916794,
+        "median": 916794,
+        "max": 916794
       }
     }
   }

--- a/l1-contracts/partial_epoch_proof_gas_report.md
+++ b/l1-contracts/partial_epoch_proof_gas_report.md
@@ -2,14 +2,14 @@
 
 | Proof submission | Gas |
 |---|---:|
-| 1 Checkpoint | 656,546 |
-| 1 Checkpoint With Two Overrides | 683,299 |
-| 8 Checkpoints | 960,537 |
-| 8 Checkpoints With Two Overrides | 1,057,116 |
-| 8 More Checkpoints | 943,741 |
-| 16 Checkpoints | 1,251,816 |
-| 16 Checkpoints With Two Overrides | 1,416,995 |
-| 32 Checkpoints | 1,742,662 |
-| 32 Checkpoints With Two Overrides | 2,001,294 |
+| 1 Checkpoint | 658,412 |
+| 1 Checkpoint With Two Overrides | 685,559 |
+| 8 Checkpoints | 963,262 |
+| 8 Checkpoints With Two Overrides | 1,060,278 |
+| 8 More Checkpoints | 916,794 |
+| 16 Checkpoints | 1,255,881 |
+| 16 Checkpoints With Two Overrides | 1,421,159 |
+| 32 Checkpoints | 1,748,763 |
+| 32 Checkpoints With Two Overrides | 2,007,827 |
 
 _Uses the mock epoch proof verifier._

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -39,11 +39,17 @@ struct PublicInputArgs {
   address proverId;
 }
 
+struct ProvenCheckpointFees {
+  address coinbase;
+  uint256 accumulatedFees;
+}
+
 struct SubmitEpochRootProofArgs {
   uint256 start; // inclusive
   uint256 end; // inclusive
   PublicInputArgs args;
-  ProposedHeader[] headers; // Must match what was proposed by the committee
+  ProvenCheckpointFees[] provenCheckpointFees; // Optional prefix already proven and accounted for
+  ProposedHeader[] headers; // Remaining suffix; must match what was proposed by the committee
   CommitteeAttestations attestations; // attestations for the last checkpoint in epoch
   bytes blobInputs;
   bytes proof;

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -55,6 +55,7 @@ library Errors {
   error Rollup__InvalidArchive(bytes32 expected, bytes32 actual); // 0xb682a40e
   error Rollup__InvalidCheckpointHeader(bytes32 expected, bytes32 actual);
   error Rollup__InvalidCheckpointHeaderCount(uint256 expected, uint256 actual);
+  error Rollup__InvalidProvenCheckpointCount(uint256 maximum, uint256 actual);
   error Rollup__InvalidCheckpointNumber(uint256 expected, uint256 actual); // 0xd1ba9bfa
   error Rollup__InvalidInboxRollingHash(bytes32 expected, bytes32 actual); // 0xed1f7bb5
   error Rollup__InvalidPreviousInboxRollingHash(bytes32 expected, bytes32 actual); // 0x2fe7cae5

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -6,6 +6,7 @@ import {BlobLib} from "@aztec-blob-lib/BlobLib.sol";
 import {IEscapeHatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
 import {
   SubmitEpochRootProofArgs,
+  ProvenCheckpointFees,
   PublicInputArgs,
   IRollupCore,
   RollupStore,
@@ -107,7 +108,8 @@ library EpochProofLib {
    *              - start: First checkpoint number in the epoch (inclusive)
    *              - end: Last checkpoint number in the epoch (inclusive)
    *              - args: Public inputs (previousArchive, endArchive, endTimestamp, proverId)
-   *              - headers: Proposed headers for each checkpoint, supplying the fee recipient and value
+   *              - provenCheckpointFees: Fee recipient and value for an already proven and accounted prefix
+   *              - headers: Proposed headers for the remaining checkpoints
    *              - attestations: Committee attestations for the last checkpoint in the epoch
    *              - blobInputs: Batched blob data for EIP-4844 point evaluation precompile
    *              - proof: The validity proof bytes for the root rollup circuit
@@ -123,17 +125,23 @@ library EpochProofLib {
     }
 
     (Epoch endEpoch, Epoch currentEpoch, uint256 provenBeforeSubmission) = assertAcceptable(_args.start, _args.end);
-    uint256 firstHeaderToVerify;
-    if (provenBeforeSubmission >= _args.start) {
-      uint256 provenPrefixLength = provenBeforeSubmission - _args.start + 1;
-      uint256 accountedPrefixLength = RewardLib.getLongestProvenLength(endEpoch);
-      firstHeaderToVerify = provenPrefixLength < accountedPrefixLength ? provenPrefixLength : accountedPrefixLength;
-    }
-
     {
-      // The skipped calldata prefix is untrusted, but rewards have already consumed it and proof verification binds its
-      // fee data to the canonical checkpoint headers. We only verify new headers since the last proof
-      bytes32[] memory headerHashes = verifyHeaders(_args.start, _args.end, _args.headers, firstHeaderToVerify);
+      uint256 firstHeaderToVerify;
+      if (provenBeforeSubmission >= _args.start) {
+        uint256 provenPrefixLength = provenBeforeSubmission - _args.start + 1;
+        uint256 accountedPrefixLength = RewardLib.getLongestProvenLength(endEpoch);
+        firstHeaderToVerify = provenPrefixLength < accountedPrefixLength ? provenPrefixLength : accountedPrefixLength;
+      }
+
+      uint256 prefixLength = _args.provenCheckpointFees.length;
+      require(
+        prefixLength <= firstHeaderToVerify,
+        Errors.Rollup__InvalidProvenCheckpointCount(firstHeaderToVerify, prefixLength)
+      );
+
+      // Proof verification binds compact fee data to canonical header hashes. Rewards may only consume full headers.
+      bytes32[] memory headerHashes =
+        verifyHeaders(_args.start, _args.end, _args.headers, prefixLength, firstHeaderToVerify);
 
       require(verifyEpochRootProof(_args, _config, headerHashes), Errors.Rollup__InvalidProof());
     }
@@ -204,7 +212,7 @@ library EpochProofLib {
     bytes calldata _blobPublicInputs,
     RollupConfig memory _config
   ) internal view returns (bytes32[] memory) {
-    bytes32[] memory headerHashes = verifyHeaders(_start, _end, _headers, 0);
+    bytes32[] memory headerHashes = verifyHeaders(_start, _end, _headers, 0, 0);
     return computeEpochProofPublicInputs(_start, _end, _args, _headers, _blobPublicInputs, _config, headerHashes);
   }
 
@@ -273,7 +281,7 @@ library EpochProofLib {
    * @param  _start - The start of the epoch (inclusive)
    * @param  _end - The end of the epoch (inclusive)
    * @param  _args - Array of public inputs to the proof (previousArchive, endArchive, endTimestamp, outHash, proverId)
-   * @param  _headers - The proposed checkpoint headers supplying the fee recipient and value for each checkpoint
+   * @param  _headers - The proposed checkpoint headers supplying fee data for the remaining suffix
    * @param  _blobPublicInputs - The blob public inputs for the proof
    * @param  _config - The rollup's deployment-time configuration
    * @param  _headerHashes - The canonical stored header hashes returned by verifyHeaders
@@ -367,11 +375,11 @@ library EpochProofLib {
 
     uint256 offset = 5 + Constants.MAX_CHECKPOINTS_PER_EPOCH;
 
-    // Taking recipient/value from the checkpoint headers rather than the prover
-    // as defense in depth. Slots past numCheckpoints stay zero.
-    for (uint256 i = 0; i < numCheckpoints; i++) {
-      publicInputs[offset + 2 * i] = addressToField(_headers[i].coinbase);
-      publicInputs[offset + 2 * i + 1] = bytes32(_headers[i].accumulatedFees);
+    // The submit path fills the compact prefix directly from calldata before verifying the proof.
+    uint256 suffixOffset = offset + 2 * (numCheckpoints - _headers.length);
+    for (uint256 i = 0; i < _headers.length; i++) {
+      publicInputs[suffixOffset + 2 * i] = addressToField(_headers[i].coinbase);
+      publicInputs[suffixOffset + 2 * i + 1] = bytes32(_headers[i].accumulatedFees);
     }
     offset += Constants.MAX_CHECKPOINTS_PER_EPOCH * 2;
 
@@ -430,7 +438,8 @@ library EpochProofLib {
    *
    * @param _start The first checkpoint number in the epoch (inclusive)
    * @param _end The last checkpoint number in the epoch (inclusive)
-   * @param _headers The proposed headers for each checkpoint in [_start, _end]
+   * @param _headers The proposed headers after the compact prefix
+   * @param _prefixLength The number of checkpoints represented by compact fee data
    * @param _firstHeaderToVerify The index of the first header that has not already been proven and accounted for
    * @return headerHashes The canonical stored header hashes for the checkpoint range
    */
@@ -438,17 +447,19 @@ library EpochProofLib {
     uint256 _start,
     uint256 _end,
     ProposedHeader[] calldata _headers,
+    uint256 _prefixLength,
     uint256 _firstHeaderToVerify
   ) private view returns (bytes32[] memory headerHashes) {
     uint256 numCheckpoints = _end - _start + 1;
     require(
-      _headers.length == numCheckpoints, Errors.Rollup__InvalidCheckpointHeaderCount(numCheckpoints, _headers.length)
+      _headers.length + _prefixLength == numCheckpoints,
+      Errors.Rollup__InvalidCheckpointHeaderCount(numCheckpoints, _headers.length + _prefixLength)
     );
 
     headerHashes = STFLib.getHeaderHashes(_start, _end);
     for (uint256 i = _firstHeaderToVerify; i < numCheckpoints; i++) {
       bytes32 expectedHeaderHash = headerHashes[i];
-      bytes32 providedHeaderHash = ProposedHeaderLib.hashCalldata(_headers[i]);
+      bytes32 providedHeaderHash = ProposedHeaderLib.hashCalldata(_headers[i - _prefixLength]);
       require(
         providedHeaderHash == expectedHeaderHash,
         Errors.Rollup__InvalidCheckpointHeader(expectedHeaderHash, providedHeaderHash)
@@ -584,6 +595,13 @@ library EpochProofLib {
     bytes32[] memory publicInputs = computeEpochProofPublicInputs(
       _args.start, _args.end, _args.args, _args.headers, _args.blobInputs, _config, _headerHashes
     );
+
+    uint256 offset = 5 + Constants.MAX_CHECKPOINTS_PER_EPOCH;
+    ProvenCheckpointFees[] calldata provenFees = _args.provenCheckpointFees;
+    for (uint256 i = 0; i < provenFees.length; i++) {
+      publicInputs[offset + 2 * i] = addressToField(provenFees[i].coinbase);
+      publicInputs[offset + 2 * i + 1] = bytes32(provenFees[i].accumulatedFees);
+    }
 
     require(_config.epochProofVerifier.verify(_args.proof, publicInputs), Errors.Rollup__InvalidProof());
 

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.27;
 import {RollupConfig, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {CompressedFeeHeader, FeeHeaderLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {ProposedHeader} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
 import {StakingLib} from "@aztec/core/libraries/rollup/StakingLib.sol";
 import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelectionLib.sol";
@@ -73,6 +74,8 @@ struct RewardStorage {
 
 struct Values {
   address sequencer;
+  uint256 fee;
+  uint256 protocolFee;
   uint256 proverFee;
   uint256 sequencerFee;
   uint256[] sequencerCheckpointRewards;
@@ -275,27 +278,29 @@ library RewardLib {
 
       Totals memory t;
       for (uint256 i = $er.longestProvenLength; i < length; i++) {
+        {
+          ProposedHeader calldata header = _args.headers[i - _args.provenCheckpointFees.length];
+          v.fee = header.accumulatedFees;
+          v.sequencer = header.coinbase;
+        }
         uint256 index = i - $er.longestProvenLength;
         CompressedFeeHeader feeHeader = STFLib.getFeeHeader(_args.start + i);
 
         v.manaUsed = feeHeader.getManaUsed();
+        v.protocolFee = feeHeader.getProtocolFee() * v.manaUsed;
 
-        uint256 fee = _args.headers[i].accumulatedFees;
-        uint256 protocolFee = feeHeader.getProtocolFee() * v.manaUsed;
-
-        t.feesToClaim += fee;
-        t.totalProtocolFee += protocolFee;
+        t.feesToClaim += v.fee;
+        t.totalProtocolFee += v.protocolFee;
 
         // Compute the proving fee in the fee asset
-        v.proverFee = Math.min(v.manaUsed * feeHeader.getProverCost(), fee - protocolFee);
+        v.proverFee = Math.min(v.manaUsed * feeHeader.getProverCost(), v.fee - v.protocolFee);
         if (v.proverFee > 0) {
           $er.rewards += v.proverFee.toUint128();
         }
 
-        v.sequencerFee = fee - protocolFee - v.proverFee;
+        v.sequencerFee = v.fee - v.protocolFee - v.proverFee;
 
         {
-          v.sequencer = _args.headers[i].coinbase;
           uint256 toSequencer = v.sequencerCheckpointRewards[index] + v.sequencerFee;
           if (toSequencer > 0) {
             rewardStorage.sequencerRewards[v.sequencer] += toSequencer;
@@ -451,6 +456,7 @@ library RewardLib {
     context.proposerRewards = new uint256[](_committee.length);
     context.gse = StakingLib.getStorage().gse;
     context.registryRewardOverrides = _registryRewardOverrides;
+    _from -= _args.provenCheckpointFees.length;
     for (uint256 i = 0; i < desiredSequencerCheckpointRewards.length; i++) {
       uint256 proposerIndex = ValidatorSelectionLib.computeProposerIndex(
         _endEpoch, _args.headers[_from + i].slotNumber, seed, _committee.length

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "./base/DecoderBase.sol";
 
 import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
@@ -1108,6 +1110,7 @@ contract RollupTest is RollupBase {
         start: _start,
         end: _end,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
         blobInputs: _blobInputs,

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "./DecoderBase.sol";
 
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
@@ -102,6 +104,7 @@ contract RollupBase is DecoderBase {
         start: startCheckpointNumber,
         end: endCheckpointNumber,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
         blobInputs: endFull.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/benchmark/CompactEpochProof.t.sol
+++ b/l1-contracts/test/benchmark/CompactEpochProof.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {PartialEpochProofGasReportBase} from "./happy.t.sol";
+import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {ProposedHeader, ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+import {CommitteeAttestations} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Epoch} from "@aztec/core/libraries/TimeLib.sol";
+
+contract ExpectedEpochPublicInputsVerifier {
+  bytes32 private immutable expected;
+
+  constructor(bytes32[] memory _inputs) {
+    expected = keccak256(abi.encode(_inputs));
+  }
+
+  function verify(bytes calldata, bytes32[] calldata _inputs) external view returns (bool) {
+    return keccak256(abi.encode(_inputs)) == expected;
+  }
+}
+
+contract CompactEpochProofTest is PartialEpochProofGasReportBase {
+  struct LegacySubmission {
+    uint256 start;
+    uint256 end;
+    PublicInputArgs args;
+    ProposedHeader[] headers;
+    CommitteeAttestations attestations;
+    bytes blobInputs;
+    bytes proof;
+  }
+
+  function _bindPublicInputs(SubmitEpochRootProofArgs memory _args) internal {
+    bytes32[] memory inputs =
+      rollup.getEpochProofPublicInputs(_args.start, _args.end, _args.args, _args.headers, _args.blobInputs);
+    ExpectedEpochPublicInputsVerifier verifier = new ExpectedEpochPublicInputsVerifier(inputs);
+    vm.etch(address(rollup.getEpochProofVerifier()), address(verifier).code);
+  }
+
+  function testCompactExtensionPreservesPublicInputsAndRewards() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory fullArgs = _getGasReportSubmission(16);
+    _bindPublicInputs(fullArgs);
+    uint256 snapshot = vm.snapshotState();
+    rollup.submitEpochRootProof(fullArgs);
+    uint256 rewards = rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(GAS_REPORT_EPOCH));
+    uint256[] memory sequencerRewards = new uint256[](16);
+    for (uint256 i = 0; i < 16; i++) {
+      sequencerRewards[i] = rollup.getSequencerRewards(checkpointHeaders[i + 1].coinbase);
+    }
+    vm.revertToState(snapshot);
+    rollup.submitEpochRootProof(_compactSubmission(fullArgs, 8));
+    assertEq(rollup.getProvenCheckpointNumber(), 16);
+    assertEq(rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(GAS_REPORT_EPOCH)), rewards);
+    for (uint256 i = 0; i < 16; i++) {
+      assertEq(rollup.getSequencerRewards(checkpointHeaders[i + 1].coinbase), sequencerRewards[i]);
+    }
+  }
+
+  function testCompactPrefixRejectsUnprovenCheckpoints() public {
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(8), 1);
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidProvenCheckpointCount.selector, 0, 1));
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixCannotExtendPastProvenTip() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(16), 9);
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidProvenCheckpointCount.selector, 8, 9));
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixCannotOmitUnaccountedCheckpoints() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    bytes32 epochRewardsSlot = keccak256(abi.encode(GAS_REPORT_EPOCH, uint256(keccak256("aztec.reward.storage")) + 1));
+    uint256 rewards = uint256(vm.load(address(rollup), epochRewardsSlot));
+    vm.store(address(rollup), epochRewardsSlot, bytes32((rewards & ~uint256(type(uint128).max)) | 4));
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(16), 8);
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidProvenCheckpointCount.selector, 4, 8));
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testFuzzCompactPrefix(uint256 _proven, uint256 _prefix, uint256 _end) public {
+    uint256 proven = bound(_proven, 1, 31);
+    uint256 prefix = bound(_prefix, 0, proven);
+    uint256 end = bound(_end, proven + 1, 32);
+    rollup.submitEpochRootProof(_getGasReportSubmission(proven));
+    SubmitEpochRootProofArgs memory args = _getGasReportSubmission(end);
+    _bindPublicInputs(args);
+    rollup.submitEpochRootProof(_compactSubmission(args, prefix));
+    assertEq(rollup.getProvenCheckpointNumber(), end);
+  }
+
+  function testCompactPrefixRejectsMissingHeader() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(15), 8);
+    args.end = 16;
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidCheckpointHeaderCount.selector, 16, 15));
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixRejectsChangedNewHeader() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(16), 8);
+    bytes32 expected = ProposedHeaderLib.hash(args.headers[0]);
+    args.headers[0].accumulatedFees++;
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.Rollup__InvalidCheckpointHeader.selector, expected, ProposedHeaderLib.hash(args.headers[0])
+      )
+    );
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixBindsFeesToProof() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _getGasReportSubmission(16);
+    _bindPublicInputs(args);
+    args = _compactSubmission(args, 8);
+    args.provenCheckpointFees[0].accumulatedFees++;
+    vm.expectRevert(Errors.Rollup__InvalidProof.selector);
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixBindsCoinbaseToProof() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _getGasReportSubmission(16);
+    _bindPublicInputs(args);
+    args = _compactSubmission(args, 8);
+    args.provenCheckpointFees[0].coinbase = address(0xdead);
+    vm.expectRevert(Errors.Rollup__InvalidProof.selector);
+    rollup.submitEpochRootProof(args);
+  }
+
+  function testCompactPrefixAllowsProvenTipToAdvanceBeforeInclusion() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    SubmitEpochRootProofArgs memory args = _compactSubmission(_getGasReportSubmission(16), 8);
+    rollup.submitEpochRootProof(_getGasReportSubmission(12));
+    rollup.submitEpochRootProof(args);
+    assertEq(rollup.getProvenCheckpointNumber(), 16);
+  }
+
+  function testCompactRepeatedAndShorterProofs() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(16));
+    SubmitEpochRootProofArgs memory repeated = _compactSubmission(_getGasReportSubmission(16), 16);
+    repeated.args.proverId = address(0xbeef);
+    rollup.submitEpochRootProof(repeated);
+    rollup.submitEpochRootProof(_compactSubmission(_getGasReportSubmission(8), 8));
+    assertEq(rollup.getProvenCheckpointNumber(), 16);
+  }
+
+  function testCompactCalldataSavings() public {
+    uint256[5] memory prefixes = [uint256(0), 1, 8, 16, 31];
+    uint256[5] memory lengths = [uint256(1), 2, 16, 32, 32];
+    for (uint256 i = 0; i < prefixes.length; i++) {
+      SubmitEpochRootProofArgs memory args = _getGasReportSubmission(lengths[i]);
+      bytes memory legacy = abi.encode(
+        LegacySubmission(args.start, args.end, args.args, args.headers, args.attestations, args.blobInputs, args.proof)
+      );
+      bytes memory compact = abi.encode(_compactSubmission(args, prefixes[i]));
+      assertEq(int256(legacy.length) - int256(compact.length), int256(352 * prefixes[i]) - 64);
+      emit log_named_uint("Compact checkpoints", prefixes[i]);
+      emit log_named_uint("Checkpoints in proof", lengths[i]);
+      emit log_named_int("Calldata bytes saved", int256(legacy.length) - int256(compact.length));
+      emit log_named_int("Calldata gas saved (4/16)", int256(_calldataGas(legacy)) - int256(_calldataGas(compact)));
+    }
+  }
+
+  function _calldataGas(bytes memory _data) private pure returns (uint256 result) {
+    for (uint256 i = 0; i < _data.length; i++) {
+      result += _data[i] == 0 ? 4 : 16;
+    }
+  }
+}

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "../base/DecoderBase.sol";
 
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
@@ -553,6 +555,7 @@ abstract contract BenchmarkRollupBase is FeeModelTestPoints, DecoderBase {
             start: start,
             end: start + epochSize - 1,
             args: args,
+            provenCheckpointFees: new ProvenCheckpointFees[](0),
             headers: headers,
             attestations: checkpointAttestations[start + epochSize - 1],
             blobInputs: full.checkpoint.batchedBlobInputs,
@@ -678,6 +681,7 @@ abstract contract PartialEpochProofGasReportBase is BenchmarkRollupBase {
       start: 1,
       end: _length,
       args: args,
+      provenCheckpointFees: new ProvenCheckpointFees[](0),
       headers: headers,
       attestations: checkpointAttestations[_length],
       blobInputs: full.checkpoint.batchedBlobInputs,
@@ -687,6 +691,23 @@ abstract contract PartialEpochProofGasReportBase is BenchmarkRollupBase {
 
   function _gasReporter() internal view returns (PartialEpochProofGasReporter) {
     return PartialEpochProofGasReporter(address(rollup));
+  }
+
+  function _compactSubmission(SubmitEpochRootProofArgs memory _args, uint256 _prefixLength)
+    internal
+    pure
+    returns (SubmitEpochRootProofArgs memory)
+  {
+    _args.provenCheckpointFees = new ProvenCheckpointFees[](_prefixLength);
+    ProposedHeader[] memory headers = new ProposedHeader[](_args.headers.length - _prefixLength);
+    for (uint256 i = 0; i < _prefixLength; i++) {
+      _args.provenCheckpointFees[i] = ProvenCheckpointFees(_args.headers[i].coinbase, _args.headers[i].accumulatedFees);
+    }
+    for (uint256 i = 0; i < headers.length; i++) {
+      headers[i] = _args.headers[_prefixLength + i];
+    }
+    _args.headers = headers;
+    return _args;
   }
 }
 
@@ -755,6 +776,23 @@ contract PartialEpochProofWithTwoOverridesGasReportTest is PartialEpochProofGasR
     _gasReporter().gasReportSubmit32CheckpointsWithTwoOverrides(_getGasReportSubmission(32));
     assertEq(rollup.getProvenCheckpointNumber(), 32);
   }
+
+  function testCompactExtensionWithTwoOverridesPreservesRewards() public {
+    rollup.submitEpochRootProof(_getGasReportSubmission(8));
+    uint256 snapshot = vm.snapshotState();
+    rollup.submitEpochRootProof(_getGasReportSubmission(16));
+    uint256 rewards = rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(GAS_REPORT_EPOCH));
+    uint256[] memory sequencerRewards = new uint256[](16);
+    for (uint256 i = 0; i < 16; i++) {
+      sequencerRewards[i] = rollup.getSequencerRewards(checkpointHeaders[i + 1].coinbase);
+    }
+    vm.revertToState(snapshot);
+    rollup.submitEpochRootProof(_compactSubmission(_getGasReportSubmission(16), 8));
+    assertEq(rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(GAS_REPORT_EPOCH)), rewards);
+    for (uint256 i = 0; i < 16; i++) {
+      assertEq(rollup.getSequencerRewards(checkpointHeaders[i + 1].coinbase), sequencerRewards[i]);
+    }
+  }
 }
 
 contract PartialEpochProofExtensionGasReportTest is PartialEpochProofGasReportBase {
@@ -765,7 +803,7 @@ contract PartialEpochProofExtensionGasReportTest is PartialEpochProofGasReportBa
   }
 
   function testGasReportSubmit8MoreCheckpoints() public {
-    _gasReporter().gasReportSubmit8MoreCheckpoints(_getGasReportSubmission(16));
+    _gasReporter().gasReportSubmit8MoreCheckpoints(_compactSubmission(_getGasReportSubmission(16), 8));
     assertEq(rollup.getProvenCheckpointNumber(), 16);
   }
 }

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "../base/DecoderBase.sol";
 
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
@@ -274,6 +276,7 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
               start: start,
               end: start + epochSize - 1,
               args: args,
+              provenCheckpointFees: new ProvenCheckpointFees[](0),
               headers: headers,
               attestations: checkpointAttestations[start + epochSize - 1],
               blobInputs: full.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
+++ b/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
@@ -2,6 +2,8 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {ValidatorSelectionTestBase} from "@test/validator-selection/ValidatorSelectionBase.sol";
 import {DecoderBase} from "@test/base/DecoderBase.sol";
 import {IEscapeHatchCore, Status, CandidateInfo, Hatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
@@ -351,6 +353,7 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
         start: _start,
         end: _end,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
         blobInputs: endFull.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/escape-hatch/integration/regression/OutHashValidationSkipped.t.sol
+++ b/l1-contracts/test/escape-hatch/integration/regression/OutHashValidationSkipped.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {EscapeHatchIntegrationBase} from "../EscapeHatchIntegrationBase.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Epoch} from "@aztec/shared/libraries/TimeMath.sol";
@@ -74,6 +76,7 @@ contract OutHashValidationSkippedTest is EscapeHatchIntegrationBase {
         start: 1,
         end: 1,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
         blobInputs: full.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/escape-hatch/integration/submitEpochRootProof.t.sol
+++ b/l1-contracts/test/escape-hatch/integration/submitEpochRootProof.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {EscapeHatchIntegrationBase} from "./EscapeHatchIntegrationBase.sol";
 import {IEscapeHatchCore, Status, CandidateInfo, Hatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
@@ -128,6 +130,7 @@ contract submitEpochRootProofTest is EscapeHatchIntegrationBase {
         start: 1,
         end: 1,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: AttestationLibHelper.packAttestations(_attestations),
         blobInputs: full.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "../base/DecoderBase.sol";
 
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
@@ -251,6 +253,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
         start: _start,
         end: _start + _epochSize - 1,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
         blobInputs: full.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -3,6 +3,8 @@
 // solhint-disable imports-order
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {Strings} from "@oz/utils/Strings.sol";
 import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 import {
@@ -771,6 +773,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
         start: startCheckpointNumber,
         end: endCheckpointNumber,
         args: args,
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: _attestations,
         blobInputs: endFull.checkpoint.batchedBlobInputs,

--- a/l1-contracts/test/validator-selection/tmnt207.t.sol
+++ b/l1-contracts/test/validator-selection/tmnt207.t.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {ProvenCheckpointFees} from "@aztec/core/interfaces/IRollup.sol";
+
 import {DecoderBase} from "../base/DecoderBase.sol";
 
 import {Registry} from "@aztec/governance/Registry.sol";
@@ -235,6 +237,7 @@ contract Tmnt207Test is RollupBase {
           endInboxRollingHash: 0,
           proverId: address(0)
         }),
+        provenCheckpointFees: new ProvenCheckpointFees[](0),
         headers: headers,
         attestations: AttestationLibHelper.packAttestations(l2CheckpointReal.attestations),
         blobInputs: full.checkpoint.batchedBlobInputs,

--- a/labs-patches/0002-fix-link-epoch-proof-library-when-deploying-rollup.patch
+++ b/labs-patches/0002-fix-link-epoch-proof-library-when-deploying-rollup.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Gherghisan <alexghr@users.noreply.github.com>
+Date: Mon, 7 Sep 2026 09:54:14 +0000
+Subject: [PATCH] fix: link epoch proof library when deploying rollup
+
+Register EpochProofExtLib with the Rollup deployment artifacts and verify that every link reference has deployable bytecode. Requires regenerated foundation L1 artifacts exporting the epoch proof library.
+
+diff --git a/yarn-project/ethereum/src/l1_artifacts.test.ts b/yarn-project/ethereum/src/l1_artifacts.test.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..570d2852ce95b796c9614638303dc6708e8a0dd7
+--- /dev/null
++++ b/yarn-project/ethereum/src/l1_artifacts.test.ts
+@@ -0,0 +1,13 @@
++import { RollupArtifact } from './l1_artifacts.js';
++
++describe('Rollup deployment artifacts', () => {
++  it('supplies deployable bytecode for every linked library', () => {
++    const libraries: Record<string, { contractBytecode: string }> = RollupArtifact.libraries.libraryCode;
++    for (const references of Object.values(RollupArtifact.libraries.linkReferences)) {
++      for (const name of Object.keys(references)) {
++        expect(libraries[name]).toBeDefined();
++        expect(libraries[name]?.contractBytecode).toMatch(/^0x[0-9a-f]+$/i);
++      }
++    }
++  });
++});
+diff --git a/yarn-project/ethereum/src/l1_artifacts.ts b/yarn-project/ethereum/src/l1_artifacts.ts
+index d404aac730012d52c0c095fdddbf6a816b8ec705..2e6979daa1c516ddb8741772f705985674bf0f4c 100644
+--- a/yarn-project/ethereum/src/l1_artifacts.ts
++++ b/yarn-project/ethereum/src/l1_artifacts.ts
+@@ -3,6 +3,8 @@ import {
+   CoinIssuerBytecode,
+   DateGatedRelayerAbi,
+   DateGatedRelayerBytecode,
++  EpochProofExtLibAbi,
++  EpochProofExtLibBytecode,
+   FeeAssetHandlerAbi,
+   FeeAssetHandlerBytecode,
+   FeeJuicePortalAbi,
+@@ -91,6 +93,11 @@ export const RollupArtifact = {
+         contractAbi: RollupOperationsExtLibAbi,
+         contractBytecode: RollupOperationsExtLibBytecode as Hex,
+       },
++      EpochProofExtLib: {
++        name: 'EpochProofExtLib',
++        contractAbi: EpochProofExtLibAbi,
++        contractBytecode: EpochProofExtLibBytecode as Hex,
++      },
+       ValidatorOperationsExtLib: {
+         name: 'ValidatorOperationsExtLib',
+         contractAbi: ValidatorOperationsExtLibAbi,

--- a/labs-patches/0003-feat-submit-compact-fees-for-proven-checkpoints.patch
+++ b/labs-patches/0003-feat-submit-compact-fees-for-proven-checkpoints.patch
@@ -1,0 +1,255 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Gherghisan <alexghr@users.noreply.github.com>
+Date: Mon, 7 Sep 2026 09:55:13 +0000
+Subject: [PATCH] feat: submit compact fees for proven checkpoints
+
+Use the proven tip observed during validation to send only coinbase and accumulated fees for the proven prefix. Keep full headers for the suffix and for public-input validation. Apply the same encoding to gas estimation and test fresh, partial, and fully proven prefixes.
+
+diff --git a/yarn-project/prover-node/src/prover-node-publisher.test.ts b/yarn-project/prover-node/src/prover-node-publisher.test.ts
+index 390a9d84f0082ae241c9a38dc2b37b75f98579b8..8d78e336101d82bfe1ad2ccc3c5dd9339c01c1cb 100644
+--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
++++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
+@@ -1,3 +1,5 @@
++import { RollupAbi } from '@aztec-foundation/l1-artifacts';
++
+ import { BatchedBlob } from '@aztec-labs/blob-lib/types';
+ import type { RollupContract } from '@aztec-labs/ethereum/contracts';
+ import { randomL1ContractAddresses } from '@aztec-labs/ethereum/l1-contract-addresses';
+@@ -13,6 +15,7 @@ import { Proof } from '@aztec-labs/stdlib/proofs';
+ import { CheckpointHeader, RootRollupPublicInputs } from '@aztec-labs/stdlib/rollup';
+ import { jest } from '@jest/globals';
+ import { type MockProxy, mock } from 'jest-mock-extended';
++import { decodeFunctionData, getAddress } from 'viem';
+ 
+ import { ProverNodePublisher } from './prover-node-publisher.js';
+ 
+@@ -197,6 +200,30 @@ describe('prover-node-publisher', () => {
+     },
+   );
+ 
++  describe('compact checkpoint headers', () => {
++    it.each([
++      { proven: 32, end: 48, prefixLength: 0 },
++      { proven: 40, end: 48, prefixLength: 8 },
++      { proven: 48, end: 48, prefixLength: 16 },
++    ])('encodes $prefixLength compact entries when proven is $proven', async ({ proven, end, prefixLength }) => {
++      const args = setupPublishData(64, proven, 33, end);
++      await publisher.submitEpochProof(args);
++      const [{ data }] = l1Utils.sendAndMonitorTransaction.mock.calls[0];
++      const decoded = decodeFunctionData({ abi: RollupAbi, data: data! });
++      if (decoded.functionName !== 'submitEpochRootProof') {
++        throw new Error(`Unexpected function ${decoded.functionName}`);
++      }
++      const [submission] = decoded.args;
++      const fullHeaders = args.headers.map(header => header.toViem());
++      const headers = fullHeaders.map(header => ({ ...header, coinbase: getAddress(header.coinbase) }));
++      expect(submission.provenCheckpointFees).toEqual(
++        headers.slice(0, prefixLength).map(({ coinbase, accumulatedFees }) => ({ coinbase, accumulatedFees })),
++      );
++      expect(submission.headers).toEqual(headers.slice(prefixLength));
++      expect(rollup.getEpochProofPublicInputs.mock.calls[0][0][3]).toEqual(fullHeaders);
++    });
++  });
++
+   describe('proof submission target', () => {
+     it('defaults the submit tx target to the rollup address', async () => {
+       const rollupAddress = EthAddress.random().toString();
+@@ -227,11 +254,11 @@ describe('prover-node-publisher', () => {
+     });
+   });
+ 
+-  it('analyzeEpochProofSubmission validates, estimates, and does not send tx', async () => {
++  it.each([32, 40, 64])('estimates compact calldata without sending when proven is %i', async proven => {
+     const fromCheckpoint = 33;
+     const toCheckpoint = 64;
+ 
+-    rollup.getTips.mockResolvedValue({ pending: CheckpointNumber(65), proven: CheckpointNumber(32) });
++    rollup.getTips.mockResolvedValue({ pending: CheckpointNumber(65), proven: CheckpointNumber(proven) });
+ 
+     const checkpoints = Array.from({ length: 100 }, () => RootRollupPublicInputs.random());
+     rollup.getCheckpoint.mockImplementation((n: CheckpointNumber) =>
+@@ -271,18 +298,33 @@ describe('prover-node-publisher', () => {
+       ourPublicInputs.blobPublicInputs.c.negate(),
+     );
+ 
++    const headers = makeHeadersForRange(fromCheckpoint, toCheckpoint);
+     await publisher.analyzeEpochProofSubmission({
+       epochNumber: EpochNumber(2),
+       fromCheckpoint: CheckpointNumber(fromCheckpoint),
+       toCheckpoint: CheckpointNumber(toCheckpoint),
+       publicInputs: ourPublicInputs,
+-      headers: makeHeadersForRange(fromCheckpoint, toCheckpoint),
++      headers,
+       proof: Proof.empty(),
+       batchedBlobInputs: batchedBlob,
+       attestations: [],
+     });
+ 
+-    expect(l1Utils.estimateGas).toHaveBeenCalled();
++    const [, { data }] = l1Utils.estimateGas.mock.calls[0];
++    const decoded = decodeFunctionData({ abi: RollupAbi, data: data! });
++    if (decoded.functionName !== 'submitEpochRootProof') {
++      throw new Error(`Unexpected function ${decoded.functionName}`);
++    }
++    const [submission] = decoded.args;
++    const prefixLength = proven - fromCheckpoint + 1;
++    const expectedHeaders = headers.map(header => {
++      const viem = header.toViem();
++      return { ...viem, coinbase: getAddress(viem.coinbase) };
++    });
++    expect(submission.provenCheckpointFees).toEqual(
++      expectedHeaders.slice(0, prefixLength).map(({ coinbase, accumulatedFees }) => ({ coinbase, accumulatedFees })),
++    );
++    expect(submission.headers).toEqual(expectedHeaders.slice(prefixLength));
+     expect(l1Utils.getFeesPerGas).toHaveBeenCalled();
+     expect(l1Utils.sendAndMonitorTransaction).not.toHaveBeenCalled();
+   });
+diff --git a/yarn-project/prover-node/src/prover-node-publisher.ts b/yarn-project/prover-node/src/prover-node-publisher.ts
+index 3b66d55bcfff92c4d79498c691e76d001d2be749..086ab3340b18fb88489444723153c6a5f8846dec 100644
+--- a/yarn-project/prover-node/src/prover-node-publisher.ts
++++ b/yarn-project/prover-node/src/prover-node-publisher.ts
+@@ -89,9 +89,9 @@ export class ProverNodePublisher {
+ 
+     const timer = new Timer();
+     // Validate epoch proof range and hashes are correct before submitting
+-    await this.validateEpochProofSubmission(args);
++    const provenPrefixLength = await this.validateEpochProofSubmission(args);
+ 
+-    const txReceipt = await this.sendSubmitEpochProofTx(args);
++    const txReceipt = await this.sendSubmitEpochProofTx(args, provenPrefixLength);
+     if (!txReceipt) {
+       this.log.error(`Failed to mine submitEpochProof tx`, undefined, ctx);
+       return false;
+@@ -138,7 +138,7 @@ export class ProverNodePublisher {
+     batchedBlobInputs: BatchedBlob;
+     attestations: ViemCommitteeAttestation[];
+     headers: CheckpointHeader[];
+-  }) {
++  }): Promise<number> {
+     const { fromCheckpoint, toCheckpoint, publicInputs, batchedBlobInputs } = args;
+ 
+     // Check that the checkpoint numbers match the expected epoch to be proven
+@@ -196,6 +196,10 @@ export class ProverNodePublisher {
+         log: this.log,
+       });
+     }
++
++    // The production rollup advances the proven tip and accounts for rewards atomically. A later proof may
++    // advance it further before inclusion; the contract accepts any already-proven prefix, including a shorter one.
++    return Math.max(0, proven - fromCheckpoint + 1);
+   }
+ 
+   /**
+@@ -215,9 +219,9 @@ export class ProverNodePublisher {
+   }): Promise<void> {
+     const { epochNumber, fromCheckpoint, toCheckpoint } = args;
+ 
+-    await this.validateEpochProofSubmission(args);
++    const provenPrefixLength = await this.validateEpochProofSubmission(args);
+ 
+-    const data = this.encodeSubmitEpochProofCalldata(args);
++    const data = this.encodeSubmitEpochProofCalldata(args, provenPrefixLength);
+     const senderAddress = this.l1TxUtils.getSenderAddress();
+ 
+     const [gasLimit, feesPerGas, latestBlock] = await Promise.all([
+@@ -252,33 +256,39 @@ export class ProverNodePublisher {
+     this.metrics.recordEstimatedSubmitProof(stats);
+   }
+ 
+-  private encodeSubmitEpochProofCalldata(args: {
+-    fromCheckpoint: CheckpointNumber;
+-    toCheckpoint: CheckpointNumber;
+-    publicInputs: RootRollupPublicInputs;
+-    proof: Proof;
+-    batchedBlobInputs: BatchedBlob;
+-    attestations: ViemCommitteeAttestation[];
+-    headers: CheckpointHeader[];
+-  }): Hex {
++  private encodeSubmitEpochProofCalldata(
++    args: {
++      fromCheckpoint: CheckpointNumber;
++      toCheckpoint: CheckpointNumber;
++      publicInputs: RootRollupPublicInputs;
++      proof: Proof;
++      batchedBlobInputs: BatchedBlob;
++      attestations: ViemCommitteeAttestation[];
++      headers: CheckpointHeader[];
++    },
++    provenPrefixLength: number,
++  ): Hex {
+     return encodeFunctionData({
+       abi: RollupAbi,
+       functionName: 'submitEpochRootProof',
+-      args: [this.getSubmitEpochProofArgs(args)],
++      args: [this.getSubmitEpochProofArgs(args, provenPrefixLength)],
+     });
+   }
+ 
+-  private async sendSubmitEpochProofTx(args: {
+-    fromCheckpoint: CheckpointNumber;
+-    toCheckpoint: CheckpointNumber;
+-    deadline?: Date;
+-    publicInputs: RootRollupPublicInputs;
+-    proof: Proof;
+-    batchedBlobInputs: BatchedBlob;
+-    attestations: ViemCommitteeAttestation[];
+-    headers: CheckpointHeader[];
+-  }): Promise<TransactionReceipt | undefined> {
+-    const txArgs = [this.getSubmitEpochProofArgs(args)] as const;
++  private async sendSubmitEpochProofTx(
++    args: {
++      fromCheckpoint: CheckpointNumber;
++      toCheckpoint: CheckpointNumber;
++      deadline?: Date;
++      publicInputs: RootRollupPublicInputs;
++      proof: Proof;
++      batchedBlobInputs: BatchedBlob;
++      attestations: ViemCommitteeAttestation[];
++      headers: CheckpointHeader[];
++    },
++    provenPrefixLength: number,
++  ): Promise<TransactionReceipt | undefined> {
++    const txArgs = [this.getSubmitEpochProofArgs(args, provenPrefixLength)] as const;
+ 
+     this.log.info(`Submitting epoch proof to L1 rollup contract`, {
+       proofSize: args.proof.withoutPublicInputs().length,
+@@ -342,15 +352,18 @@ export class ProverNodePublisher {
+     ] as const;
+   }
+ 
+-  private getSubmitEpochProofArgs(args: {
+-    fromCheckpoint: CheckpointNumber;
+-    toCheckpoint: CheckpointNumber;
+-    publicInputs: RootRollupPublicInputs;
+-    proof: Proof;
+-    batchedBlobInputs: BatchedBlob;
+-    attestations: ViemCommitteeAttestation[];
+-    headers: CheckpointHeader[];
+-  }) {
++  private getSubmitEpochProofArgs(
++    args: {
++      fromCheckpoint: CheckpointNumber;
++      toCheckpoint: CheckpointNumber;
++      publicInputs: RootRollupPublicInputs;
++      proof: Proof;
++      batchedBlobInputs: BatchedBlob;
++      attestations: ViemCommitteeAttestation[];
++      headers: CheckpointHeader[];
++    },
++    provenPrefixLength: number,
++  ) {
+     // Returns arguments for EpochProofLib.sol -> submitEpochRootProof()
+     const proofHex: Hex = `0x${args.proof.withoutPublicInputs().toString('hex')}`;
+     const argsArray = this.getEpochProofPublicInputsArgs(args);
+@@ -358,7 +371,10 @@ export class ProverNodePublisher {
+       start: argsArray[0],
+       end: argsArray[1],
+       args: argsArray[2],
+-      headers: argsArray[3],
++      provenCheckpointFees: argsArray[3]
++        .slice(0, provenPrefixLength)
++        .map(({ coinbase, accumulatedFees }) => ({ coinbase, accumulatedFees })),
++      headers: argsArray[3].slice(provenPrefixLength),
+       attestations: CommitteeAttestationsAndSigners.packAttestations(
+         args.attestations.map(a => CommitteeAttestation.fromViem(a)),
+       ),


### PR DESCRIPTION
This PR optimized the partial proof flow by enabling provers to only send the headers for new checkpoints that are proven by the proof. The provers can send smaller payloads (just fees + coinbase) for the already proven checkpoints (which also have their rewards accounted for).

This PR slightly increases gas costs for full epoch proofs (because of all the new checks we have to run on the proven-prefix) but it reduces gas costs on partial epoch proofs that build on previously submitted proof by about ~3.5K/already proven checkpoint (so in the scneario where we prove 8 checkpoints and then another 8 checkpoints we save approx 27k on the second proof)

This PR requires changes to be made to aztec-node to make it compatible with the new contracts.