### PR TITLE
fix(l1-artifacts): build minimal Foundry bundle

### DIFF
--- a/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Copies select Foundry artifacts from the parent l1-contracts into l1-contracts/l1-artifacts/l1-contracts.
-# This produces a self-contained, publishable foundry subtree for runtime contract deployment.
+# Builds a self-contained, publishable Foundry subtree for runtime contract deployment from the
+# parent l1-contracts sources.
 #
-# We use cp -p to preserve timestamps - forge cache uses timestamps to detect changes.
 # See release-image/Dockerfile.dockerignore for the canonical list of what's needed.
 
 cd $(git rev-parse --show-toplevel)/l1-contracts/l1-artifacts
@@ -16,13 +15,10 @@ src=".."
 rm -rf "l1-contracts"
 mkdir -p "l1-contracts/script" "l1-contracts/lib" "l1-contracts/broadcast"
 
-# Copy build artifacts, cache, sources, and config (preserving timestamps for cache validity)
-cp -rp "$src"/{out,cache,src,generated} "l1-contracts/"
+# Copy sources and config, then compile the bundle independently so its cache and artifacts contain
+# only files that can be reached from the published source tree.
+cp -rp "$src"/{src,generated} "l1-contracts/"
 cp -rp "$src/script/deploy" "l1-contracts/script/"  # only deploy/, other scripts depend on test files
-# Kludge: copy test files that forge cache references to avoid stale artifact warnings
-mkdir -p "l1-contracts/test/script"
-cp -p "$src/test/shouting.t.sol" "l1-contracts/test/"
-cp -p "$src"/test/script/*.sol "l1-contracts/test/script/"
 # EmptyPayload for the rollup-upgrade docs tutorial's quick-test path
 # (docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md); the tutorial's main
 # payload, RegisterNewRollupVersionPayload, ships with src/periphery. Compiles against src/ only.
@@ -38,6 +34,5 @@ abs_dest=$(pwd)/l1-contracts
 # Keep only the foundry relevant files from lib
 (cd "$src" && find lib \( -name "*.sol" -o -name "remappings.txt" -o -name "foundry.toml" \) -exec cp --parents -t "$abs_dest" {} +)
 
-# Foundry is very finicky about copying out subsets.
-# Patch over what foundry feels needs to be rebuild (~3 seconds on mainframe)
+# Build a cache and artifact tree that exactly matches the files in the published bundle.
 (cd "l1-contracts" && forge build)


### PR DESCRIPTION
Build the published Foundry subtree from its own source set so the npm package contains only artifacts it can use.

## Context

The bundle copied the parent `out/` and cache wholesale. Because the parent project is built with its tests, that brought roughly 100 MB of test artifacts into `@aztec-foundation/l1-artifacts`, along with test sources copied only to satisfy the inherited cache.

## Approach

Assemble the published sources, deployment scripts, libraries, and configuration first, then run a clean `forge build` inside that subtree. Forge now creates an artifact tree and cache that exactly match the published sources, reducing `out/` from 117 MB to 12 MB without depending on cache internals or a pruning pass. A subsequent default build skips compilation, release-style compiler configuration also skips compilation, and both deployment scripts produce the same execution traces as the parent project.
