### PR TITLE
feat(fnd): real-kernel Chonk flow with an in-app UltraHonk verifier

### DIFF
--- a/noir-projects/fnd/noir-protocol-circuits/Nargo.template.toml
+++ b/noir-projects/fnd/noir-protocol-circuits/Nargo.template.toml
@@ -7,6 +7,11 @@ members = [
     "crates/ts-types",
     "crates/types",
     "crates/protocol-test-utils",
+    # Integration tests (see integration-tests/README.md). Members so nargo can build them; their
+    # artifacts are moved out of target/ by build_integration_tests.
+    "integration-tests/verify-uh-proof-within-smart-contract/crates/inner-circuit",
+    "integration-tests/verify-uh-proof-within-smart-contract/crates/app-uh-verifier",
+    "integration-tests/verify-uh-proof-within-smart-contract/crates/flow-inputs-builder",
     "crates/blob",
     "crates/inbox-parity-64",
     "crates/inbox-parity-256",

--- a/noir-projects/fnd/noir-protocol-circuits/README.md
+++ b/noir-projects/fnd/noir-protocol-circuits/README.md
@@ -50,6 +50,8 @@ To compile a circuit:
 For most circuits, you will see its sample inputs Prover.toml in the folder. You can execute the circuits with these private inputs by running:
 `nargo execute --package rollup_root`
 
+Tests that prove the real circuits end to end with bb live in `integration-tests/`; see the README there.
+
 ## Naming Conventions
 
 **What is a "Hint"**

--- a/noir-projects/fnd/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/fnd/noir-protocol-circuits/bootstrap.sh
@@ -222,7 +222,7 @@ function build {
 
   [ -f "package.json" ] && denoise "yarn && yarn generate_variants"
 
-  grep -oP '(?<=crates/)[^"]+' Nargo.toml | \
+  grep -oP '(?<="crates/)[^"]+' Nargo.toml | \
     while read -r dir; do
       toml_file=./crates/$dir/Nargo.toml
       if grep -q 'type = "bin"' "$toml_file"; then
@@ -236,6 +236,26 @@ function build {
   [ "$code" -eq 0 ] || return $code
 
   check_reset_costs
+  build_integration_tests
+}
+
+# Compiles the integration tests' circuits (see integration-tests/README.md). They are members of
+# this workspace because nargo always resolves the topmost Nargo.toml, and nargo only writes into
+# the workspace's target/, so each artifact is moved into its test's own target/ afterwards to keep
+# the protocol artifacts directory free of test circuits. The mock circuits reuse this script and
+# have no integration tests.
+function build_integration_tests {
+  set -euo pipefail
+  local test_dir pkg
+  for test_dir in ./integration-tests/*/; do
+    [ -d "$test_dir/crates" ] || continue
+    echo_stderr "Compiling integration test: $test_dir"
+    mkdir -p "$test_dir/target"
+    for pkg in $(grep -hoP '(?<=^name = ")[^"]+' "$test_dir"/crates/*/Nargo.toml); do
+      $NARGO compile --package "$pkg" --skip-brillig-constraints-check --silence-warnings
+      mv "target/$pkg.json" "$test_dir/target/"
+    done
+  done
 }
 
 # Fails if any `cost` in private_kernel_reset_config.json no longer matches the gate count
@@ -280,6 +300,23 @@ function test_cmds {
   for circuit in $circuits_to_execute; do
     echo "$circuits_hash $nargo_root_rel execute --program-dir noir-projects/fnd/noir-protocol-circuits/crates/$circuit --silence-warnings  --skip-brillig-constraints-check"
   done
+  integration_test_cmds
+}
+
+# The integration tests prove real circuits with bb, so their hash also covers bb and the Noir
+# verifier library. Each test lists its own commands here (see integration-tests/README.md).
+function integration_test_cmds {
+  [ -d ./integration-tests ] || return 0
+  local hash test_dir
+  hash=$(hash_str "$circuits_hash" "$BB_HASH" $(cache_content_hash \
+    "^noir-projects/fnd/noir-protocol-circuits/integration-tests/" \
+    "^barretenberg/noir/bb_proof_verification/"))
+
+  # verify-uh-proof-within-smart-contract: the flow must prove and verify, and must be rejected
+  # once the proof the app verifies is corrupted.
+  test_dir=noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract
+  echo "$hash:CPUS=8:MEM=16g:TIMEOUT=20m $test_dir/prove_uh_verifier_app_with_real_kernels.py --skip-compile"
+  echo "$hash:CPUS=8:MEM=16g:TIMEOUT=20m $test_dir/prove_uh_verifier_app_with_real_kernels.py --skip-compile --corrupt-inner-proof --work-dir target/flow-corrupt"
 }
 
 function test {

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/README.md
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/README.md
@@ -1,0 +1,16 @@
+# integration-tests
+
+Tests that prove the real protocol circuits end to end with bb, as opposed to the `nargo test`
+unit tests inside the crates and the `nargo execute` runs over committed `Prover.toml` inputs.
+Everything they need is generated from code in this repository, so they run without the labs
+repository, and their inputs cannot go stale.
+
+Each subdirectory is one test: its circuits under `crates/`, a driver script, and a README
+explaining the flow. The crates are members of the protocol-circuits workspace, listed in
+`Nargo.template.toml`, because nargo always resolves the topmost `Nargo.toml`; `build_integration_tests`
+in the protocol-circuits `bootstrap.sh` compiles them and moves their artifacts into the test's own
+`target/`, so they never reach the protocol artifacts. `integration_test_cmds` lists each test's
+commands. To add a test: add the directory, its crates to the template, and its commands there.
+
+- `verify-uh-proof-within-smart-contract`: an app that verifies an UltraHonk proof, folded by
+  `private_kernel_init`, `private_kernel_reset_tail` and `hiding_kernel_to_rollup`.

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/.gitignore
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/.gitignore
@@ -1,0 +1,3 @@
+target
+# nargo check drops input templates next to each crate.
+crates/*/Prover.toml

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/README.md
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/README.md
@@ -1,0 +1,47 @@
+# verify-uh-proof-within-smart-contract
+
+A Chonk (ClientIVC) flow over the **real** private kernels whose app verifies an UltraHonk proof,
+the way a smart contract does when it verifies a Noir proof in a private function. It is generated
+entirely from code in this repository: no captured fixtures, no aztec-nr, no PXE.
+
+## The flow
+
+```
+app_uh_verifier  ->  private_kernel_init  ->  private_kernel_reset_tail  ->  hiding_kernel_to_rollup
+```
+
+`app_uh_verifier` is a private function as the kernels see one: it emits `PrivateCircuitPublicInputs`
+on the return data bus and, on the way, recursively verifies an UltraHonk ZK proof of
+`inner_circuit` through `bb_proof_verification::verify_honk_proof`. That is the pattern a contract
+uses to verify a Noir proof in-app, compiled into a Mega circuit and folded by the real kernels.
+
+`flow_inputs_builder` derives every kernel input from the circuits' real verification keys: the VK
+tree with the kernels at their protocol indices, the app's function tree and contract address, the
+public data tree non-membership proof for class updates, and the (all-skip) reset hints. It runs
+unconstrained and is never proven.
+
+`prove_uh_verifier_app_with_real_kernels.py` compiles the flow circuits, proves the inner circuit with bb, executes the
+builder, chains each circuit's return data into the next one's call data with `noir-execute`,
+assembles the `ivc-inputs.msgpack` stack, then runs `bb prove --scheme chonk` and `bb verify`.
+
+## Running
+
+```
+noir-projects/fnd/noir-protocol-circuits/bootstrap.sh generate_variants   # once, if the workspace is absent
+noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/prove_uh_verifier_app_with_real_kernels.py
+```
+
+The kernels are taken from `noir-protocol-circuits/target` and compiled there if missing. The
+protocol-circuits build compiles the crates here too (into this directory's `target/`), after which
+`--skip-compile` reuses them; that is how the test commands in `noir-protocol-circuits/bootstrap.sh`
+run it. Pass
+`--flow-dir <dir>` to also write the stack in the `chonk-pinned-flows` layout, which the C++ and
+bb.js pinned-flow tests (`CHONK_PINNED_IVC_INPUTS_DIR=<dir>`) accept as-is. `--stack-only` skips
+proving.
+
+## Extending it
+
+Other transaction shapes (a second call through `private_kernel_inner`, an intermediate reset, the
+to-public tail) need the same treatment as the three circuits above: real VK hashes in the VK tree
+and inputs derived from the previous kernel's output. Add them as a builder variant and a chain in
+the driver, or as a sibling test directory.

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/app-uh-verifier/Nargo.toml
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/app-uh-verifier/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "app_uh_verifier"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.18.0"
+
+[dependencies]
+types = { path = "../../../../crates/types" }
+bb_proof_verification = { path = "../../../../../../../barretenberg/noir/bb_proof_verification" }

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/app-uh-verifier/src/main.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/app-uh-verifier/src/main.nr
@@ -1,0 +1,22 @@
+use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_honk_proof};
+use types::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs;
+
+// A private function as the private kernels see one: it puts `PrivateCircuitPublicInputs` on the
+// return data bus, and it recursively verifies an UltraHonk ZK proof on the way. The public inputs
+// arrive ready-made (the kernels only ever consume them as-is), so the verifier is all this circuit
+// does.
+fn main(
+    public_inputs: PrivateCircuitPublicInputs,
+    inner_verification_key: UltraHonkVerificationKey,
+    inner_proof: UltraHonkZKProof,
+    inner_public_inputs: [Field; 1],
+    inner_key_hash: Field,
+) -> return_data PrivateCircuitPublicInputs {
+    verify_honk_proof(
+        inner_verification_key,
+        inner_proof,
+        inner_public_inputs,
+        inner_key_hash,
+    );
+    public_inputs
+}

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/flow-inputs-builder/Nargo.toml
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/flow-inputs-builder/Nargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "flow_inputs_builder"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.18.0"
+
+[dependencies]
+types = { path = "../../../../crates/types" }
+protocol_test_utils = { path = "../../../../crates/protocol-test-utils" }
+private_kernel_lib = { path = "../../../../crates/private-kernel-lib" }

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/flow-inputs-builder/src/main.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/flow-inputs-builder/src/main.nr
@@ -1,0 +1,233 @@
+// Derives the private inputs of a minimal real-kernel Chonk flow: one app call folded by
+// `private_kernel_init`, terminated by `private_kernel_reset_tail` and wrapped by
+// `hiding_kernel_to_rollup`. Everything the kernels check by re-hashing (contract address, function
+// tree membership, VK tree membership, public data tree non-membership) is derived here, so the flow
+// needs no captured fixtures. The derivation runs unconstrained: this program only generates
+// witnesses for other circuits and nothing in it is proven.
+use private_kernel_lib::{PaddedSideEffects, PrivateKernelResetHints};
+use protocol_test_utils::{
+    FixtureBuilder,
+    fixtures::{
+        contract_functions::ContractFunction, contracts::ContractData, vk_tree::VK_TREE_WIDTH,
+    },
+};
+use types::{
+    abis::{
+        contract_class_function_leaf_preimage::ContractClassFunctionLeafPreimage,
+        function_data::FunctionData, function_selector::FunctionSelector, gas::Gas,
+        private_circuit_public_inputs::PrivateCircuitPublicInputs,
+        private_kernel::private_call_data::PrivateCallDataWithoutPublicInputs,
+        private_kernel_data::PrivateKernelDataWithoutPublicInputs,
+        protocol_contracts::ProtocolContracts, transaction::tx_request::TxRequest,
+    },
+    address::{AztecAddress, PartialAddress, SaltedInitializationHash},
+    constants::{
+        FUNCTION_TREE_HEIGHT, MAX_KEY_VALIDATION_REQUESTS_PER_TX,
+        MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NOTE_HASHES_PER_TX,
+        MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIERS_PER_TX, MEGA_APP_VK_LENGTH_IN_FIELDS,
+        MEGA_KERNEL_VK_LENGTH_IN_FIELDS, PRIVATE_KERNEL_INIT_VK_INDEX,
+        PRIVATE_KERNEL_RESET_TAIL_VK_INDEX,
+    },
+    contract_class_id::ContractClassId,
+    hash::poseidon2_hash,
+    merkle_tree::{MembershipWitness, merkle_tree::MerkleTree},
+    proof::{verification_key::VerificationKey, vk_data::VkData},
+    public_keys::PublicKeys,
+    traits::{Empty, Hash},
+};
+
+global FUNCTION_TREE_WIDTH: u32 = (1 as u8 << FUNCTION_TREE_HEIGHT as u8) as u32;
+
+// Preimage data of the app's contract. The values are arbitrary; the kernels only need them to be
+// consistent with the address they derive.
+global FUNCTION_SELECTOR: u32 = 0x1c5c9e8f;
+global ARTIFACT_HASH: Field = 0x1111;
+global PUBLIC_BYTECODE_COMMITMENT: Field = 0x2222;
+global CONTRACT_ADDRESS_SALT: Field = 0x3333;
+global INITIALIZATION_HASH: Field = 0x4444;
+global IMMUTABLES_HASH: Field = 0;
+
+// The inputs of `private_kernel_init`, minus `app_public_inputs`, which the driver takes from the
+// app's return data.
+pub struct InitInputs {
+    pub tx_request: TxRequest,
+    pub vk_tree_root: Field,
+    pub protocol_contracts: ProtocolContracts,
+    pub private_call: PrivateCallDataWithoutPublicInputs,
+    pub is_private_only: bool,
+    pub revertible_counter_hint: u32,
+}
+
+// The reset hints of the full-size `private_kernel_reset_tail` variant compiled by
+// noir-protocol-circuits: every hint array is as long as the array it indexes.
+type ResetHints = PrivateKernelResetHints<MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_KEY_VALIDATION_REQUESTS_PER_TX, MAX_NULLIFIERS_PER_TX>;
+
+// The inputs of `private_kernel_reset_tail`, minus `previous_kernel_public_inputs`.
+pub struct ResetTailInputs {
+    pub previous_kernel: PrivateKernelDataWithoutPublicInputs,
+    pub padded_side_effects: PaddedSideEffects,
+    pub hints: ResetHints,
+    pub expiration_timestamp_upper_bound: u64,
+}
+
+// The inputs of `hiding_kernel_to_rollup`, minus `previous_kernel_public_inputs`.
+pub struct HidingInputs {
+    pub previous_kernel_vk_data: VkData<MEGA_KERNEL_VK_LENGTH_IN_FIELDS>,
+}
+
+pub struct FlowInputs {
+    pub app_public_inputs: PrivateCircuitPublicInputs,
+    pub init: InitInputs,
+    pub reset_tail: ResetTailInputs,
+    pub hiding: HidingInputs,
+}
+
+fn main(
+    app_vk: [Field; MEGA_APP_VK_LENGTH_IN_FIELDS],
+    init_vk: [Field; MEGA_KERNEL_VK_LENGTH_IN_FIELDS],
+    reset_tail_vk: [Field; MEGA_KERNEL_VK_LENGTH_IN_FIELDS],
+) -> pub FlowInputs {
+    // Safety: this program only derives witnesses for other circuits; nothing in it is constrained.
+    unsafe {
+        build(app_vk, init_vk, reset_tail_vk)
+    }
+}
+
+unconstrained fn build(
+    app_vk: [Field; MEGA_APP_VK_LENGTH_IN_FIELDS],
+    init_vk: [Field; MEGA_KERNEL_VK_LENGTH_IN_FIELDS],
+    reset_tail_vk: [Field; MEGA_KERNEL_VK_LENGTH_IN_FIELDS],
+) -> FlowInputs {
+    // bb hashes a Mega VK as poseidon2 over its field representation.
+    let app_vk_hash = poseidon2_hash(app_vk);
+    let init_vk_hash = poseidon2_hash(init_vk);
+    let reset_tail_vk_hash = poseidon2_hash(reset_tail_vk);
+
+    // A VK tree holding the real kernel VKs at their protocol indices. The root is a free input of
+    // the init kernel; the later kernels only check membership against it.
+    let mut vk_leaves = [0; VK_TREE_WIDTH];
+    vk_leaves[PRIVATE_KERNEL_INIT_VK_INDEX] = init_vk_hash;
+    vk_leaves[PRIVATE_KERNEL_RESET_TAIL_VK_INDEX] = reset_tail_vk_hash;
+    let vk_tree = MerkleTree::new(vk_leaves);
+    let vk_tree_root = vk_tree.get_root();
+
+    // The app function is leaf 0 of an otherwise empty private function tree, from which the class
+    // id and the contract address follow the way the kernel re-derives them.
+    let selector = FunctionSelector::from_u32(FUNCTION_SELECTOR);
+    let mut function_leaves = [0; FUNCTION_TREE_WIDTH];
+    function_leaves[0] =
+        ContractClassFunctionLeafPreimage { selector, vk_hash: app_vk_hash }.hash();
+    let function_tree = MerkleTree::new(function_leaves);
+    let private_functions_root = function_tree.get_root();
+    let contract_class_id = ContractClassId::compute(
+        ARTIFACT_HASH,
+        private_functions_root,
+        PUBLIC_BYTECODE_COMMITMENT,
+    );
+    let deployer = AztecAddress::zero();
+    let salted_initialization_hash = SaltedInitializationHash::compute(
+        CONTRACT_ADDRESS_SALT,
+        INITIALIZATION_HASH,
+        deployer,
+        IMMUTABLES_HASH,
+    );
+    let partial_address = PartialAddress::compute_from_salted_initialization_hash(
+        contract_class_id,
+        salted_initialization_hash,
+    );
+    let public_keys = PublicKeys::default();
+    let app_contract = ContractData {
+        address: AztecAddress::compute(public_keys, partial_address),
+        artifact_hash: ARTIFACT_HASH,
+        contract_address_salt: CONTRACT_ADDRESS_SALT,
+        contract_class_id,
+        private_functions_root,
+        public_bytecode_commitment: PUBLIC_BYTECODE_COMMITMENT,
+        public_keys,
+        salted_initialization_hash,
+        partial_address,
+        deployer,
+    };
+    let app_function = ContractFunction {
+        data: FunctionData { selector, is_private: true },
+        vk_hash: app_vk_hash,
+        membership_witness: MembershipWitness {
+            leaf_index: 0,
+            sibling_path: function_tree.get_sibling_path(0),
+        },
+    };
+
+    let mut app = FixtureBuilder::new().is_first_call();
+    // The tail meters the tx's gas against these limits; the fixture's defaults are zero.
+    app.tx_context.gas_settings.gas_limits = Gas::new(1_000_000_000, 1_000_000_000);
+    let _ = app.use_contract(app_contract);
+    let _ = app.use_function(app_function, app_vk);
+    // The tail kernel requires a fee payer, and a private-only tx has nobody else to name.
+    app.is_fee_payer = true;
+    app.vk_tree_root = vk_tree_root;
+    // Proves no class update is scheduled for this address in an (otherwise empty) public data tree.
+    app.compute_update_tree_and_hints();
+
+    let app_public_inputs = app.to_private_circuit_public_inputs();
+
+    let init = InitInputs {
+        tx_request: app.to_tx_request(),
+        vk_tree_root,
+        protocol_contracts: app.protocol_contracts,
+        private_call: PrivateCallDataWithoutPublicInputs {
+            vk: app.vk,
+            verification_key_hints: app.to_private_verification_key_hints(),
+        },
+        is_private_only: true,
+        revertible_counter_hint: app.min_revertible_side_effect_counter,
+    };
+
+    let reset_tail = ResetTailInputs {
+        previous_kernel: PrivateKernelDataWithoutPublicInputs {
+            vk_data: VkData {
+                vk: VerificationKey { key: init_vk, hash: init_vk_hash },
+                leaf_index: PRIVATE_KERNEL_INIT_VK_INDEX,
+                sibling_path: vk_tree.get_sibling_path(PRIVATE_KERNEL_INIT_VK_INDEX),
+            },
+        },
+        padded_side_effects: PaddedSideEffects::empty(),
+        hints: reset_hints_for_nothing_to_reset(),
+        expiration_timestamp_upper_bound: app.expiration_timestamp,
+    };
+
+    let hiding = HidingInputs {
+        previous_kernel_vk_data: VkData {
+            vk: VerificationKey { key: reset_tail_vk, hash: reset_tail_vk_hash },
+            leaf_index: PRIVATE_KERNEL_RESET_TAIL_VK_INDEX,
+            sibling_path: vk_tree.get_sibling_path(PRIVATE_KERNEL_RESET_TAIL_VK_INDEX),
+        },
+    };
+
+    FlowInputs { app_public_inputs, init, reset_tail, hiding }
+}
+
+// Reset hints for a tx with nothing to reset. The hint types are private to private_kernel_lib and
+// the struct has no constructor, so start from zeroes (every read request action is SKIP) and set
+// the inactive sentinels the reset validators look for: a read hint whose `read_request_index` is
+// the read request array length, and a squashing hint whose indices are the note hash and
+// nullifier array lengths.
+unconstrained fn reset_hints_for_nothing_to_reset() -> ResetHints {
+    let mut hints: ResetHints = std::mem::zeroed();
+    for i in 0..MAX_NOTE_HASH_READ_REQUESTS_PER_TX {
+        hints.note_hash_read_request_hints.pending_read_hints[i].read_request_index =
+            MAX_NOTE_HASH_READ_REQUESTS_PER_TX;
+        hints.note_hash_read_request_hints.settled_read_hints[i].read_request_index =
+            MAX_NOTE_HASH_READ_REQUESTS_PER_TX;
+    }
+    for i in 0..MAX_NULLIFIER_READ_REQUESTS_PER_TX {
+        hints.nullifier_read_request_hints.pending_read_hints[i].read_request_index =
+            MAX_NULLIFIER_READ_REQUESTS_PER_TX;
+        hints.nullifier_read_request_hints.settled_read_hints[i].read_request_index =
+            MAX_NULLIFIER_READ_REQUESTS_PER_TX;
+    }
+    for i in 0..MAX_NULLIFIERS_PER_TX {
+        hints.transient_data_squashing_hints[i].note_hash_index = MAX_NOTE_HASHES_PER_TX;
+        hints.transient_data_squashing_hints[i].nullifier_index = MAX_NULLIFIERS_PER_TX;
+    }
+    hints
+}

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/inner-circuit/Nargo.toml
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/inner-circuit/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "inner_circuit"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.18.0"
+
+[dependencies]

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/inner-circuit/src/main.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/crates/inner-circuit/src/main.nr
@@ -1,0 +1,5 @@
+// The statement whose UltraHonk ZK proof the app circuit verifies. It only needs to be small and to
+// have a public input.
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}

--- a/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/prove_uh_verifier_app_with_real_kernels.py
+++ b/noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract/prove_uh_verifier_app_with_real_kernels.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Builds, proves and verifies a real-kernel Chonk flow from foundation code only.
+
+The stack is app_uh_verifier (a private function that recursively verifies an UltraHonk ZK
+proof) -> private_kernel_init -> private_kernel_reset_tail -> hiding_kernel_to_rollup. The
+flow_inputs_builder circuit derives every kernel input; each circuit's return data is chained
+into the next one's call data with noir-execute; bb proves the stack and verifies the proof.
+See README.md next to this script.
+"""
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+FLOWS_DIR = Path(__file__).resolve().parent
+ROOT = Path(
+    subprocess.check_output(["git", "-C", str(FLOWS_DIR), "rev-parse", "--show-toplevel"], text=True).strip()
+)
+KERNELS_DIR = FLOWS_DIR.parents[1]
+NARGO = Path(os.environ.get("NARGO") or ROOT / "noir/noir-repo/target/release/nargo")
+NOIR_EXECUTE = Path(os.environ.get("NOIR_EXECUTE") or NARGO.parent / "noir-execute")
+BB = Path(os.environ.get("BB") or ROOT / "barretenberg/cpp/build/bin/bb")
+NARGO_FLAGS = ["--skip-brillig-constraints-check", "--silence-warnings"]
+
+INNER, APP, BUILDER = "inner_circuit", "app_uh_verifier", "flow_inputs_builder"
+INIT, RESET_TAIL, HIDING = "private_kernel_init", "private_kernel_reset_tail", "hiding_kernel_to_rollup"
+FLOW_NAME = "uh-verifier-app"
+
+# CircuitKind wire values, see barretenberg/cpp/src/barretenberg/chonk/circuit_input.hpp.
+KIND_APP, KIND_KERNEL, KIND_HIDING = 0, 1, 2
+CIRCUIT_KIND_FLAG = {KIND_APP: "app", KIND_KERNEL: "kernel", KIND_HIDING: "hiding"}
+
+START = time.monotonic()
+VERBOSE = False
+
+
+def log(msg):
+    print(f"[{time.monotonic() - START:7.1f}s] {msg}", file=sys.stderr, flush=True)
+
+
+def run(cmd, cwd=None):
+    cmd = [str(c) for c in cmd]
+    log("$ " + " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if proc.returncode != 0 or VERBOSE:
+        sys.stderr.write(proc.stdout)
+    if proc.returncode != 0:
+        raise SystemExit(f"command failed with exit code {proc.returncode}: {' '.join(cmd)}")
+    return proc.stdout
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def dump_json(path, value):
+    with open(path, "w") as f:
+        json.dump(value, f)
+
+
+def kernel_artifact(name):
+    """The compiled kernel, compiling it if the protocol-circuits build has not."""
+    path = KERNELS_DIR / "target" / f"{name}.json"
+    if path.exists():
+        return path
+    if not (KERNELS_DIR / "Nargo.toml").exists():
+        raise SystemExit(
+            f"{path} is missing and {KERNELS_DIR}/Nargo.toml does not exist; run "
+            "noir-protocol-circuits/bootstrap.sh generate_variants (or the full build) first"
+        )
+    run([NARGO, "compile", "--package", name, *NARGO_FLAGS], cwd=KERNELS_DIR)
+    return path
+
+
+def chonk_vk(artifact_path, kind, out_dir):
+    """The Chonk VK bytes of a circuit: the ones the protocol-circuits build embedded, else computed now."""
+    embedded = load_json(artifact_path).get("verificationKey", {}).get("bytes")
+    if embedded:
+        return bytes.fromhex(embedded)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run([BB, "write_vk", "--scheme", "chonk", "--circuit_kind", CIRCUIT_KIND_FLAG[kind], "-b", artifact_path, "-o", out_dir])
+    return (out_dir / "vk").read_bytes()
+
+
+def vk_fields(vk_bytes):
+    """A serialized Mega VK is its field elements back to back, 32 bytes each."""
+    if len(vk_bytes) % 32 != 0:
+        raise SystemExit(f"VK of {len(vk_bytes)} bytes is not a whole number of field elements")
+    return ["0x" + vk_bytes[i : i + 32].hex() for i in range(0, len(vk_bytes), 32)]
+
+
+def execute(artifact_path, inputs, work, name, witness=True):
+    """Executes a circuit on ABI-encoded inputs; returns its ABI-encoded return value and witness path."""
+    prover_file = work / f"{name}.inputs.json"
+    dump_json(prover_file, inputs)
+    cmd = [NOIR_EXECUTE, "execute", "-a", artifact_path, "-p", prover_file, "--overwrite-return"]
+    if witness:
+        cmd += ["-o", work, "-w", name]
+    run(cmd)
+    ret = load_json(prover_file).get("return")
+    return ret, (work / f"{name}.gz" if witness else None)
+
+
+def inner_proof(work, corrupt):
+    """An UltraHonk ZK proof of inner_circuit, in the field layout bb_proof_verification expects.
+
+    With `corrupt`, one proof element is altered. ACVM does not check proofs during witness
+    generation, so the corruption only surfaces when bb builds the in-app verifier's constraints.
+    """
+    artifact_path = FLOWS_DIR / "target" / f"{INNER}.json"
+    _, witness = execute(artifact_path, {"x": "1", "y": "2"}, work, INNER)
+    out = work / "inner-proof"
+    out.mkdir(exist_ok=True)
+    run([BB, "prove", "--scheme", "ultra_honk", "--write_vk", "--output_format", "json", "-b", artifact_path, "-w", witness, "-o", out])
+    vk = load_json(out / "vk.json")
+    proof = load_json(out / "proof.json")["proof"]
+    if corrupt:
+        proof[0] = hex(int(proof[0], 16) ^ 1)
+    return {
+        "inner_verification_key": vk["vk"],
+        "inner_key_hash": vk["hash"],
+        "inner_proof": proof,
+        "inner_public_inputs": load_json(out / "public_inputs.json")["public_inputs"],
+    }
+
+
+def msgpack_str(s):
+    b = s.encode()
+    if len(b) < 32:
+        return bytes([0xA0 | len(b)]) + b
+    return b"\xd9" + bytes([len(b)]) + b
+
+
+def msgpack_bin(b):
+    return b"\xc6" + len(b).to_bytes(4, "big") + b
+
+
+def msgpack_steps(steps):
+    """The ivc-inputs.msgpack layout bb reads: an array of PrivateExecutionStepRaw maps."""
+    out = bytearray([0x90 | len(steps)])
+    for step in steps:
+        out += bytes([0x85])
+        out += msgpack_str("bytecode") + msgpack_bin(step["bytecode"])
+        out += msgpack_str("witness") + msgpack_bin(step["witness"])
+        out += msgpack_str("vk") + msgpack_bin(step["vk"])
+        out += msgpack_str("functionName") + msgpack_str(step["functionName"])
+        out += msgpack_str("kind") + bytes([step["kind"]])
+    return bytes(out)
+
+
+def build_stack(work, corrupt_inner_proof):
+    app_artifact = FLOWS_DIR / "target" / f"{APP}.json"
+    builder_artifact = FLOWS_DIR / "target" / f"{BUILDER}.json"
+    kernels = {name: kernel_artifact(name) for name in (INIT, RESET_TAIL, HIDING)}
+
+    log("computing Chonk VKs")
+    vks = {
+        APP: chonk_vk(app_artifact, KIND_APP, work / "vk" / APP),
+        INIT: chonk_vk(kernels[INIT], KIND_KERNEL, work / "vk" / INIT),
+        RESET_TAIL: chonk_vk(kernels[RESET_TAIL], KIND_KERNEL, work / "vk" / RESET_TAIL),
+        HIDING: chonk_vk(kernels[HIDING], KIND_HIDING, work / "vk" / HIDING),
+    }
+
+    log("proving the inner circuit")
+    inner = inner_proof(work, corrupt_inner_proof)
+
+    log("deriving kernel inputs")
+    flow, _ = execute(
+        builder_artifact,
+        {"app_vk": vk_fields(vks[APP]), "init_vk": vk_fields(vks[INIT]), "reset_tail_vk": vk_fields(vks[RESET_TAIL])},
+        work,
+        BUILDER,
+        witness=False,
+    )
+
+    log("executing the app and the kernels")
+    app_out, app_witness = execute(app_artifact, {"public_inputs": flow["app_public_inputs"], **inner}, work, APP)
+    init_out, init_witness = execute(kernels[INIT], {**flow["init"], "app_public_inputs": app_out}, work, INIT)
+    reset_tail_out, reset_tail_witness = execute(
+        kernels[RESET_TAIL], {**flow["reset_tail"], "previous_kernel_public_inputs": init_out}, work, RESET_TAIL
+    )
+    _, hiding_witness = execute(
+        kernels[HIDING], {**flow["hiding"], "previous_kernel_public_inputs": reset_tail_out}, work, HIDING
+    )
+
+    def step(name, artifact_path, witness, kind):
+        return {
+            "bytecode": base64.b64decode(load_json(artifact_path)["bytecode"]),
+            "witness": witness.read_bytes(),
+            "vk": vks[name],
+            "functionName": name,
+            "kind": kind,
+        }
+
+    return msgpack_steps(
+        [
+            step(APP, app_artifact, app_witness, KIND_APP),
+            step(INIT, kernels[INIT], init_witness, KIND_KERNEL),
+            step(RESET_TAIL, kernels[RESET_TAIL], reset_tail_witness, KIND_KERNEL),
+            step(HIDING, kernels[HIDING], hiding_witness, KIND_HIDING),
+        ]
+    )
+
+
+def main():
+    global VERBOSE
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--work-dir", type=Path, default=Path("target/flow"), help="scratch directory, relative to this test's directory"
+    )
+    parser.add_argument("--flow-dir", type=Path, help="also write the stack as <flow-dir>/%s/ivc-inputs.msgpack" % FLOW_NAME)
+    parser.add_argument("--skip-compile", action="store_true", help="reuse the compiled flow circuits in target/")
+    parser.add_argument("--stack-only", action="store_true", help="build the stack but do not prove it")
+    parser.add_argument(
+        "--corrupt-inner-proof",
+        action="store_true",
+        help="alter the inner proof the app verifies; the flow must then fail to prove or verify",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="show the output of every command")
+    args = parser.parse_args()
+    VERBOSE = args.verbose
+
+    for tool in (NARGO, NOIR_EXECUTE, BB):
+        if not tool.exists():
+            raise SystemExit(f"{tool} not found; build noir and barretenberg first")
+
+    if not args.skip_compile:
+        # The flow crates are members of the protocol-circuits workspace (nargo resolves the topmost
+        # manifest) and nargo writes into that workspace's target/, so move each artifact here.
+        log("compiling the flow circuits")
+        (FLOWS_DIR / "target").mkdir(exist_ok=True)
+        for pkg in (INNER, APP, BUILDER):
+            run([NARGO, "compile", "--package", pkg, *NARGO_FLAGS], cwd=KERNELS_DIR)
+            shutil.move(KERNELS_DIR / "target" / f"{pkg}.json", FLOWS_DIR / "target" / f"{pkg}.json")
+
+    work = args.work_dir if args.work_dir.is_absolute() else FLOWS_DIR / args.work_dir
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir(parents=True)
+
+    stack = build_stack(work, args.corrupt_inner_proof)
+    stack_path = work / "ivc-inputs.msgpack"
+    stack_path.write_bytes(stack)
+    log(f"wrote {stack_path} ({len(stack)} bytes)")
+    if args.flow_dir:
+        flow_dir = args.flow_dir / FLOW_NAME
+        flow_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(stack_path, flow_dir / "ivc-inputs.msgpack")
+        log(f"wrote {flow_dir / 'ivc-inputs.msgpack'}")
+    if args.stack_only:
+        return
+
+    proof_dir = work / "proof"
+    proof_dir.mkdir()
+    try:
+        log("proving the stack with Chonk")
+        run([BB, "prove", "--scheme", "chonk", "--ivc_inputs_path", stack_path, "--write_vk", "-o", proof_dir])
+        log("verifying the Chonk proof")
+        run([BB, "verify", "--scheme", "chonk", "-p", proof_dir / "proof", "-k", proof_dir / "vk"])
+    except SystemExit as failure:
+        if args.corrupt_inner_proof:
+            log(f"PASS: the flow with a corrupted inner proof was rejected ({failure})")
+            return
+        raise
+    if args.corrupt_inner_proof:
+        raise SystemExit("FAIL: the flow with a corrupted inner proof proved and verified")
+    log("PASS: real-kernel Chonk flow with an in-app UltraHonk verifier proves and verifies")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `noir-projects/fnd/noir-protocol-circuits/integration-tests/verify-uh-proof-within-smart-contract`: a Chonk (ClientIVC) flow over the **real** private kernels whose app verifies an UltraHonk proof, the way a smart contract does when it verifies a Noir proof in a private function. It is generated entirely from code in this repository (no captured fixtures, no aztec-nr, no PXE), so proving-system regressions in a real kernel stack are caught here without a round trip through the labs repository.

The flow is `app_uh_verifier` -> `private_kernel_init` -> `private_kernel_reset_tail` -> `hiding_kernel_to_rollup`. The app is a private function as the kernels see one: it emits `PrivateCircuitPublicInputs` on the return data bus and, on the way, recursively verifies an UltraHonk ZK proof through `bb_proof_verification::verify_honk_proof`. Until now this path had no proving coverage anywhere: bb's DSL test only checks the circuit and its VK, the stdlib test proves a standalone Mega circuit, acir_tests proves the verifier programs under UltraHonk, and none of the pinned Chonk flows contains an app that verifies a proof.

This also introduces `noir-protocol-circuits/integration-tests/` as the home for tests that prove the real protocol circuits end to end with bb, alongside the existing `nargo test` unit tests and `nargo execute` fixture runs. See its README.

## How it works

- `flow-inputs-builder` is an unconstrained Noir program that derives every kernel input from the circuits' real verification keys: the VK tree with the kernels at their protocol indices, the app's function tree and contract address, the public data tree non-membership proof for class updates, and the no-op reset hints. It reuses `protocol_test_utils::FixtureBuilder` and is never proven. The kernel library itself is untouched; the reset hints are built from `std::mem::zeroed()` plus the documented inactive sentinels, set through the hint structs' public fields.
- `prove_uh_verifier_app_with_real_kernels.py` (stdlib Python) proves `inner_circuit` with bb, runs the builder, chains each circuit's return data into the next one's call data with `noir-execute`, assembles `ivc-inputs.msgpack`, and runs `bb prove` and `bb verify --scheme chonk`. `--flow-dir` also writes the stack in the `chonk-pinned-flows` layout, which the existing C++ and bb.js pinned-flow tests accept as-is.
- The test's crates are members of the protocol-circuits workspace (listed in `Nargo.template.toml`) because nargo always resolves the topmost `Nargo.toml`. `build_integration_tests` in the protocol-circuits `bootstrap.sh` compiles them and moves their artifacts into the test's own `target/`, so they never reach the protocol artifacts, benches, or pins. The build loop's member grep is tightened to top-level `crates/` so it ignores them.
- `integration_test_cmds` emits two test commands under the existing `noir-protocol-circuits-tests` target, hashed over the circuits, bb, and the Noir verifier library: the flow must prove and verify, and with `--corrupt-inner-proof` (one element of the inner proof flipped; ACVM does not check proofs during witness generation) bb must reject it.

## Test plan

- `noir-projects/fnd/noir-protocol-circuits/bootstrap.sh build_integration_tests`, then `integration-tests/verify-uh-proof-within-smart-contract/prove_uh_verifier_app_with_real_kernels.py --skip-compile`: bb accumulates the four real circuits and the Chonk proof verifies.
- The same with `--corrupt-inner-proof`: bb fails while building the app circuit, reported as a pass.
- `bootstrap.sh test_cmds` lists both commands; `nargo fmt --check` and `nargo check` are clean; the protocol `target/` holds no test circuits after the build.

Not covered yet, as sibling tests to add: multi-call transactions (`private_kernel_inner`), intermediate resets, and the to-public tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dct8Fqzq1WFqckm9vCEbMS
