### PR TITLE
fix: restore l1 gas report generation

### DIFF
--- a/l1-contracts/gas_report.json
+++ b/l1-contracts/gas_report.json
@@ -76,7 +76,7 @@
     },
     "functions": {
       "getCanonicalRollup()": {
-        "calls": 1780,
+        "calls": 1750,
         "min": 1073,
         "mean": 4073,
         "median": 4073,
@@ -106,7 +106,7 @@
     },
     "functions": {
       "availableTo(address)": {
-        "calls": 890,
+        "calls": 875,
         "min": 20573,
         "mean": 20573,
         "median": 20573,
@@ -136,7 +136,7 @@
         "max": 2509
       },
       "getCheckpoint(uint256)": {
-        "calls": 900,
+        "calls": 885,
         "min": 27185,
         "mean": 27185,
         "median": 27185,
@@ -157,7 +157,7 @@
         "max": 5837
       },
       "getCurrentEpoch()": {
-        "calls": 891,
+        "calls": 876,
         "min": 915,
         "mean": 915,
         "median": 915,
@@ -291,8 +291,8 @@
       },
       "propose((bytes32,(int256),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256),uint256),(bytes,bytes),address[],(uint8,bytes32,bytes32),bytes)": {
         "calls": 2339,
-        "min": 0,
-        "mean": 266764,
+        "min": 55119,
+        "mean": 266907,
         "median": 284282,
         "max": 325392
       },
@@ -311,11 +311,11 @@
         "max": 52474
       },
       "submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))": {
-        "calls": 897,
-        "min": 58286,
-        "mean": 374005,
-        "median": 379619,
-        "max": 418311
+        "calls": 882,
+        "min": 58310,
+        "mean": 373264,
+        "median": 379571,
+        "max": 418335
       },
       "updateManaTarget(uint256)": {
         "calls": 512,

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -243,7 +243,12 @@ contract RollupTest is RollupBase {
 
     _proposeCheckpointWithExtraBlobs("mixed_checkpoint_1", 1, 1e6, extraBlobHashes);
 
-    assertTrue(Rollup(address(rollup)).checkBlob());
+    bool blobCheckEnabled = Rollup(address(rollup)).checkBlob();
+    if (vm.envOr("FORGE_GAS_REPORT", false)) {
+      assertFalse(blobCheckEnabled);
+      return;
+    }
+    assertTrue(blobCheckEnabled);
     bytes32[] memory blobs = vm.getBlobhashes();
     assertEq(blobs.length, originalBlobHashes.length + extraBlobHashes.length);
     for (uint256 i = 0; i < originalBlobHashes.length; i++) {
@@ -642,7 +647,6 @@ contract RollupTest is RollupBase {
   function testRevertInvalidTimestamp() public setUpFor("empty_checkpoint_1") {
     DecoderBase.Data memory data = load("empty_checkpoint_1").checkpoint;
     ProposedHeader memory header = data.header;
-    vm.blobhashes(this.getBlobHashes(data.blobCommitments));
     bytes32 archive = data.archive;
 
     Timestamp realTs = header.timestamp;
@@ -678,8 +682,6 @@ contract RollupTest is RollupBase {
     // Tweak the coinbase.
     header.coinbase = address(0);
 
-    bytes32[] memory blobHashes = this.getBlobHashes(data.blobCommitments);
-    vm.blobhashes(blobHashes);
     skipBlobCheck(address(rollup));
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidCoinbase.selector));
     ProposeArgs memory args =


### PR DESCRIPTION
Fixes `./bootstrap.sh gas_report` failing because Foundry gas reporting is incompatible with `vm.blobhashes` in three selected Rollup tests. The tests now preserve their normal blob assertions while avoiding incompatible cheatcode use in gas-report mode, and the stable report is regenerated.
