### PR TITLE
fix(bb): open files and stdio in binary mode on Windows

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/file_io.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/file_io.hpp
@@ -15,6 +15,12 @@
 #include <unistd.h>
 #include <vector>
 
+// On Windows the CRT opens descriptors in text mode unless O_BINARY is passed: reads stop at the
+// first 0x1A and writes expand 0x0A into 0x0D 0x0A. POSIX has no text mode, so the flag is 0 there.
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 namespace bb {
 inline size_t get_file_size(std::string const& filename)
 {
@@ -66,7 +72,7 @@ inline std::vector<uint8_t> read_file(const std::string& filename, size_t bytes 
     auto raw_size = std::filesystem::file_size(filename, ec);
     std::optional<size_t> file_size = ec ? std::nullopt : std::optional<size_t>(static_cast<size_t>(raw_size));
 
-    int fd = open(filename.c_str(), O_RDONLY);
+    int fd = open(filename.c_str(), O_RDONLY | O_BINARY);
     if (fd == -1) {
         THROW std::runtime_error("Unable to open file: " + filename + " (" + strerror(errno) + ")");
     }
@@ -103,7 +109,7 @@ inline void write_file(const std::string& filename, std::span<const uint8_t> dat
     // For regular files, truncate and create if missing (O_TRUNC | O_CREAT).
     // For FIFOs/pipes the file already exists and O_CREAT/O_TRUNC are no-ops, so
     // the same flags work uniformly for both cases — no need to stat() first.
-    int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
     if (fd == -1) {
         THROW std::runtime_error("Failed to open file for writing: " + filename + " (" + strerror(errno) + ")");
     }

--- a/barretenberg/cpp/src/barretenberg/api/file_io.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/file_io.test.cpp
@@ -23,3 +23,17 @@ TEST(APIFileIO, ManyFromBufferExactAcceptsAlignedBuffers)
 
     EXPECT_EQ(parsed, expected);
 }
+
+TEST(APIFileIO, WriteReadRoundTripPreservesBinaryBytes)
+{
+    // 0x1A is the text-mode EOF marker on Windows, and text mode rewrites 0x0A and 0x0D 0x0A.
+    std::vector<uint8_t> data{ 0x00, 0x1A, 0x0A, 0x0D, 0x0A, 0x0D, 0xFF, 0x1A, 0x0A };
+    auto path = (std::filesystem::temp_directory_path() / "bb_file_io_binary_round_trip.bin").string();
+
+    write_file(path, data);
+    // get_file_size opens in binary mode, so this catches write-side expansion on its own.
+    EXPECT_EQ(get_file_size(path), data.size());
+    EXPECT_EQ(read_file(path), data);
+
+    std::filesystem::remove(path);
+}

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -1,6 +1,18 @@
 #include "barretenberg/bb/cli.hpp"
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <stdio.h>
+#endif
+
 int main(int argc, char* argv[])
 {
+#ifdef _WIN32
+    // stdin/stdout carry binary data (`-` paths, the msgpack API, curve constants), but the CRT
+    // opens them in text mode, which stops reads at 0x1A and rewrites 0x0A.
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     return bb::parse_and_run_cli_command(argc, argv);
 }


### PR DESCRIPTION
Fixes #25434.

Since #21262, `read_file` and `write_file` in `api/file_io.hpp` use POSIX `open()` without `O_BINARY`. On Windows the CRT opens such descriptors in text mode: reads stop at the first `0x1A` byte and fold `0x0D 0x0A` into `0x0A`, and writes expand every `0x0A` into `0x0D 0x0A`. Everything `bb.exe` reads or writes through these helpers is binary (keys, proofs, public inputs). As a result, `bb prove -k vk` fails with `verification key has wrong size: expected 3680, got 983`, and written proofs gain one byte per `0x0A`.

## Changes

- `api/file_io.hpp`: pass `O_BINARY` to both `open()` calls. Where the flag doesn't exist (POSIX has no text mode), a fallback defines it as `0`. MinGW's `<fcntl.h>` defines it.
- `bb/main.cpp`: on Windows, switch stdin and stdout to binary mode at startup. Besides `read_file("-")`, they carry binary data in `get_bytecode("-")`, the msgpack API (`api_msgpack.cpp`) and `write_curve_constants_msgpack_to_stdout`, which have the same problem. Fixing it at the entry point covers all of them. Side effect: on Windows, text written to stdout now ends lines with LF instead of CRLF.
- `api/file_io.test.cpp`: a `write_file` → `read_file` round-trip test with `0x1A`, `0x0A` and `0x0D` bytes. It also checks the on-disk size, because text-mode writes and reads partly cancel each other out (`0x0A` → `0x0D 0x0A` on write, folded back on read). On POSIX the test passes with or without the fix. It guards Windows test runs, which CI doesn't do today (the Windows build is syntax-only).

## Existing CRS caches on Windows

The CRS cache (`~/.bb-crs`, or `CRS_PATH` / `-c`) goes through the same helpers: `srs/factories/get_bn254_crs.cpp` and `get_grumpkin_crs.cpp` write it with `write_file` and read it with `read_file`. Current Windows builds write it in text mode and read it back in text mode, which folds the `0x0D 0x0A` pairs back, so the corruption went unnoticed. With this fix, a cache written by an earlier Windows `bb.exe` is read as-is, and `prove` fails with `affine_element::serialize_from_buffer: point is not on the curve`. In the Windows check below, the official 5.2.0 build writes a 2,106,329-byte `bn254_g1.dat` where the patched build writes 2,097,152 bytes, and the patched build fails in this way when reusing the official build's cache. Deleting the cache directory resolves it: bb downloads the CRS again. If you'd rather have bb handle it automatically, e.g. by versioning the cache file names or re-downloading when a cached point fails to deserialize, I'm happy to add that here or in a follow-up.

## Testing

- macOS arm64: `api_tests --gtest_filter='APIFileIO.*'` passes, and `clang-format-20` reports no changes.
- Windows: [r3sako/bb-windows-check](https://github.com/r3sako/bb-windows-check) cross-compiles `bb.exe` from `v5.2.0` plus this commit, using the release preset (`amd64-windows`, Zig 0.15.1). On a `windows-2025` runner it then runs the issue's scenario on the issue's fixtures with both the patched and the official `bb.exe` 5.2.0: `prove -k vk` and `prove --write_vk`, both compared byte for byte with the bb.js outputs, and `verify`. Each binary gets its own CRS cache, and an extra informational step runs the patched binary on the cache the official one wrote (the upgrade case above). The run passes only if the official binary reproduces the bug and the patched one passes every check. [Passing run](https://github.com/r3sako/bb-windows-check/actions/runs/35264643391): the official build fails with `verification key has wrong size: expected 3680, got 983` and `UltraHonk proof file size must be a multiple of 32 bytes, got 1201`, and the patched build produces the bb.js proof and vk byte for byte and verifies the reference proof.
