### PR TITLE
feat: add UnconstrainedArray::from_array

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/facts/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/facts/mod.nr
@@ -157,14 +157,6 @@ mod test {
         (env, scope)
     }
 
-    unconstrained fn make_payload<let N: u32>(values: [Field; N]) -> EphemeralArray<Field> {
-        let payload: EphemeralArray<Field> = EphemeralArray::empty();
-        for i in 0..N {
-            payload.push(values[i]);
-        }
-        payload
-    }
-
     unconstrained fn assert_payload(payload: EphemeralArray<Field>) {
         assert_eq(payload.len(), PAYLOAD.len());
         for i in 0..PAYLOAD.len() {
@@ -179,7 +171,7 @@ mod test {
             TYPE_ID,
             COLLECTION_ID,
             FACT_TYPE_ID,
-            make_payload(PAYLOAD),
+            EphemeralArray::from_array(PAYLOAD),
         );
     }
 
@@ -236,7 +228,7 @@ mod test {
                 TYPE_ID,
                 COLLECTION_ID,
                 FACT_TYPE_ID,
-                make_payload(PAYLOAD),
+                EphemeralArray::from_array(PAYLOAD),
                 BlockReference { block_number: origin_block_number, block_hash: 0xabc },
             );
 
@@ -267,7 +259,7 @@ mod test {
                 TYPE_ID,
                 COLLECTION_ID,
                 FACT_TYPE_ID,
-                make_payload(PAYLOAD),
+                EphemeralArray::from_array(PAYLOAD),
                 BlockReference { block_number: future_block_number, block_hash: 0xabc },
             );
 

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/offchain/reception.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/offchain/reception.nr
@@ -292,12 +292,7 @@ impl OffchainReception {
 
 /// Serializes an [`OffchainMessage`] into a fact payload.
 unconstrained fn to_payload(message: OffchainMessage) -> EphemeralArray<Field> {
-    let fields = message.serialize();
-    let payload: EphemeralArray<Field> = EphemeralArray::empty();
-    for i in 0..fields.len() {
-        payload.push(fields[i]);
-    }
-    payload
+    EphemeralArray::from_array(message.serialize())
 }
 
 mod test {

--- a/noir-projects/aztec-nr/aztec/src/partial_notes/fsm.nr
+++ b/noir-projects/aztec-nr/aztec/src/partial_notes/fsm.nr
@@ -335,12 +335,7 @@ impl PartialNoteFsm {
 
 /// Serializes a [`DeliveredPendingPartialNote`] into a fact payload.
 unconstrained fn to_payload(pending: DeliveredPendingPartialNote) -> EphemeralArray<Field> {
-    let fields = pending.serialize();
-    let payload: EphemeralArray<Field> = EphemeralArray::empty();
-    for i in 0..fields.len() {
-        payload.push(fields[i]);
-    }
-    payload
+    EphemeralArray::from_array(pending.serialize())
 }
 
 mod test {
@@ -607,9 +602,10 @@ mod test {
             // A single pending partial note can resolve to more than one completion log (e.g. the same partial note
             // completed twice). Both logs here would independently discover a note, but step must complete only once
             // (enqueuing exactly one note) rather than panic, so this cannot break sync.
-            let completion_logs: EphemeralArray<LogRetrievalResponse> = EphemeralArray::empty();
-            completion_logs.push(matching_completion_log(address, COMPLETION_LOG_FIRST_NULLIFIER));
-            completion_logs.push(matching_completion_log(address, SECOND_COMPLETION_LOG_FIRST_NULLIFIER));
+            let completion_logs: EphemeralArray<LogRetrievalResponse> = EphemeralArray::from_array([
+                matching_completion_log(address, COMPLETION_LOG_FIRST_NULLIFIER),
+                matching_completion_log(address, SECOND_COMPLETION_LOG_FIRST_NULLIFIER),
+            ]);
 
             PartialNoteFsm::load_all(address, scope).get(0).step(
                 Option::some(completion_logs),

--- a/noir-projects/aztec-nr/aztec/src/unconstrained_array/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/unconstrained_array/mod.nr
@@ -75,6 +75,18 @@ where
         Self::at(random())
     }
 
+    /// Returns an array at a fresh, randomly allocated slot holding `values` in order.
+    pub unconstrained fn from_array<let N: u32>(values: [T; N]) -> Self
+    where
+        T: Serialize,
+    {
+        let array = Self::empty();
+        for i in 0..N {
+            array.push(values[i]);
+        }
+        array
+    }
+
     /// Returns the number of elements stored in the array.
     pub unconstrained fn len(self) -> u32 {
         Oracle::len_oracle(self.slot)

--- a/noir-projects/aztec-nr/aztec/src/unconstrained_array/test_helpers.nr
+++ b/noir-projects/aztec-nr/aztec/src/unconstrained_array/test_helpers.nr
@@ -285,6 +285,32 @@ where
     });
 }
 
+pub(crate) unconstrained fn from_array_stores_values_in_order<Oracle>()
+where
+    Oracle: ArrayOracles,
+{
+    let env = TestEnvironment::new();
+    env.utility_context(|_| {
+        let array: UnconstrainedArray<Field, Oracle> = UnconstrainedArray::from_array([10, 20, 30]);
+        assert_eq(array.len(), 3);
+        assert_eq(array.get(0), 10);
+        assert_eq(array.get(1), 20);
+        assert_eq(array.get(2), 30);
+    });
+}
+
+pub(crate) unconstrained fn from_array_of_no_values_is_empty<Oracle>()
+where
+    Oracle: ArrayOracles,
+{
+    let env = TestEnvironment::new();
+    env.utility_context(|_| {
+        let values: [Field; 0] = [];
+        let array: UnconstrainedArray<Field, Oracle> = UnconstrainedArray::from_array(values);
+        assert_eq(array.len(), 0);
+    });
+}
+
 pub(crate) unconstrained fn map_transforms_each_element<Oracle>()
 where
     Oracle: ArrayOracles,

--- a/noir-projects/noir-contracts/contracts/standard/handshake_registry_contract/src/sync/rewindable_register.nr
+++ b/noir-projects/noir-contracts/contracts/standard/handshake_registry_contract/src/sync/rewindable_register.nr
@@ -163,12 +163,7 @@ pub(crate) unconstrained fn serialize_payload<T>(value: T) -> EphemeralArray<Fie
 where
     T: Serialize,
 {
-    let fields = value.serialize();
-    let payload = EphemeralArray::empty();
-    for i in 0..fields.len() {
-        payload.push(fields[i]);
-    }
-    payload
+    EphemeralArray::from_array(value.serialize())
 }
 
 /// Deserializes a fact payload into a value.

--- a/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/tx_effect_oracle_test_contract/src/main.nr
@@ -20,9 +20,7 @@ pub contract TxEffectOracleTest {
 
     #[external("utility")]
     unconstrained fn get_tx_effects_hashes(tx_hashes: [Field; 2]) -> [Field; 2] {
-        let ephemeral_tx_hashes: EphemeralArray<Field> = EphemeralArray::empty();
-        ephemeral_tx_hashes.push(tx_hashes[0]);
-        ephemeral_tx_hashes.push(tx_hashes[1]);
+        let ephemeral_tx_hashes: EphemeralArray<Field> = EphemeralArray::from_array(tx_hashes);
 
         let tx_effects = get_tx_effects(ephemeral_tx_hashes);
         [poseidon2_hash(tx_effects.get(0).unwrap().serialize()), poseidon2_hash(tx_effects.get(1).unwrap().serialize())]


### PR DESCRIPTION
Adds `UnconstrainedArray::from_array`, which returns a new array at a fresh slot holding the given fixed-size array's values in order. This helper replaces a bunch of ad hoc fns used to construct arrays.

**Why not `From`/`Into`**

`From::from` is a constrained trait method, while every operation on `UnconstrainedArray` is unconstrained by design. Implementing `From` would need an `unsafe` block and would hand constrained code a constructor for a value it can never read. An inherent unconstrained constructor gives the same call-site ergonomics without that.