### PR TITLE
feat: batch nullifier status oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -116,7 +116,12 @@ pub mod message_processing;
     ],
 )]
 pub mod notes;
-#[generate_oracle_tests]
+#[generate_oracle_tests_excluding(
+    @[
+        // TODO: implement once the test resolver can serve EphemeralArray contents.
+        quote { get_nullifier_statuses_oracle },
+    ],
+)]
 pub mod nullifiers;
 #[generate_oracle_tests]
 pub mod offchain_effect;

--- a/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
@@ -1,6 +1,8 @@
 //! Nullifier creation, existence checks, etc.
 
-use crate::protocol::address::aztec_address::AztecAddress;
+use crate::ephemeral::EphemeralArray;
+use crate::oracle::block_reference::BlockReference;
+use crate::protocol::{address::aztec_address::AztecAddress, traits::Deserialize};
 
 /// Notifies the simulator that a nullifier has been created, so that its correct status (pending or settled) can be
 /// determined when reading nullifiers in subsequent private function calls. The first non-revertible nullifier emitted
@@ -29,14 +31,42 @@ pub unconstrained fn is_nullifier_pending(inner_nullifier: Field, contract_addre
 #[oracle(aztec_prv_isNullifierPending)]
 unconstrained fn is_nullifier_pending_oracle(_inner_nullifier: Field, _contract_address: AztecAddress) -> bool {}
 
-/// Returns `true` if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
-/// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before
-/// the current transaction is included in a block. While this might seem of little use at first, certain design
-/// patterns benefit from this abstraction (see e.g. `PrivateMutable`).
-// TODO(F-498): review naming consistency
-pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
-    does_nullifier_exist_oracle(inner_nullifier)
+/// The existence status of a nullifier.
+#[derive(Deserialize, Eq)]
+pub struct NullifierStatus {
+    pub exists: bool,
+
+    /// The block the nullifier was included in.
+    ///
+    /// `None` if the nullifier does not exist, or if it is pending (emitted earlier in the current transaction and not
+    /// yet in any block).
+    pub origin_block: Option<BlockReference>,
 }
 
-#[oracle(aztec_utl_doesNullifierExist)]
-unconstrained fn does_nullifier_exist_oracle(_inner_nullifier: Field) -> bool {}
+/// Returns the existence status of multiple nullifiers.
+///
+/// Same guarantees as [`check_nullifier_exists`]: an existing nullifier can be constrained by proving its inclusion,
+/// but a non-existent one cannot be relied upon. Proving the `origin_block` however is fairly involved, as it'd require
+/// proving existence of the transaction in which the nullifier was emitted, inclusion of the transaction in the block,
+/// and ancestry of the block in the anchor block.
+pub unconstrained fn get_nullifier_statuses(
+    inner_nullifiers: EphemeralArray<Field>,
+) -> EphemeralArray<NullifierStatus> {
+    get_nullifier_statuses_oracle(inner_nullifiers)
+}
+
+/// Returns `true` if the nullifier exists.
+///
+/// Note that a `true` value can be constrained by proving existence of the nullifier, but a `false` value should not be
+/// relied upon since other transactions may emit this nullifier before the current transaction is included in a block.
+/// While this might seem of little use at first, certain design patterns benefit from this abstraction (see e.g.
+/// `PrivateMutable`).
+// TODO(F-498): review naming consistency
+pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
+    get_nullifier_statuses(EphemeralArray::from_array([inner_nullifier])).get(0).exists
+}
+
+#[oracle(aztec_utl_getNullifierStatuses)]
+unconstrained fn get_nullifier_statuses_oracle(
+    _inner_nullifiers: EphemeralArray<Field>,
+) -> EphemeralArray<NullifierStatus> {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
-pub global ORACLE_VERSION_MINOR: Field = 8;
+pub global ORACLE_VERSION_MINOR: Field = 9;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -1,9 +1,11 @@
-use crate::oracle::nullifiers::check_nullifier_exists;
+use crate::ephemeral::EphemeralArray;
+use crate::oracle::block_header::get_block_header_at;
+use crate::oracle::nullifiers::{check_nullifier_exists, get_nullifier_statuses};
 use crate::protocol::{
     abis::{function_selector::FunctionSelector, gas::Gas, gas_fees::GasFees, gas_settings::GasSettings},
     address::AztecAddress,
     constants::{MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT, MAX_PROCESSABLE_L2_GAS},
-    traits::FromField,
+    traits::{FromField, Hash},
 };
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 
@@ -219,5 +221,72 @@ unconstrained fn check_nullifier_exists_pending() {
     env.private_context(|context| {
         context.push_nullifier_unsafe(1);
         assert(check_nullifier_exists(1));
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_nonexistent() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|_| {
+        let status = get_nullifier_statuses(EphemeralArray::from_array([1])).get(0);
+        assert(!status.exists);
+        assert(status.origin_block.is_none());
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_settled() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
+    let settled_block_number = env.last_block_number();
+
+    env.private_context(|context| {
+        let status = get_nullifier_statuses(EphemeralArray::from_array([1])).get(0);
+        assert(status.exists);
+
+        let origin_block = status.origin_block.unwrap();
+        assert_eq(origin_block.block_number, settled_block_number);
+        assert_eq(origin_block.block_hash, get_block_header_at(settled_block_number, *context).hash());
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_pending() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| {
+        context.push_nullifier_unsafe(1);
+
+        let status = get_nullifier_statuses(EphemeralArray::from_array([1])).get(0);
+        assert(status.exists);
+        assert(status.origin_block.is_none());
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_mixed() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
+
+    env.private_context(|context| {
+        context.push_nullifier_unsafe(2);
+
+        let statuses = get_nullifier_statuses(EphemeralArray::from_array([1, 2, 3]));
+        assert_eq(statuses.len(), 3);
+
+        let settled = statuses.get(0);
+        assert(settled.exists);
+        assert(settled.origin_block.is_some());
+
+        let pending = statuses.get(1);
+        assert(pending.exists);
+        assert(pending.origin_block.is_none());
+
+        let nonexistent = statuses.get(2);
+        assert(!nonexistent.exists);
+        assert(nonexistent.origin_block.is_none());
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
@@ -1,6 +1,7 @@
 use crate::test::helpers::test_environment::TestEnvironment;
 
-use crate::oracle::nullifiers::check_nullifier_exists;
+use crate::ephemeral::EphemeralArray;
+use crate::oracle::nullifiers::{check_nullifier_exists, get_nullifier_statuses};
 use crate::protocol::{address::AztecAddress, traits::FromField};
 
 #[test]
@@ -78,4 +79,49 @@ unconstrained fn check_nullifier_exists_settled() {
     env.private_context(|context| { context.push_nullifier_unsafe(1); });
 
     env.utility_context(|_| { assert(check_nullifier_exists(1)); });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_nonexistent() {
+    let env = TestEnvironment::new();
+
+    env.utility_context(|_| {
+        let status = get_nullifier_statuses(EphemeralArray::from_array([1])).get(0);
+        assert(!status.exists);
+        assert(status.origin_block.is_none());
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_settled() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
+    let settled_block_number = env.last_block_number();
+
+    env.utility_context(|_| {
+        let status = get_nullifier_statuses(EphemeralArray::from_array([1])).get(0);
+        assert(status.exists);
+        assert_eq(status.origin_block.unwrap().block_number, settled_block_number);
+    });
+}
+
+#[test]
+unconstrained fn get_nullifier_statuses_mixed() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
+
+    env.utility_context(|_| {
+        let statuses = get_nullifier_statuses(EphemeralArray::from_array([1, 2]));
+        assert_eq(statuses.len(), 2);
+
+        let settled = statuses.get(0);
+        assert(settled.exists);
+        assert(settled.origin_block.is_some());
+
+        let nonexistent = statuses.get(1);
+        assert(!nonexistent.exists);
+        assert(nonexistent.origin_block.is_none());
+    });
 }

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -71,6 +71,7 @@ export { pickNotes } from './pick_notes.js';
 export type { IMiscOracle, IUtilityExecutionOracle, IPrivateExecutionOracle } from './oracle/interfaces.js';
 export type { FactCollection } from './noir-structs/fact_collection.js';
 export type { NoteData } from './noir-structs/note_data.js';
+export type { NullifierStatus } from './noir-structs/nullifier_status.js';
 export type { ResolvedTaggingStrategy } from './noir-structs/resolved_tagging_strategy.js';
 export type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
 export { TxResolverService } from '../messages/tx_resolver_service.js';

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_status.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_status.ts
@@ -1,10 +1,7 @@
 import type { BlockReference } from '../../storage/fact_store/index.js';
 import type { Option } from './option.js';
 
-/**
- * TypeScript counterpart of `NullifierStatus` in Aztec.nr. Used only as a return value of the getNullifierStatuses
- * oracle.
- */
+/** TypeScript counterpart of `NullifierStatus` in Aztec.nr. */
 export type NullifierStatus = {
   exists: boolean;
   /** The block the nullifier was included in. Absent when it does not exist or is pending in the current transaction. */

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_status.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/nullifier_status.ts
@@ -1,0 +1,12 @@
+import type { BlockReference } from '../../storage/fact_store/index.js';
+import type { Option } from './option.js';
+
+/**
+ * TypeScript counterpart of `NullifierStatus` in Aztec.nr. Used only as a return value of the getNullifierStatuses
+ * oracle.
+ */
+export type NullifierStatus = {
+  exists: boolean;
+  /** The block the nullifier was included in. Absent when it does not exist or is pending in the current transaction. */
+  originBlock: Option<BlockReference>;
+};

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_registry.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_registry.test.ts
@@ -4,6 +4,8 @@ import { toACVMField } from '@aztec/simulator/client';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeFeeJuiceMessageNullifier } from '@aztec/stdlib/messaging';
 
+import { EphemeralArrayService } from '../ephemeral_array_service.js';
+import { EphemeralArray } from '../noir-structs/ephemeral_array.js';
 import { Option } from '../noir-structs/option.js';
 import { buildACIRCallback } from './acir_callback.js';
 import { LEGACY_ORACLE_REGISTRY, type LegacyOracleEntry } from './legacy_oracle_registry.js';
@@ -105,6 +107,30 @@ describe('legacy oracle dispatch', () => {
     expect(mappedNullifier).toEqual(
       Option.some({ contractAddress, nullifier: await computeFeeJuiceMessageNullifier(messageHash, secret) }),
     );
+  });
+
+  it('serves the retired single-nullifier existence check from the batch status oracle', async () => {
+    const service = new EphemeralArrayService();
+    const existing = Fr.random();
+    const handler = {
+      isUtility: true,
+      getNullifierStatuses: (innerNullifiers: EphemeralArray<Fr>) =>
+        Promise.resolve(
+          EphemeralArray.fromValues(
+            service,
+            innerNullifiers
+              .readAll(service)
+              .map(innerNullifier => ({ exists: innerNullifier.equals(existing), originBlock: Option.none() })),
+          ),
+        ),
+    } as unknown as Handler;
+
+    const callback = buildACIRCallback(handler);
+
+    expect(await callback['aztec_utl_doesNullifierExist']([toACVMField(existing)])).toEqual([toACVMField(new Fr(1))]);
+    expect(await callback['aztec_utl_doesNullifierExist']([toACVMField(Fr.random())])).toEqual([
+      toACVMField(new Fr(0)),
+    ]);
   });
 
   it('rejects a legacy name that collides with a live oracle', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_registry.ts
@@ -2,7 +2,8 @@
 import { MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_CIPHERTEXT_LEN, PRIVATE_LOG_SIZE_IN_FIELDS } from '@aztec/constants';
 import { computeFeeJuiceMessageNullifier } from '@aztec/stdlib/messaging';
 
-import type { EphemeralArray } from '../noir-structs/ephemeral_array.js';
+import { EphemeralArrayService } from '../ephemeral_array_service.js';
+import { EphemeralArray } from '../noir-structs/ephemeral_array.js';
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
@@ -16,6 +17,7 @@ import {
 } from './oracle_registry.js';
 import {
   AZTEC_ADDRESS,
+  BOOL,
   EPHEMERAL_ARRAY,
   FIELD,
   FIXED_BOUNDED_VEC,
@@ -43,6 +45,10 @@ const LEGACY_PENDING_TAGGED_LOG: TypeMapping<LegacyPendingTaggedLog> = STRUCT<Le
   { name: 'log', type: FIXED_BOUNDED_VEC(FIELD, PRIVATE_LOG_SIZE_IN_FIELDS) },
   { name: 'context', type: LEGACY_MESSAGE_CONTEXT },
 ]);
+
+// Ephemeral arrays bridged by an adapter never get a slot: a param built here is only read back by the handler, and a
+// handler result is only read back here, and neither read touches the service an in-memory array was created with.
+const neverMaterialized = new EphemeralArrayService();
 
 /**
  * Wire shapes that already-deployed contracts still call by their original oracle name, keyed by that retired name.
@@ -86,6 +92,17 @@ export const LEGACY_ORACLE_REGISTRY: Record<string, LegacyOracleEntry> = {
       legacyType: EPHEMERAL_ARRAY(LEGACY_PENDING_TAGGED_LOG),
       // We can map this directly, since `ResolvedTx` carries the legacy context's fields under the same names
       mapping: result => result as unknown as EphemeralArray<LegacyPendingTaggedLog>,
+    },
+  }),
+  aztec_utl_doesNullifierExist: legacyOracle({
+    modernOracle: 'aztec_utl_getNullifierStatuses',
+    params: {
+      legacyType: [{ name: 'innerNullifier', type: FIELD }],
+      mapping: ([innerNullifier]) => [EphemeralArray.fromValues(neverMaterialized, [innerNullifier])],
+    },
+    returnType: {
+      legacyType: BOOL,
+      mapping: statuses => statuses.readAll(neverMaterialized)[0].exists,
     },
   }),
 };

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -35,6 +35,7 @@ import {
   NOTE_SELECTOR,
   NOTE_VALIDATION_REQUEST,
   NULLIFIER_MEMBERSHIP_WITNESS,
+  NULLIFIER_STATUS,
   OPTION,
   type OutputSlot,
   PENDING_TAGGED_LOG,
@@ -187,9 +188,9 @@ export const ORACLE_REGISTRY = {
     returnType: OPTION(PUBLIC_KEYS_AND_PARTIAL_ADDRESS),
   }),
 
-  aztec_utl_doesNullifierExist: makeEntry({
-    params: [{ name: 'innerNullifier', type: FIELD }],
-    returnType: BOOL,
+  aztec_utl_getNullifierStatuses: makeEntry({
+    params: [{ name: 'innerNullifiers', type: EPHEMERAL_ARRAY(FIELD) }],
+    returnType: EPHEMERAL_ARRAY(NULLIFIER_STATUS),
   }),
 
   aztec_utl_getL1ToL2MembershipWitnessV2: makeEntry({

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -69,6 +69,7 @@ import { type LogRetrievalRequest, type LogSource, logSourceFromField } from '..
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
+import type { NullifierStatus } from '../noir-structs/nullifier_status.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
@@ -565,6 +566,11 @@ export const PENDING_TAGGED_LOG: TypeMapping<PendingTaggedLog> = STRUCT([
 export const BLOCK_REFERENCE: TypeMapping<BlockReference> = STRUCT([
   { name: 'blockNumber', type: U32 },
   { name: 'blockHash', type: FIELD },
+]);
+
+export const NULLIFIER_STATUS: TypeMapping<NullifierStatus> = STRUCT([
+  { name: 'exists', type: BOOL },
+  { name: 'originBlock', type: OPTION(BLOCK_REFERENCE) },
 ]);
 
 const ORIGIN_BLOCK_STATE: TypeMapping<OriginBlockState> = SCALAR({

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -339,9 +339,8 @@ describe('Private Execution test suite', () => {
     // on the input.
     aztecNode.getPrivateLogsByTags.mockImplementation(query => Promise.resolve(query.tags.map(() => [])));
 
-    // Constrained-delivery tag derivation calls `doesNullifierExist` (e.g. the handshake bootstrap), which reads the
-    // node's nullifier tree. Default to "not found" so the destructured result is iterable; tests that need a specific
-    // nullifier override this.
+    // Constrained-delivery tag derivation calls `getNullifierStatuses` (e.g. the handshake bootstrap), which reads the
+    // node's nullifier tree. Default to "not found"; tests that need a specific nullifier override this.
     aztecNode.findLeavesIndexes.mockResolvedValue([]);
 
     // Mock getL2Tips and getBlockHeader for syncTaggedPrivateLogs

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -341,7 +341,9 @@ describe('Private Execution test suite', () => {
 
     // Constrained-delivery tag derivation calls `getNullifierStatuses` (e.g. the handshake bootstrap), which reads the
     // node's nullifier tree. Default to "not found"; tests that need a specific nullifier override this.
-    aztecNode.findLeavesIndexes.mockResolvedValue([]);
+    aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+      Promise.resolve(leaves.map(() => undefined)),
+    );
 
     // Mock getL2Tips and getBlockHeader for syncTaggedPrivateLogs
     l2TipsStore.getL2Tips.mockResolvedValue(makeL2Tips(anchorBlockHeader.globalVariables.blockNumber));
@@ -811,9 +813,9 @@ describe('Private Execution test suite', () => {
         aztecNode.getL1ToL2MessageMembershipWitness.mockImplementation(async () => {
           return Promise.resolve([0n, await fork.getSiblingPath(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, 0n)]);
         });
-        aztecNode.findLeavesIndexes.mockImplementation(() => {
-          return Promise.resolve([]);
-        });
+        aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+          Promise.resolve(leaves.map(() => undefined)),
+        );
       };
 
       it('Should be able to consume a dummy cross chain message', async () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
@@ -1,4 +1,5 @@
 import { MAX_PROCESSABLE_L2_GAS, MAX_TX_DA_GAS } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import type { KeyStore } from '@aztec/key-store';
@@ -6,15 +7,16 @@ import { WASMSimulator } from '@aztec/simulator/client';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2TipsProvider } from '@aztec/stdlib/block';
+import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
 import { CompleteAddress } from '@aztec/stdlib/contract';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
+import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { AppTaggingSecret, AppTaggingSecretKind } from '@aztec/stdlib/logs';
-import { type BlockHeader, CallContext, type Capsule, TxContext } from '@aztec/stdlib/tx';
+import { BlockHeader, CallContext, type Capsule, TxContext } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
-import { mock } from 'jest-mock-extended';
+import { type MockProxy, mock } from 'jest-mock-extended';
 
 import type { ContractSyncService } from '../../contract/contract_sync_service.js';
 import type { ResolveCustomRequest } from '../../hooks/resolve_custom_request.js';
@@ -34,9 +36,11 @@ import type { RecipientTaggingStore } from '../../storage/tagging_store/recipien
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import type { TaggingSecretSourcesStore } from '../../storage/tagging_store/tagging_secret_sources_store.js';
 import type { AnchoredContractData } from '../anchored_contract_data.js';
+import { EphemeralArrayService } from '../ephemeral_array_service.js';
 import { ExecutionNoteCache } from '../execution_note_cache.js';
 import { ExecutionTaggingIndexCache } from '../execution_tagging_index_cache.js';
 import { HashedValuesCache } from '../hashed_values_cache.js';
+import { EphemeralArray } from '../noir-structs/ephemeral_array.js';
 import { Option } from '../noir-structs/option.js';
 import { TransientArrayService } from '../transient_array_service.js';
 import { PrivateExecutionOracle, type PrivateExecutionOracleArgs } from './private_execution_oracle.js';
@@ -274,6 +278,55 @@ describe('PrivateExecutionOracle', () => {
       keyStore.hasAccount.mockResolvedValue(ownsRecipient);
       return keyStore;
     };
+  });
+
+  describe('getNullifierStatuses', () => {
+    const pending = new Fr(1);
+    const settled = new Fr(2);
+    const missing = new Fr(3);
+    const settledBlock = { l2BlockNumber: BlockNumber(7), l2BlockHash: BlockHash.random() };
+
+    const service = new EphemeralArrayService();
+    let noteCache: ExecutionNoteCache;
+    let aztecNode: MockProxy<AztecNode>;
+    let oracle: PrivateExecutionOracle;
+
+    const getNullifierStatuses = async (innerNullifiers: Fr[]) =>
+      (await oracle.getNullifierStatuses(EphemeralArray.fromValues(service, innerNullifiers))).readAll(service);
+
+    beforeEach(async () => {
+      noteCache = new ExecutionNoteCache(Fr.ZERO);
+      await noteCache.nullifierCreated(contractAddress, pending);
+
+      const settledSiloed = await siloNullifier(contractAddress, settled);
+      aztecNode = mock<AztecNode>();
+      aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+        Promise.resolve(leaves.map(leaf => (leaf.equals(settledSiloed) ? { data: 0n, ...settledBlock } : undefined))),
+      );
+
+      oracle = makeOracle({ noteCache, aztecNode, anchorBlockHeader: BlockHeader.empty() });
+    });
+
+    it('reports a nullifier emitted in this transaction as existing with no origin block, without querying the node', async () => {
+      await expect(getNullifierStatuses([pending])).resolves.toEqual([{ exists: true, originBlock: Option.none() }]);
+      expect(aztecNode.findLeavesIndexes).not.toHaveBeenCalled();
+    });
+
+    it('reports a settled nullifier with the block it was included in', async () => {
+      await expect(getNullifierStatuses([settled])).resolves.toEqual([
+        {
+          exists: true,
+          originBlock: Option.some({ blockNumber: 7, blockHash: new Fr(settledBlock.l2BlockHash.toBuffer()) }),
+        },
+      ]);
+    });
+
+    it('keeps results aligned across pending, settled and nonexistent nullifiers', async () => {
+      const statuses = await getNullifierStatuses([missing, pending, settled, pending]);
+
+      expect(statuses.map(status => status.exists)).toEqual([false, true, true, true]);
+      expect(statuses.map(status => status.originBlock.isSome())).toEqual([false, false, true, false]);
+    });
   });
 
   describe('resolveCustomRequest', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -46,6 +46,7 @@ import type { HashedValuesCache } from '../hashed_values_cache.js';
 import { BoundedVec } from '../noir-structs/bounded_vec.js';
 import type { ContractClassLogData } from '../noir-structs/contract_class_log_data.js';
 import type { NoteData } from '../noir-structs/note_data.js';
+import type { NullifierStatus } from '../noir-structs/nullifier_status.js';
 import { Option } from '../noir-structs/option.js';
 import type { ResolvedTaggingStrategy } from '../noir-structs/resolved_tagging_strategy.js';
 import { pickNotes } from '../pick_notes.js';
@@ -418,21 +419,23 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return Promise.resolve(preimage);
   }
 
-  override async doesNullifierExist(innerNullifier: Fr): Promise<boolean> {
-    // This oracle must be overridden because while utility execution can only meaningfully check if a nullifier exists
-    // in the synched block, during private execution there's also the possibility of it being pending, i.e. created
-    // in the current transaction.
+  protected override async getSiloedNullifierStatuses(siloedNullifiers: Fr[]): Promise<NullifierStatus[]> {
+    // This must be overridden because while utility execution can only meaningfully check if a nullifier exists in
+    // the anchor block, during private execution there's also the possibility of it being pending, i.e. created in
+    // the current transaction.
 
-    this.logger.debug(`Checking existence of inner nullifier ${innerNullifier}`, {
+    this.logger.debug(`Checking existence of ${siloedNullifiers.length} nullifiers`, {
       contractAddress: this.contractAddress,
+      siloedNullifiers,
     });
 
-    const nullifier = (await siloNullifier(this.contractAddress, innerNullifier)).toBigInt();
+    const pendingNullifiers = this.noteCache.getNullifiers(this.contractAddress);
+    const isPending = siloedNullifiers.map(nullifier => pendingNullifiers.has(nullifier.toBigInt()));
+    const settledStatuses = await super.getSiloedNullifierStatuses(siloedNullifiers.filter((_, i) => !isPending[i]));
 
-    return (
-      this.noteCache.getNullifiers(this.contractAddress).has(nullifier) ||
-      (await super.doesNullifierExist(innerNullifier))
-    );
+    const pendingStatus: NullifierStatus = { exists: true, originBlock: Option.none() };
+    let nextSettled = 0;
+    return isPending.map(pending => (pending ? pendingStatus : settledStatuses[nextSettled++]));
   }
 
   /**

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -28,7 +28,7 @@ import {
   type ContractInstanceWithAddress,
   computeContractAddressFromInstance,
 } from '@aztec/stdlib/contract';
-import { computeUniqueNoteHash, siloNoteHash } from '@aztec/stdlib/hash';
+import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
@@ -730,6 +730,39 @@ describe('Utility Execution test suite', () => {
         );
 
         expect(result.readAll(service)).toEqual([true, false, true]);
+      });
+    });
+
+    describe('getNullifierStatuses', () => {
+      const service = new EphemeralArrayService();
+      const settled = new Fr(1);
+      const missing = new Fr(2);
+      const settledBlock = { l2BlockNumber: BlockNumber(7), l2BlockHash: BlockHash.random() };
+
+      const getNullifierStatuses = async (innerNullifiers: Fr[]) =>
+        (
+          await utilityExecutionOracle.getNullifierStatuses(EphemeralArray.fromValues(service, innerNullifiers))
+        ).readAll(service);
+
+      beforeEach(async () => {
+        const settledSiloed = await siloNullifier(contractAddress, settled);
+        aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+          Promise.resolve(leaves.map(leaf => (leaf.equals(settledSiloed) ? { data: 0n, ...settledBlock } : undefined))),
+        );
+      });
+
+      it('returns aligned statuses with the origin block of each settled nullifier in one node call', async () => {
+        const statuses = await getNullifierStatuses([missing, settled, missing]);
+
+        expect(statuses).toEqual([
+          { exists: false, originBlock: Option.none() },
+          {
+            exists: true,
+            originBlock: Option.some({ blockNumber: 7, blockHash: new Fr(settledBlock.l2BlockHash.toBuffer()) }),
+          },
+          { exists: false, originBlock: Option.none() },
+        ]);
+        expect(aztecNode.findLeavesIndexes).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -210,9 +210,9 @@ describe('Utility Execution test suite', () => {
 
     aztecNode.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
     // The init check calls check_nullifier_exists, which queries findLeavesIndexes.
-    aztecNode.findLeavesIndexes.mockResolvedValue([
-      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.random() },
-    ]);
+    aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+      Promise.resolve(leaves.map(() => ({ data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.random() }))),
+    );
     contractStore.getFunctionArtifact.mockResolvedValue(artifact);
     contractStore.getContractInstance.mockResolvedValue({
       ...instanceFields,
@@ -302,9 +302,9 @@ describe('Utility Execution test suite', () => {
     const contractAddress = await computeContractAddressFromInstance(instanceFields);
 
     aztecNode.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
-    aztecNode.findLeavesIndexes.mockResolvedValue([
-      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.random() },
-    ]);
+    aztecNode.findLeavesIndexes.mockImplementation((_referenceBlock, _treeId, leaves) =>
+      Promise.resolve(leaves.map(() => ({ data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.random() }))),
+    );
     contractStore.getFunctionArtifact.mockResolvedValue(artifact);
     contractStore.getContractInstance.mockResolvedValue({
       ...instanceFields,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -518,18 +518,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
         ),
       )
     ).flat();
-    return siloedNullifiers.map((_, i): NullifierStatus => {
-      const leaf = leaves[i];
-      return leaf
-        ? {
-            exists: true,
-            originBlock: Option.some({
-              blockNumber: leaf.l2BlockNumber,
-              blockHash: new Fr(leaf.l2BlockHash.toBuffer()),
-            }),
-          }
-        : { exists: false, originBlock: Option.none() };
-    });
+    return leaves.map(
+      (leaf): NullifierStatus =>
+        leaf
+          ? {
+              exists: true,
+              originBlock: Option.some({ blockNumber: leaf.l2BlockNumber, blockHash: leaf.l2BlockHash.toFr() }),
+            }
+          : { exists: false, originBlock: Option.none() },
+    );
   }
 
   /**

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -1,6 +1,6 @@
 import { ARCHIVE_HEIGHT, type NOTE_HASH_TREE_HEIGHT, PRIVATE_LOG_CIPHERTEXT_LEN } from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
-import { uniqueBy } from '@aztec/foundation/collection';
+import { chunk, uniqueBy } from '@aztec/foundation/collection';
 import { Aes128 } from '@aztec/foundation/crypto/aes128';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
@@ -26,7 +26,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstancePreimageWithAddress, PartialAddress } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
-import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/server';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
@@ -73,6 +73,7 @@ import type { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
 import type { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
+import type { NullifierStatus } from '../noir-structs/nullifier_status.js';
 import { Option } from '../noir-structs/option.js';
 import type { PendingTaggedLog } from '../noir-structs/pending_tagged_log.js';
 import type { ProvidedSecret } from '../noir-structs/provided_secret.js';
@@ -494,19 +495,41 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   /**
-   * Check if a nullifier exists in the nullifier tree.
-   * @param innerNullifier - The inner nullifier.
-   * @returns A boolean indicating whether the nullifier exists in the tree or not.
+   * Returns the status of each inner nullifier: whether it exists in the nullifier tree at the anchor block and, if
+   * so, the block it was inserted in. Results are aligned with the input.
    */
-  public async doesNullifierExist(innerNullifier: Fr) {
-    const [nullifier, anchorBlockHash] = await allToCompletion([
-      siloNullifier(this.contractAddress, innerNullifier!),
-      this.anchorBlockHeader.hash(),
-    ]);
-    const [leafIndex] = await this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, [
-      nullifier,
-    ]);
-    return leafIndex?.data !== undefined;
+  public async getNullifierStatuses(innerNullifiers: EphemeralArray<Fr>): Promise<EphemeralArray<NullifierStatus>> {
+    const siloedNullifiers = await allToCompletion(
+      innerNullifiers
+        .readAll(this.ephemeralArrayService)
+        .map(innerNullifier => siloNullifier(this.contractAddress, innerNullifier)),
+    );
+    const statuses = await this.getSiloedNullifierStatuses(siloedNullifiers);
+    return EphemeralArray.fromValues(this.ephemeralArrayService, statuses);
+  }
+
+  /** Looks up siloed nullifiers in the nullifier tree at the anchor block, returning one status per input. */
+  protected async getSiloedNullifierStatuses(siloedNullifiers: Fr[]): Promise<NullifierStatus[]> {
+    const anchorBlockHash = await this.anchorBlockHeader.hash();
+    const leaves = (
+      await allToCompletion(
+        chunk(siloedNullifiers, MAX_RPC_LEN).map(batch =>
+          this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch),
+        ),
+      )
+    ).flat();
+    return siloedNullifiers.map((_, i): NullifierStatus => {
+      const leaf = leaves[i];
+      return leaf
+        ? {
+            exists: true,
+            originBlock: Option.some({
+              blockNumber: leaf.l2BlockNumber,
+              blockHash: new Fr(leaf.l2BlockHash.toBuffer()),
+            }),
+          }
+        : { exists: false, originBlock: Option.none() };
+    });
   }
 
   /**

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -26,7 +26,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstancePreimageWithAddress, PartialAddress } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
-import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/server';
+import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
-export const ORACLE_VERSION_MINOR = 8;
+export const ORACLE_VERSION_MINOR = 9;
 
 /// This hash is computed from `ORACLE_REGISTRY` (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 8;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'fec4d3a95fc57a62a20bfeb659bb3bfd91b31cd93e07f8cf97b368f9f55cc67b';
+export const ORACLE_INTERFACE_HASH = '334ec64096ddb1c3ff381ff029efcd675bd20b1b0ee55bff235bd816a87954fb';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -437,11 +437,11 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
-  aztec_utl_doesNullifierExist(...inputs: ForeignCallArgs) {
+  aztec_utl_getNullifierStatuses(...inputs: ForeignCallArgs) {
     return callTxeHandler({
-      oracle: 'aztec_utl_doesNullifierExist',
+      oracle: 'aztec_utl_getNullifierStatuses',
       inputs,
-      handler: ([innerNullifier]) => this.handlerAsUtility().doesNullifierExist(innerNullifier),
+      handler: ([innerNullifiers]) => this.handlerAsUtility().getNullifierStatuses(innerNullifiers),
     });
   }
 


### PR DESCRIPTION
Replaces the single-nullifier existence oracle with `getNullifierStatuses`, which checks any number of nullifiers in one call and reports, for each settled one, the block it was included in. The old `check_nullifier_exists` API is kept to avoid breakage (and because it's used often).

This is fairly straightforward: it's just an extension of the oracle that provides more information (the block) and allows for batch queries. It'll be useful in contexts where fact stores need to be updated depending on nullifier existence, which in turn requires knowledge of the block number to serve as origin blocks.