### PR TITLE
feat: settled note origin oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -1,7 +1,8 @@
 use crate::messages::delivery::OnchainDeliveryMode;
 use crate::note::{HintedNote, note_interface::NoteType};
+use crate::oracle::block_reference::BlockReference;
 
-use crate::protocol::{address::AztecAddress, traits::Packable};
+use crate::protocol::{address::AztecAddress, traits::{Deserialize, Packable}};
 
 /// Notifies the simulator that a note has been created, so that it can be returned in future read requests in the same
 /// transaction. This note should only be added to the non-volatile database if found in an actual block.
@@ -174,6 +175,37 @@ where
 
     notes_array
 }
+
+/// Where a settled note was created.
+///
+/// None of this can be cheaply constrained: doing so requires proving the transaction, its inclusion in the block, and
+/// the block's ancestry in the anchor block.
+// TODO(F-890): also expose the transaction and block in which the note was nullified, if it was.
+#[derive(Deserialize, Eq)]
+pub struct NoteOrigin {
+    /// Hash of the transaction that created the note.
+    pub tx_hash: Field,
+    /// The block that transaction was included in.
+    pub block: BlockReference,
+}
+
+/// Returns where the settled note with the given hash and nonce was created, or `None` if the note is unknown.
+///
+/// Nullified notes are also returned. Only notes of the executing contract can be looked up.
+pub unconstrained fn get_settled_note_origin(
+    note_hash: Field,
+    contract_address: AztecAddress,
+    note_nonce: Field,
+) -> Option<NoteOrigin> {
+    get_settled_note_origin_oracle(note_hash, contract_address, note_nonce)
+}
+
+#[oracle(aztec_utl_getSettledNoteOrigin)]
+unconstrained fn get_settled_note_origin_oracle(
+    _note_hash: Field,
+    _contract_address: AztecAddress,
+    _note_nonce: Field,
+) -> Option<NoteOrigin> {}
 
 // TODO: Oracles below are generic private log oracles and are not specific to notes. Move them somewhere else.
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
-pub global ORACLE_VERSION_MINOR: Field = 9;
+pub global ORACLE_VERSION_MINOR: Field = 10;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
@@ -1,8 +1,16 @@
 use crate::test::helpers::test_environment::TestEnvironment;
 
+use crate::context::{PrivateContext, UtilityContext};
 use crate::ephemeral::EphemeralArray;
+use crate::note::{
+    HintedNote, note_getter::view_note, note_getter_options::NoteGetterOptions, note_interface::NoteHash,
+    note_viewer_options::NoteViewerOptions,
+};
+use crate::oracle::notes::get_settled_note_origin;
 use crate::oracle::nullifiers::{check_nullifier_exists, get_nullifier_statuses};
 use crate::protocol::{address::AztecAddress, traits::FromField};
+use crate::state_vars::{OwnedStateVariable, PrivateImmutable, PrivateSet};
+use crate::test::mocks::mock_note::MockNote;
 
 #[test]
 unconstrained fn at_sets_contract_address() {
@@ -123,5 +131,70 @@ unconstrained fn get_nullifier_statuses_mixed() {
         let nonexistent = statuses.get(1);
         assert(!nonexistent.exists);
         assert(nonexistent.origin_block.is_none());
+    });
+}
+
+#[test]
+unconstrained fn get_settled_note_origin_found() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+    let storage_slot = 17;
+
+    let note_message = env.private_context(|context| {
+        PrivateImmutable::new(context, storage_slot, owner).initialize(MockNote::new(23).build_note())
+    });
+    let settled_block_number = env.last_block_number();
+    env.discover_note(note_message);
+
+    env.utility_context(|context| {
+        let hinted_note: HintedNote<MockNote> = view_note(Option::some(owner), storage_slot);
+        let note_hash =
+            hinted_note.note.compute_note_hash(hinted_note.owner, hinted_note.storage_slot, hinted_note.randomness);
+        let note_nonce = hinted_note.metadata.to_settled().note_nonce();
+
+        let origin = get_settled_note_origin(note_hash, context.this_address(), note_nonce).unwrap();
+        assert_eq(origin.block.block_number, settled_block_number);
+        assert(origin.tx_hash != 0);
+    });
+}
+
+#[test]
+unconstrained fn get_settled_note_origin_unknown_note() {
+    let env = TestEnvironment::new();
+
+    env.utility_context(|context| { assert(get_settled_note_origin(1, context.this_address(), 2).is_none()); });
+}
+
+#[test]
+unconstrained fn get_settled_note_origin_nullified_note() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+    let storage_slot = 17;
+
+    let note_message = env.private_context(|context| {
+        let state_var: PrivateSet<MockNote, &mut PrivateContext> = PrivateSet::new(context, storage_slot, owner);
+        state_var.insert(MockNote::new(23).build_note())
+    });
+    let settled_block_number = env.last_block_number();
+    env.discover_note(note_message);
+
+    let (note_hash, note_nonce) = env.utility_context(|_| {
+        let hinted_note: HintedNote<MockNote> = view_note(Option::some(owner), storage_slot);
+        let note_hash =
+            hinted_note.note.compute_note_hash(hinted_note.owner, hinted_note.storage_slot, hinted_note.randomness);
+        (note_hash, hinted_note.metadata.to_settled().note_nonce())
+    });
+
+    env.private_context(|context| {
+        let state_var: PrivateSet<MockNote, &mut PrivateContext> = PrivateSet::new(context, storage_slot, owner);
+        assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 1);
+    });
+
+    env.utility_context(|context| {
+        let state_var: PrivateSet<MockNote, UtilityContext> = PrivateSet::new(context, storage_slot, owner);
+        assert_eq(state_var.view_notes(NoteViewerOptions::new()).len(), 0);
+
+        let origin = get_settled_note_origin(note_hash, context.this_address(), note_nonce).unwrap();
+        assert_eq(origin.block.block_number, settled_block_number);
     });
 }

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -72,6 +72,7 @@ export type { IMiscOracle, IUtilityExecutionOracle, IPrivateExecutionOracle } fr
 export type { FactCollection } from './noir-structs/fact_collection.js';
 export type { NoteData } from './noir-structs/note_data.js';
 export type { NullifierStatus } from './noir-structs/nullifier_status.js';
+export type { NoteOrigin } from './noir-structs/note_origin.js';
 export type { ResolvedTaggingStrategy } from './noir-structs/resolved_tagging_strategy.js';
 export type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
 export { TxResolverService } from '../messages/tx_resolver_service.js';

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/note_origin.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/note_origin.ts
@@ -1,0 +1,11 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+
+import type { BlockReference } from '../../storage/fact_store/index.js';
+
+/** TypeScript counterpart of `NoteOrigin` in Aztec.nr. */
+export type NoteOrigin = {
+  /** Hash of the tx that created the note. */
+  txHash: Fr;
+  /** The block that tx was included in. */
+  block: BlockReference;
+};

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -32,6 +32,7 @@ import {
   MESSAGE_LOAD_ORACLE_INPUTS,
   type MaybePromise,
   NOTE,
+  NOTE_ORIGIN,
   NOTE_SELECTOR,
   NOTE_VALIDATION_REQUEST,
   NULLIFIER_MEMBERSHIP_WITNESS,
@@ -240,6 +241,15 @@ export const ORACLE_REGISTRY = {
       { name: 'packedHintedNoteLength', type: U32 },
     ],
     returnType: BOUNDED_VEC(NOTE),
+  }),
+
+  aztec_utl_getSettledNoteOrigin: makeEntry({
+    params: [
+      { name: 'noteHash', type: FIELD },
+      { name: 'contractAddress', type: AZTEC_ADDRESS },
+      { name: 'noteNonce', type: FIELD },
+    ],
+    returnType: OPTION(NOTE_ORIGIN),
   }),
 
   aztec_utl_getPendingTaggedLogsV2: makeEntry({

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -68,6 +68,7 @@ import type { FactCollection } from '../noir-structs/fact_collection.js';
 import { type LogRetrievalRequest, type LogSource, logSourceFromField } from '../noir-structs/log_retrieval_request.js';
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
+import type { NoteOrigin } from '../noir-structs/note_origin.js';
 import { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
 import type { NullifierStatus } from '../noir-structs/nullifier_status.js';
 import { Option } from '../noir-structs/option.js';
@@ -571,6 +572,11 @@ export const BLOCK_REFERENCE: TypeMapping<BlockReference> = STRUCT([
 export const NULLIFIER_STATUS: TypeMapping<NullifierStatus> = STRUCT([
   { name: 'exists', type: BOOL },
   { name: 'originBlock', type: OPTION(BLOCK_REFERENCE) },
+]);
+
+export const NOTE_ORIGIN: TypeMapping<NoteOrigin> = STRUCT([
+  { name: 'txHash', type: FIELD },
+  { name: 'block', type: BLOCK_REFERENCE },
 ]);
 
 const ORIGIN_BLOCK_STATE: TypeMapping<OriginBlockState> = SCALAR({

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -32,7 +32,7 @@ import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdli
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
-import { Note, NoteDao } from '@aztec/stdlib/note';
+import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
 import { makeL2Tips, randomContractInstanceWithAddress } from '@aztec/stdlib/testing';
 import {
   BlockHeader,
@@ -763,6 +763,57 @@ describe('Utility Execution test suite', () => {
           { exists: false, originBlock: Option.none() },
         ]);
         expect(aztecNode.findLeavesIndexes).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('getSettledNoteOrigin', () => {
+      const noteHash = Fr.random();
+      const noteNonce = Fr.random();
+      const txHash = TxHash.random();
+      const blockHash = BlockHash.random();
+
+      beforeEach(async () => {
+        const sameHashOtherNonce = await NoteDao.random({ contractAddress, noteHash });
+        const note = await NoteDao.random({
+          contractAddress,
+          noteHash,
+          noteNonce,
+          txHash,
+          l2BlockNumber: BlockNumber(7),
+          l2BlockHash: blockHash.toString(),
+        });
+        noteStore.getNotes.mockResolvedValue([sameHashOtherNonce, note]);
+      });
+
+      it('returns the tx and block of the note with the given hash and nonce', async () => {
+        const origin = await utilityExecutionOracle.getSettledNoteOrigin(noteHash, contractAddress, noteNonce);
+
+        expect(origin).toEqual(
+          Option.some({ txHash: txHash.hash, block: { blockNumber: 7, blockHash: blockHash.toFr() } }),
+        );
+      });
+
+      it('looks up nullified notes too', async () => {
+        await utilityExecutionOracle.getSettledNoteOrigin(noteHash, contractAddress, noteNonce);
+
+        expect(noteStore.getNotes).toHaveBeenCalledWith(
+          { contractAddress, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: [scope] },
+          expect.anything(),
+        );
+      });
+
+      it('returns none when no note matches', async () => {
+        const origin = await utilityExecutionOracle.getSettledNoteOrigin(noteHash, contractAddress, Fr.random());
+
+        expect(origin).toEqual(Option.none());
+      });
+
+      it('rejects lookups for other contracts', async () => {
+        const otherContract = await AztecAddress.random();
+
+        await expect(utilityExecutionOracle.getSettledNoteOrigin(noteHash, otherContract, noteNonce)).rejects.toThrow(
+          `Contract ${otherContract} is not allowed to access ${contractAddress}'s PXE DB`,
+        );
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -31,7 +31,7 @@ import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, FlatPublicLogs, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
 import { type UnsiloedMessageNullifier, getL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
-import type { NoteStatus } from '@aztec/stdlib/note';
+import { NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import {
   type BlockHeader,
@@ -72,6 +72,7 @@ import { type FactCollection, emptyFactCollection, toNoirFactCollection } from '
 import type { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.js';
 import type { LogRetrievalResponse } from '../noir-structs/log_retrieval_response.js';
 import type { NoteData } from '../noir-structs/note_data.js';
+import type { NoteOrigin } from '../noir-structs/note_origin.js';
 import type { NoteValidationRequest } from '../noir-structs/note_validation_request.js';
 import type { NullifierStatus } from '../noir-structs/nullifier_status.js';
 import { Option } from '../noir-structs/option.js';
@@ -492,6 +493,33 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       offset,
     });
     return BoundedVec.from({ data: picked, maxLength: maxNotes, elementSize: packedHintedNoteLength });
+  }
+
+  /**
+   * Returns the tx and block in which a settled note of the executing contract was created, or `None` if no such note
+   * is known. Nullified notes are also returned.
+   */
+  public async getSettledNoteOrigin(
+    noteHash: Fr,
+    contractAddress: AztecAddress,
+    noteNonce: Fr,
+  ): Promise<Option<NoteOrigin>> {
+    this.#assertOwnContract(contractAddress);
+
+    // The store is only indexed by contract, so this scans all of the contract's notes. The query is rare enough and
+    // stores are small enough that this is not a concern.
+    const notes = await this.noteStore.getNotes(
+      { contractAddress, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: this.scopes },
+      this.changeSetId,
+    );
+    const note = notes.find(note => note.noteHash.equals(noteHash) && note.noteNonce.equals(noteNonce));
+
+    return note
+      ? Option.some({
+          txHash: note.txHash.hash,
+          block: { blockNumber: note.l2BlockNumber, blockHash: Fr.fromHexString(note.l2BlockHash) },
+        })
+      : Option.none();
   }
 
   /**

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
-export const ORACLE_VERSION_MINOR = 9;
+export const ORACLE_VERSION_MINOR = 10;
 
 /// This hash is computed from `ORACLE_REGISTRY` (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 9;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '334ec64096ddb1c3ff381ff029efcd675bd20b1b0ee55bff235bd816a87954fb';
+export const ORACLE_INTERFACE_HASH = '684ab49e1fad3cc8c166c6e515c3c1d46daaee780a33f61556213df0772a0b51';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -437,6 +437,16 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
+  aztec_utl_getSettledNoteOrigin(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_utl_getSettledNoteOrigin',
+      inputs,
+      handler: ([noteHash, contractAddress, noteNonce]) =>
+        this.handlerAsUtility().getSettledNoteOrigin(noteHash, contractAddress, noteNonce),
+    });
+  }
+
+  // eslint-disable-next-line camelcase
   aztec_utl_getNullifierStatuses(...inputs: ForeignCallArgs) {
     return callTxeHandler({
       oracle: 'aztec_utl_getNullifierStatuses',


### PR DESCRIPTION
Adds `aztec_utl_getSettledNoteOrigin`, which returns a note's creation transaction hash and block. The note store already holds this data but the get notes oracle omits it because it cannot be cheaply constrained - the use case is unconstrained utilities (e.g. the sync process)  where this is not a concern. Nullified notes are also returned - in v6 we'll return the nullifier tx and block, but not now because a) that requires a db change and b) we don't need it yet.

The lookup scans the contract's notes at the call site rather than adding a store index, which would require a schema migration of deployed PXEs.