### PR TITLE
fix(l1-artifacts): drop unreferenced test artifacts from the published bundle

### DIFF
--- a/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
@@ -41,3 +41,6 @@ abs_dest=$(pwd)/l1-contracts
 # Foundry is very finicky about copying out subsets.
 # Patch over what foundry feels needs to be rebuild (~3 seconds on mainframe)
 (cd "l1-contracts" && forge build)
+
+# The parent's out/ holds an artifact for every test contract too; drop what the cache never names.
+scripts/prune-unreferenced-artifacts.sh

--- a/l1-contracts/l1-artifacts/scripts/prune-unreferenced-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/prune-unreferenced-artifacts.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deletes everything under the bundled foundry subtree's out/ that forge's cache does not reference.
+#
+# The subtree is copied from a parent l1-contracts built with its tests, so out/ carries an artifact
+# for every test contract — ~100MB of the ~140MB package, for sources the bundle does not even ship.
+# The deploy path (yarn-project/ethereum's forge script run) only ever reads the artifacts named by
+# cache/solidity-files-cache.json, so anything absent from the cache is dead weight. Deriving the
+# keep set from the cache rather than a name pattern keeps this correct as contracts come and go.
+
+# Defaults to the bundle the copy script produces; takes a path so it can be run against an
+# extracted package tarball.
+cd "${1:-$(git rev-parse --show-toplevel)/l1-contracts/l1-artifacts/l1-contracts}"
+
+cache="cache/solidity-files-cache.json"
+[ -f "$cache" ] || { echo "Error: $cache not found. Run copy-foundry-artifacts.sh first." >&2; exit 1; }
+[ -d out ] || { echo "Error: out/ not found. Run copy-foundry-artifacts.sh first." >&2; exit 1; }
+
+keep=$(mktemp) all=$(mktemp)
+trap 'rm -f "$keep" "$all"' EXIT
+
+# Every artifact a cached source compiled to, plus the build-info each of those builds refers back to.
+jq -r '([.files[].artifacts[][][].path] + [.builds[] | "build-info/" + . + ".json"]) | unique[]' \
+  "$cache" | sort -u > "$keep"
+find out -type f -printf '%P\n' | sort > "$all"
+
+# A forge cache whose shape we no longer understand would yield an empty keep set and take the whole
+# of out/ with it, leaving a package that silently recompiles (or fails) at deploy time.
+kept=$(wc -l < "$keep")
+if [ "$kept" -lt 100 ]; then
+  echo "Error: cache named only $kept artifacts; refusing to prune. Has the forge cache format changed?" >&2
+  exit 1
+fi
+
+before=$(du -sk out | cut -f1)
+comm -23 "$all" "$keep" | sed 's|^|out/|' | tr '\n' '\0' | xargs -0 --no-run-if-empty rm -f
+find out -type d -empty -delete
+after=$(du -sk out | cut -f1)
+
+echo "Pruned $(( (before - after) / 1024 ))MB of unreferenced artifacts from out/ ($(( before / 1024 ))MB -> $(( after / 1024 ))MB)."


### PR DESCRIPTION
`@aztec-foundation/l1-artifacts` publishes at 141MB unpacked / 1402 files. **101MB of that is Foundry artifacts for test contracts**, and nothing reads them.

## Why they were there

`copy-foundry-artifacts.sh` builds the self-contained foundry subtree by copying the parent `l1-contracts/out` wholesale. The parent is built with its tests, so `out/` holds an artifact for every `*.t.sol` contract. The bundle exists so `yarn-project/ethereum`'s runtime `forge script` deploy can run against prebuilt artifacts; test artifacts play no part in it, and the bundle doesn't even ship their sources.

The shipped forge cache makes this precise: it names 217 artifact files and 4 build-infos. The package contained 491. The other 274 — 172 `*.t.sol` directories among them — have no source in the bundle and no cache entry.

## The change

After the copy's `forge build`, prune `out/` to exactly what `cache/solidity-files-cache.json` references. The keep set is derived from the cache rather than from a `*.t.sol` name pattern, so it stays correct as contracts come and go, and it catches non-`.t.sol` test scaffolding (`Vm.sol`, `RollupBuilder.sol`, `GseBuilder.sol`) that a pattern would miss. A floor of 100 kept artifacts makes a future forge cache-format change fail the build instead of silently emptying `out/`.

**138MB → 32MB unpacked** (the parent's `out/`: 116MB → 13MB).

## Verification

Against the real published tarball (`6.0.0-nightly.20260911`), extracted twice, pruned one copy:

- `forge build` reports `No files changed, compilation skipped` on both — pruning triggers no recompilation.
- `forge script script/deploy/DeployAztecL1Contracts.s.sol --sig 'run()'` produces **byte-identical output** on both, 175 lines, same `Gas used: 21704466`, stopping at the same missing-env-var revert (no env supplied).
- Same for `DeployRollupForUpgrade.s.sol`, the other script the deploy path invokes.
- End-to-end in-tree: `copy-foundry-artifacts.sh` produces a 13MB `out/`, `forge build` still skips, and the deploy script reaches the identical gas figure.
- Re-running the prune is a no-op; an emptied cache is refused by the guard.

## Context

Size had been creeping: 6.6MB before the standalone-package move in January, ~136MB through early September, 141MB on the 11th, and 150MB for a build cut the same afternoon. At that size npm routes the publish through staged publishing and malware scanning, where a nightly got stuck mid-scan and blocked its own re-publish with `E409 Cannot publish over previously staged version`. Smaller packages from the same run cleared in seconds.