### PR TITLE
docs(bb): read the Prover.toml inventory off the scenarios array

### DIFF
--- a/barretenberg/.claude/skills/gate-counts/SKILL.md
+++ b/barretenberg/.claude/skills/gate-counts/SKILL.md
@@ -183,7 +183,7 @@ another. The proof length must agree across **three** places:
 1. barretenberg C++ — the `bb` binary.
 2. the noir stdlib — the pinned `noir/noir-repo` submodule, baked into the
    compiled circuit bytecode at `nargo compile` time.
-3. the TS constants in `yarn-project/constants/src/constants.gen.ts` —
+3. the TS constants in `labs/yarn-project/constants/src/constants.gen.ts` —
    `RECURSIVE_ROLLUP_HONK_PROOF_LENGTH` / `NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH`
    (Honk, e.g. 480) and `CHONK_PROOF_LENGTH` (e.g. 1271). These fill the
    **fake recursive-proof arrays** in the committed `Prover.toml` fixtures.
@@ -212,26 +212,32 @@ change they must be regenerated (or hacked — see below). Two commands cover al
 protocol circuits, split by whether the sample needs a real client-proved
 transaction.
 
+Both commands below run from `labs/yarn-project`, the TypeScript node's git
+submodule; see the `update-prover-toml` skill for the directory the captured
+tomls actually land in, which is not this repository.
+
 **Block-root and above rollup circuits — prover-client suite** (simulated
 orchestrator, no L1 sandbox):
 
 ```bash
 AZTEC_GENERATE_TEST_DATA=1 \
-  yarn workspace @aztec/prover-client test regenerate_rollup_sample_inputs
+  yarn workspace @aztec-labs/prover-client test regenerate_rollup_sample_inputs
 ```
 
-Regenerates `Prover.toml` for `rollup-block-root-first-empty-tx`,
-`rollup-block-root-first`, `rollup-block-root-first-single-tx`,
-`rollup-block-root`, `rollup-block-root-single-tx`, `rollup-block-root-msgs-only`,
-`rollup-block-merge`, `rollup-checkpoint-root`, `rollup-checkpoint-root-single-block`,
-`rollup-checkpoint-merge`, `rollup-tx-merge`, `rollup-root`.
+Regenerates the `Prover.toml` of every block-root variant plus the block-merge,
+checkpoint-root, checkpoint-merge, tx-merge and root circuits. Read the exact
+inventory off the `dump` fields of the `scenarios` array in
+`labs/yarn-project/prover-client/src/test/regenerate_rollup_sample_inputs.test.ts`
+rather than from a list here: each scenario declares which circuits it is
+responsible for, and the set changes whenever a block-root variant is added or
+removed.
 
 **Private-kernel + transaction-base circuits — e2e prover full test** (spins up
 an L1/anvil sandbox):
 
 ```bash
 AZTEC_GENERATE_TEST_DATA=1 FAKE_PROOFS=1 \
-  yarn workspace @aztec/end-to-end test:e2e single-node/prover/server/full.test
+  yarn workspace @aztec-labs/end-to-end test:e2e single-node/prover/server/full.test
 ```
 
 Regenerates `Prover.toml` for: `private-kernel-init` and its `private-kernel-init-N`
@@ -242,17 +248,18 @@ transactions the simulated orchestrator cannot produce. (`private-kernel-reset`,
 the inner reset, is commented out and hand-maintained — not regenerated.)
 
 The circuit lists live in the `updateProtocolCircuitSampleInputs(...)` loops in
-`yarn-project/end-to-end/src/single-node/prover/server/full.test.ts` and the
+`labs/yarn-project/end-to-end/src/single-node/prover/server/full.test.ts` and the
 `scenarios` array in
-`yarn-project/prover-client/src/test/regenerate_rollup_sample_inputs.test.ts`;
+`labs/yarn-project/prover-client/src/test/regenerate_rollup_sample_inputs.test.ts`;
 re-read them if a circuit seems missing (entries get commented in/out).
 
 ### Build prerequisites for regeneration
 
-The fake-proof lengths come from `@aztec/constants`, so the TS build must be
+The fake-proof lengths come from `@aztec-labs/constants`, so the TS build must be
 current *after* any proof-length change — otherwise regeneration re-emits the
-old length. Build in dependency order (simplest: `make yarn-project` from the
-git root, which does bb → noir → l1-contracts → yarn-project):
+old length. Build in dependency order (simplest: `make labs-yarn-project` from
+the git root, which does bb → noir → l1-contracts → protocol circuits → the
+submodule's yarn-project):
 
 - **bb / bb-avm native** at `barretenberg/cpp/build/bin/{bb,bb-avm}`. The
   prover-client test looks for `bb-avm` and the e2e test for `bb`; both fall
@@ -260,10 +267,12 @@ git root, which does bb → noir → l1-contracts → yarn-project):
 - **noir-execute** at `noir/noir-repo/target/release/noir-execute` (witness
   generation; WASM fallback if absent).
 - **Protocol circuits compiled** under `noir-projects/fnd/noir-protocol-circuits`
-  (artifacts are bundled into `@aztec/noir-protocol-circuits-types`).
-- **TS build current**, especially `@aztec/constants` (regenerated from
-  `noir-projects/.../constants.nr`), then `@aztec/noir-protocol-circuits-types`,
-  `@aztec/bb-prover`, `@aztec/simulator`, and the test's own package.
+  (artifacts are staged into `@aztec-foundation/protocol-circuits-artifacts`,
+  which `@aztec-labs/noir-protocol-circuits-types` consumes).
+- **TS build current**, especially `@aztec-labs/constants` (regenerated from
+  `noir-projects/.../constants.nr`), then
+  `@aztec-labs/noir-protocol-circuits-types`, `@aztec-labs/bb-prover`,
+  `@aztec-labs/simulator`, and the test's own package.
 - The e2e command additionally needs `l1-contracts` built (it runs anvil).
 
 After regenerating, recompile the affected circuit (Step 2) and re-run

--- a/barretenberg/.claude/skills/update-prover-toml/SKILL.md
+++ b/barretenberg/.claude/skills/update-prover-toml/SKILL.md
@@ -5,7 +5,7 @@ description: Regenerate the protocol-circuit sample Prover.toml files (the witne
 
 # Updating protocol-circuit Prover.toml files
 
-All paths are from the repository root (one level above `barretenberg/`).
+All paths are from the repository root (one level above `barretenberg/`). The circuit crates and their tomls live in this repository; the TypeScript that regenerates them lives in the `labs/` git submodule, so its paths start with `labs/yarn-project/` and its workspaces are named `@aztec-labs/*`. Run the yarn commands below from `labs/yarn-project`.
 
 ## What these files are
 
@@ -19,19 +19,27 @@ nargo execute --program-dir noir-projects/fnd/noir-protocol-circuits/crates/<cir
 
 The tomls are captured from a real end-to-end run, not written by hand (except the reset one — see below).
 
+Each toml is self-contained on the verification-key side: it carries its own `vk_tree_root`, plus a `vk_data` membership witness (`leaf_index` + `sibling_path`) under that root for every child proof the circuit verifies. So a change that only moves the real VK tree root — adding or removing a circuit, say — does not by itself need a regeneration pass: the committed samples still execute against the root they were captured with.
+
 ## How regeneration works
 
-Two commands cover the protocol-circuit tomls, split by whether the sample needs a real client-proved transaction. Both capture circuit inputs during proving via `pushTestData`/`getTestData` and write them with `updateProtocolCircuitSampleInputs(circuitName, TOML.stringify(...))` (`yarn-project/foundation/src/testing/files/index.ts`), which writes `noir-projects/fnd/noir-protocol-circuits/crates/<circuitName>/Prover.toml`.
+Two commands cover the protocol-circuit tomls, split by whether the sample needs a real client-proved transaction. Both capture circuit inputs during proving via `pushTestData`/`getTestData` and write them with `updateProtocolCircuitSampleInputs(circuitName, TOML.stringify(...))` (`labs/yarn-project/foundation/src/testing/files/index.ts`), which writes `noir-projects/fnd/noir-protocol-circuits/crates/<circuitName>/Prover.toml` under whichever repository root it resolves from — which is no longer this one, see the warning next.
+
+> ⚠️ **The tests that write the tomls no longer live in the repository that holds them.** `getPathToFile` derives the repository root from the calling module's own location, so a run inside the submodule targets `labs/noir-projects/fnd/noir-protocol-circuits/crates/<circuitName>/Prover.toml`. The submodule has no `noir-projects/fnd` — it consumes the compiled circuits as the `@aztec-foundation/protocol-circuits-artifacts` package rather than as a source tree — so the write fails there instead of updating the tomls committed here. As a local stopgap, point the missing directory at this repository before running either command, and remove it afterwards so it does not sit untracked in the submodule:
+>
+> ```bash
+> ln -s ../../noir-projects/fnd labs/noir-projects/fnd   # ... regenerate ... then: rm labs/noir-projects/fnd
+> ```
 
 ### Block-root and above rollup circuits — prover-client suite
 
-`yarn-project/prover-client/src/test/regenerate_rollup_sample_inputs.test.ts` drives representative epochs through the simulated orchestrator and dumps each rollup circuit's captured input. The whole suite is `describe.skip`ped unless `AZTEC_GENERATE_TEST_DATA=1`, and it needs no L1 sandbox.
+`labs/yarn-project/prover-client/src/test/regenerate_rollup_sample_inputs.test.ts` drives representative epochs through the simulated orchestrator and dumps each rollup circuit's captured input. The whole suite is `describe.skip`ped unless `AZTEC_GENERATE_TEST_DATA=1`, and it needs no L1 sandbox.
 
 ```bash
-AZTEC_GENERATE_TEST_DATA=1 yarn workspace @aztec/prover-client test regenerate_rollup_sample_inputs
+AZTEC_GENERATE_TEST_DATA=1 yarn workspace @aztec-labs/prover-client test regenerate_rollup_sample_inputs
 ```
 
-Regenerates: `rollup-block-root-first-empty-tx`, `rollup-block-root-first`, `rollup-block-root-first-single-tx`, `rollup-block-root`, `rollup-block-root-single-tx`, `rollup-block-root-msgs-only`, `rollup-block-merge`, `rollup-checkpoint-root`, `rollup-checkpoint-root-single-block`, `rollup-checkpoint-merge`, `rollup-tx-merge`, `rollup-root`. The scenario list lives in the `scenarios` array in that test; each scenario's `dump` field names the tomls it owns.
+Regenerates every block-root variant plus the block-merge, checkpoint-root, checkpoint-merge, tx-merge and root tomls. Take the exact inventory from the `scenarios` array in that test rather than from a list here: each scenario's `dump` field names the tomls it owns, and the set changes whenever a block-root variant is added or removed.
 
 ### Private-kernel and transaction-base circuits — e2e prover full test
 
@@ -40,10 +48,10 @@ Regenerates: `rollup-block-root-first-empty-tx`, `rollup-block-root-first`, `rol
 From the repo root:
 
 ```bash
-AZTEC_GENERATE_TEST_DATA=1 FAKE_PROOFS=1 yarn-project/end-to-end/scripts/run_test.sh simple single-node/prover/server/full
+AZTEC_GENERATE_TEST_DATA=1 FAKE_PROOFS=1 labs/yarn-project/end-to-end/scripts/run_test.sh simple single-node/prover/server/full
 ```
 
-(Equivalently, from `yarn-project/end-to-end`: `AZTEC_GENERATE_TEST_DATA=1 FAKE_PROOFS=1 yarn test:e2e single-node/prover/server/full.test`.) This is a full-stack run (L1 anvil + node + prover), ~15 min with fake proofs.
+(Equivalently, from `labs/yarn-project/end-to-end`: `AZTEC_GENERATE_TEST_DATA=1 FAKE_PROOFS=1 yarn test:e2e single-node/prover/server/full.test`.) This is a full-stack run (L1 anvil + node + prover), ~15 min with fake proofs.
 
 Regenerates:
 


### PR DESCRIPTION
Both barretenberg skill docs — `gate-counts` and `update-prover-toml` — carried a hand-written list of the `Prover.toml` files that `regenerate_rollup_sample_inputs` rewrites. The list had gone stale: it named `rollup-block-root-first`, `rollup-block-root-first-empty-tx`, `rollup-block-root-first-single-tx` and `rollup-block-root-msgs-only`, none of which are crates any more, and it missed `rollup-block-root-no-txs`. A list like that goes wrong every time a block-root variant is added or removed, so both docs now send the reader to the `dump` fields of the `scenarios` array in the test itself, where each scenario declares the circuits it is responsible for.

While in there, the rest of both documents needed the repository split applied. The TypeScript node now lives in the `labs/` submodule, so every path the docs gave for it was wrong and so was every workspace name: paths become `labs/yarn-project/...`, workspaces become `@aztec-labs/*`, the one-shot build is `make labs-yarn-project` rather than `make yarn-project`, and the compiled protocol circuits reach the node as `@aztec-foundation/protocol-circuits-artifacts` instead of being bundled directly.

The split also broke the regeneration flow these docs exist to describe, which they now say plainly. `updateProtocolCircuitSampleInputs` resolves its repository root from the calling module's own location, so a run inside the submodule targets `labs/noir-projects/fnd/noir-protocol-circuits/crates/<circuit>/Prover.toml` — a directory the submodule does not have, since it consumes the circuits as a package rather than as a source tree. The write therefore fails instead of updating the tomls committed in this repository. The doc records that, plus the symlink stopgap that puts the captured tomls back on the committed files, until the resolution is made repo-aware.

One correction worth having before anyone reaches for this skill: each committed toml carries its own `vk_tree_root` together with a matching `vk_data` membership witness (`leaf_index` + `sibling_path`) for every child proof it verifies. A change that only moves the real VK tree root therefore needs no regeneration pass — the samples still execute against the root they were captured with.

Docs only; no code, no circuits, no patch-queue entry.