### PR TITLE
chore(circuits): correct inbox and append-only tree comments

### DIFF
--- a/l1-contracts/test/RollupFieldRange.t.sol
+++ b/l1-contracts/test/RollupFieldRange.t.sol
@@ -175,7 +175,9 @@ contract RollupFieldRangeTest is RollupBase {
 
     vm.blobhashes(this.getBlobHashes(full.checkpoint.blobCommitments));
 
-    // Streaming Inbox: nothing is seeded here, so reference the genesis bucket (hash 0).
+    // Streaming Inbox: `_populateInbox` above did seed messages, but consuming them is optional at this timestamp,
+    // since their buckets are not yet past the censorship cutoff. The genesis bucket (hash 0, total 0) is therefore
+    // still a legal endpoint for this checkpoint.
     header.inboxRollingHash = bytes32(0);
 
     ProposeArgs memory args =

--- a/noir-projects/fnd/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
@@ -81,10 +81,11 @@ impl<let NumPreviousRollups: u32, let NumVkIndices: u32> CheckpointRootInputsVal
     /// values across the rest of the checkpoint. Do not drop or weaken any of them on the assumption that some flag
     /// still marks the first block — none does.
     ///
-    /// Together they also pin the first-block behaviour of the block roots themselves: a block absorbs the l1-to-l2
-    /// tree root into its blob data exactly when its start sponge blob is still uninitialized, which the sponge blob
-    /// assert below allows only for the leftmost block (every block absorbs its block-end fields, so a mid-checkpoint
-    /// block always inherits a sponge blob with fields already absorbed).
+    /// Together they also pin the first-block behaviour of the block roots themselves. Every block absorbs its own
+    /// block-end fields, the l1-to-l2 message tree root among them, since any block may insert its own bundle; the
+    /// root is per-block, not checkpoint-constant. What distinguishes the leftmost block is therefore the *start*
+    /// sponge blob: only it may still be uninitialized, which the sponge blob assert below is what enforces, so a
+    /// mid-checkpoint block always inherits a sponge blob with fields already absorbed.
     fn validate_start_states(self) {
         let first_rollup = self.previous_rollups[0].public_inputs;
 

--- a/noir-projects/fnd/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
@@ -28,7 +28,7 @@ use types::{
     },
     hash::{poseidon2_hash, poseidon2_hash_with_separator},
     merkle_tree::{
-        append_only_tree::append_leaves_to_snapshot, compute_empty_tree_root, MerkleTree,
+        append_only_tree::append_leaves_to_snapshot, MerkleTree,
         test_utils::SingleSubtreeMerkleTree,
     },
     proof::proof_data::{AvmV2ProofData, ProofData},
@@ -137,52 +137,6 @@ impl RollupFixtureBuilder {
         let sibling_path_for_insertion = tree.get_sibling_path(block_number as Field);
 
         (previous_snapshot, sibling_path_for_insertion)
-    }
-
-    pub fn build_l1_to_l2_message_subtree_for_insertion(
-        self,
-        slot_number: Field,
-    ) -> (AppendOnlyTreeSnapshot, [Field; L1_TO_L2_MSG_TREE_HEIGHT - L1_TO_L2_MSG_SUBTREE_HEIGHT], AppendOnlyTreeSnapshot) {
-        // Create a subtree of size 4 filled with subtree roots before the current slot.
-        let new_slot_index = self.get_l1_to_l2_message_next_available_leaf_index(slot_number - 1)
-             as u32
-            >> L1_TO_L2_MSG_SUBTREE_HEIGHT;
-        let start_slot_index = new_slot_index - new_slot_index % 4;
-        let mut subtree_roots = [0; 4];
-        for i in start_slot_index..new_slot_index {
-            subtree_roots[i % 4] =
-                self.get_l1_to_l2_message_subtree_root(slot_number - 4 + i as Field);
-        }
-        let empty_subtree_root = compute_empty_tree_root::<L1_TO_L2_MSG_SUBTREE_HEIGHT>();
-        subtree_roots[new_slot_index % 4] = empty_subtree_root;
-
-        let mut tree = SingleSubtreeMerkleTree::<4, 2, L1_TO_L2_MSG_TREE_HEIGHT - L1_TO_L2_MSG_SUBTREE_HEIGHT>::new_tree_roots_at_index::<L1_TO_L2_MSG_SUBTREE_HEIGHT>(
-            subtree_roots,
-            start_slot_index as Field,
-        );
-        let previous_snapshot = AppendOnlyTreeSnapshot {
-            root: tree.get_root(),
-            next_available_leaf_index: self.get_l1_to_l2_message_next_available_leaf_index(
-                slot_number - 1,
-            ),
-        };
-
-        // Get the sibling path for inserting the current l1-to-l2 messages.
-        let sibling_path_for_insertion = tree.get_sibling_path(new_slot_index as Field);
-
-        // Insert subtree of the current l1-to-l2 messages.
-        tree.update_leaf(
-            new_slot_index as Field,
-            self.get_l1_to_l2_message_subtree_root(slot_number),
-        );
-        let new_snapshot = AppendOnlyTreeSnapshot {
-            root: tree.get_root(),
-            next_available_leaf_index: self.get_l1_to_l2_message_next_available_leaf_index(
-                slot_number,
-            ),
-        };
-
-        (previous_snapshot, sibling_path_for_insertion, new_snapshot)
     }
 
     /// Builds a per-block L1-to-L2 message bundle appended to an empty tree, returning
@@ -592,10 +546,6 @@ impl RollupFixtureBuilder {
             nullifier_tree: self.make_fixture(self.start_slot_number, tx_or_block_number, 4783),
             public_data_tree: self.make_fixture(self.start_slot_number, tx_or_block_number, 19342),
         }
-    }
-
-    fn get_l1_to_l2_message_subtree_root(_self: Self, slot_number: Field) -> Field {
-        slot_number * 7639901
     }
 
     fn get_l1_to_l2_message_next_available_leaf_index(_self: Self, slot_number: Field) -> Field {

--- a/noir-projects/fnd/noir-protocol-circuits/crates/types/src/constants.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/crates/types/src/constants.nr
@@ -62,7 +62,9 @@ pub global NOTE_HASH_SUBTREE_ROOT_SIBLING_PATH_LENGTH: u32 =
 pub global NULLIFIER_SUBTREE_ROOT_SIBLING_PATH_LENGTH: u32 =
     NULLIFIER_TREE_HEIGHT - NULLIFIER_SUBTREE_HEIGHT;
 // Cap on L1-to-L2 messages bundled into a single L2 block. One quarter of the per-checkpoint
-// cap: a checkpoint drains its Inbox consumption across up to four message-bearing blocks.
+// cap, so four blocks at full bundles are the fewest that can drain a checkpoint's whole Inbox
+// allowance. It is a floor, not a ceiling: blocks end at arbitrary message prefixes, so a
+// checkpoint may spread the same allowance over any number of partially filled blocks.
 pub global MAX_L1_TO_L2_MSGS_PER_BLOCK: u32 = 256;
 // Cap on L1-to-L2 messages consumed by a single checkpoint.
 pub global MAX_L1_TO_L2_MSGS_PER_CHECKPOINT: u32 = 1024;

--- a/noir-projects/fnd/noir-protocol-circuits/crates/types/src/merkle_tree/append_only_tree.nr
+++ b/noir-projects/fnd/noir-protocol-circuits/crates/types/src/merkle_tree/append_only_tree.nr
@@ -111,7 +111,8 @@ pub fn insert_subtree_root_to_snapshot_with_hasher<let TreeHeight: u32, let Subt
 /// boundary: the whole batch is merged into the tree's frontier (the incremental-merkle-tree "filled subtrees") level
 /// by level, so a compact bundle can start wherever the previous append left off. Only `leaves[0..num_leaves]` are
 /// inserted; the remaining lanes are no-ops and must be zero. The pair-hash lanes halve at each level as the batch
-/// rises, so the total cost is ~`MaxLeaves + 3 * TreeHeight` hashes rather than `MaxLeaves * TreeHeight`.
+/// rises, so the total cost is ~`MaxLeaves + 4 * TreeHeight` hashes (merge, hint validation, final root
+/// recomputation, and the zero-subtree-root chain) rather than `MaxLeaves * TreeHeight`.
 ///
 /// `frontier_hint` is the frontier at `snapshot.next_available_leaf_index`, i.e. `frontier_hint[level]` is the pending
 /// left-sibling node at each level. It is validated against `snapshot.root` before use, pinning it to the snapshot the
@@ -119,11 +120,12 @@ pub fn insert_subtree_root_to_snapshot_with_hasher<let TreeHeight: u32, let Subt
 /// index is a right child, which are exactly the entries the validation pins, so an incorrect hint cannot produce a
 /// wrong result: it either fails validation or is never read.
 ///
-/// A completely full tree (`next_available_leaf_index == 2^TreeHeight`) has no representable frontier, so every call
-/// against one fails hint validation — including `num_leaves = 0`. Callers that append a bundle unconditionally
-/// therefore stop being provable altogether once the tree fills up, so this is a chain halt rather than a graceful
-/// degradation to "no more messages". It fails closed and is accepted behavior: at the heights used in practice the
-/// tree cannot be filled within the lifetime of the chain.
+/// Once the tree is completely full, no call to this function can succeed: appending more leaves fails the capacity
+/// check, and even a `num_leaves = 0` call fails, because a full tree has no frontier for the hint to match. (The
+/// one exception: a tree whose leaves are all zero is indistinguishable from an empty tree, so a `num_leaves = 0`
+/// call against it passes as a harmless no-op.) A caller that appends a bundle unconditionally therefore becomes
+/// unprovable once its tree fills up — the chain halts rather than degrading to "no more messages". This fails
+/// closed and is accepted behavior: at the heights used in practice the tree can never fill up.
 pub fn append_leaves_to_snapshot<let TreeHeight: u32, let MaxLeaves: u32>(
     snapshot: AppendOnlyTreeSnapshot,
     leaves: [Field; MaxLeaves],
@@ -155,6 +157,8 @@ pub fn append_leaves_to_snapshot<let TreeHeight: u32, let MaxLeaves: u32>(
     let start_index = snapshot.next_available_leaf_index as u64;
     let end_index = start_index + num_leaves as u64;
     // Guard against wrapping past the tree capacity, which would otherwise silently produce a wrong root.
+    // At height 64 the capacity is not representable as a u64, so the check is skipped; the `end_index` addition above
+    // rejects any overflowing appends, at the cost that a height-64 tree can never be filled to its last leaf.
     let mut tree_is_filled_exactly = false;
     if TreeHeight < 64 {
         let capacity = 1 as u64 << TreeHeight as u64;
@@ -683,6 +687,48 @@ mod append_leaves_tests {
 
         let batch: [Field; 6] = padded([201, 202, 203]);
         let _ = append_leaves_to_snapshot::<4, 6>(snapshot, batch, 3, [0; 4]);
+    }
+
+    #[test(should_fail_with = "call to assert_max_bit_size")]
+    fn append_leaf_index_past_64_bits_fails() {
+        // 2^64 truncates to 0 as a u64, so without the bit-size check on the leaf index the empty-tree frontier
+        // would validate and the batch would silently land at index 0.
+        let mut snapshot = empty_snapshot::<5>();
+        snapshot.next_available_leaf_index = 18446744073709551616;
+        let leaves: [Field; 8] = padded([42]);
+        let _ = append_leaves_to_snapshot::<5, 8>(snapshot, leaves, 1, [0; 5]);
+    }
+
+    #[test]
+    fn append_with_tree_of_height_64() {
+        // The static_assert admits heights up to 64, where the capacity check is skipped (a 2^64 capacity is not
+        // representable as a u64). Verified against the aligned subtree-insert path, as no reference tree of this
+        // height can be built.
+        let snapshot = empty_snapshot::<64>();
+
+        let subtree_root = merkle_hash(11, 22);
+        let sibling_path: [Field; 63] = subarray(compute_zero_hashes::<64>(), 0);
+        let ref_snapshot =
+            insert_subtree_root_to_snapshot::<64, 1>(snapshot, sibling_path, subtree_root);
+
+        let result = append_leaves_to_snapshot::<64, 4>(snapshot, [11, 22, 0, 0], 2, [0; 64]);
+        assert_eq(result, ref_snapshot);
+    }
+
+    #[test(should_fail_with = "attempt to add with overflow")]
+    fn append_at_height_64_past_capacity_fails() {
+        // At height 64 the skipped capacity check's job falls to the checked u64 addition computing `end_index`:
+        // 2^64 - 1 passes the 64-bit index check, so the add is the only guard, and it fires before hint
+        // validation ever sees the (bogus) frontier.
+        let mut snapshot = empty_snapshot::<64>();
+        snapshot.next_available_leaf_index = 0xffffffffffffffff;
+        let _ = append_leaves_to_snapshot::<64, 4>(snapshot, [11, 22, 0, 0], 2, [0; 64]);
+    }
+
+    #[test(should_fail_with = "num_leaves is greater than the leaves array length")]
+    fn append_num_leaves_past_array_fails() {
+        let snapshot = empty_snapshot::<5>();
+        let _ = append_leaves_to_snapshot::<5, 8>(snapshot, [0; 8], 9, [0; 5]);
     }
 
     #[test(should_fail_with = "Found non-zero field after breakpoint")]


### PR DESCRIPTION
Comment corrections, dead test-helper removal, and new coverage around the streaming Inbox circuits. Nothing here changes a circuit's constraints: the compiled ACIR bytecode and ABI of all 81 protocol circuits are byte-identical to the base branch, so no verification key moves.

**Comments that described behaviour the code does not have.**

The checkpoint root's `validate_start_states` claimed a block absorbs the l1-to-l2 message tree root into its blob data only when its start sponge blob is still uninitialized. That is not how it works: every block absorbs its own block-end fields, that root among them, because any block may insert its own bundle. The root is per-block, not checkpoint-constant. What actually singles out the leftmost block is the start sponge blob, which only it may leave uninitialized — and that is what the assert below the comment enforces.

`MAX_L1_TO_L2_MSGS_PER_BLOCK` was described as implying a checkpoint drains its Inbox allowance over up to four blocks. Four full bundles are the fewest that can drain it, not the most. Blocks end at arbitrary message prefixes, so the same allowance can spread over any number of partially filled blocks; the constant is a floor on the block count, not a ceiling.

`RollupFieldRange`'s propose helper said nothing was seeded into the Inbox, when `_populateInbox` seeds sixteen messages a few lines above. Referencing the genesis bucket is still legal, but for a different reason: the bucket holding those messages is newer than the censorship cutoff, so consuming them is optional at that timestamp. Verified against this branch — with sixteen messages in bucket 1, `propose` does enter the mandatory-consumption branch and passes it on the cutoff comparison, not on the cap escape.

**Dead code.** `build_l1_to_l2_message_subtree_for_insertion` and `get_l1_to_l2_message_subtree_root` built a slot-indexed tree of subtree roots that no test has used since the per-block message bundle replaced that shape. They were also the last users of the fixture builder's `compute_empty_tree_root` import.

**`append_leaves_to_snapshot` docs and edge coverage** (second commit, authored by Leila Wang). The hash-cost estimate undercounted: the function charges ~`MaxLeaves + 4 * TreeHeight`, once the merge, the hint validation, the final root recomputation and the zero-subtree-root chain are all counted. The full-tree paragraph also missed a case — a tree whose leaves are all zero is indistinguishable from an empty one, so a `num_leaves = 0` call against a full such tree validates and is a harmless no-op. Height 64 skips the capacity check because a 2^64 capacity is not representable as a u64; the checked `end_index` addition is what rejects overflowing appends there, at the cost that such a tree can never be filled to its last leaf. Four new tests pin those edges: the 64-bit bound on the leaf index, an append into a height-64 tree checked against the aligned subtree-insert path, the overflow at height-64 capacity, and a `num_leaves` past the leaves array.

Carries two commits so Leila's authorship survives the merge, hence `ci-no-squash`.
