### PR TITLE
feat(ci): optional suffix for manually dispatched nightly tags

### DIFF
--- a/.github/NOTES.md
+++ b/.github/NOTES.md
@@ -27,7 +27,9 @@ There are three ways to land code in `v4-next`:
 
 ### Nightly releases
 
-Every night at 5:00 AM UTC, `nightly-release-tag-v4-next.yml` creates a tag from `v4-next` in the format `v{version}-nightly.{date}`. This mirrors the nightly release process on `next`.
+Every night at 4:00 AM UTC, `nightly-release-tag.yml` tags both `next` and `v5-next` in the format `v{version}-nightly.{date}`, taking the version from `.release-please-manifest.json` on each branch. Pushing the tag triggers the release flow.
+
+The workflow can also be dispatched manually. It then accepts an optional `suffix` input and tags `v{version}-nightly.{date}.{suffix}`, so an extra nightly can be cut on a day that already has one. The suffix must be lowercase letters, digits and hyphens starting with a letter, which keeps the tag a valid semver prerelease. Without a suffix, a manual run produces the canonical tag for the day and fails if it already exists: the workflow never moves an existing tag.
 
 ### Backports
 
@@ -43,5 +45,5 @@ The existing backport infrastructure (`backport.yml`) works with `v4-next` out o
 | Workflow | Trigger | Action |
 |---|---|---|
 | `pull-v4-into-v4-next.yml` | Push to `v4` | Merges `v4` into `v4-next`; creates conflict PR if needed |
-| `nightly-release-tag-v4-next.yml` | Daily at 05:00 UTC | Tags `v4-next` with `v{version}-nightly.{date}` |
+| `nightly-release-tag.yml` | Daily at 04:00 UTC, or manual dispatch | Tags `next` and `v5-next` with `v{version}-nightly.{date}`, plus an optional `.{suffix}` on manual runs |
 | `backport.yml` | `backport-to-v4-next` label + PR merge | Cherry-picks into `v4-next` via staging branch |

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -3,7 +3,12 @@ on:
   schedule:
     # Run the workflow every night at 4:00 AM UTC.
     - cron: "0 4 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      suffix:
+        description: "Optional suffix for a manual nightly: tags v<version>-nightly.<date>.<suffix> instead of v<version>-nightly.<date>. Lowercase letters, digits and hyphens, starting with a letter."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -28,12 +33,25 @@ jobs:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
       - name: Create Nightly Tag
+        env:
+          SUFFIX: ${{ inputs.suffix }}
         run: |
           git config --global user.email "tech@aztecprotocol.com"
           git config --global user.name "AztecBot"
           current_version=$(jq -r '."."' .release-please-manifest.json)
           echo "Current version: $current_version"
           nightly_tag="v${current_version}-nightly.$(date -u +%Y%m%d)"
+          if [ -n "$SUFFIX" ]; then
+            if ! [[ "$SUFFIX" =~ ^[a-z][a-z0-9-]*$ ]]; then
+              echo "::error::Invalid suffix '$SUFFIX': use lowercase letters, digits and hyphens, starting with a letter."
+              exit 1
+            fi
+            nightly_tag="$nightly_tag.$SUFFIX"
+          fi
           echo "${{ matrix.branch }} nightly tag: $nightly_tag"
+          if git ls-remote --exit-code --tags origin "refs/tags/$nightly_tag" >/dev/null 2>&1; then
+            echo "::error::Tag $nightly_tag already exists. Re-run this workflow with a suffix input to cut a distinct tag."
+            exit 1
+          fi
           git tag -a "$nightly_tag" -m "$nightly_tag"
           git push origin "$nightly_tag"


### PR DESCRIPTION
Foundation half of the nightly-tag suffix plan (the aztec-node side — `release-tag.yml`, `create_devnet.ts`, `RELEASES.md` — lands separately).

## What changes

- `nightly-release-tag.yml` gains an optional `workflow_dispatch.inputs.suffix`. A manual run with a suffix tags `v<version>-nightly.<date>.<suffix>`; without one it tags the canonical `v<version>-nightly.<date>`. Scheduled runs are untouched and stay canonical.
- The suffix arrives through an env var and is validated in bash as a single prerelease identifier (`^[a-z][a-z0-9-]*$`), so nothing from the input reaches a ref or a shell unchecked.
- Before tagging, the job checks `git ls-remote` for the tag and fails with an actionable message instead of erroring out on the push. A manual run on a day that already has a nightly now says to re-run with a suffix.
- `.github/NOTES.md` had a stale nightly section (a `nightly-release-tag-v4-next.yml` that no longer exists, at 05:00 UTC). It now describes the actual workflow, its 04:00 UTC schedule, both tagged branches, and the manual suffix.

## Verification

- Validation table checked locally: `devnet`, `devnet-3`, `a1` accepted; `Dev`, `a b`, `a;rm -rf /`, `1abc`, `-x`, `a$(id)`, `../x`, `a.b` rejected.
- `ci3/semver` accepts a suffixed tag and sorts it as expected: `v1.2.3-nightly.20260910` < `v1.2.3-nightly.20260910.devnet-3` < `v1.2.3`, so the release path (`semver prerelease` → the `prerelease` npm dist-tag, the GitHub prerelease flag) treats it like any other nightly.
- The existence check was exercised against a real tag (`v6.0.0-nightly.20260910` is detected; an absent tag lets the run proceed).
- Workflow YAML parses and the `run` body passes `bash -n`.