### PR TITLE
fix(sequencer): reserve blob space for a transaction-less checkpoint tail block

### DIFF
--- a/yarn-project/validator-client/src/checkpoint_builder.test.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.test.ts
@@ -2,6 +2,7 @@ import { NUM_CHECKPOINT_END_MARKER_FIELDS, getNumBlockEndBlobFields } from '@azt
 import {
   BLOBS_PER_CHECKPOINT,
   CONTRACT_CLASS_LOG_SIZE_IN_FIELDS,
+  DA_BYTES_PER_FIELD,
   DA_GAS_PER_FIELD,
   FIELDS_PER_BLOB,
   MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT,
@@ -37,7 +38,7 @@ import {
 import type { TelemetryClient } from '@aztec/telemetry-client';
 import { NativeWorldStateService } from '@aztec/world-state/native';
 
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { CheckpointBuilder, FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
@@ -751,6 +752,131 @@ describe('CheckpointBuilder', () => {
       // remainingTxs = 90, remainingBlocks = 3, multiplier = 1
       // fairShareTxs = ceil(90 / 3 * 1) = 30
       expect(capped.maxTransactions).toBe(30);
+    });
+  });
+
+  describe('transaction-less tail block blob reservation', () => {
+    const totalBlobCapacity = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB - NUM_CHECKPOINT_END_MARKER_FIELDS;
+    const blockEndOverhead = getNumBlockEndBlobFields();
+    /** Blob fields left for txs in the current block once its own end fields and a tail's are held back. */
+    const txRoomBeyondTail = 10;
+    const nearCapacityUsed = totalBlobCapacity - 2 * blockEndOverhead - txRoomBeyondTail;
+
+    /** Measured size of a real transaction-less block, rather than the helper's constant. */
+    let tailBlockFields: number;
+
+    beforeAll(async () => {
+      const tailBlock = await L2Block.random(BlockNumber(1), { txsPerBlock: 0 });
+      tailBlockFields = tailBlock.toBlobFields().length;
+    });
+
+    /** Fills the checkpoint with a single prior block of the given blob size. */
+    function withPriorBlockOfSize(blockBlobFieldCount: number) {
+      lightweightCheckpointBuilder.getBlocks.mockReturnValue([
+        createMockBlock({ manaUsed: 0, txBlobFields: [], blockBlobFieldCount }),
+      ]);
+    }
+
+    /** Proposer opts where the fair share across remaining blocks is not the binding cap. */
+    function unsharedProposerOpts(maxBlocksPerCheckpoint: number, existingBlocks: number) {
+      const remainingBlocks = Math.max(1, maxBlocksPerCheckpoint - existingBlocks);
+      return proposerOpts({
+        maxBlocksPerCheckpoint,
+        perBlockAllocationMultiplier: remainingBlocks,
+        perBlockDAAllocationMultiplier: remainingBlocks,
+      });
+    }
+
+    it('serializes a transaction-less block into exactly the shared block-end field count', () => {
+      expect(tailBlockFields).toBe(blockEndOverhead);
+      expect(tailBlockFields).toBe(7);
+      expect(tailBlockFields * DA_BYTES_PER_FIELD).toBe(224);
+    });
+
+    it('leaves room for a tail block while another block can still follow', () => {
+      setupBuilder();
+      withPriorBlockOfSize(nearCapacityUsed);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 1));
+
+      expect(capped.maxBlobFields).toBe(txRoomBeyondTail);
+      // A block that packs the full allowance still ends the checkpoint with exactly a tail block's fields free.
+      const usedAfterThisBlock = nearCapacityUsed + capped.maxBlobFields! + blockEndOverhead;
+      expect(totalBlobCapacity - usedAfterThisBlock).toBe(tailBlockFields);
+    });
+
+    it('packs no txs when only the tail block fits', () => {
+      setupBuilder();
+      withPriorBlockOfSize(totalBlobCapacity - 2 * blockEndOverhead);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 1));
+
+      expect(capped.maxBlobFields).toBe(0);
+    });
+
+    it('packs no txs when the checkpoint is one field short of the tail block', () => {
+      setupBuilder();
+      withPriorBlockOfSize(totalBlobCapacity - 2 * blockEndOverhead + 1);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 1));
+
+      expect(capped.maxBlobFields).toBe(0);
+    });
+
+    it('releases the reservation on the last block the checkpoint can hold', () => {
+      setupBuilder();
+      withPriorBlockOfSize(nearCapacityUsed);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(2, 1));
+
+      expect(capped.maxBlobFields).toBe(txRoomBeyondTail + blockEndOverhead);
+    });
+
+    it('reserves the tail block alone, not a second checkpoint end marker', () => {
+      setupBuilder();
+      withPriorBlockOfSize(nearCapacityUsed);
+
+      const reserved = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 1));
+      const released = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(2, 1));
+
+      expect(released.maxBlobFields! - reserved.maxBlobFields!).toBe(tailBlockFields);
+    });
+
+    it('fits the tail block within the checkpoint after packing an ordinary block to its allowance', async () => {
+      setupBuilder();
+      withPriorBlockOfSize(nearCapacityUsed);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 1));
+      const ordinaryBlock = createMockBlock({
+        manaUsed: 0,
+        txBlobFields: [capped.maxBlobFields!],
+        blockBlobFieldCount: capped.maxBlobFields! + blockEndOverhead,
+      });
+      lightweightCheckpointBuilder.getBlocks.mockReturnValue([
+        createMockBlock({ manaUsed: 0, txBlobFields: [], blockBlobFieldCount: nearCapacityUsed }),
+        ordinaryBlock,
+      ]);
+
+      // The tail consumes the reservation: its own end fields are the only ones it adds, and the checkpoint end
+      // marker is charged once for the whole checkpoint.
+      const tailBlock = await L2Block.random(BlockNumber(2), { txsPerBlock: 0 });
+      const usedWithTail = nearCapacityUsed + ordinaryBlock.toBlobFields().length + tailBlock.toBlobFields().length;
+      expect(usedWithTail + NUM_CHECKPOINT_END_MARKER_FIELDS).toBeLessThanOrEqual(
+        BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB,
+      );
+
+      // Building the tail itself reports no room for txs rather than charging its overhead twice.
+      const tailLimits = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(unsharedProposerOpts(3, 2));
+      expect(tailLimits.maxBlobFields).toBe(0);
+    });
+
+    it('does not reserve a tail block when re-executing a peer proposal', () => {
+      setupBuilder();
+      withPriorBlockOfSize(nearCapacityUsed);
+
+      const capped = (checkpointBuilder as TestCheckpointBuilder).testCapLimits(validatorOpts());
+
+      expect(capped.maxBlobFields).toBe(txRoomBeyondTail + blockEndOverhead);
     });
   });
 

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -214,11 +214,6 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     const totalBlobCapacity = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB - NUM_CHECKPOINT_END_MARKER_FIELDS;
     const blockEndOverhead = getNumBlockEndBlobFields();
 
-    // How many more blocks this checkpoint can still hold, this one included.
-    const remainingBlocks = opts.isBuildingProposal
-      ? Math.max(1, opts.maxBlocksPerCheckpoint - existingBlocks.length)
-      : 1;
-
     // A proposer whose sub-slots run out while the consumption cursor sits at a prefix that is not a live L1 Inbox
     // bucket end appends one transaction-less block to reach one, so the checkpoint can be published at all. That
     // block still writes its own block-end fields, so hold them back from transaction packing while such a block can
@@ -226,7 +221,8 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     // proposer packs against this: re-executing a peer's proposal must not reject a block over it. The checkpoint end
     // marker is already deducted from the total capacity, so the reservation is a block's end fields alone.
     // Reserving blob space does not reserve build time, nor guarantee that the extra block can be built.
-    const rescueTailReservation = opts.isBuildingProposal && remainingBlocks > 1 ? blockEndOverhead : 0;
+    const rescueTailReservation =
+      opts.isBuildingProposal && opts.maxBlocksPerCheckpoint - existingBlocks.length > 1 ? blockEndOverhead : 0;
     const maxBlobFieldsForTxs = Math.max(
       0,
       totalBlobCapacity - usedBlobFields - blockEndOverhead - rescueTailReservation,
@@ -244,6 +240,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
 
     // Proposer mode: further cap by fair share of remaining budget across remaining blocks
     if (opts.isBuildingProposal) {
+      const remainingBlocks = Math.max(1, opts.maxBlocksPerCheckpoint - existingBlocks.length);
       const multiplier = opts.perBlockAllocationMultiplier;
       // DA gas and blob fields use a higher multiplier so the largest contract class deploy fits a block.
       const daMultiplier = opts.perBlockDAAllocationMultiplier ?? multiplier;

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -190,8 +190,9 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
   /**
    * Caps per-block gas and blob field limits by remaining checkpoint-level budgets.
    * When building a proposal (isBuildingProposal=true), computes a fair share of remaining budget
-   * across remaining blocks scaled by the multiplier. When validating, only caps by per-block limit
-   * and remaining checkpoint budget (no redistribution or multiplier).
+   * across remaining blocks scaled by the multiplier, and holds back blob space for a transaction-less block that
+   * may still be needed to end the checkpoint at a live L1 Inbox bucket end. When validating, only caps by per-block
+   * limit and remaining checkpoint budget (no redistribution, multiplier or reservation).
    */
   protected capLimitsByCheckpointBudgets(
     opts: BlockBuilderOptions,
@@ -212,7 +213,24 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     const usedBlobFields = sum(existingBlocks.map(b => b.toBlobFields().length));
     const totalBlobCapacity = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB - NUM_CHECKPOINT_END_MARKER_FIELDS;
     const blockEndOverhead = getNumBlockEndBlobFields();
-    const maxBlobFieldsForTxs = totalBlobCapacity - usedBlobFields - blockEndOverhead;
+
+    // How many more blocks this checkpoint can still hold, this one included.
+    const remainingBlocks = opts.isBuildingProposal
+      ? Math.max(1, opts.maxBlocksPerCheckpoint - existingBlocks.length)
+      : 1;
+
+    // A proposer whose sub-slots run out while the consumption cursor sits at a prefix that is not a live L1 Inbox
+    // bucket end appends one transaction-less block to reach one, so the checkpoint can be published at all. That
+    // block still writes its own block-end fields, so hold them back from transaction packing while such a block can
+    // still follow; the last block the checkpoint can hold releases them, since nothing can follow it. Only the
+    // proposer packs against this: re-executing a peer's proposal must not reject a block over it. The checkpoint end
+    // marker is already deducted from the total capacity, so the reservation is a block's end fields alone.
+    // Reserving blob space does not reserve build time, nor guarantee that the extra block can be built.
+    const rescueTailReservation = opts.isBuildingProposal && remainingBlocks > 1 ? blockEndOverhead : 0;
+    const maxBlobFieldsForTxs = Math.max(
+      0,
+      totalBlobCapacity - usedBlobFields - blockEndOverhead - rescueTailReservation,
+    );
 
     // Remaining txs
     const usedTxs = sum(existingBlocks.map(b => b.body.txEffects.length));
@@ -226,7 +244,6 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
 
     // Proposer mode: further cap by fair share of remaining budget across remaining blocks
     if (opts.isBuildingProposal) {
-      const remainingBlocks = Math.max(1, opts.maxBlocksPerCheckpoint - existingBlocks.length);
       const multiplier = opts.perBlockAllocationMultiplier;
       // DA gas and blob fields use a higher multiplier so the largest contract class deploy fits a block.
       const daMultiplier = opts.perBlockDAAllocationMultiplier ?? multiplier;


### PR DESCRIPTION
## Background

The L1 Inbox stores messages sent from Ethereum to Aztec and groups them into buckets. A checkpoint may consume
messages incrementally across several L2 blocks, but its final message count must equal the end of a live Inbox
bucket before the checkpoint can be published. If the scheduled block-building sub-slots finish before that
boundary is reached, the proposer can add a transaction-less tail block that consumes the remaining messages.

## The problem

A transaction-less block still serializes block-end metadata into the checkpoint's blobs. The existing packing
calculation reserved space for the block currently being built, but not for a possible tail block.

The test captures the failure with the protocol's actual blob geometry:

1. A checkpoint has six blobs of 4,096 fields, for 24,576 fields in total. Its one-field checkpoint-end marker
   leaves 24,575 fields for blocks.
2. A transaction-less block serializes to seven fields, or 224 bytes.
3. Suppose the existing block has used 24,551 fields and the checkpoint may still contain two more blocks.
4. The old calculation reserved seven fields for the current block and offered the remaining 17 fields to its
   transactions: `24,575 - 24,551 - 7 = 17`.
5. If those 17 fields are used, the current block brings usage to 24,575. If message consumption then stops at a
   prefix that is not a live bucket endpoint, the required seven-field tail no longer fits.
6. The proposer cannot produce a publishable checkpoint and loses the slot, even though omitting seven transaction
   fields would have left enough blob capacity for the tail.

## What this changes

While another block can still follow, proposer-side packing now reserves two sets of block-end fields: seven for
the block being built and seven for a possible transaction-less tail. In the example, the transaction allowance is
therefore 10 fields:

`24,575 - 24,551 - 7 - 7 = 10`

After using those 10 fields and writing the current block's seven fields, exactly seven fields remain. A real tail
block can consume that reservation, bringing block data to 24,575 fields; the separately accounted checkpoint-end
marker brings the encoded checkpoint to the full 24,576-field capacity.

The reservation is released when building the last block the checkpoint is allowed to contain, because no tail can
follow it. The transaction allowance is also floored at zero when the available capacity is smaller than the
required overhead.

## What this does not do

This changes only the local proposer's transaction-packing policy. A validator re-executing another node's proposal
does not apply the reservation, so the change cannot make an otherwise valid peer proposal fail validation.

The reservation protects blob capacity only. It does not reserve execution time, guarantee that the tail can be
built before the duty ends, or make an unavailable Inbox endpoint reachable. It does not change message limits,
per-block limits, the maximum checkpoint block count, checkpoint timing, or total blob capacity.

## Testing

Unit tests serialize a real transaction-less `L2Block` and pin its size at seven fields and 224 bytes. They cover
near-capacity packing, the exact-fit case, being one field short, a zero transaction allowance, releasing the
reservation on the last possible block, consuming it with a real tail, and counting the checkpoint-end marker only
once. A separate case confirms that validator re-execution does not reserve tail space.

The tests exercise checkpoint-builder accounting; they do not simulate the full timed proposer flow or prove that
an extra block can always finish within the slot.
